### PR TITLE
Associate selected files with detectors using name

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -280,6 +280,7 @@ class LoadPanel(QObject):
             QMessageBox.warning(None, 'HEXRD', msg)
             return
 
+        self.directories = sorted(dirs)[:num_det]
 
     def match_images(self, fnames):
         dets = HexrdConfig().get_detector_names()


### PR DESCRIPTION
Previous logic assumed detectors were sorted in ascending order in order to
associate selected files with the appropriate detectors. Files are now matched
to their detector using the detector name in the file name or subdirectory. This
assures that any detector name in any order will always have the correct files
associated with it.
