### PR TITLE
Do not allow cached gui yaml paths to be edited

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -200,7 +200,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         string_path = str(path)
         if string_path in self.cached_gui_yaml_dicts.keys():
-            return self.cached_gui_yaml_dicts[string_path]
+            return copy.deepcopy(self.cached_gui_yaml_dicts[string_path])
 
         res = []
         self._search_gui_yaml_dict(search_dict, res)


### PR DESCRIPTION
These gui yaml paths are cached when they are used so that
subsequent lookups are faster. We should return a deep copy
so that the cached paths will not be edited from the outside.

The cached path was edited when setting a value for a detector,
and this caused a bug that is now fixed.

Fixes: #38