### PR TITLE
Plot azimuthal integration in polar view

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -86,6 +86,7 @@ class InstrumentViewer:
                        eta_min=-180., eta_max=180.,
                        pixel_size=self.pv_pixel_size)
         wimg = pv.warp_image(self.images_dict)
+        self.angular_grid = pv.angular_grid
         self._angular_coords = pv.angular_grid
         self._extent = [tth_min, tth_max, 180., -180.]   # l, r, b, t
         self.plot_dplane(warped=wimg, snip_width=snip_width)


### PR DESCRIPTION
This is a start for plotting the azimuthal integration in the
polar view. I think it is working okay, although I am not sure
why the baseline isn't zero for my example.

There is white margin space on the left and right sides of the
images, which probably needs to be fixed. Also, the overlays
do not stretch all the way to the top and bottom of the
azimuthal integration plot, and hiding/showing the rings
expands the y axis for some reason.

Let me know how the actual plot looks.

![azimuthal_integration](https://user-images.githubusercontent.com/9558430/62826254-40e0d900-bb86-11e9-9089-9dbb34017f40.png)

Fixes: #122

@joelvbernier
@cryos 