### PR TITLE
Kill the program when ctrl-c is used

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -140,8 +140,12 @@ class MainWindow(QObject):
 
 
 def main():
+    import signal
     import sys
     from PySide2.QtWidgets import QApplication
+
+    # Kill the program when ctrl-c is used
+    signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     app = QApplication(sys.argv)
 


### PR DESCRIPTION
Because Qt catches and processes signals when it is
running, python does not immediately see the "ctrl-c" signal
when it is entered until Qt hands control back to the python
interpreter. This results in "ctrl-c" not working.

For some reason, adding the signal connection that is done in
this commit fixes the issue. The program now closes with "ctrl-c".
No saving is performed - just a hard terminate.

See [here](https://stackoverflow.com/questions/5160577/ctrl-c-doesnt-work-with-pyqt) for related discussion.