### PR TITLE
Set organization name for settings

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -81,12 +81,12 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.update_active_material_energy()
 
     def save_settings(self):
-        settings = QSettings()
+        settings = QSettings('hexrd', 'hexrd')
         settings.setValue('config_instrument', self.config['instrument'])
         settings.setValue('images_dir', self.images_dir)
 
     def load_settings(self):
-        settings = QSettings()
+        settings = QSettings('hexrd', 'hexrd')
         self.config['instrument'] = settings.value('config_instrument', None)
         self.images_dir = settings.value('images_dir', None)
 


### PR DESCRIPTION
Config settings will be saved under 'hexrd' folder instead of 'Unknown Organization'

Signed-off-by: Brianna Major <brianna.major@kitware.com>