### PR TITLE
Don't sort detectors via regex in LoadImagesDialog

### DIFF
--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -64,16 +64,12 @@ class LoadImagesDialog:
         cur_regex = self.current_regex()
 
         try:
-            detectors.sort(key=lambda s: _re_res(cur_regex, s))
             image_files.sort(key=lambda s: _re_res(cur_regex, s))
         except Exception as e:
             # The user is probably in the middle of typing...
             pass
 
         for i in range(len(detectors)):
-            d = QTableWidgetItem(detectors[i])
-            table.setItem(i, 0, d)
-
             f = QTableWidgetItem(image_files[i])
             table.setItem(i, 1, f)
 


### PR DESCRIPTION
Prior, both the detector names and the image files would be
sorted by the regex. Do not sort the detector names, but only
the image files, as it can be confusing to the user that both
are sorted.