### PR TITLE
Sync up materials' plane data with the materials panel options

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -76,10 +76,6 @@ class InstrumentViewer:
             # If it's empty, select all rings
             rings_to_use = list(range(len(all_tths)))
 
-        if HexrdConfig().limit_active_rings:
-            max_tth = HexrdConfig().rings_max_bragg_angle * 2.0
-            rings_to_use = [i for i in rings_to_use if all_tths[i] <= max_tth]
-
         if HexrdConfig().show_rings:
             # Update the tth list with the rings to use
             tth_list = [all_tths[i] for i in rings_to_use]

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -77,10 +77,6 @@ class InstrumentViewer:
             # If it's empty, select all rings
             rings_to_use = list(range(len(all_tths)))
 
-        if HexrdConfig().limit_active_rings:
-            max_tth = HexrdConfig().rings_max_bragg_angle * 2.0
-            rings_to_use = [i for i in rings_to_use if all_tths[i] <= max_tth]
-
         if HexrdConfig().show_rings:
             dp = self.dpanel
 

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -6,7 +6,6 @@ from .polarview import PolarView
 from .display_plane import DisplayPlane
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.utils import select_merged_rings
 
 
 def polar_viewer():
@@ -71,27 +70,16 @@ class InstrumentViewer:
         rbnds = []
         rbnd_indices = []
 
-        all_tths = plane_data.getTTh()
-        rings_to_use = HexrdConfig().selected_rings
-        if not rings_to_use:
-            # If it's empty, select all rings
-            rings_to_use = list(range(len(all_tths)))
+        # If there are no rings, there is nothing to do
+        if len(plane_data.getTTh()) == 0:
+            return rings, rbnds, rbnd_indices
 
         if HexrdConfig().show_rings:
-            dp = self.dpanel
-
-            # Update the tth list with the rings to use
-            tth_list = [all_tths[i] for i in rings_to_use]
-
-            for tth in np.degrees(tth_list):
+            for tth in np.degrees(plane_data.getTTh()):
                 rings.append(np.array([[-180, tth], [180, tth]]))
 
         if HexrdConfig().show_ring_ranges:
             indices, ranges = plane_data.getMergedRanges()
