### PR TITLE
Add option to log scale the colormap

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -36,6 +36,7 @@ class ColorMapEditor:
 
         self.ui.maximum.valueChanged.connect(self.update_norm)
         self.ui.minimum.valueChanged.connect(self.update_norm)
+        self.ui.log_scale.toggled.connect(self.update_norm)
 
         self.image_tab_widget.new_images_loaded.connect(self.update_bounds)
 
@@ -75,5 +76,10 @@ class ColorMapEditor:
     def update_norm(self):
         min = self.ui.minimum.value()
         max = self.ui.maximum.value()
-        norm = matplotlib.colors.Normalize(vmin=min, vmax=max)
+
+        if self.ui.log_scale.isChecked():
+            norm = matplotlib.colors.LogNorm(vmin=min, vmax=max)
+        else:
+            norm = matplotlib.colors.Normalize(vmin=min, vmax=max)
+
         self.image_tab_widget.set_norm(norm)

--- a/hexrd/ui/resources/ui/color_map_editor.ui
+++ b/hexrd/ui/resources/ui/color_map_editor.ui
@@ -17,56 +17,17 @@
       <string>Color Map</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
-        <property name="text">
-         <string>Color Map:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="4">
-       <spacer name="horizontalSpacer_3">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Range:</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QCheckBox" name="show_under">
-        <property name="toolTip">
-         <string>Color under values as blue</string>
-        </property>
-        <property name="text">
-         <string>show under</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="3">
-       <widget class="QSpinBox" name="maximum">
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="minimum">
         <property name="maximum">
          <number>100000</number>
         </property>
-        <property name="value">
-         <number>16384</number>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QCheckBox" name="reverse">
+        <property name="text">
+         <string>reverse</string>
         </property>
        </widget>
       </item>
@@ -80,35 +41,8 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="minimum">
-        <property name="maximum">
-         <number>100000</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <spacer name="horizontalSpacer">
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>40</width>
-          <height>20</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item row="0" column="3">
-       <widget class="QCheckBox" name="reverse">
-        <property name="text">
-         <string>reverse</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="4">
-       <spacer name="horizontalSpacer_2">
+      <item row="2" column="5">
+       <spacer name="horizontalSpacer_3">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
         </property>
@@ -134,6 +68,79 @@
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>-</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Color Map:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Range:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QSpinBox" name="maximum">
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="value">
+         <number>16384</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QCheckBox" name="show_under">
+        <property name="toolTip">
+         <string>Color under values as blue</string>
+        </property>
+        <property name="text">
+         <string>show under</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="5">
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="4">
+       <widget class="QCheckBox" name="log_scale">
+        <property name="text">
+         <string>log scale</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This just adds an extra checkbox to the colormap widget
to allow a log scale to be used.

Fixes [#27](https://github.com/cryos/hexrd/issues/27)