### PR TITLE
Start hexrd with the raw image mode tab selected

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -50,6 +50,7 @@ class MainWindow(QObject):
 
         self.image_mode = 'raw'
         self.image_mode_widget = ImageModeWidget(self.ui.central_widget)
+        self.image_mode_widget.setCurrentIndex(0) # Always start with raw tab
         self.ui.image_mode_dock_widgets.layout().addWidget(
             self.image_mode_widget.ui)
 

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="iconSize">
       <size>


### PR DESCRIPTION
This changes the default tab to raw image mode, and it enforces
this in the constructor, so that the raw image mode is always the
mode to start.

Fixes: #192