### PR TITLE
Generalize expected file name

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -1,6 +1,7 @@
 import os
 import yaml
 import glob
+import re
 import numpy as np
 
 from hexrd import imageseries
@@ -183,7 +184,10 @@ class LoadPanel(QObject):
                 dets = HexrdConfig().get_detector_names()
                 ext = os.path.splitext(f)[1]
                 if ext.split('.')[1] not in dets:
-                    name = name.rsplit('_', 1)[0]
+                    chunks = re.split(r'[_-]', name)
+                    for det in dets:
+                        if det in chunks:
+                            name = name.replace(det, '')
             if self.ext != '.yml':
                 tmp_ims.append(ImageFileManager().open_file(img))
 
@@ -290,13 +294,13 @@ class LoadPanel(QObject):
             ext = os.path.splitext(item.name)[1]
             det = ext.split('.')[1] if len(ext.split('.')) > 1 else ''
             if det not in dets:
-                fname = file_name.rsplit('_', 1)[0]
-                if fname == file_name:
-                    continue
-                det = file_name.rsplit('_', 1)[1]
-                if det not in dets:
-                    continue
-                file_name = fname
+                chunks = re.split(r'[_-]', file_name)
+                for name in dets:
+                    if name in chunks:
+                        det = name
+                        file_name = file_name.replace(name, '')
+            if det not in dets:
+                continue
             pos = dets.index(det)
             if os.path.isfile(item) and file_name in fnames:
                 self.files[pos].append(item.path)


### PR DESCRIPTION
When selecting files from a single directory, allow for the detector name to be
located anywhere in the file name, or possibly as the file extension. Currently
expects that the file name uses underscores, hyphens, or both as delimeters.

Signed-off-by: Brianna Major <brianna.major@kitware.com>