-
-            # This ensures the correct ranges are selected
-            indices, ranges = select_merged_rings(rings_to_use, indices,
-                                                  ranges)
 
             for ind, r in zip(indices, np.degrees(ranges)):
                 rbnds.append(np.array([[-180, r[0]],
@@ -107,13 +95,7 @@ class InstrumentViewer:
     def add_rings(self):
         self.clear_rings()
 
-        materials_list = HexrdConfig().visible_material_names
-        if HexrdConfig().selected_rings:
-            # Only show the active material, if it is part of the list
-            active = HexrdConfig().active_material_name
-            materials_list = [active] if active in materials_list else []
-
-        for name in materials_list:
+        for name in HexrdConfig().visible_material_names:
             mat = HexrdConfig().material(name)
 
             if not mat:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -883,15 +883,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
     visible_material_names = property(_visible_material_names,
                                       _set_visible_material_names)
 
-    def _selected_rings(self):
-        return self.config['materials'].get('selected_rings')
-
-    def _set_selected_rings(self, rings):
-        self.config['materials']['selected_rings'] = rings
-        self.ring_config_changed.emit()
-
-    selected_rings = property(_selected_rings, _set_selected_rings)
-
     def _active_material_tth_max(self):
         return self.active_material.planeData.tThMax
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -100,6 +100,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.load_panel_state = None
         self.polar_masks = []
         self.ring_styles = {}
+        self.backup_tth_maxes = {}
 
         self.set_euler_angle_convention('xyz', True, convert_config=False)
 
@@ -161,8 +162,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
         settings.setValue('ring_styles', self.ring_styles)
         settings.setValue('visible_material_names',
                           self.visible_material_names)
-        settings.setValue('rings_max_bragg_angle', self.rings_max_bragg_angle)
-        settings.setValue('limit_active_rings', self.limit_active_rings)
 
     def load_settings(self):
         settings = QSettings()
@@ -180,10 +179,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.collapsed_state = settings.value('collapsed_state', [])
         self.load_panel_state = settings.value('load_panel_state', None)
         self.ring_styles = settings.value('ring_styles', {})
-        self.rings_max_bragg_angle = float(
-            settings.value('rings_max_bragg_angle', 1.0))
-        self.limit_active_rings = bool(
-            settings.value('limit_active_rings', False) == 'true')
 
         # Set this manually since we don't have any materials yet
         key = 'visible_material_names'
@@ -807,10 +802,19 @@ class HexrdConfig(QObject, metaclass=Singleton):
     def active_material_name(self):
         return self.config['materials'].get('active_material')
 
+    @property
+    def beam_energy(self):
+        cfg = self.config['instrument']
+        return cfg.get('beam', {}).get('energy', {}).get('value')
+
+    @property
+    def beam_wavelength(self):
+        energy = self.beam_energy
+        return constants.KEV_TO_WAVELENGTH / energy if energy else None
+
     def update_material_energy(self, mat):
         # This is a potentially expensive operation...
-        cfg = self.config['instrument']
-        energy = cfg.get('beam', {}).get('energy', {}).get('value')
+        energy = self.beam_energy
 
         # If the plane data energy already matches, skip it
         pd_wavelength = mat.planeData.get_wavelength()
@@ -888,34 +892,41 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
     selected_rings = property(_selected_rings, _set_selected_rings)
 
-    def _rings_max_bragg_angle(self):
-        return self.config['materials'].setdefault('max_bragg_angle', 1.0)
+    def _active_material_tth_max(self):
+        return self.active_material.planeData.tThMax
 
-    def set_rings_max_bragg_angle(self, v):
-        if v != self.rings_max_bragg_angle:
-            self.config['materials']['max_bragg_angle'] = v
+    def _set_active_material_tth_max(self, v):
+        if v != self.active_material_tth_max:
+            if v is None:
+                self.backup_tth_max = self.active_material_tth_max
+
+            self.active_material.planeData.tThMax = v
             self.ring_config_changed.emit()
 
-    rings_max_bragg_angle = property(_rings_max_bragg_angle,
-                                     set_rings_max_bragg_angle)
+    active_material_tth_max = property(_active_material_tth_max,
+                                       _set_active_material_tth_max)
 
-    @property
-    def rings_min_d_spacing(self):
-        # This is a read-only property, as it is calculated from the
-        # max bragg angle.
-        # Any material should have an up-to-date wavelength.
-        wavelength = self.active_material.planeData.get_wavelength()
-        return wavelength / (2.0 * math.sin(self.rings_max_bragg_angle))
+    def _backup_tth_max(self):
+        return self.backup_tth_maxes.setdefault(self.active_material_name, 1.0)
+
+    def _set_backup_tth_max(self, v):
+        self.backup_tth_maxes[self.active_material_name] = v
+
+    backup_tth_max = property(_backup_tth_max, _set_backup_tth_max)
 
     def _limit_active_rings(self):
-        return self.config['materials'].setdefault('limit_active_rings', False)
+        return self.active_material_tth_max is not None
 
     def set_limit_active_rings(self, v):
+        # This will restore the backup of tth max, or set tth max to None
         if v != self.limit_active_rings:
-            self.config['materials']['limit_active_rings'] = v
-            self.ring_config_changed.emit()
+            if v:
+                self.active_material_tth_max = self.backup_tth_max
+            else:
+                self.active_material_tth_max = None
 
-    limit_active_rings = property(_limit_active_rings, set_limit_active_rings)
+    limit_active_rings = property(_limit_active_rings,
+                                  set_limit_active_rings)
 
     def _show_rings(self):
         return self.config['materials'].get('show_rings')

--- a/hexrd/ui/material_editor_widget.py
+++ b/hexrd/ui/material_editor_widget.py
@@ -4,7 +4,6 @@ from hexrd import spacegroup
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
-from hexrd.ui import utils
 
 
 class MaterialEditorWidget(QObject):
@@ -20,7 +19,8 @@ class MaterialEditorWidget(QObject):
 
         self.setup_space_group_widgets()
 
-        self.material = material
+        self._material = material
+        self.update_gui_from_material()
 
         self.setup_connections()
 
@@ -149,7 +149,6 @@ class MaterialEditorWidget(QObject):
         # already equal before setting.
         if self.material.sgnum != sgid:
             self.material.sgnum = sgid
-            utils.fix_exclusions(self.material)
             self.material_modified.emit()
 
     def set_max_hkl(self):
@@ -158,7 +157,6 @@ class MaterialEditorWidget(QObject):
         val = self.ui.max_hkl.value()
         if self.material.hklMax != val:
             self.material.hklMax = val
-            utils.fix_exclusions(self.material)
             self.material_modified.emit()
 
     @property
@@ -167,5 +165,6 @@ class MaterialEditorWidget(QObject):
 
     @material.setter
     def material(self, m):
-        self._material = m
-        self.update_gui_from_material()
+        if m != self.material:
+            self._material = m
+            self.update_gui_from_material()

--- a/hexrd/ui/resources/materials/materials_panel_defaults.yml
+++ b/hexrd/ui/resources/materials/materials_panel_defaults.yml
@@ -1,5 +1,4 @@
 active_material: 'ceo2'
-selected_rings: []
 show_rings: true
 show_ring_ranges: false
 ring_ranges: 0.125

--- a/hexrd/ui/resources/materials/materials_panel_defaults.yml
+++ b/hexrd/ui/resources/materials/materials_panel_defaults.yml
@@ -3,5 +3,3 @@ selected_rings: []
 show_rings: true
 show_ring_ranges: false
 ring_ranges: 0.125
-max_bragg_angle: 1.0
-limit_active_rings: false

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -61,19 +61,12 @@ def convert_tilt_convention(iconfig, old_convention,
         _set_tilt_array(tilts, np.array(rme.angles).tolist())
 
 
-def fix_exclusions(mat):
-    # The default is to exclude all hkl's after the 5th one.
-    # (See Material._newPdata() for more info)
-    # Let's not do this...
-    excl = [False] * len(mat.planeData.exclusions)
-    mat.planeData.exclusions = excl
-
-
 def make_new_pdata(mat):
     # This generates new PlaneData for a material
-    # It also fixes the exclusions (see fix_exclusions() for details)
+    # This also preserves the previous exclusions of the plane data
+    prev_exclusions = mat.planeData.exclusions
     mat._newPdata()
-    fix_exclusions(mat)
+    mat.planeData.exclusions = prev_exclusions
 
 
 def coords2index(im, x, y):
@@ -105,24 +98,6 @@ def coords2index(im, x, y):
              mtransforms.BboxTransformTo(array_extent))
 
     return trans.transform_point([y, x]).astype(int)
-
-
-def select_merged_rings(selected_rings, indices, ranges):
-    """Select indices and ranges for merged rings
-
-    This utility function filters the indices and ranges and returns
-    new (indices, ranges) that were selected in the selected_rings.
-    """
-    new_indices = []
-    new_ranges = []
-    for ring in selected_rings:
-        for i, entry in enumerate(indices):
-            if ring in entry:
-                new_indices.append(entry)
-                new_ranges.append(ranges[i])
-                break
-
-    return new_indices, new_ranges
 
 
 def snip_width_pixels():


### PR DESCRIPTION
Previously, the materials panel only stored its configuration internally to hexrdgui, and it did not change options on the materials' plane data.

This update intends to change that, so that modifying things in the materials panel will produce correct calibrations.

So far, this PR only syncs up the maxtTh, which is why it is a draft. One more commit is intended, which will modify materials' exclusions when the selections in the materials panel change.

Fixes: #107
Fixes: #235
Fixes: #237