### PR TITLE
Update tilt angles on Euler convention change

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -1,8 +1,8 @@
 import numpy as np
 import warnings
 
-from hexrd.gridutil import cellIndices
 from hexrd import instrument
+from hexrd.gridutil import cellIndices
 
 from hexrd.ui.hexrd_config import HexrdConfig
 
@@ -19,7 +19,9 @@ def cartesian_viewer():
     plane_data = HexrdConfig().active_material.planeData
     pixel_size = HexrdConfig().cartesian_pixel_size
 
-    instr = instrument.HEDMInstrument(instrument_config=iconfig)
+    rme = HexrdConfig().rotation_matrix_euler()
+    instr = instrument.HEDMInstrument(instrument_config=iconfig,
+                                      tilt_calibration_mapping=rme)
 
     # Make sure each key in the image dict is in the panel_ids
     if images_dict.keys() != instr._detectors.keys():

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -31,7 +31,9 @@ def log_scale_img(img):
 
 
 def load_instrument(config):
-    return instrument.HEDMInstrument(instrument_config=config)
+    rme = HexrdConfig().rotation_matrix_euler()
+    return instrument.HEDMInstrument(instrument_config=config,
+                                     tilt_calibration_mapping=rme)
 
 
 class InstrumentViewer:

--- a/hexrd/ui/calibration/powder_calibration.py
+++ b/hexrd/ui/calibration/powder_calibration.py
@@ -263,15 +263,13 @@ class PowderCalibrator(object):
 
 
 def run_powder_calibration():
+    # Set up the tilt calibration mapping
+    rme = HexrdConfig().rotation_matrix_euler()
 
     # Set up the instrument
     iconfig = HexrdConfig().instrument_config
-    instr = instrument.HEDMInstrument(instrument_config=iconfig)
-
-    # Set up the tilt calibration mapping
-    axes, extrinsic = HexrdConfig().euler_angle_convention
-    rme = RotMatEuler(np.zeros(3), axes, extrinsic)
-    instr.tilt_calibration_mapping = rme
+    instr = instrument.HEDMInstrument(instrument_config=iconfig,
+                                      tilt_calibration_mapping=rme)
 
     flags = HexrdConfig().get_statuses_instrument_format()
 

--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -3,6 +3,8 @@ from PySide2.QtWidgets import (
     QAbstractSpinBox, QComboBox, QLineEdit, QPushButton
 )
 
+import numpy as np
+
 from hexrd.ui import constants
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
@@ -186,12 +188,22 @@ class CalibrationConfigWidget(QObject):
             gui_yaml_paths = self.cfg.get_gui_yaml_paths(['detectors',
                                                           'detector_name'])
 
+            tilt_path = ['transform', 'tilt', 'value']
             for var, path in gui_yaml_paths:
                 gui_var = getattr(self.ui, var)
                 full_path = ['detectors', cur_detector] + path
                 config_val = self.cfg.get_instrument_config_val(full_path)
                 full_path[full_path.index('value')] = 'status'
                 status_val = self.cfg.get_instrument_config_val(full_path)
+
+                if path[:-1] == tilt_path:
+                    # Special treatment for tilt widgets
+                    if HexrdConfig().rotation_matrix_euler() is None:
+                        gui_var.setSuffix('')
+                    else:
+                        gui_var.setSuffix('°')
+                        config_val = np.degrees(config_val)
+
                 self._set_gui_value(gui_var, config_val, status_val)
 
             combo_items = []

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -261,16 +261,18 @@ class MainWindow(QObject):
 
     def on_action_edit_euler_angle_convention(self):
         allowed_conventions = [
+            'None',
             'Extrinsic XYZ',
             'Intrinsic ZXZ'
         ]
         current = HexrdConfig().euler_angle_convention
         ind = 0
-        for i, convention in enumerate(allowed_conventions):
-            is_extrinsic = 'Extrinsic' in convention
-            if current[0].upper() in convention and current[1] == is_extrinsic:
-                ind = i
-                break
+        if current[0] is not None and current[1] is not None:
+            for i, convention in enumerate(allowed_conventions):
+                is_extr = 'Extrinsic' in convention
+                if current[0].upper() in convention and current[1] == is_extr:
+                    ind = i
+                    break
 
         name, ok = QInputDialog.getItem(self.ui, 'HEXRD',
                                         'Select Euler Angle Convention',
@@ -280,9 +282,20 @@ class MainWindow(QObject):
             # User canceled...
             return
 
-        chosen = name.split()[1].lower()
-        extrinsic = 'Extrinsic' in name
-        HexrdConfig().set_euler_angle_convention(chosen, extrinsic)
+        if name == 'None':
+            chosen = None
+            extrinsic = None
+        else:
+            chosen = name.split()[1].lower()
+            extrinsic = 'Extrinsic' in name
+
+        msg = 'Update current tilt angles?'
+        if QMessageBox.question(self.ui, 'HEXRD', msg):
+            HexrdConfig().set_euler_angle_convention(chosen, extrinsic)
+        else:
+            HexrdConfig()._euler_angle_convention = (chosen, extrinsic)
+
+        self.update_config_gui()
 
     def show_images(self):
         self.ui.image_tab_widget.load_images()

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -1,5 +1,44 @@
 # Some general utilities that are used in multiple places
 
+import numpy as np
+
+from hexrd.rotations import angleAxisOfRotMat, RotMatEuler
+from hexrd.transforms.xfcapi import makeRotMatOfExpMap
+
+
+def convert_tilt_convention(iconfig, old_convention,
+                            new_convention):
+    """
+    convert the tilt angles from an old convention to a new convention
+    """
+    if new_convention == old_convention:
+        return
+
+    old_axes, old_extrinsic = old_convention
+    new_axes, new_extrinsic = new_convention
+
+    det_keys = iconfig['detectors'].keys()
+    if old_axes is not None and old_extrinsic is not None:
+        # First, convert these to the matrix invariants
+        rme = RotMatEuler(np.zeros(3), old_axes, old_extrinsic)
+        for key in det_keys:
+            tilt_dict = iconfig['detectors'][key]['transform']['tilt']
+            tilt = np.array(tilt_dict['value'])
+            rme.rmat = makeRotMatOfExpMap(tilt)
+            tilt_dict['value'] = list(rme.angles)
+
+        if new_axes is None or new_extrinsic is None:
+            # We are done
+            return
+
+    # Update to the new mapping
+    rme = RotMatEuler(np.zeros(3), new_axes, new_extrinsic)
+    for key in det_keys:
+       tilt_dict = iconfig['detectors'][key]['transform']['tilt']
+       rme.angles = np.array(tilt_dict['value'])
+       phi, n = angleAxisOfRotMat(rme.rmat)
+       tilt_dict['value'] = (phi * n.flatten()).tolist()
+
 
 def fix_exclusions(mat):
     # The default is to exclude all hkl's after the 5th one.


### PR DESCRIPTION
This updates the values of the tilt angles when the Euler
convention changes.

It seems to be working correctly for the most part. Switching
between Extrinsic and Intrinsic seems to work. Switch between
Extrinsic and None also seems to work. But switching between
Intrinsic and None results in some strange behavior.

Also, sometimes the tiles get oriented incorrectly when switching
from Intrinsic to Extrinsic, but they get re-oriented correctly
when switching back to Intrinsic. Additionally, when switching the
Euler angle convention, sometimes two of the tiles disappear in the
polar view.

In addition, the "Form View" now displays degrees when using any
Euler convention except for "None". The degrees automatically get
converted to radians before the configuration is edited.