### PR TITLE
Allow user to pick options for powder calibration

### DIFF
--- a/hexrd/ui/calibration/powder_calibration.py
+++ b/hexrd/ui/calibration/powder_calibration.py
@@ -285,11 +285,9 @@ def run_powder_calibration():
     img_dict = HexrdConfig().images()
 
     # tolerances for patches
-    tth_tol = 0.2
-    eta_tol = 2.
-
-    # pktype = 'gaussian'
-    pktype = 'pvoigt'
+    tth_tol = HexrdConfig().config['calibration']['powder']['tth_tol']
+    eta_tol = HexrdConfig().config['calibration']['powder']['eta_tol']
+    pktype = HexrdConfig().config['calibration']['powder']['pk_type']
 
     # powder calibrator
     pc = PowderCalibrator(instr, plane_data, img_dict,

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -84,6 +84,10 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 self.default_config['instrument'])
             self.create_internal_config(self.config['instrument'])
 
+        if self.config.get('calibration') is None:
+            self.config['calibration'] = copy.deepcopy(
+                self.default_config['calibration'])
+
         # Load the GUI to yaml maps
         self.load_gui_yaml_dict()
 
@@ -98,6 +102,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
     def save_settings(self):
         settings = QSettings()
         settings.setValue('config_instrument', self.config['instrument'])
+        settings.setValue('config_calibration', self.config['calibration'])
         settings.setValue('images_dir', self.images_dir)
         settings.setValue('hdf5_path', self.hdf5_path)
         settings.setValue('live_update', self.live_update)
@@ -105,6 +110,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
     def load_settings(self):
         settings = QSettings()
         self.config['instrument'] = settings.value('config_instrument', None)
+        self.config['calibration'] = settings.value('config_calibration', None)
         self.images_dir = settings.value('images_dir', None)
         self.hdf5_path = settings.value('hdf5_path', None)
         # All QSettings come back as strings.
@@ -150,6 +156,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
                                              'default_resolution_config.yml')
         self.default_config['resolution'] = yaml.load(text,
                                                       Loader=yaml.FullLoader)
+
+        text = resource_loader.load_resource(hexrd.ui.resources.calibration,
+                                             'default_calibration_config.yml')
+        self.default_config['calibration'] = yaml.load(text,
+                                                       Loader=yaml.FullLoader)
 
     def image(self, name):
         return self.images_dict.get(name)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -14,6 +14,7 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_file_manager import ImageFileManager
 from hexrd.ui.load_images_dialog import LoadImagesDialog
 from hexrd.ui.materials_panel import MaterialsPanel
+from hexrd.ui.powder_calibration_dialog import PowderCalibrationDialog
 from hexrd.ui.resolution_editor import ResolutionEditor
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.process_ims_dialog import ProcessIMSDialog
@@ -268,6 +269,15 @@ class MainWindow(QObject):
         self.ui.image_tab_widget.show_polar()
 
     def start_powder_calibration(self):
+        if not HexrdConfig().images():
+            msg = ('No images available for calibration.')
+            QMessageBox.warning(self.ui, 'HEXRD', msg)
+            return
+
+        d = PowderCalibrationDialog(self.ui)
+        if not d.exec_():
+            return
+
         run_powder_calibration()
         self.update_config_gui()
         self.update_all()

--- a/hexrd/ui/powder_calibration_dialog.py
+++ b/hexrd/ui/powder_calibration_dialog.py
@@ -1,0 +1,42 @@
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class PowderCalibrationDialog:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('powder_calibration_dialog.ui', parent)
+
+        self.update_gui_from_config()
+        self.setup_connections()
+
+    def setup_connections(self):
+        pass
+
+    def update_gui_from_config(self):
+        tth_tol = HexrdConfig().config['calibration']['powder']['tth_tol']
+        eta_tol = HexrdConfig().config['calibration']['powder']['eta_tol']
+        pk_type = HexrdConfig().config['calibration']['powder']['pk_type']
+
+        if pk_type == 'pvoigt':
+            pk_type = 'PVoigt'
+        elif pk_type == 'gaussian':
+            pk_type = 'Gaussian'
+
+        self.ui.tth_tolerance.setValue(tth_tol)
+        self.ui.eta_tolerance.setValue(eta_tol)
+        self.ui.peak_fit_type.setCurrentText(pk_type)
+
+    def exec_(self):
+        if not self.ui.exec_():
+            return False
+
+        tth_tol = self.ui.tth_tolerance.value()
+        eta_tol = self.ui.eta_tolerance.value()
+        pk_type = self.ui.peak_fit_type.currentText().lower()
+
+        HexrdConfig().config['calibration']['powder']['tth_tol'] = tth_tol
+        HexrdConfig().config['calibration']['powder']['eta_tol'] = eta_tol
+        HexrdConfig().config['calibration']['powder']['pk_type'] = pk_type
+        return True

--- a/hexrd/ui/resources/calibration/default_calibration_config.yml
+++ b/hexrd/ui/resources/calibration/default_calibration_config.yml
@@ -1,0 +1,4 @@
+powder:
+  tth_tol: 0.2
+  eta_tol: 2.0
+  pk_type: 'pvoigt'

--- a/hexrd/ui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrd/ui/resources/ui/powder_calibration_dialog.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>powder_calibration_dialog</class>
+ <widget class="QDialog" name="powder_calibration_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>302</width>
+    <height>140</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="eta_tolerance">
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>2.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="eta_label">
+       <property name="text">
+        <string>η tolerance:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="tth_label">
+       <property name="text">
+        <string>2θ tolerance:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QDoubleSpinBox" name="tth_tolerance">
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.200000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="peak_fit_type">
+       <item>
+        <property name="text">
+         <string>PVoigt</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Gaussian</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Peak fitting type:</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>tth_tolerance</tabstop>
+  <tabstop>eta_tolerance</tabstop>
+  <tabstop>peak_fit_type</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>powder_calibration_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>powder_calibration_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
A new powder calibration dialog appears when a user tries to run
a powder calibration. This allows the user to choose three
different settings for the calibration:

1. Two theta tolerance
2. Eta tolerance
3. Peak fit type

These choices are saved in the QSettings and reloaded in future
runs.

An example image of the dialog can be seen below:

![image](https://user-images.githubusercontent.com/9558430/62571928-981e3b00-b860-11e9-9613-bc94f2dbeb7a.png)