### PR TITLE
Allow multiple materials to be displayed simultaneously

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -119,13 +119,13 @@ class InstrumentViewer:
             self.pixel_size = HexrdConfig().cartesian_pixel_size
             self.make_dpanel()
 
-        # If there are any rings selected, only do the active material
-        if HexrdConfig().selected_rings or not HexrdConfig().show_all_materials:
-            material_names = [HexrdConfig().active_material_name()]
-        else:
-            material_names = HexrdConfig().materials.keys()
+        materials_list = HexrdConfig().visible_material_names
+        if HexrdConfig().selected_rings:
+            # Only show the active material, if it is part of the list
+            active = HexrdConfig().active_material_name
+            materials_list = [active] if active in materials_list else []
 
-        for name in material_names:
+        for name in materials_list:
             mat = HexrdConfig().material(name)
 
             rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData)

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -114,13 +114,13 @@ class InstrumentViewer:
     def add_rings(self):
         self.clear_rings()
 
-        # If there are any rings selected, only do the active material
-        if HexrdConfig().selected_rings or not HexrdConfig().show_all_materials:
-            material_names = [HexrdConfig().active_material_name()]
-        else:
-            material_names = HexrdConfig().materials.keys()
+        materials_list = HexrdConfig().visible_material_names
+        if HexrdConfig().selected_rings:
+            # Only show the active material, if it is part of the list
+            active = HexrdConfig().active_material_name
+            materials_list = [active] if active in materials_list else []
 
-        for name in material_names:
+        for name in materials_list:
             mat = HexrdConfig().material(name)
 
             rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData)

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -223,7 +223,7 @@ class CalibrationSliderWidget(QObject):
             iconfig = HexrdConfig().config['instrument']
             if key == 'energy':
                 iconfig['beam'][key]['value'] = val
-                HexrdConfig().update_active_material_energy()
+                HexrdConfig().update_visible_material_energies()
             elif key == 'polar':
                 iconfig['beam']['vector']['polar_angle']['value'] = val
                 self.emit_update_if_polar()

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -126,45 +126,59 @@ class ImageCanvas(FigureCanvas):
 
         self.clear_rings()
 
-        # In case the plane data has changed
-        self.iviewer.plane_data = HexrdConfig().active_material.planeData
-
         ring_data = self.iviewer.add_rings()
 
-        colorspec = 'c.'
-        if self.iviewer.type == 'polar':
-            colorspec = 'c.-'
+        for mat_name in ring_data.keys():
+            style = HexrdConfig().get_ring_style(mat_name)
+            ring_color = style['ring_color']
+            ring_linestyle = style['ring_linestyle']
+            ring_linewidth = style['ring_linewidth']
+            rbnd_color = style['rbnd_color']
+            rbnd_linestyle = style['rbnd_linestyle']
+            rbnd_linewidth = style['rbnd_linewidth']
 
-        for pr in ring_data:
-            x, y = self.extract_ring_coords(pr)
-            ring, = self.axis.plot(x, y, colorspec, ms=2)
-            self.cached_rings.append(ring)
+            rings = ring_data[mat_name]['ring_data']
+            rbnds = ring_data[mat_name]['rbnd_data']
+            rbnd_indices = ring_data[mat_name]['rbnd_indices']
 
-        # Add the rbnds too
-        for ind, pr in zip(self.iviewer.rbnd_indices,
-                           self.iviewer.rbnd_data):
-            x, y = self.extract_ring_coords(pr)
-            color = 'g:'
-            if len(ind) > 1:
-                color = 'r:'
-            rbnd, = self.axis.plot(x, y, color, ms=1)
-            self.cached_rbnds.append(rbnd)
-
-        if self.azimuthal_integral_axis is not None:
-            axis = self.azimuthal_integral_axis
-            yrange = axis.get_ylim()
-            for pr in ring_data:
-                ring, = axis.plot(pr[:, 1], yrange, colorspec, ms=2)
+            for pr in rings:
+                x, y = self.extract_ring_coords(pr)
+                ring, = self.axis.plot(x, y, color=ring_color,
+                                       linestyle=ring_linestyle,
+                                       lw=ring_linewidth)
                 self.cached_rings.append(ring)
 
             # Add the rbnds too
-            for ind, pr in zip(self.iviewer.rbnd_indices,
-                               self.iviewer.rbnd_data):
-                color = 'g:'
+            for ind, pr in zip(rbnd_indices, rbnds):
+                x, y = self.extract_ring_coords(pr)
+                color = rbnd_color
                 if len(ind) > 1:
-                    color = 'r:'
-                rbnd, = axis.plot(pr[:, 1], yrange, color, ms=1)
+                    # If rbnds are combined, override the color to red
+                    color = 'r'
+                rbnd, = self.axis.plot(x, y, color=color,
+                                       linestyle=rbnd_linestyle,
+                                       lw=rbnd_linewidth)
                 self.cached_rbnds.append(rbnd)
