### PR TITLE
Don't grow azimuthal y-axis on ring selections

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -296,6 +296,10 @@ class ImageCanvas(FigureCanvas):
                 axis = self.figure.add_subplot(grid[2, 0], sharex=self.axis)
                 axis.plot(tth, np.sum(img, axis=0))
 
+                # Turn off autoscale so modifying the rings does not
+                # rescale the y axis.
+                axis.autoscale(False)
+
                 self.axis.set_ylabel(r'$\eta$ (deg)')
 
                 self.azimuthal_integral_axis = axis


### PR DESCRIPTION
Because the azimuthal overlays are being drawn from the top of the
azimuthal plot to the bottom, the axis would get automatically
re-scaled so that there is a margin between the bounds of the image
and the overlays.

This means that every time the overlays would be re-drawn, the y-axis
would grow, and the plot would look smaller. This would happen every
time the user changed ring selections.

We can either fix this issue by turning off autoscaling for the
azimuthal plot, or by manually setting the y limits of the plot after
it has been autoscaled. I went with the former.

To provide a picture of what this fixes, the azimuthal plot would originally
look like this for the example:

![Screenshot from 2019-09-19 07-27-56](https://user-images.githubusercontent.com/9558430/65240400-308a1b00-daaf-11e9-8179-7df180c31b0b.png)

After changing the rings a few times, it would then look something like this:

![Screenshot from 2019-09-19 07-28-24](https://user-images.githubusercontent.com/9558430/65240428-44358180-daaf-11e9-9625-51c298ce60b0.png)

This PR fixes this issue.