### PR TITLE
Set organization and application names

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -83,14 +83,14 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.update_active_material_energy()
 
     def save_settings(self):
-        settings = QSettings('hexrd', 'hexrd')
+        settings = QSettings()
         settings.setValue('config_instrument', self.config['instrument'])
         settings.setValue('images_dir', self.images_dir)
         settings.setValue('hdf5_path', self.hdf5_path)
         settings.setValue('live_update', self.live_update)
 
     def load_settings(self):
-        settings = QSettings('hexrd', 'hexrd')
+        settings = QSettings()
         self.config['instrument'] = settings.value('config_instrument', None)
         self.images_dir = settings.value('images_dir', None)
         self.hdf5_path = settings.value('hdf5_path', None)

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -11,6 +11,10 @@ def main():
     signal.signal(signal.SIGINT, signal.SIG_DFL)
 
     QCoreApplication.setAttribute(Qt.AA_ShareOpenGLContexts)
+
+    QCoreApplication.setOrganizationName('hexrd')
+    QCoreApplication.setApplicationName('hexrd')
+
     app = QApplication(sys.argv)
 
     window = MainWindow()


### PR DESCRIPTION
Use QCoreApplication to set the organization and application names, so
that they do not need to be specified when initializing QSettings.