### PR TITLE
Limit the number of frames uses for dark stats

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -595,6 +595,8 @@ class LoadPanel(QObject):
         # Create or load the dark image if selected
         if self.state['dark'][idx] != 4:
             frames = len(ims)
+            if frames > 120:
+                frames = 120
             if self.state['dark'][idx] == 0:
                 darkimg = imageseries.stats.median(ims, frames)
             elif self.state['dark'][idx] == 1:


### PR DESCRIPTION
Joel would prefer to truncate at 120 frames max for stats based dark
subtraction for now. We may want to expose this in a UI option in
future.