### PR TITLE
Add vertical spacer to bottom of slider view

### DIFF
--- a/hexrd/ui/resources/ui/calibration_slider_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_slider_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>391</width>
-    <height>369</height>
+    <height>375</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -321,6 +321,19 @@
    </item>
    <item row="0" column="1">
     <widget class="QComboBox" name="detector"/>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This pushes the widgets closer together to reduce the amount
of vertical mouse movement required.

![Screenshot from 2019-08-30 15-54-27](https://user-images.githubusercontent.com/9558430/64048073-abaa8200-cb3e-11e9-887c-eba77ba36d83.png)

Fixes comment mentioned in #157.