### PR TITLE
Increase digits for Add Material dialog

### DIFF
--- a/hexrd/ui/resources/ui/add_material_dialog.ui
+++ b/hexrd/ui/resources/ui/add_material_dialog.ui
@@ -339,6 +339,9 @@
           <property name="suffix">
            <string> Å</string>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>1000.000000000000000</double>
           </property>
@@ -429,6 +432,9 @@
           <property name="suffix">
            <string> Å</string>
           </property>
+          <property name="decimals">
+           <number>5</number>
+          </property>
           <property name="maximum">
            <double>1000.000000000000000</double>
           </property>
@@ -447,6 +453,9 @@
           </property>
           <property name="suffix">
            <string> Å</string>
+          </property>
+          <property name="decimals">
+           <number>5</number>
           </property>
           <property name="maximum">
            <double>1000.000000000000000</double>


### PR DESCRIPTION
Increase sig figs from 2 to 5 for lattice parameters a, b, and c. Should solve #23.

Signed-off-by: Brianna Major <brianna.major@kitware.com>