### PR TITLE
Add options to change the polar view min/max tth

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -13,9 +13,6 @@ from hexrd.ui.hexrd_config import HexrdConfig
 
 snip_width = 9
 
-tth_min = 1.
-tth_max = 20.
-
 
 def polar_viewer():
     iconfig = HexrdConfig().instrument_config
@@ -82,6 +79,9 @@ class InstrumentViewer:
     # ========== Drawing
     def draw_polar(self, snip_width=snip_width):
         """show polar view of rings"""
+        tth_min = HexrdConfig().polar_res_tth_min
+        tth_max = HexrdConfig().polar_res_tth_max
+
         pv = PolarView([tth_min, tth_max], self.instr,
                        eta_min=-180., eta_max=180.,
                        pixel_size=self.pv_pixel_size)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -654,6 +654,24 @@ class HexrdConfig(QObject, metaclass=Singleton):
     polar_pixel_size_eta = property(_polar_pixel_size_eta,
                                     _set_polar_pixel_size_eta)
 
+    def _polar_res_tth_min(self):
+        return self.config['resolution']['polar']['tth_min']
+
+    def set_polar_res_tth_min(self, v):
+        self.config['resolution']['polar']['tth_min'] = v
+
+    polar_res_tth_min = property(_polar_res_tth_min,
+                                 set_polar_res_tth_min)
+
+    def _polar_res_tth_max(self):
+        return self.config['resolution']['polar']['tth_max']
+
+    def set_polar_res_tth_max(self, v):
+        self.config['resolution']['polar']['tth_max'] = v
+
+    polar_res_tth_max = property(_polar_res_tth_max,
+                                 set_polar_res_tth_max)
+
     def _cartesian_pixel_size(self):
         return self.config['resolution']['cartesian']['pixel_size']
 

--- a/hexrd/ui/resolution_editor.py
+++ b/hexrd/ui/resolution_editor.py
@@ -15,7 +15,9 @@ class ResolutionEditor:
         widgets = [
             self.ui.cartesian_pixel_size,
             self.ui.polar_pixel_size_tth,
-            self.ui.polar_pixel_size_eta
+            self.ui.polar_pixel_size_eta,
+            self.ui.polar_res_tth_min,
+            self.ui.polar_res_tth_max
         ]
 
         return widgets
@@ -40,6 +42,10 @@ class ResolutionEditor:
                 HexrdConfig().polar_pixel_size_tth)
             self.ui.polar_pixel_size_eta.setValue(
                 HexrdConfig().polar_pixel_size_eta)
+            self.ui.polar_res_tth_min.setValue(
+                HexrdConfig().polar_res_tth_min)
+            self.ui.polar_res_tth_max.setValue(
+                HexrdConfig().polar_res_tth_max)
         finally:
             self.unblock_widgets(block_list)
 
@@ -50,3 +56,7 @@ class ResolutionEditor:
             HexrdConfig()._set_polar_pixel_size_tth)
         self.ui.polar_pixel_size_eta.valueChanged.connect(
             HexrdConfig()._set_polar_pixel_size_eta)
+        self.ui.polar_res_tth_min.valueChanged.connect(
+            HexrdConfig().set_polar_res_tth_min)
+        self.ui.polar_res_tth_max.valueChanged.connect(
+            HexrdConfig().set_polar_res_tth_max)

--- a/hexrd/ui/resources/calibration/default_resolution_config.yml
+++ b/hexrd/ui/resources/calibration/default_resolution_config.yml
@@ -1,5 +1,7 @@
 polar:
   pixel_size_tth: 0.05
   pixel_size_eta: 0.20
+  tth_min: 1.0
+  tth_max: 20.0
 cartesian:
   pixel_size: 0.5

--- a/hexrd/ui/resources/ui/resolution_editor.ui
+++ b/hexrd/ui/resources/ui/resolution_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>267</width>
-    <height>171</height>
+    <height>202</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
@@ -23,7 +23,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <property name="iconSize">
       <size>
@@ -116,6 +116,26 @@
             </property>
            </widget>
           </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>η Pixel Size:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>2θ Min:</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="1">
            <widget class="QDoubleSpinBox" name="polar_pixel_size_tth">
             <property name="decimals">
@@ -129,13 +149,33 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_2">
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_5">
             <property name="text">
-             <string>η Pixel Size:</string>
+             <string>2θ Max:</string>
             </property>
             <property name="alignment">
              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QDoubleSpinBox" name="polar_res_tth_min">
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QDoubleSpinBox" name="polar_res_tth_max">
+            <property name="maximum">
+             <double>10000.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>20.000000000000000</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This adds the options to the resolution editor. However, it seems
to me that this is making the top dock widget too big. We might
want to consider putting it somewhere else, maybe in a menu like
"Edit"->"Polar Resolution" or something.

Fixes part of #109.

![image](https://user-images.githubusercontent.com/9558430/62803527-ac5c7500-bab8-11e9-9f5e-59b424316ad4.png)