### PR TITLE
Add buttons to reset instrument config

### DIFF
--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -37,6 +37,8 @@ class CalibrationSliderWidget(QObject):
         self.ui.sb_tilt_range.valueChanged.connect(self.update_ranges)
         self.ui.sb_beam_range.valueChanged.connect(self.update_ranges)
 
+        self.ui.push_reset_config.pressed.connect(self.reset_config)
+
     def update_ranges(self):
         r = self.ui.sb_translation_range.value()
         slider_r = r * self.CONF_VAL_TO_SLIDER_VAL
@@ -279,3 +281,7 @@ class CalibrationSliderWidget(QObject):
                 lambda: self.update_if_mode_matches.emit('polar'))
 
         self._update_if_polar_timer.start(500)
+
+    def reset_config(self):
+        HexrdConfig().restore_instrument_config_backup()
+        self.update_gui_from_config()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -122,6 +122,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # Add the statuses to the config
         self.create_internal_config(self.config['instrument'])
 
+        # Save a backup of the previous config for later
+        self.backup_instrument_config()
+
         # Load the GUI to yaml maps
         self.load_gui_yaml_dict()
 
@@ -180,6 +183,16 @@ class HexrdConfig(QObject, metaclass=Singleton):
     @property
     def internal_instrument_config(self):
         return self.config['instrument']
+
+    def backup_instrument_config(self):
+        self.instrument_config_backup = copy.deepcopy(
+            self.config['instrument'])
+
+    def restore_instrument_config_backup(self):
+        self.config['instrument'] = copy.deepcopy(
+            self.instrument_config_backup)
+        self.rerender_needed.emit()
+        self.update_active_material_energy()
 
     def set_images_dir(self, images_dir):
         self.images_dir = images_dir
@@ -266,6 +279,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # Set any required keys that might be missing to prevent key errors
         self.set_defaults_if_missing()
         self.create_internal_config(self.config['instrument'])
+
+        # Create a backup
+        self.backup_instrument_config()
 
         self.update_active_material_energy()
         return self.config['instrument']

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -98,6 +98,8 @@ class MainWindow(QObject):
             self.on_action_edit_euler_angle_convention)
         self.ui.action_edit_calibration_crystal.triggered.connect(
             self.on_action_edit_calibration_crystal)
+        self.ui.action_edit_reset_instrument_config.triggered.connect(
+            self.on_action_edit_reset_instrument_config)
         self.ui.action_show_live_updates.toggled.connect(
             self.live_update)
         self.ui.action_show_detector_borders.toggled.connect(
@@ -354,6 +356,10 @@ class MainWindow(QObject):
             self.calibration_crystal_editor.update_gui_from_config()
 
         self.calibration_crystal_editor.exec_()
+
+    def on_action_edit_reset_instrument_config(self):
+        HexrdConfig().restore_instrument_config_backup()
+        self.update_config_gui()
 
     def change_image_mode(self, text):
         self.image_mode = text.lower()

--- a/hexrd/ui/resources/ui/calibration_slider_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_slider_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>547</height>
+    <height>618</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -340,7 +340,7 @@
    <item row="1" column="1">
     <widget class="QComboBox" name="detector"/>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -509,6 +509,16 @@
        </widget>
       </item>
      </layout>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <widget class="QPushButton" name="push_reset_config">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the instrument configuration to the state when the most recent instrument file was loaded, or when the program started.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Reset Configuration</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -91,6 +91,7 @@
     </property>
     <addaction name="action_edit_euler_angle_convention"/>
     <addaction name="action_edit_calibration_crystal"/>
+    <addaction name="action_edit_reset_instrument_config"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -424,6 +425,11 @@
    </property>
    <property name="text">
     <string>Polar Plot</string>
+   </property>
+  </action>
+  <action name="action_edit_reset_instrument_config">
+   <property name="text">
+    <string>Reset Instrument Config</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This resets the instrument config to the most recent loaded
configuration (either loaded at startup or loaded manually).

Two ways were added to do this:

1. The menu "Edit"->"Reset Instrument Config"
2. A button in the slider view: "Reset Config"

Fixes: #193