### PR TITLE
Do not perform live updates with no images

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -198,6 +198,11 @@ class MainWindow(QObject):
         return False
 
     def update_all(self):
+
+        # If there are no images loaded, skip the request
+        if not HexrdConfig().images():
+            return
+
         prev_blocked = self.calibration_config_widget.block_all_signals()
 
         # Need to clear focus from current widget if enter is pressed or


### PR DESCRIPTION
This prevents an error that appears in the console when changing options, if
live updates are being performed and there are no images.