### PR TITLE
Emit valueChanged when scientific spinbox steps

### DIFF
--- a/hexrd/ui/scientificspinbox.py
+++ b/hexrd/ui/scientificspinbox.py
@@ -69,4 +69,9 @@ class ScientificDoubleSpinBox(QDoubleSpinBox):
         decimal = float(groups[1])
         decimal += steps
         new_string = '{:g}'.format(decimal) + (groups[3] if groups[3] else '')
-        self.lineEdit().setText(new_string)
+
+        # Set the value so that signals get emitted properly
+        self.setValue(self.valueFromText(new_string))
+
+        # Select the text just like a regular spin box would...
+        self.selectAll()


### PR DESCRIPTION
Before, valueChanged() was not being emitted when the up/down arrows
were clicked. This resulted in the internal config not being updated.

Use setValue() on the spin box so that the signals get emitted. Also,
call "selectAll()" so that it behaves more like a regular spinbox,
which also calls "selectAll()" when the arrows are clicked.

Fixes: #167