### PR TITLE
Rename resolution tab to "Rendering Resolution"

### DIFF
--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -197,7 +197,7 @@
   </widget>
   <widget class="QDockWidget" name="resolution_dock_widget">
    <property name="windowTitle">
-    <string>Calibration Resolution</string>
+    <string>Rendering Resolution</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>4</number>


### PR DESCRIPTION
This is a more accurate name rather than "Calibration Resolution".

This addresses part of #109 