### PR TITLE
Fix ring range selection

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -5,6 +5,7 @@ from hexrd import instrument
 from hexrd.gridutil import cellIndices
 
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils import select_merged_rings
 
 from skimage import transform as tf
 from skimage.exposure import equalize_adapthist
@@ -83,16 +84,8 @@ class InstrumentViewer:
 
             if selected_rings:
                 # This ensures the correct ranges are selected
-                new_indices = []
-                new_ranges = []
-                for ring in selected_rings:
-                    for i, entry in enumerate(indices):
-                        if ring in entry:
-                            new_indices.append(entry)
-                            new_ranges.append(ranges[i])
-                            break
-                indices = new_indices
-                ranges = new_ranges
+                indices, ranges = select_merged_rings(selected_rings, indices,
+                                                      ranges)
 
             r_lower = [r[0] for r in ranges]
             r_upper = [r[1] for r in ranges]

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -10,6 +10,7 @@ from skimage.exposure import equalize_adapthist
 from .display_plane import DisplayPlane
 
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils import select_merged_rings
 
 snip_width = 9
 
@@ -132,16 +133,8 @@ class InstrumentViewer:
 
             if selected_rings:
                 # This ensures the correct ranges are selected
-                new_indices = []
-                new_ranges = []
-                for ring in selected_rings:
-                    for i, entry in enumerate(indices):
-                        if ring in entry:
-                            new_indices.append(entry)
-                            new_ranges.append(ranges[i])
-                            break
-                indices = new_indices
-                ranges = new_ranges
+                indices, ranges = select_merged_rings(selected_rings, indices,
+                                                      ranges)
 
             for ind, r in zip(indices, np.degrees(ranges)):
                 self.rbnd_data.append(np.array([[-180, r[0]],

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -86,3 +86,21 @@ def coords2index(im, x, y):
              mtransforms.BboxTransformTo(array_extent))
 
     return trans.transform_point([y, x]).astype(int)
+
+
+def select_merged_rings(selected_rings, indices, ranges):
+    """Select indices and ranges for merged rings
+
+    This utility function filters the indices and ranges and returns
+    new (indices, ranges) that were selected in the selected_rings.
+    """
+    new_indices = []
+    new_ranges = []
+    for ring in selected_rings:
+        for i, entry in enumerate(indices):
+            if ring in entry:
+                new_indices.append(entry)
+                new_ranges.append(ranges[i])
+                break
+
+    return new_indices, new_ranges


### PR DESCRIPTION
This fixes ring selection for polar ranges, which did not work previously.

It also fixes ring selection for both cartesian and polar for merged ranges, which had several
issues before (wrong ranges being drawn, indexing errors, etc.).

Fixes: #173