### PR TITLE
Update active material when beam energy changes

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -278,7 +278,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             raise Exception(msg)
 
         # If the beam energy was modified, update the active material
-        if path == ['beam', 'energy']:
+        if path == ['beam', 'energy', 'value']:
             self.update_active_material_energy()
 
     def get_instrument_config_val(self, path):


### PR DESCRIPTION
The behavior we want here is for the overlays to update when the
beam energy is changed. This worked before, but the path needs to
be updated to contain the new 'value' in the path. This fixes the
issue.