### PR TITLE
Allow saving of imageseries as hdf5 or npz

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -5,6 +5,8 @@ from PySide2.QtCore import Signal, QObject, QSettings
 
 import yaml
 
+import hexrd.imageseries.save
+
 from hexrd.ui import constants
 from hexrd.ui import resource_loader
 from hexrd.ui import utils
@@ -149,6 +151,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
     def imageseries(self):
         return self.imageseries_dict
+
+    def save_imageseries(self, name, write_file, selected_format, **kwargs):
+        ims = self.ims_image(name)
+        hexrd.imageseries.save.write(ims, write_file, selected_format,
+                                     **kwargs)
 
     def load_instrument_config(self, yml_file):
         with open(yml_file, 'r') as f:

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -45,6 +45,7 @@
      <property name="title">
       <string>Save</string>
      </property>
+     <addaction name="action_save_imageseries"/>
      <addaction name="action_save_config"/>
      <addaction name="action_save_materials"/>
     </widget>
@@ -217,9 +218,9 @@
     <string>Configuration</string>
    </property>
   </action>
-  <action name="action_save_config">
+  <action name="action_save_imageseries">
    <property name="text">
-    <string>Configuration</string>
+    <string>ImageSeries</string>
    </property>
   </action>
   <action name="action_open_materials">
@@ -227,9 +228,9 @@
     <string>Materials</string>
    </property>
   </action>
-  <action name="action_save_materials">
+  <action name="action_save_config">
    <property name="text">
-    <string>Materials</string>
+    <string>Configuration</string>
    </property>
   </action>
   <action name="action_show_toolbar">
@@ -276,6 +277,11 @@
    </property>
    <property name="text">
     <string>Process Image Series</string>
+   </property>
+  </action>
+  <action name="action_save_materials">
+   <property name="text">
+    <string>Materials</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This allows users to save an imageseries as either an hdf5 file
or an npz file. The option is `File`->`Save`->`ImageSeries`.

The dialogs that appear go like this:

1. If there is more than one imageseries available, it will ask the
user to pick an imageseries via a QInputDialog combo box.

2. When the user is choosing the file to save to, the type (either
hdf5 or npz) is chosen based upon the filter the user selects. It is
NOT based upon any file endings the user gives the file.

3. If an NPZ file was chosen, the user then needs to pick a threshold
from a QInputDialog double spinbox. This is a required option for NPZ
in hexrd.

I am able to successfully modify an imageseries, save it as an HDF5
file, load it, and see that the modifications still remain. So HDF5
seems to work.

For NPZ, I can write an npz file, but then hexrd cannot load it for
some reason. I might need to change something to make it work.

Fixes: #53 