### PR TITLE
Always clear saturation text before another is shown

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -208,18 +208,17 @@ class ImageCanvas(FigureCanvas):
         self.draw()
 
     def show_saturation(self):
+        self.clear_saturation()
+
         # Do not proceed without config approval
         if not HexrdConfig().show_saturation_level:
-            self.clear_saturation()
             return
 
         if not self.axes_images:
-            self.clear_saturation()
             return
 
         # Do not show the saturation in calibration mode
         if self.mode == 'cartesian' or self.mode == 'polar':
-            self.clear_saturation()
             return
 
         for img in self.axes_images:


### PR DESCRIPTION
This fixes a problem where, if files are opened more than one time
during a single run, the old saturation text doesn't get cleared
before the new one gets placed on top of it.

This makes it so that the saturation text is always cleared before
the next saturation text gets drawn.

Fixes: #234