### PR TITLE
Move "Modify Material Dialog" into materials panel

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -603,6 +603,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         if old_name != new_name:
             self.config['materials']['materials'][new_name] = (
                 self.config['materials']['materials'][old_name])
+            self.config['materials']['materials'][new_name].name = new_name
 
             if self.active_material_name() == old_name:
                 # Change the active material before removing the old one

--- a/hexrd/ui/resources/ui/material_editor_widget.ui
+++ b/hexrd/ui/resources/ui/material_editor_widget.ui
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>Dialog</class>
- <widget class="QDialog" name="Dialog">
+ <class>Widget</class>
+ <widget class="QWidget" name="Widget">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>999</width>
+    <width>263</width>
     <height>508</height>
    </rect>
   </property>
@@ -20,22 +20,6 @@
   <layout class="QHBoxLayout" name="horizontalLayout_2">
    <item>
     <layout class="QVBoxLayout" name="verticalLayout">
-     <item>
-      <widget class="QGroupBox" name="material_name_group">
-       <property name="title">
-        <string>Material Name</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QLineEdit" name="material_name">
-          <property name="text">
-           <string>material</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </widget>
-     </item>
      <item>
       <widget class="QGroupBox" name="space_group_info_group">
        <property name="font">
@@ -234,6 +218,9 @@
          <widget class="QSpinBox" name="max_hkl">
           <property name="alignment">
            <set>Qt::AlignCenter</set>
+          </property>
+          <property name="keyboardTracking">
+           <bool>false</bool>
           </property>
           <property name="maximum">
            <number>1000</number>
@@ -499,51 +486,22 @@
      </item>
     </layout>
    </item>
-   <item>
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>space_group</tabstop>
+  <tabstop>max_hkl</tabstop>
+  <tabstop>hall_symbol</tabstop>
+  <tabstop>hermann_mauguin</tabstop>
+  <tabstop>laue_group</tabstop>
+  <tabstop>lattice_type</tabstop>
+  <tabstop>lattice_a</tabstop>
+  <tabstop>lattice_alpha</tabstop>
+  <tabstop>lattice_b</tabstop>
+  <tabstop>lattice_beta</tabstop>
+  <tabstop>lattice_c</tabstop>
+  <tabstop>lattice_gamma</tabstop>
+ </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>Dialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>buttonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>Dialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -46,7 +46,7 @@
         <string/>
        </property>
        <property name="editable">
-        <bool>false</bool>
+        <bool>true</bool>
        </property>
        <item>
         <property name="text">


### PR DESCRIPTION
This makes the "Modify Material Dialog" into a widget, and it moves
it into the materials panel.

When the values in the spinboxes are modified (keyboard tracking is
off), or the combo boxes change, the rings and the materials panel
table are updated immediately.

You can add a material or remove a material via the tool button.

You can also rename the material since the combo box is now editable.

![image](https://user-images.githubusercontent.com/9558430/68237364-f92aeb80-ffd4-11e9-9d3e-d1430b3499f7.png)

Fixes: #191