### PR TITLE
Reset index to zero when new files are loaded

### DIFF
--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -64,6 +64,7 @@ class ImageSeriesToolbar(QWidget):
     def update_range(self):
         self.ims = HexrdConfig().imageseries(self.name)
         self.set_range()
+        HexrdConfig().current_imageseries_idx = 0
 
     def set_visible(self, b=False):
         if self.show:


### PR DESCRIPTION
Reset the current index in the series to zero when new files are loaded.