### PR TITLE
Suppress loss of precision warnings from skimage

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pickle
+import warnings
 
 from hexrd.gridutil import cellIndices
 from hexrd import instrument
@@ -121,7 +122,9 @@ class InstrumentViewer:
         """
         IMAGE PLOTTING AND LIMIT CALCULATION
         """
-        img = equalize_adapthist(warped, clip_limit=0.1, nbins=2**16)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            img = equalize_adapthist(warped, clip_limit=0.1, nbins=2**16)
 
         # Rescale the data to match the scale of the original dataset
         # TODO: try to get create_calibration_image to not rescale the

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -1,4 +1,5 @@
 import numpy as np
+import warnings
 
 from hexrd import instrument
 from .polarview import PolarView
@@ -143,7 +144,9 @@ class InstrumentViewer:
         # plotting
         self.warped_image = warped
 
-        img = equalize_adapthist(img, clip_limit=0.1, nbins=2**16)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            img = equalize_adapthist(img, clip_limit=0.1, nbins=2**16)
 
         # Rescale the data to match the scale of the original dataset
         # TODO: try to get the function to not rescale the


### PR DESCRIPTION
Basically the issue here is that transform.warp(...) converts our image
from uint16 to float64, its converted back to uint16 by the histogram
equalization. This produces warnings about a possible loss of precision,
we can safely ignore them.