### PR TITLE
Allow wedges to be added to image series and edited

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -21,6 +21,7 @@ from hexrd.ui.resolution_editor import ResolutionEditor
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.process_ims_dialog import ProcessIMSDialog
 from hexrd.ui.frame_aggregation import FrameAggregation
+from hexrd.ui.wedge_editor import WedgeEditor
 
 
 class MainWindow(QObject):
@@ -84,6 +85,8 @@ class MainWindow(QObject):
             self.on_action_save_materials_triggered)
         self.ui.action_edit_ims.triggered.connect(
             self.on_action_edit_ims)
+        self.ui.action_edit_angles.triggered.connect(
+            self.on_action_edit_angles)
         self.ui.action_edit_euler_angle_convention.triggered.connect(
             self.on_action_edit_euler_angle_convention)
         self.ui.action_show_live_updates.toggled.connect(
@@ -183,6 +186,7 @@ class MainWindow(QObject):
                 detector_names, image_files = dialog.results()
                 ImageFileManager().load_images(detector_names, image_files)
                 self.ui.action_edit_ims.setEnabled(True)
+                self.ui.action_edit_angles.setEnabled(True)
                 self.ui.image_tab_widget.load_images()
 
     def on_action_open_materials_triggered(self):
@@ -258,6 +262,9 @@ class MainWindow(QObject):
     def on_action_edit_ims(self):
         # open dialog
         ProcessIMSDialog(self)
+
+    def on_action_edit_angles(self):
+        WedgeEditor(self.ui)
 
     def on_action_edit_euler_angle_convention(self):
         allowed_conventions = [

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -66,6 +66,7 @@
      <string>Edit</string>
     </property>
     <addaction name="action_edit_ims"/>
+    <addaction name="action_edit_angles"/>
     <addaction name="action_edit_euler_angle_convention"/>
    </widget>
    <widget class="QMenu" name="menu_run">
@@ -313,6 +314,14 @@
     <string>Euler Angle Convention</string>
    </property>
   </action>
+  <action name="action_edit_angles">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Edit Angles</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>
@@ -323,6 +332,7 @@
    <slots>
     <slot>open_files()</slot>
     <slot>set_tabbed_view(bool)</slot>
+    <slot>show_nav_toolbar(bool)</slot>
     <slot>show_toolbar(bool)</slot>
    </slots>
   </customwidget>

--- a/hexrd/ui/resources/ui/wedge_form.ui
+++ b/hexrd/ui/resources/ui/wedge_form.ui
@@ -1,0 +1,221 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Frame</class>
+ <widget class="QFrame" name="Frame">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>446</width>
+    <height>296</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Frame</string>
+  </property>
+  <property name="frameShape">
+   <enum>QFrame::StyledPanel</enum>
+  </property>
+  <property name="frameShadow">
+   <enum>QFrame::Raised</enum>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QTableWidget" name="angles_table">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>139</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Start Angle</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>End Angle</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Steps</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Start</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="start_angle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>End</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="end_angle">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Steps</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="steps">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="add_new_wedge">
+       <property name="text">
+        <string>Add New Wedge</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>78</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="remove_wedge">
+       <property name="text">
+        <string>Remove Wedge</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/wedges_dialog.ui
+++ b/hexrd/ui/resources/ui/wedges_dialog.ui
@@ -1,0 +1,108 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>dialog</class>
+ <widget class="QDialog" name="dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>494</width>
+    <height>336</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Tab 1</string>
+      </attribute>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Tab 2</string>
+      </attribute>
+     </widget>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="save">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Export the wedges as a numpy array for use with YAML files&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Export Angles</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/wedge_editor.py
+++ b/hexrd/ui/wedge_editor.py
@@ -1,0 +1,184 @@
+from PySide2.QtCore import Qt, QPersistentModelIndex
+from PySide2.QtWidgets import (
+    QDialog, QTableWidgetItem, QFileDialog, QMessageBox
+)
+
+from hexrd import imageseries
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class WedgeEditor(QDialog):
+
+    def __init__(self, parent=None):
+        super(WedgeEditor, self).__init__(parent)
+
+        self.tabs = []
+        self.index = 0
+        self.row = 0
+        self.steps = []
+        self.changed = []
+        self.name = None
+        self.table = None
+        self.omw = None
+
+        self.ui = UiLoader().load_file(
+            'wedges_dialog.ui', self.parent())
+        self.button_box = self.ui.button_box
+        self.save = self.ui.save
+        self.tab_widget = self.ui.tab_widget
+
+        self.create_tabs()
+        self.load_metadata()
+        self.current_changed(0)
+
+        self.setup_connections()
+
+        self.ui.show()
+
+    def create_tabs(self):
+        self.tab_widget.clear()
+        for key in HexrdConfig().imageseries_dict:
+            tab_ui = UiLoader().load_file('wedge_form.ui', self.parent())
+            self.tab_widget.addTab(tab_ui, key)
+            self.setup_tab_connections(tab_ui)
+            self.tabs.append(tab_ui)
+            self.steps.append(len(HexrdConfig().imageseries(key)))
+            self.changed.append(False)
+            tab_ui.steps.setText(str(len(HexrdConfig().imageseries(key))))
+
+    def load_metadata(self):
+        idx = 0
+        for detector in HexrdConfig().imageseries_dict.keys():
+            self.current_changed(idx)
+            data = HexrdConfig().imageseries(detector).metadata
+            if 'omega' not in data:
+                return
+
+            for i in range(len(data['omega'])):
+                self.create_row(False, data['omega'][i])
+            idx += 1
+
+    def setup_connections(self):
+        self.save.clicked.connect(self.save_omega)
+        self.save.clicked.connect(self.ui.accept)
+        self.button_box.accepted.connect(self.add_omega_data)
+        self.tab_widget.currentChanged.connect(self.current_changed)
+
+    def setup_tab_connections(self, ui):
+        ui.add_new_wedge.clicked.connect(self.create_row)
+        ui.remove_wedge.clicked.connect(self.delete_wedge)
+
+    def create_row(self, new_wedge=True, values=None):
+        if new_wedge:
+            if not self.steps:
+                return
+
+            if not self.tabs[self.index].start_angle.text():
+                return
+
+            if not self.tabs[self.index].end_angle.text():
+                return
+
+        self.table.blockSignals(True)
+
+        self.changed[self.index] = True
+
+        self.table.setRowCount(self.row + 1)
+        for i in range(self.table.columnCount()):
+            item = QTableWidgetItem()
+            item.setTextAlignment(Qt.AlignHCenter)
+            self.table.setItem(self.row, i, item)
+
+        if new_wedge:
+            self.table.item(self.row, 0).setText(
+                self.tabs[self.index].start_angle.text())
+            self.table.item(self.row, 1).setText(
+                self.tabs[self.index].end_angle.text())
+            self.table.item(self.row, 2).setText(
+                self.tabs[self.index].steps.text())
+        else:
+            self.table.item(self.row, 0).setText(
+                str(values[0]))
+            self.table.item(self.row, 1).setText(
+                str(values[1]))
+            self.table.item(self.row, 2).setText(
+                str(1))
+
+        self.row += 1
+        self.reset_inputs()
+
+        self.table.blockSignals(False)
+
+    def reset_inputs(self):
+        self.tabs[self.index].start_angle.clear()
+        self.tabs[self.index].end_angle.clear()
+        self.steps[self.index] -= int(self.tabs[self.index].steps.text())
+        self.tabs[self.index].steps.setText(str(self.steps[self.index]))
+
+        self.tabs[self.index].start_angle.setFocus()
+
+    def current_changed(self, idx):
+        self.name = self.tab_widget.tabText(idx)
+        self.index = idx
+        self.table = self.tabs[idx].angles_table
+        self.row = self.table.rowCount()
+
+    def delete_wedge(self):
+        indices = []
+        for index in self.table.selectedIndexes():
+            if index.column() == 0:
+                indices.append(QPersistentModelIndex(index))
+
+        for idx in indices:
+            row = idx.row()
+            if row >= 0:
+                self.steps[self.index] += int(self.table.item(row, 2).text())
+                self.table.removeRow(row)
+                self.tabs[self.index].steps.setText(
+                    str(self.steps[self.index]))
+                self.row -= 1
+
+    def add_omega_data(self, name=None):
+        try:
+            for i in range(len(self.tabs)):
+                if self.changed[self.index]:
+                    self.current_changed(i)
+                    tot_frames = len(HexrdConfig().imageseries(self.name))
+                    omw = imageseries.omega.OmegaWedges(tot_frames)
+                    for j in range(self.table.rowCount()):
+                        omw.addwedge(
+                            float(self.table.item(j, 0).text()),
+                            float(self.table.item(j, 1).text()),
+                            int(self.table.item(j, 2).text()))
+
+                    if self.table.rowCount():
+                        HexrdConfig().imageseries(
+                            self.name).metadata['omega'] = omw.omegas
+                    else:
+                        HexrdConfig().imageseries(
+                            self.name).metadata['omega'] = []
+
+                    if self.name == name:
+                        self.omw = omw
+
+        except imageseries.omega.OmegaSeriesError as error:
+            msg = ('ERROR: \n' + str(error) + '\nThe angles for ' +
+                    self.name + ' will not be saved.')
+            QMessageBox.warning(self.ui, 'HEXRD', msg)
+            return
+
+    def save_omega(self, omw):
+        self.add_omega_data(self.name)
+
+        if self.omw is None:
+            msg = ('ERROR: No angles to export.')
+            QMessageBox.warning(self.ui, 'HEXRD', msg)
+            return
+
+        selected_file, selected_filter = QFileDialog.getSaveFileName(
+            self, 'Save Omega', HexrdConfig().working_dir,
+            'NUMPY files (*.npy)')
+
+        self.omw.save_omegas(selected_file)


### PR DESCRIPTION
Angle data will be displayed if it exists. Users can add new or additional wedges as well as edit or delete existing ones. Omega data will be saved if the imageseries is saved, or it can be saved as a numpy array for use with YAML files.

Signed-off-by: Brianna Major <brianna.major@kitware.com>