+
+            if self.azimuthal_integral_axis is not None:
+                axis = self.azimuthal_integral_axis
+                yrange = axis.get_ylim()
+                for pr in rings:
+                    ring, = axis.plot(pr[:, 1], yrange, color=ring_color,
+                                      linestyle=ring_linestyle,
+                                      lw=ring_linewidth)
+                    self.cached_rings.append(ring)
+
+                # Add the rbnds too
+                for ind, pr in zip(rbnd_indices, rbnds):
+                    color = rbnd_color
+                    if len(ind) > 1:
+                        # If rbnds are combined, override the color to red
+                        color = 'r'
+                    rbnd, = axis.plot(pr[:, 1], yrange, color=color,
+                                      linestyle=rbnd_linestyle,
+                                      lw=rbnd_linewidth)
+                    self.cached_rbnds.append(rbnd)
 
         self.draw()
 

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -252,9 +252,11 @@ class ImageTabWidget(QTabWidget):
                 tth = np.radians(info['x_data'])
                 eta = np.radians(info['y_data'])
 
-            dsp = 0.5 * iviewer.plane_data.wavelength / np.sin(0.5 * tth)
-            hkl = str(iviewer.plane_data.getHKLs(asStr=True, allHKLs=True,
-                                                 thisTTh=tth))
+            # We will only display the active material's hkls
+            plane_data = HexrdConfig().active_material.planeData
+            dsp = 0.5 * plane_data.wavelength / np.sin(0.5 * tth)
+            hkl = str(plane_data.getHKLs(asStr=True, allHKLs=True,
+                                         thisTTh=tth))
 
             info['tth'] = np.degrees(tth)
             info['eta'] = np.degrees(eta)

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -62,8 +62,8 @@ class MaterialsPanel(QObject):
 
         self.ui.edit_style_button.pressed.connect(self.edit_overlay_style)
 
-        self.ui.show_all_materials.toggled.connect(
-            HexrdConfig().set_show_all_materials)
+        self.ui.material_visible.toggled.connect(
+            self.material_visibility_toggled)
 
         HexrdConfig().new_plane_data.connect(self.update_gui_from_config)
 
@@ -73,7 +73,7 @@ class MaterialsPanel(QObject):
             self.ui.show_rings,
             self.ui.show_ranges,
             self.ui.tth_ranges,
-            self.ui.show_all_materials
+            self.ui.material_visible
         ]
 
         block_signals = []
@@ -90,13 +90,13 @@ class MaterialsPanel(QObject):
                 self.ui.materials_combo.clear()
                 self.ui.materials_combo.addItems(materials_keys)
                 self.ui.materials_combo.setCurrentText(
-                    HexrdConfig().active_material_name())
+                    HexrdConfig().active_material_name)
 
             self.ui.show_rings.setChecked(HexrdConfig().show_rings)
             self.ui.show_ranges.setChecked(HexrdConfig().show_ring_ranges)
             self.ui.tth_ranges.setValue(HexrdConfig().ring_ranges)
-            self.ui.show_all_materials.setChecked(
-                HexrdConfig().show_all_materials)
+            self.ui.material_visible.setChecked(
+                HexrdConfig().material_is_visible(self.current_material()))
         finally:
             for b, item in zip(block_signals, block_list):
                 item.blockSignals(b)
@@ -181,7 +181,7 @@ class MaterialsPanel(QObject):
             # Just ignore it
             return
 
-        old_name = HexrdConfig().active_material_name()
+        old_name = HexrdConfig().active_material_name
         HexrdConfig().rename_material(old_name, new_name)
         self.update_gui_from_config()
 
@@ -191,3 +191,8 @@ class MaterialsPanel(QObject):
         # The overlay style picker will modify the HexrdConfig() itself
         picker = OverlayStylePicker(material_name, self.ui)
         picker.ui.exec_()
+
+    def material_visibility_toggled(self):
+        visible = self.ui.material_visible.isChecked()
+        name = self.current_material()
+        HexrdConfig().set_material_visibility(name, visible)

