### PR TITLE
Fix ambiguous condition that was preventing dark subtraction

### DIFF
--- a/hexrd/ui/process_ims_dialog.py
+++ b/hexrd/ui/process_ims_dialog.py
@@ -125,7 +125,7 @@ class ProcessIMSDialog(QDialog):
                     self.oplists[name] = [['flip', key]]
 
     def create_dark(self):
-        if not self.dark_img:
+        if self.dark_img is None:
             return
 
         name = self.prev_tab


### PR DESCRIPTION
Improper conditional check was preventing dark subtraction when an image was uploaded. Corrected from 'not' to 'is None'.

Signed-off-by: Brianna Major <brianna.major@kitware.com>