### PR TITLE
Fix typo to function call

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -96,7 +96,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
     # This is here for backward compatibility
     @property
     def instrument_config(self):
-        return self.filer_instrument_config(
+        return self.filter_instrument_config(
             self.config['instrument'])
 
     @property


### PR DESCRIPTION
Typo in call to filter_instrument_config caused calibrations to fail.

Signed-off-by: Brianna Major <brianna.major@kitware.com>