### PR TITLE
Handle unchanged tree state

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -362,9 +362,10 @@ class CalTreeView(QTreeView):
         for i in range(self.model().rowCount(parent)):
             index = self.model().index(i, KEY_COL, parent)
             item = self.model().get_item(index)
-
             path = self.model().get_path_from_root(item, KEY_COL)
-            if path not in HexrdConfig().collapsed_state:
+
+            if (HexrdConfig().collapsed_state is None
+                    or path not in HexrdConfig().collapsed_state):
                 self.expand(index)
 
             self.display_status_checkbox(i, parent)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -248,10 +248,13 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return cur_config
 
     def update_collapsed_state(self, item):
-        if item in self.collapsed_state:
-            self.collapsed_state.remove(item)
-        else:
+        if self.collapsed_state is None:
+            self.collapsed_state = []
+
+        if item not in self.collapsed_state:
             self.collapsed_state.append(item)
+        else:
+            self.collapsed_state.remove(item)
 
     def has_status(self, config):
         if isinstance(config, dict):


### PR DESCRIPTION
Handle the case where the tree expanded/collapsed state has not been changed and the list of changes is None.

Signed-off-by: Brianna Major <brianna.major@kitware.com>