### PR TITLE
Reload previous active material if available

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -67,6 +67,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.hdf5_path = []
         self.live_update = False
         self._show_saturation_level = False
+        self.previous_active_material = None
 
         self._euler_angle_convention = ('xyz', True)
 
@@ -100,6 +101,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # Load the default materials
         self.load_default_materials()
 
+        # Re-load the previous active material if available
+        mat = self.previous_active_material
+        if mat is not None and mat in self.materials.keys():
+            self.active_material = mat
+
         self.update_plane_data_tth_width()
         self.update_active_material_energy()
 
@@ -111,6 +117,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         settings.setValue('hdf5_path', self.hdf5_path)
         settings.setValue('live_update', self.live_update)
         settings.setValue('euler_angle_convention', self._euler_angle_convention)
+        settings.setValue('active_material', self.active_material_name())
 
     def load_settings(self):
         settings = QSettings()
@@ -124,6 +131,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
                                                       ('xyz', True))
         if self.config.get('instrument') is not None:
             self.create_internal_config(self.config['instrument'])
+        self.previous_active_material = settings.value('active_material', None)
 
     # This is here for backward compatibility
     @property


### PR DESCRIPTION
When starting the program, reload the previous active material if
it is available.

This will currently just reload default materials (with all of their
default settings) that were previously selected. So, if ruby was
previously selected, for instance, it will automatically change the
active material to ruby when the program starts. But ruby will have
all of its default settings (none of the settings such as the max hkl
are currently saved in between runs).

Let me know if we want to save other settings in the config as well.

Addresses part of #107