### PR TITLE
Change default npz writer threshold to 10

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -222,7 +222,7 @@ class MainWindow(QObject):
                 # Get the user to pick a threshold
                 result, ok = QInputDialog.getDouble(self.ui, 'HEXRD',
                                                     'Choose Threshold',
-                                                    1000, 0, 1e12, 3)
+                                                    10, 0, 1e12, 3)
                 if not ok:
                     # User canceled...
                     return


### PR DESCRIPTION
It was 1000 before, which was perhaps too high. This is being
changed to reflect the discussion in #53.