### PR TITLE
Quick fix for multiple rings

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -128,6 +128,11 @@ class InstrumentViewer:
         for name in materials_list:
             mat = HexrdConfig().material(name)
 
+            if not mat:
+                # FIXME: This shouldn't happen, but it is
+                # This is a quick fix...
+                continue
+
             rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData)
 
             self.ring_data[name] = {

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -123,6 +123,11 @@ class InstrumentViewer:
         for name in materials_list:
             mat = HexrdConfig().material(name)
 
+            if not mat:
+                # FIXME: This shouldn't happen, but it is
+                # This is a quick fix...
+                continue
+
             rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData)
 
             self.ring_data[name] = {


### PR DESCRIPTION
This appears to happen if the user adds a new material, makes it visible, then exits the application and starts it up again.

The root problem is that the visible materials list is keeping the new material in it, but when you start the program back up, it is not a material in hexrd anymore. We should keep the visible materials list in sync with the materials in hexrd.