### PR TITLE
Fix warnings about path not found on status toggle

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -97,9 +97,6 @@ class CalTreeItemModel(QAbstractItemModel):
         if value == item.data(index.column()):
             return True
 
-        path = self.get_path_from_root(item, index.column())
-        old_value = self.cfg.get_instrument_config_val(path)
-
         if index.column() == VALUE_COL:
             old_value = self.cfg.get_instrument_config_val(path)
 


### PR DESCRIPTION
A improperly resolved merge conflict resulted in duplicated code, causing warnings to appear when 'fixed' status was toggled. Removed duplicate code.

Signed-off-by: Brianna Major <brianna.major@kitware.com>