### PR TITLE
Added button to view images after calibration

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -64,6 +64,7 @@ class MainWindow(QObject):
             self.on_action_save_materials_triggered)
         self.ui.calibration_tab_widget.currentChanged.connect(
             self.update_config_gui)
+        self.ui.image_view.pressed.connect(self.show_images)
         self.ui.cartesian_view.pressed.connect(self.show_cartesian)
         self.ui.polar_view.pressed.connect(self.show_polar)
 
@@ -147,6 +148,9 @@ class MainWindow(QObject):
 
         if selected_file:
             return HexrdConfig().save_materials(selected_file)
+
+    def show_images(self):
+        self.ui.image_tab_widget.load_images()
 
     def show_cartesian(self):
         # Automatically make the cartesian resolution tab the active tab

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -72,7 +72,7 @@
    <property name="minimumSize">
     <size>
      <width>550</width>
-     <height>229</height>
+     <height>260</height>
     </size>
    </property>
    <property name="windowTitle">
@@ -100,7 +100,7 @@
           <x>0</x>
           <y>0</y>
           <width>532</width>
-          <height>657</height>
+          <height>626</height>
          </rect>
         </property>
         <attribute name="label">
@@ -113,7 +113,7 @@
           <x>0</x>
           <y>0</y>
           <width>532</width>
-          <height>657</height>
+          <height>626</height>
          </rect>
         </property>
         <attribute name="label">
@@ -139,6 +139,13 @@
          </item>
         </layout>
        </widget>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="image_view">
+       <property name="text">
+        <string>Image View</string>
+       </property>
       </widget>
      </item>
      <item>


### PR DESCRIPTION
Added a `View Images` button so that the images can be more
easily viewed again after a calibration has been ran.

Fixes: #34