### PR TITLE
Make copies when setting default config

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -216,7 +216,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
     def _recursive_set_defaults(self, current, default):
         for key in default.keys():
-            current.setdefault(key, default[key])
+            current.setdefault(key, copy.deepcopy(default[key]))
 
             if key == 'detectors':
                 # Don't copy the default detectors into the current ones


### PR DESCRIPTION
Not making copies resulted in an issue where, when a dictionary
default was added, that dictionary default would get modified. We
need to make copies so that the defaults won't be modified.

Fixes: #106