### PR TITLE
Enable live updates by default

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -88,7 +88,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.imageseries_dict = {}
         self.current_imageseries_idx = 0
         self.hdf5_path = []
-        self.live_update = False
+        self.live_update = True
         self._show_saturation_level = False
         self._tab_images = False
         self.previous_active_material = None
@@ -161,7 +161,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.images_dir = settings.value('images_dir', None)
         self.hdf5_path = settings.value('hdf5_path', None)
         # All QSettings come back as strings.
-        self.live_update = bool(settings.value('live_update', False) == 'true')
+        self.live_update = bool(settings.value('live_update', True) == 'true')
 
         conv = settings.value('euler_angle_convention', ('xyz', True))
         self.set_euler_angle_convention(conv[0], conv[1], convert_config=False)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -78,6 +78,7 @@ class MainWindow(QObject):
         self.calibration_config_widget.update_gui_from_config()
 
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
+        self.live_update(HexrdConfig().live_update)
 
     def setup_connections(self):
         """This is to setup connections for non-gui objects"""

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -174,8 +174,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>550</width>
-          <height>708</height>
+          <width>98</width>
+          <height>28</height>
          </rect>
         </property>
         <attribute name="label">
@@ -187,8 +187,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>550</width>
-          <height>708</height>
+          <width>127</width>
+          <height>49</height>
          </rect>
         </property>
         <attribute name="label">
@@ -342,6 +342,9 @@
   </action>
   <action name="action_show_live_updates">
    <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
     <bool>true</bool>
    </property>
    <property name="text">


### PR DESCRIPTION
Since single detectors always live update, but other settings updating
depend on the status of the "live_update" configuration, the program
can be a little unintuitive when "live_update" is not checked.

Check it by default since it is almost always used anyways.