### PR TITLE
Display d-spacing, tth, eta, and hkl on status bar

### DIFF
--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -3,6 +3,8 @@ from PySide2.QtWidgets import QMessageBox, QTabWidget, QHBoxLayout
 
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
+import numpy as np
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_canvas import ImageCanvas
 from hexrd.ui.image_series_toolbar import ImageSeriesToolbar
@@ -27,7 +29,7 @@ class ImageTabWidget(QTabWidget):
 
     # Emitted when the mouse moves on top of an image/plot
     # Arguments are: x, y, xdata, ydata, intensity
-    new_mouse_position = Signal(int, int, float, float, float)
+    new_mouse_position = Signal(dict)
 
     def __init__(self, parent=None):
         super(ImageTabWidget, self).__init__(parent)
@@ -229,10 +231,18 @@ class ImageTabWidget(QTabWidget):
             self.clear_mouse_position.emit()
             return
 
-        x = event.x
-        y = event.y
-        x_data = event.xdata
-        y_data = event.ydata
+        mode = self.image_canvases[0].mode
+
+        if mode is None:
+            mode = 'images'
+
+        info = {
+            'x': event.x,
+            'y': event.y,
+            'x_data': event.xdata,
+            'y_data': event.ydata,
+            'mode': mode
+        }
 
         # TODO: we are currently calculating the pixel intensity
         # mathematically, because I couldn't find any other way
@@ -241,12 +251,39 @@ class ImageTabWidget(QTabWidget):
         if event.inaxes.get_images():
             # Image was created with imshow()
             artist = event.inaxes.get_images()[0]
-            intensity = utils.calculate_intensity(event, artist)
+            i, j = utils.coords2index(artist, info['x_data'], info['y_data'])
+            intensity = artist.get_array()[i, j]
         else:
             # This is probably just a plot. Do not calculate intensity.
             intensity = None
 
-        self.new_mouse_position.emit(x, y, x_data, y_data, intensity)
+        info['intensity'] = intensity
+
+        # intensity being None implies here that the mouse is on top of the
+        # azimuthal integration plot in the polar view.
+        if mode in ['cartesian', 'polar'] and intensity is not None:
+
+            iviewer = self.image_canvases[0].iviewer
+
+            if mode == 'cartesian':
+                xy_data = iviewer.dpanel.pixelToCart(np.vstack([i, j]).T)
+                ang_data, gvec = iviewer.dpanel.cart_to_angles(xy_data)
+                tth = ang_data[:, 0][0]
+                eta = ang_data[:, 1][0]
+            else:
+                tth = np.radians(info['x_data'])
+                eta = np.radians(info['y_data'])
+
+            dsp = 0.5 * iviewer.plane_data.wavelength / np.sin(0.5 * tth)
+            hkl = str(iviewer.plane_data.getHKLs(asStr=True, allHKLs=True,
+                                                 thisTTh=tth))
+
+            info['tth'] = np.degrees(tth)
+            info['eta'] = np.degrees(eta)
+            info['dsp'] = dsp
+            info['hkl'] = hkl
+
+        self.new_mouse_position.emit(info)
 
 
 if __name__ == '__main__':

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -440,15 +440,21 @@ class MainWindow(QObject):
                 widget.editingFinished.disconnect(self.update_all)
             widget.setKeyboardTracking(not enabled)
 
-    def new_mouse_position(self, x, y, x_data, y_data, intensity):
-        x_str = 'x = {:8.3f}'.format(x_data)
-        y_str = 'y = {:8.3f}'.format(y_data)
-        between = ',  '
-        msg = x_str + between + y_str
+    def new_mouse_position(self, info):
+        labels = []
+        labels.append('x = {:8.3f}'.format(info['x_data']))
+        labels.append('y = {:8.3f}'.format(info['y_data']))
+        delimiter = ',  '
 
-        if intensity != 0.0:
-            # The intensity will be exactly 0.0 if "None" was passed
-            intensity = 'value = {:8.3f}'.format(intensity)
-            msg += between + intensity
+        intensity = info['intensity']
+        if intensity is not None:
+            labels.append('value = {:8.3f}'.format(info['intensity']))
 
+            if info['mode'] in ['cartesian', 'polar']:
+                labels.append('tth = {:8.3f}'.format(info['tth']))
+                labels.append('eta = {:8.3f}'.format(info['eta']))
+                labels.append('dsp = {:8.3f}'.format(info['dsp']))
+                labels.append('hkl = ' + info['hkl'])
+
+        msg = delimiter.join(labels)
         self.ui.status_bar.showMessage(msg)

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -57,7 +57,7 @@ def make_new_pdata(mat):
     fix_exclusions(mat)
 
 
-def _coords2index(im, x, y):
+def coords2index(im, x, y):
     """
     This function is modified from here:
     https://github.com/joferkington/mpldatacursor/blob/7dabc589ed02c35ac5d89de5931f91e0323aa795/mpldatacursor/pick_info.py#L28
@@ -86,27 +86,3 @@ def _coords2index(im, x, y):
              mtransforms.BboxTransformTo(array_extent))
 
     return trans.transform_point([y, x]).astype(int)
-
-
-def calculate_intensity(event, artist):
-    """
-    This function is modified from here:
-    https://github.com/joferkington/mpldatacursor/blob/7dabc589ed02c35ac5d89de5931f91e0323aa795/mpldatacursor/pick_info.py#L61
-
-    Get uninterpolated pixel intensity for the pixel behind the mouse
-    event.
-
-    Parameters
-    -----------
-    event : MouseEvent
-        The mouse event to process
-    artist : An AxesImage instance
-        The image artist to operate on
-
-    Returns
-    --------
-    pixel intensity : float
-    """
-    x, y = event.xdata, event.ydata
-    i, j = _coords2index(artist, x, y)
-    return artist.get_array()[i, j]


### PR DESCRIPTION
This is working for both Cartesian and Polar views.

However, x and y are the same as tth and eta in the polar view.
Perhaps I should remove one of them?
![pic](https://user-images.githubusercontent.com/9558430/63119623-98a88700-bf6e-11e9-8037-0da9e60ba979.png)
![img2](https://user-images.githubusercontent.com/9558430/63119628-9ba37780-bf6e-11e9-9afa-f0146b615678.png)
