### PR TITLE
Allow transform and dark mode to be set per detector

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -75,6 +75,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """
     update_status_bar = Signal(str)
 
+    """Emitted when a new instrument configuration file has been loaded"""
+    instrument_config_loaded = Signal()
+
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)
@@ -305,6 +308,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.backup_instrument_config()
 
         self.update_active_material_energy()
+        self.instrument_config_loaded.emit()
         return self.config['instrument']
 
     def save_instrument_config(self, output_file):

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -40,7 +40,6 @@ class LoadPanel(QObject):
         self.files = []
         self.omega_min = []
         self.omega_max = []
-        self.dark_file = None
         self.idx = 0
         self.ext = ''
 
@@ -50,15 +49,12 @@ class LoadPanel(QObject):
     # Setup GUI
 
     def setup_gui(self):
-        if not HexrdConfig().load_panel_state:
-            HexrdConfig().load_panel_state = {'agg': 0, 'trans': 0, 'dark': 0}
-        self.state = HexrdConfig().load_panel_state
+        self.state = self.setup_processing_options()
 
         self.ui.aggregation.setCurrentIndex(self.state['agg'])
-        self.ui.transform.setCurrentIndex(self.state['trans'])
-        self.ui.darkMode.setCurrentIndex(self.state['dark'])
-        if 'dark_file' in self.state:
-            self.dark_file = self.state['dark_file']
+        self.ui.transform.setCurrentIndex(self.state['trans'][0])
+        self.ui.darkMode.setCurrentIndex(self.state['dark'][0])
+        self.dark_files = self.state['dark_files']
 
         self.dark_mode_changed()
         if not self.parent_dir:
@@ -75,32 +71,44 @@ class LoadPanel(QObject):
         self.ui.read.clicked.connect(self.read_data)
 
         self.ui.darkMode.currentIndexChanged.connect(self.dark_mode_changed)
-        self.ui.detector.currentIndexChanged.connect(self.create_table)
+        self.ui.detector.currentIndexChanged.connect(self.switch_detector)
         self.ui.aggregation.currentIndexChanged.connect(self.agg_changed)
         self.ui.transform.currentIndexChanged.connect(self.trans_changed)
+        self.ui.all_detectors.toggled.connect(self.apply_to_all_changed)
 
         self.ui.file_options.customContextMenuRequested.connect(
             self.contextMenuEvent)
         self.ui.file_options.cellChanged.connect(self.omega_data_changed)
         HexrdConfig().detectors_changed.connect(self.detectors_changed)
 
+    def setup_processing_options(self):
+        num_dets = len(HexrdConfig().get_detector_names())
+        if (not HexrdConfig().load_panel_state
+                or not isinstance(HexrdConfig().load_panel_state['trans'], list)):
+            HexrdConfig().load_panel_state = {
+                'agg': 0,
+                'trans': [0 for x in range(num_dets)],
+                'dark': [0 for x in range(num_dets)],
+                'dark_files': [None for x in range(num_dets)]}
+
+        return HexrdConfig().load_panel_state
+
     # Handle GUI changes
 
     def dark_mode_changed(self):
-        self.state['dark'] = self.ui.darkMode.currentIndex()
+        self.state['dark'][self.idx] = self.ui.darkMode.currentIndex()
 
-        if self.state['dark'] == 4:
+        if self.state['dark'][self.idx] == 4:
             self.ui.selectDark.setEnabled(True)
             self.ui.dark_file.setText(
-                self.dark_file if self.dark_file else '(No File Selected)')
+                self.dark_files[self.idx] if self.dark_files[self.idx] else '(No File Selected)')
             self.enable_read()
         else:
             self.ui.selectDark.setEnabled(False)
             self.ui.dark_file.setText(
                 '(Using ' + str(self.ui.darkMode.currentText()) + ')')
             self.enable_read()
-            if 'dark_file' in self.state:
-                del self.state['dark_file']
+            self.state['dark_files'][self.idx] = None
 
     def detectors_changed(self):
         self.ui.detector.clear()
@@ -110,10 +118,22 @@ class LoadPanel(QObject):
         self.state['agg'] = self.ui.aggregation.currentIndex()
 
     def trans_changed(self):
-        self.state['trans'] = self.ui.transform.currentIndex()
+        self.state['trans'][self.idx] = self.ui.transform.currentIndex()
 
     def dir_changed(self):
         self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
+
+    def switch_detector(self):
+        self.idx = self.ui.detector.currentIndex()
+        if not self.ui.all_detectors.isChecked():
+            self.ui.transform.setCurrentIndex(self.state['trans'][self.idx])
+            self.ui.darkMode.setCurrentIndex(self.state['dark'][self.idx])
+            self.dark_mode_changed()
+        self.create_table()
+
+    def apply_to_all_changed(self, checked):
+        if not checked:
+            self.switch_detector()
 
     def select_folder(self, new_dir=None):
         # This expects to define the root image folder.
@@ -136,8 +156,8 @@ class LoadPanel(QObject):
             self.ui, caption, dir=self.parent_dir)
 
         if selected_file:
-            self.dark_file = selected_file[0]
-            self.state['dark_file'] = self.dark_file
+            self.dark_files[self.idx] = selected_file[0]
+            self.state['dark_files'][self.idx] = self.dark_files[self.idx]
             self.dark_mode_changed()
             self.enable_read()
 
@@ -342,10 +362,10 @@ class LoadPanel(QObject):
     def enable_read(self):
         if (self.ext == '.tiff'
                 or '' not in self.omega_min and '' not in self.omega_max):
-            if self.state['dark'] == 4 and self.dark_file is not None:
+            if self.state['dark'][self.idx] == 4 and self.dark_files is not None:
                 self.ui.read.setEnabled(len(self.files))
                 return
-            elif self.state['dark'] != 4 and len(self.files):
+            elif self.state['dark'][self.idx] != 4 and len(self.files):
                 self.ui.read.setEnabled(True)
                 return
         self.ui.read.setEnabled(False)
@@ -362,7 +382,6 @@ class LoadPanel(QObject):
         else:
             table_files = self.files
 
-        self.idx = self.ui.detector.currentIndex()
         self.ui.file_options.setRowCount(
             len(table_files[self.idx]))
 
@@ -522,57 +541,59 @@ class LoadPanel(QObject):
 
     def apply_operations(self, ims_dict):
         # Apply the operations to the imageseries
-        for key in ims_dict.keys():
+        for idx, key in enumerate(ims_dict.keys()):
+            if self.ui.all_detectors.isChecked():
+                idx = self.idx
             ops = []
-            if self.state['dark'] != 5:
-                if not self.empty_frames and self.state['dark'] == 1:
+            if self.state['dark'][idx] != 5:
+                if not self.empty_frames and self.state['dark'][idx] == 1:
                     msg = ('ERROR: \n No empty frames set. '
                             + 'No dark subtracion will be performed.')
                     QMessageBox.warning(None, 'HEXRD', msg)
                     return
                 else:
-                    self.get_dark_op(ops, ims_dict[key])
+                    self.get_dark_op(ops, ims_dict[key], idx)
 
-            if self.state['trans']:
-                self.get_flip_op(ops)
+            if self.state['trans'][idx]:
+                self.get_flip_op(ops, idx)
 
             frames = self.get_range(ims_dict[key])
 
             ims_dict[key] = imageseries.process.ProcessedImageSeries(
                 ims_dict[key], ops, frame_list=frames)
 
-    def get_dark_op(self, oplist, ims):
+    def get_dark_op(self, oplist, ims, idx):
         # Create or load the dark image if selected
-        if self.state['dark'] != 4:
+        if self.state['dark'][idx] != 4:
             frames = len(ims)
-            if self.state['dark'] == 0:
+            if self.state['dark'][idx] == 0:
                 darkimg = imageseries.stats.median(ims, frames)
-            elif self.state['dark'] == 1:
+            elif self.state['dark'][idx] == 1:
                 darkimg = imageseries.stats.average(ims, self.empty_frames)
-            elif self.state['dark'] == 2:
+            elif self.state['dark'][idx] == 2:
                 darkimg = imageseries.stats.average(ims, frames)
             else:
                 darkimg = imageseries.stats.max(ims, frames)
         else:
             darkimg = imageseries.stats.median(
-                ImageFileManager().open_file(self.dark_file))
+                ImageFileManager().open_file(self.dark_files[idx]))
 
         oplist.append(('dark', darkimg))
 
-    def get_flip_op(self, oplist):
+    def get_flip_op(self, oplist, idx):
         # Change the image orientation
-        if self.state['trans'] == 0:
+        if self.state['trans'][idx] == 0:
             return
 
-        if self.state['trans'] == 1:
+        if self.state['trans'][idx] == 1:
             key = 'v'
-        elif self.state['trans'] == 2:
+        elif self.state['trans'][idx] == 2:
             key = 'h'
-        elif self.state['trans'] == 3:
+        elif self.state['trans'][idx] == 3:
             key = 't'
-        elif self.state['trans'] == 4:
+        elif self.state['trans'][idx] == 4:
             key = 'r90'
-        elif self.state['trans'] == 5:
+        elif self.state['trans'][idx] == 5:
             key = 'r180'
         else:
             key = 'r270'

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -80,6 +80,7 @@ class LoadPanel(QObject):
             self.contextMenuEvent)
         self.ui.file_options.cellChanged.connect(self.omega_data_changed)
         HexrdConfig().detectors_changed.connect(self.detectors_changed)
+        HexrdConfig().instrument_config_loaded.connect(self.config_changed)
 
     def setup_processing_options(self):
         num_dets = len(HexrdConfig().get_detector_names())
@@ -122,6 +123,13 @@ class LoadPanel(QObject):
 
     def dir_changed(self):
         self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
+
+    def config_changed(self):
+        current_state = len(self.state['trans'])
+        num_dets = len(HexrdConfig().get_detector_names())
+        if current_state != num_dets:
+            HexrdConfig().load_panel_state = {}
+            self.setup_processing_options()
 
     def switch_detector(self):
         self.idx = self.ui.detector.currentIndex()

--- a/hexrd/ui/resources/ui/load_panel.ui
+++ b/hexrd/ui/resources/ui/load_panel.ui
@@ -35,54 +35,6 @@
       <property name="spacing">
        <number>0</number>
       </property>
-      <item row="3" column="1">
-       <widget class="QPushButton" name="image_folder">
-        <property name="text">
-         <string>Change Image Folder</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_4">
-        <property name="text">
-         <string>Image Files:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
-       <widget class="QPushButton" name="read">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Read Files</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="aggregation">
-        <item>
-         <property name="text">
-          <string>None</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Maximum</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Median</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>Average</string>
-         </property>
-        </item>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QComboBox" name="transform">
         <item>
@@ -122,10 +74,45 @@
         </item>
        </widget>
       </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Image Files:</string>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>Dark Mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="subdirectories">
+        <property name="text">
+         <string>Use Subdirectories</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="image_files">
+        <property name="text">
+         <string>Select Image Files</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Aggregation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Image Transform:</string>
         </property>
        </widget>
       </item>
@@ -163,10 +150,13 @@
         </item>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label">
+      <item row="4" column="1">
+       <widget class="QPushButton" name="read">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="text">
-         <string>Aggregation:</string>
+         <string>Read Files</string>
         </property>
        </widget>
       </item>
@@ -180,25 +170,35 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
-       <widget class="QPushButton" name="image_files">
+      <item row="3" column="1">
+       <widget class="QPushButton" name="image_folder">
         <property name="text">
-         <string>Select Image Files</string>
+         <string>Change Image Folder</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Image Transform:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0">
-       <widget class="QCheckBox" name="subdirectories">
-        <property name="text">
-         <string>Use Subdirectories</string>
-        </property>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="aggregation">
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Maximum</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Median</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Average</string>
+         </property>
+        </item>
        </widget>
       </item>
      </layout>
@@ -210,26 +210,8 @@
       <string>Multiframe Options</string>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout">
-      <property name="spacing">
-       <number>0</number>
-      </property>
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
-        <property name="spacing">
-         <number>0</number>
-        </property>
         <item>
          <widget class="QLabel" name="label_5">
           <property name="text">
@@ -251,6 +233,26 @@
         </item>
         <item>
          <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="all_detectors">
+          <property name="text">
+           <string>Apply Selections to All Detectors</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="horizontalSpacer_2">
           <property name="orientation">
            <enum>Qt::Horizontal</enum>
           </property>


### PR DESCRIPTION
This adds a checkbox that allows the user to choose whether to apply the selected
transformation and dark mode to all detectors, or to set them per detector. The
default state is per detector.

When selecting per detector, each detector must be changed by selecting the
detector from the drop down menu and then updating the tranformation and/or dark
mode. If left unchanged, that detector will receive the default value. Switching
between detectors will update values accordingly and make it clear which values
will be used for that detector when the files are read in.

When 'Apply Selections to All Detectors' has been selected, the current settings
will be used for all detectors, regardless of which detector is currently
visible. Switching between detectors will display the same transformation and
dark mode selections for all.

Signed-off-by: Brianna Major <brianna.major@kitware.com>