--- a/hexrd/ui/overlay_style_picker.py
+++ b/hexrd/ui/overlay_style_picker.py
@@ -1,0 +1,111 @@
+import copy
+
+from PySide2.QtCore import QObject
+from PySide2.QtGui import QColor
+from PySide2.QtWidgets import QColorDialog
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class OverlayStylePicker(QObject):
+
+    def __init__(self, material_name, parent=None):
+        super(OverlayStylePicker, self).__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('overlay_style_picker.ui', parent)
+
+        self.material_name = material_name
+        self.ui.material_name.setText(material_name)
+
+        self.original_style = copy.deepcopy(self.ring_style)
+
+        self.setup_connections()
+        self.update_gui_from_config()
+
+    def setup_connections(self):
+        self.ui.ring_color.pressed.connect(self.pick_color)
+        self.ui.range_color.pressed.connect(self.pick_color)
+        self.ui.ring_linestyle.currentIndexChanged.connect(
+            self.update_config_from_gui)
+        self.ui.range_linestyle.currentIndexChanged.connect(
+            self.update_config_from_gui)
+        self.ui.ring_linewidth.valueChanged.connect(
+            self.update_config_from_gui)
+        self.ui.range_linewidth.valueChanged.connect(
+            self.update_config_from_gui)
+
+        # Reset the style if the dialog is rejected
+        self.ui.rejected.connect(self.reset_style)
+
+    @property
+    def ring_style(self):
+        return HexrdConfig().get_ring_style(self.material_name)
+
+    @property
+    def all_widgets(self):
+        return [
+            self.ui.ring_color,
+            self.ui.ring_linestyle,
+            self.ui.ring_linewidth,
+            self.ui.range_color,
+            self.ui.range_linestyle,
+            self.ui.range_linewidth
+        ]
+
+    def block_signals(self):
+        # Returns the list of previous block states
+        return [w.blockSignals(True) for w in self.all_widgets]
+
+    def unblock_signals(self, previously_blocked):
+        for block, w in zip(previously_blocked, self.all_widgets):
+            w.blockSignals(block)
+
+    def reset_style(self):
+        styles = HexrdConfig().ring_styles
+        styles[self.material_name] = copy.deepcopy(self.original_style)
+        self.update_gui_from_config()
+        HexrdConfig().ring_config_changed.emit()
+
+    def update_gui_from_config(self):
+        style = self.ring_style
+        previously_blocked = self.block_signals()
+        try:
+            self.ui.ring_color.setText(style['ring_color'])
+            self.ui.ring_linestyle.setCurrentText(style['ring_linestyle'])
+            self.ui.ring_linewidth.setValue(style['ring_linewidth'])
+            self.ui.range_color.setText(style['rbnd_color'])
+            self.ui.range_linestyle.setCurrentText(style['rbnd_linestyle'])
+            self.ui.range_linewidth.setValue(style['rbnd_linewidth'])
+        finally:
+            self.unblock_signals(previously_blocked)
+
+        self.update_button_colors()
+
+    def update_config_from_gui(self):
+        style = self.ring_style
+        style['ring_color'] = self.ui.ring_color.text()
+        style['ring_linestyle'] = self.ui.ring_linestyle.currentText()
+        style['ring_linewidth'] = self.ui.ring_linewidth.value()
+        style['rbnd_color'] = self.ui.range_color.text()
+        style['rbnd_linestyle'] = self.ui.range_linestyle.currentText()
+        style['rbnd_linewidth'] = self.ui.range_linewidth.value()
+        HexrdConfig().ring_config_changed.emit()
+
+    def pick_color(self):
+        # This should only be called by signals/slots
+        # It uses the sender() to get the button that called it
+        sender = self.sender()
+        color = sender.text()
+
+        dialog = QColorDialog(QColor(color), self.ui)
+        if dialog.exec_():
+            sender.setText(dialog.selectedColor().name())
+            self.update_button_colors()
+            self.update_config_from_gui()
+
+    def update_button_colors(self):
+        buttons = [self.ui.ring_color, self.ui.range_color]
+        for b in buttons:
+            b.setStyleSheet('QPushButton {background-color: %s}' % b.text())

--- a/hexrd/ui/resources/materials/materials_panel_defaults.yml
+++ b/hexrd/ui/resources/materials/materials_panel_defaults.yml
@@ -3,3 +3,4 @@ selected_rings: []
 show_rings: true
 show_ring_ranges: false
 ring_ranges: 0.125
+show_all_materials: false

--- a/hexrd/ui/resources/materials/materials_panel_defaults.yml
+++ b/hexrd/ui/resources/materials/materials_panel_defaults.yml
@@ -3,4 +3,3 @@ selected_rings: []
 show_rings: true
 show_ring_ranges: false
 ring_ranges: 0.125
-show_all_materials: false

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
+    <width>377</width>
     <height>538</height>
    </rect>
   </property>
@@ -166,24 +166,21 @@
     </widget>
    </item>
    <item>
-    <widget class="QCheckBox" name="show_rings">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show powder rings for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Show Rings</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="5">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="1" column="0">
       <widget class="QCheckBox" name="show_ranges">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show 2θ ranges for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -193,7 +190,37 @@
        </property>
       </widget>
      </item>
-     <item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="show_rings">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show powder rings for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Show Rings</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="edit_style_button">
+       <property name="text">
+        <string>Edit Style...</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="show_all_materials">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This will show overlays for all materials in hexrd. The styles of the overlays may be edited for each material by selecting it and clicking &amp;quot;Edit Styles...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Show All Materials</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QDoubleSpinBox" name="tth_ranges">
        <property name="enabled">
         <bool>false</bool>
