### PR TITLE
Toggle directory path

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -54,6 +54,9 @@ class LoadPanel(QObject):
             HexrdConfig().load_panel_state = {'agg': 0, 'trans': 0, 'dark': 0}
         self.state = HexrdConfig().load_panel_state
 
+        if 'subdirs' in self.state:
+            self.ui.subdirectories.setChecked(self.state['subdirs'])
+        self.ui.image_folder.setEnabled(self.ui.subdirectories.isChecked())
         self.ui.aggregation.setCurrentIndex(self.state['agg'])
         self.ui.transform.setCurrentIndex(self.state['trans'])
         self.ui.darkMode.setCurrentIndex(self.state['dark'])
@@ -126,6 +129,7 @@ class LoadPanel(QObject):
     def subdirs_changed(self, checked):
         self.dir_changed()
         self.ui.image_folder.setEnabled(checked)
+        self.state['subdirs'] = checked
 
     def select_folder(self, new_dir=None):
         # This expects to define the root image folder.

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -64,7 +64,11 @@ class LoadPanel(QObject):
         if not self.parent_dir:
             self.ui.img_directory.setText('No directory set')
         else:
-            self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
+            if self.ui.subdirectories.isChecked():
+                self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
+            else:
+                self.ui.img_directory.setText(self.parent_dir)
+
         self.detectors_changed()
         self.ui.file_options.resizeColumnsToContents()
 
@@ -73,6 +77,7 @@ class LoadPanel(QObject):
         self.ui.image_files.clicked.connect(self.select_images)
         self.ui.selectDark.clicked.connect(self.select_dark_img)
         self.ui.read.clicked.connect(self.read_data)
+        self.ui.subdirectories.toggled.connect(self.subdirs_changed)
 
         self.ui.darkMode.currentIndexChanged.connect(self.dark_mode_changed)
         self.ui.detector.currentIndexChanged.connect(self.create_table)
@@ -113,7 +118,13 @@ class LoadPanel(QObject):
         self.state['trans'] = self.ui.transform.currentIndex()
 
     def dir_changed(self):
-        self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
+        if self.ui.subdirectories.isChecked():
+            self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
+        else:
+            self.ui.img_directory.setText(self.parent_dir)
+
+    def subdirs_changed(self, checked):
+        self.dir_changed()
 
     def select_folder(self, new_dir=None):
         # This expects to define the root image folder.


### PR DESCRIPTION
If `Use Subdirectories` is selected, the directory path will display the parent directory, otherwise it will display the current directory. Additionally, the `Change Image Folder` will be disabled when not using sub-directories, and the directory will instead be pulled from the file path.

This also adds the status of `Use Subdirectories` to the state file to remember the selection after exiting the program.