### PR TITLE
Allow user to choose Euler angle convention

### DIFF
--- a/hexrd/ui/calibration/powder_calibration.py
+++ b/hexrd/ui/calibration/powder_calibration.py
@@ -269,7 +269,8 @@ def run_powder_calibration():
     instr = instrument.HEDMInstrument(instrument_config=iconfig)
 
     # Set up the tilt calibration mapping
-    rme = RotMatEuler(np.zeros(3), 'xyz', extrinsic=True)
+    axes, extrinsic = HexrdConfig().euler_angle_convention
+    rme = RotMatEuler(np.zeros(3), axes, extrinsic)
     instr.tilt_calibration_mapping = rme
 
     flags = HexrdConfig().get_statuses_instrument_format()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -67,6 +67,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.live_update = False
         self._show_saturation_level = False
 
+        self.set_euler_angle_convention()
+
         if '--ignore-settings' not in QCoreApplication.arguments():
             self.load_settings()
 
@@ -101,6 +103,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         settings.setValue('images_dir', self.images_dir)
         settings.setValue('hdf5_path', self.hdf5_path)
         settings.setValue('live_update', self.live_update)
+        settings.setValue('euler_angle_convention', self._euler_angle_convention)
 
     def load_settings(self):
         settings = QSettings()
@@ -109,6 +112,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.hdf5_path = settings.value('hdf5_path', None)
         # All QSettings come back as strings.
         self.live_update = bool(settings.value('live_update', False) == 'true')
+        self._euler_angle_convention = settings.value('euler_angle_convention',
+                                                      ('xyz', True))
         if self.config.get('instrument') is not None:
             self.create_internal_config(self.config['instrument'])
 
@@ -636,3 +641,10 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
     show_saturation_level = property(get_show_saturation_level,
                                      set_show_saturation_level)
+
+    def set_euler_angle_convention(self, axes_order='xyz', extrinsic=True):
+        self._euler_angle_convention = (axes_order, extrinsic)
+
+    @property
+    def euler_angle_convention(self):
+        return self._euler_angle_convention

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -78,6 +78,8 @@ class MainWindow(QObject):
             self.on_action_save_materials_triggered)
         self.ui.action_edit_ims.triggered.connect(
             self.on_action_edit_ims)
+        self.ui.action_edit_euler_angle_convention.triggered.connect(
+            self.on_action_edit_euler_angle_convention)
         self.ui.action_show_live_updates.toggled.connect(
             self.live_update)
         self.ui.action_show_saturation_percentages.toggled.connect(
@@ -253,6 +255,31 @@ class MainWindow(QObject):
     def on_action_edit_ims(self):
         # open dialog
         ProcessIMSDialog(self)
+
+    def on_action_edit_euler_angle_convention(self):
+        allowed_conventions = [
+            'Extrinsic XYZ',
+            'Intrinsic ZXZ'
+        ]
+        current = HexrdConfig().euler_angle_convention
+        ind = 0
+        for i, convention in enumerate(allowed_conventions):
+            is_extrinsic = 'Extrinsic' in convention
+            if current[0].upper() in convention and current[1] == is_extrinsic:
+                ind = i
+                break
+
+        name, ok = QInputDialog.getItem(self.ui, 'HEXRD',
+                                        'Select Euler Angle Convention',
+                                        allowed_conventions, ind, False)
+
+        if not ok:
+            # User canceled...
+            return
+
+        chosen = name.split()[1].lower()
+        extrinsic = 'Extrinsic' in name
+        HexrdConfig().set_euler_angle_convention(chosen, extrinsic)
 
     def show_images(self):
         self.ui.image_tab_widget.load_images()

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -66,6 +66,7 @@
      <string>Edit</string>
     </property>
     <addaction name="action_edit_ims"/>
+    <addaction name="action_edit_euler_angle_convention"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -305,6 +306,11 @@
   <action name="action_run_powder_calibration">
    <property name="text">
     <string>Powder Calibration</string>
+   </property>
+  </action>
+  <action name="action_edit_euler_angle_convention">
+   <property name="text">
+    <string>Euler Angle Convention</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This is a menu option under "Edit"->"Euler Angle Convention".
It brings up a combo box where the user chooses the convention
that they wish to use. This convention is then used for the
powder calibration (this is currently the only place where it is
used).

It is also saved in between runs.

I think this fixes #69, although it currently doesn't change anything in the instrument calibration form view.