### PR TITLE
Update Plane Data tThWidth on ring range changes

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -597,7 +597,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
     def update_plane_data_tth_width(self):
         mat = self.active_material
-        mat.planeData.tThWidth = self.ring_ranges
+        mat.planeData.tThWidth = np.radians(self.ring_ranges)
 
     def _selected_rings(self):
         return self.config['materials'].get('selected_rings')


### PR DESCRIPTION
The plane data tThWidth is used in the calibration. Update it with
the value of the ring range when the ring range changes.

This fixes part of #29