### PR TITLE
Make expand/collapse context specific

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -356,12 +356,16 @@ class CalTreeView(QTreeView):
 
     def expand_selection(self, parent, index):
         for child in range(parent.child_count()):
-            self.expand(self.model().index(child, KEY_COL, index))
+            self.expand_selection(
+                parent.child_items[child],
+                self.model().index(child, KEY_COL, index))
         self.expand(index)
 
     def collapse_selection(self, parent, index):
         for child in range(parent.child_count()):
-            self.collapse(self.model().index(child, KEY_COL, index))
+            self.collapse_selection(
+                parent.child_items[child],
+                self.model().index(child, KEY_COL, index))
         self.collapse(index)
 
     # Display status checkbox for the row if the requirements are met


### PR DESCRIPTION
The context menu now only appears when the selected item has children. Choosing 'Expand All' or 'Collapse All' will expand or collapse that item as well as all of its children, not the entire tree.

Signed-off-by: Brianna Major <brianna.major@kitware.com>