### PR TITLE
Warn when no imageseries available for processing

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -245,6 +245,11 @@ class MainWindow(QObject):
             return HexrdConfig().save_materials(selected_file)
 
     def on_action_edit_ims(self):
+        if not HexrdConfig().imageseries():
+            msg = 'No ImageSeries available for processing'
+            QMessageBox.warning(self.ui, 'HEXRD', msg)
+            return
+
         # open dialog
         ProcessIMSDialog(self)
 


### PR DESCRIPTION
If a user tries to process an imageseries, check to make sure
one is available for processing, and if not, pop up a warning.
Otherwise, there will be a key error.