### PR TITLE
Reload all canvases when a new config is loaded

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -134,6 +134,7 @@ class MainWindow(QObject):
             HexrdConfig().load_instrument_config(selected_file)
             self.cal_tree_view.rebuild_tree()
             self.calibration_config_widget.update_gui_from_config()
+            self.update_all(clear_canvases=True)
 
     def on_action_save_config_triggered(self):
         selected_file, selected_filter = QFileDialog.getSaveFileName(
@@ -375,7 +376,7 @@ class MainWindow(QObject):
 
         return False
 
-    def update_all(self):
+    def update_all(self, clear_canvases=False):
         # If there are no images loaded, skip the request
         if not HexrdConfig().has_images():
             return
@@ -387,13 +388,19 @@ class MainWindow(QObject):
         # constantly re-rendered
         if QApplication.focusWidget() is not None:
             QApplication.focusWidget().clearFocus()
+
         # Determine current canvas and update
-        canvas = self.ui.image_tab_widget.image_canvases[0]
-        if canvas.iviewer is not None:
-            if canvas.iviewer.type == 'polar':
-                canvas.show_polar()
-            else:
-                canvas.show_cartesian()
+        first_canvas = self.ui.image_tab_widget.image_canvases[0]
+        mode = first_canvas.mode
+
+        if clear_canvases:
+            for canvas in self.ui.image_tab_widget.image_canvases:
+                canvas.clear()
+
+        if mode == 'cartesian':
+            first_canvas.show_cartesian()
+        elif mode == 'polar':
+            first_canvas.show_polar()
         else:
             self.show_images()
 


### PR DESCRIPTION
This adds an option to MainWindow.update_all() to allow for
clearing of all canvases. This ensures that they are all re-drawn
from scratch.

The commit also uses this option to re-draw all canvases when a
new config is loaded.

I noticed that if a new config is loaded and the normal
MainWindow.update_all() is called without clearing the canvases,
the rings in the Cartesian view are placed a little differently
than if the canvas is cleared. In my case, the rings were placed
a little more downward (in y) if the canvas was cleared beforehand.
I am not sure what is causing the difference, but I assume the
cleared canvas is probably the correct one, which is why we are
clearing the canvases.

If clearing the canvases is something we want to avoid when we
reload the config, I can try to look into what is causing the
difference.

Fixes: #133 