### PR TITLE
changed default cmap and updated constants

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -1,5 +1,7 @@
-# Wavelength to kilo electron volt conversion
-WAVELENGTH_TO_KEV = 12.398425
-KEV_TO_WAVELENGTH = 12.398425
+from hexrd import constants
 
-DEFAULT_CMAP = 'viridis'
+# Wavelength to kilo electron volt conversion
+WAVELENGTH_TO_KEV = constants.keVToAngstrom(1.)
+KEV_TO_WAVELENGTH = constants.keVToAngstrom(1.)
+
+DEFAULT_CMAP = 'plasma'


### PR DESCRIPTION
just updated the keV/Angstrom constant to double precision and changed the default cmap to plasma.  Perhaps you can replace `WAVELENGTH_TO_KEV` and `KEV_TO_WAVELENGTH` with a call to my function `hexrd.constants.keVToAngstrom()`.