### PR TITLE
Enable multi-selection of rows

### DIFF
--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -105,7 +105,7 @@
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::MultiSelection</enum>
+      <enum>QAbstractItemView::ExtendedSelection</enum>
      </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>


### PR DESCRIPTION
Single click will select single row, ctrl+click will select all rows clicked, shift+click will select all items between current row and clicked row. Should solve issue #40.

Signed-off-by: Brianna Major <brianna.major@kitware.com>