@@ -227,23 +254,20 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
     </layout>
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>materials_combo</tabstop>
+  <tabstop>materials_tool_button</tabstop>
+  <tabstop>materials_table</tabstop>
+  <tabstop>show_rings</tabstop>
+  <tabstop>show_all_materials</tabstop>
+  <tabstop>edit_style_button</tabstop>
+  <tabstop>show_ranges</tabstop>
+  <tabstop>tth_ranges</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>377</width>
+    <width>382</width>
     <height>538</height>
    </rect>
   </property>
@@ -167,7 +167,7 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="5">
+     <item row="3" column="5">
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -180,7 +180,7 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="0">
+     <item row="3" column="0">
       <widget class="QCheckBox" name="show_ranges">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show 2θ ranges for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -190,7 +190,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
+     <item row="1" column="0">
       <widget class="QCheckBox" name="show_rings">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show powder rings for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -203,24 +203,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="edit_style_button">
-       <property name="text">
-        <string>Edit Style...</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QCheckBox" name="show_all_materials">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This will show overlays for all materials in hexrd. The styles of the overlays may be edited for each material by selecting it and clicking &amp;quot;Edit Styles...&amp;quot;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Show All Materials</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="tth_ranges">
        <property name="enabled">
         <bool>false</bool>
@@ -254,6 +237,20 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="material_visible">
+       <property name="text">
+        <string>Visible</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QPushButton" name="edit_style_button">
+       <property name="text">
+        <string>Edit Style...</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -262,9 +259,9 @@
   <tabstop>materials_combo</tabstop>
   <tabstop>materials_tool_button</tabstop>
   <tabstop>materials_table</tabstop>
-  <tabstop>show_rings</tabstop>
-  <tabstop>show_all_materials</tabstop>
+  <tabstop>material_visible</tabstop>
   <tabstop>edit_style_button</tabstop>
+  <tabstop>show_rings</tabstop>
   <tabstop>show_ranges</tabstop>
   <tabstop>tth_ranges</tabstop>
  </tabstops>

--- a/hexrd/ui/resources/ui/overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/overlay_style_picker.ui
@@ -1,0 +1,234 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>overlay_style_picker</class>
+ <widget class="QDialog" name="overlay_style_picker">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>468</width>
+    <height>212</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="5" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="4">
+    <widget class="QLabel" name="material_name">
+     <property name="text">
+      <string>MaterialName</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="4">
+    <widget class="QGroupBox" name="ring_style_group">
+     <property name="title">
+      <string>Ring Style</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="4">
+       <widget class="QLabel" name="ring_linestyle_label">
+        <property name="text">
+         <string>Line Style:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="ring_color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="ring_color">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QComboBox" name="ring_linestyle">
+        <item>
+         <property name="text">
+          <string>solid</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dotted</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dashed</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dashdot</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="ring_linewidth_label">
+        <property name="text">
+         <string>Line Width:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="QDoubleSpinBox" name="ring_linewidth">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="minimum">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="4">
+    <widget class="QGroupBox" name="range_style_group">
+     <property name="title">
+      <string>Range Style</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="1">
+       <widget class="QPushButton" name="range_color">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="range_color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="range_linestyle_label">
+        <property name="text">
+         <string>Line Style:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QComboBox" name="range_linestyle">
+        <property name="currentText">
+         <string>solid</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>solid</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dotted</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dashed</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dashdot</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="range_linewidth_label">
+        <property name="text">
+         <string>Line Width:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="QDoubleSpinBox" name="range_linewidth">
+        <property name="minimum">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>overlay_style_picker</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>296</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>196</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>overlay_style_picker</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>296</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>196</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
This adds a checkbox to the materials panel called "Visible", which can be used to show/hide each individual material.

Additionally, a button was added to the materials panel called "Edit Style...". When clicked, this pops up a dialog box that allows the user to edit the overlay style for the current material. The line color, line style, and line width can be edited, both for the "rings" and for the "ranges".

Updated materials panel:
===================
![image](https://user-images.githubusercontent.com/9558430/73092822-4cf9f200-3eab-11ea-9769-352038017635.png)

The overlay style editor:
==================
![image](https://user-images.githubusercontent.com/9558430/73092944-8df20680-3eab-11ea-839a-cb987261ed46.png)

One thing that might be confusing is that "Show Rings", "Show Ranges", and the range spinbox are all global settings for the whole program. But everything else in the panel are local settings for the individual material. Maybe we should make those global settings into local settings as well, and the "Visible" checkbox will be combined with the "Show Rings" checkbox?

What do you think, @joelvbernier?

This addresses part of #92 