### PR TITLE
Update instrument config names

### DIFF
--- a/hexrd/ui/resources/calibration/default_instrument_config.yml
+++ b/hexrd/ui/resources/calibration/default_instrument_config.yml
@@ -18,8 +18,8 @@ detectors:
       size: [1.0, 1.0]
     saturation_level: 14000.0
     transform:
-      t_vec_d: [0.0, 0.0, 0.0]
-      tilt_angles: [0.0, 0.0, 0.0]
+      translation: [0.0, 0.0, 0.0]
+      tilt: [0.0, 0.0, 0.0]
   ge2:
     distortion:
       function_name: GE_41RT
@@ -31,8 +31,8 @@ detectors:
       size: [1.0, 1.0]
     saturation_level: 14000.0
     transform:
-      t_vec_d: [0.0, 0.0, 0.0]
-      tilt_angles: [0.0, 0.0, 0.0]
+      translation: [0.0, 0.0, 0.0]
+      tilt: [0.0, 0.0, 0.0]
 oscillation_stage:
   chi: 0.0
-  t_vec_s: [0.0, 0.0, 0.0]
+  translation: [0.0, 0.0, 0.0]

--- a/hexrd/ui/resources/calibration/yaml_to_gui.yml
+++ b/hexrd/ui/resources/calibration/yaml_to_gui.yml
@@ -45,20 +45,20 @@ detectors:
       ]
     saturation_level: 'cal_det_saturation'
     transform:
-      t_vec_d: [
-        'cal_det_t_vec_d_0',
-        'cal_det_t_vec_d_1',
-        'cal_det_t_vec_d_2'
+      translation: [
+        'cal_det_translation_0',
+        'cal_det_translation_1',
+        'cal_det_translation_2'
       ]
-      tilt_angles: [
-        'cal_det_angles_0',
-        'cal_det_angles_1',
-        'cal_det_angles_2'
+      tilt: [
+        'cal_det_tilt_0',
+        'cal_det_tilt_1',
+        'cal_det_tilt_2'
       ]
 oscillation_stage:
   chi: 'cal_osc_chi'
-  t_vec_s: [
-    'cal_osc_t_vec_d_0',
-    'cal_osc_t_vec_d_1',
-    'cal_osc_t_vec_d_2'
+  translation: [
+    'cal_osc_translation_0',
+    'cal_osc_translation_1',
+    'cal_osc_translation_2'
   ]

--- a/hexrd/ui/resources/ui/calibration_config_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_config_widget.ui
@@ -469,7 +469,7 @@
         </property>
         <layout class="QGridLayout" name="gridLayout_7">
          <item row="0" column="2">
-          <widget class="QDoubleSpinBox" name="cal_det_t_vec_d_1">
+          <widget class="QDoubleSpinBox" name="cal_det_translation_1">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -498,7 +498,7 @@
           </widget>
          </item>
          <item row="0" column="3">
-          <widget class="QDoubleSpinBox" name="cal_det_t_vec_d_2">
+          <widget class="QDoubleSpinBox" name="cal_det_translation_2">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -517,7 +517,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="cal_det_t_vec_d_0">
+          <widget class="QDoubleSpinBox" name="cal_det_translation_0">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -546,7 +546,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="cal_det_angles_0">
+          <widget class="QDoubleSpinBox" name="cal_det_tilt_0">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -565,7 +565,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QDoubleSpinBox" name="cal_det_angles_1">
+          <widget class="QDoubleSpinBox" name="cal_det_tilt_1">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -584,7 +584,7 @@
           </widget>
          </item>
          <item row="1" column="3">
-          <widget class="QDoubleSpinBox" name="cal_det_angles_2">
+          <widget class="QDoubleSpinBox" name="cal_det_tilt_2">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -941,7 +941,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="cal_osc_t_vec_d_0">
+       <widget class="QDoubleSpinBox" name="cal_osc_translation_0">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -960,7 +960,7 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QDoubleSpinBox" name="cal_osc_t_vec_d_2">
+       <widget class="QDoubleSpinBox" name="cal_osc_translation_2">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -979,7 +979,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QDoubleSpinBox" name="cal_osc_t_vec_d_1">
+       <widget class="QDoubleSpinBox" name="cal_osc_translation_1">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -1054,16 +1054,16 @@
   <tabstop>cal_det_size_0</tabstop>
   <tabstop>cal_det_size_1</tabstop>
   <tabstop>cal_det_saturation</tabstop>
-  <tabstop>cal_det_t_vec_d_0</tabstop>
-  <tabstop>cal_det_t_vec_d_1</tabstop>
-  <tabstop>cal_det_t_vec_d_2</tabstop>
-  <tabstop>cal_det_angles_0</tabstop>
-  <tabstop>cal_det_angles_1</tabstop>
-  <tabstop>cal_det_angles_2</tabstop>
+  <tabstop>cal_det_translation_0</tabstop>
+  <tabstop>cal_det_translation_1</tabstop>
+  <tabstop>cal_det_translation_2</tabstop>
+  <tabstop>cal_det_tilt_0</tabstop>
+  <tabstop>cal_det_tilt_1</tabstop>
+  <tabstop>cal_det_tilt_2</tabstop>
   <tabstop>cal_osc_chi</tabstop>
-  <tabstop>cal_osc_t_vec_d_0</tabstop>
-  <tabstop>cal_osc_t_vec_d_1</tabstop>
-  <tabstop>cal_osc_t_vec_d_2</tabstop>
+  <tabstop>cal_osc_translation_0</tabstop>
+  <tabstop>cal_osc_translation_1</tabstop>
+  <tabstop>cal_osc_translation_2</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
A few instrument config names were changed in the latest updates
of hexrd (currently on the master branch [here](https://github.com/joelvbernier/hexrd3)).

The changes:
- `t_vec_d` -> `translation`
- `t_vec_s` -> `translation`
- `tilt_angles` -> `tilt`

Note that after this commit, an error will occur when starting hexrd
if previous QSettings are loaded. This can be prevented by the fix
in #81.

Also, running a default calibration is a tad bit slow because there are
many overlays. This is fixed by #83.

Otherwise, the calibrations now seem to work as they should.

Fixes: #82