### PR TITLE
Ensure visible materials exist

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -129,8 +129,9 @@ class InstrumentViewer:
             mat = HexrdConfig().material(name)
 
             if not mat:
-                # FIXME: This shouldn't happen, but it is
-                # This is a quick fix...
+                # Print a warning, as this shouldn't happen
+                print('Warning in InstrumentViewer.add_rings():',
+                      name, 'is not a valid material')
                 continue
 
             rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData)

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -124,8 +124,9 @@ class InstrumentViewer:
             mat = HexrdConfig().material(name)
 
             if not mat:
-                # FIXME: This shouldn't happen, but it is
-                # This is a quick fix...
+                # Print a warning, as this shouldn't happen
+                print('Warning in InstrumentViewer.add_rings():',
+                      name, 'is not a valid material')
                 continue
 
             rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -710,6 +710,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
             pd_wavelength = material.planeData.get_wavelength()
             material._beamEnergy = constants.WAVELENGTH_TO_KEV / pd_wavelength
 
+        # Make sure all materials on the visible materials list exist
+        material_names = materials.keys()
+        self.visible_material_names = [
+            x for x in self.visible_material_names if x in material_names]
+
         self.materials = materials
 
     def add_material(self, name, material):


### PR DESCRIPTION
This adds a check when loading new materials to update the visible
materials list, to ensure that the members of the visible materials
list actually exist.

This also keeps in the previous safety check and adds a warning so
that we can see if this problem occurs again.