### PR TITLE
Remove shortcuts from windowTitles

### DIFF
--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -117,7 +117,7 @@
     </size>
    </property>
    <property name="windowTitle">
-    <string>&amp;Configuration</string>
+    <string>Configuration</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>1</number>
@@ -238,7 +238,7 @@
   </widget>
   <widget class="QDockWidget" name="color_map_dock_widget">
    <property name="windowTitle">
-    <string>Co&amp;lor Map</string>
+    <string>Color Map</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>4</number>
@@ -265,7 +265,7 @@
   </widget>
   <widget class="QDockWidget" name="resolution_dock_widget">
    <property name="windowTitle">
-    <string>Re&amp;ndering Resolution</string>
+    <string>Rendering Resolution</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>4</number>
@@ -289,7 +289,7 @@
   </widget>
   <widget class="QDockWidget" name="frame_aggregation_widget">
    <property name="windowTitle">
-    <string>Frame A&amp;ggregation</string>
+    <string>Frame Aggregation</string>
    </property>
    <attribute name="dockWidgetArea">
     <number>4</number>
@@ -329,7 +329,7 @@
   </action>
   <action name="action_open_config">
    <property name="text">
-    <string>&amp;Configuration</string>
+    <string>Configuration</string>
    </property>
   </action>
   <action name="action_save_imageseries">


### PR DESCRIPTION
It doesn't look like QDockWidgets support shortcuts on the title.
They are being rendered as "&".