### PR TITLE
Fix reset range when old max is less than new min

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -75,6 +75,10 @@ class ColorMapEditor:
         return l, h
 
     def reset_range(self):
+        if self.ui.minimum.maximum() < self.bounds[0]:
+            # Make sure we can actually set the value...
+            self.ui.minimum.setMaximum(self.bounds[0])
+
         self.ui.minimum.setValue(self.bounds[0])
         self.ui.maximum.setValue(self.bounds[1])
 


### PR DESCRIPTION
Before this fix, if the default range was something like
"2181 - 5164", and the range was changed to "200 - 400", when
"Reset Range" would be clicked, the range values would appear
as "400 - 5164", and then, when clicked again, they would appear
as "2181 - 5164".

This is because the min value was being limited by the old max
value, 400 in this case. Ensure the new min is not limited by
the old max value.

This might be related to #160, but I am not sure.