### PR TITLE
Plot detector borders on top of the image

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -43,6 +43,7 @@ class InstrumentViewer:
         self.images_dict = images_dict
         self.pixel_size = pixel_size
         self.warp_dict = {}
+        self.detector_corners = {}
 
         dist = HexrdConfig().cartesian_virtual_plane_distance
         dplane_tvec = np.array([0., 0., -dist])
@@ -141,19 +142,93 @@ class InstrumentViewer:
         # Generate the final image
         self.generate_image()
 
+    def detector_borders(self, det):
+        corners = self.detector_corners.get(det, [])
+        x_vals = [x[0] for x in corners]
+        y_vals = [x[1] for x in corners]
+
+        if x_vals and y_vals:
+            # Double each set of points.
+            # This is so that if a point is moved, it won't affect the
+            # other line sharing this point.
+            x_vals = [x for x in x_vals for _ in (0, 1)]
+            y_vals = [y for y in y_vals for _ in (0, 1)]
+
+            # Move the first point to the back to complete the line
+            x_vals += [x_vals.pop(0)]
+            y_vals += [y_vals.pop(0)]
+
+            # Make sure all points are inside the frame.
+            # If there are points outside the frame, move them inside.
+            x_range = (0, self.dpanel.cols)
+            y_range = (0, self.dpanel.rows)
+
+            def out_of_frame(p):
+                # Check if point p is out of the frame
+                return (not x_range[0] <= p[0] <= x_range[1] or
+                        not y_range[0] <= p[1] <= y_range[1])
+
+            def move_point_into_frame(p, p2):
+                # Make sure we don't divide by zero
+                if p2[0] == p[0]:
+                    return
+
+                # Move point p into the frame via its line equation
+                # y = mx + b
+                m = (p2[1] - p[1]) / (p2[0] - p[0])
+                b = p[1] - m * p[0]
+                if p[0] < x_range[0]:
+                    p[0] = x_range[0]
+                    p[1] = m * p[0] + b
+                elif p[0] > x_range[1]:
+                    p[0] = x_range[1]
+                    p[1] = m * p[0] + b
+
+                if p[1] < y_range[0]:
+                    p[1] = y_range[0]
+                    p[0] = (p[1] - b) / m
+                elif p[1] > y_range[1]:
+                    p[1] = y_range[1]
+                    p[0] = (p[1] - b) / m
+
+            i = 0
+            while i < len(x_vals) - 1:
+                # We look at pairs of points at a time
+                p1 = [x_vals[i], y_vals[i]]
+                p2 = [x_vals[i + 1], y_vals[i + 1]]
+
+                if out_of_frame(p1):
+                    # Move the point into the frame via its line equation
+                    move_point_into_frame(p1, p2)
+                    x_vals[i], y_vals[i] = p1[0], p1[1]
+
+                    # Insert a pair of Nones to disconnect the drawing
+                    x_vals.insert(i, None)
+                    y_vals.insert(i, None)
+                    i += 1
+
+                if out_of_frame(p2):
+                    # Move the point into the frame via its line equation
+                    move_point_into_frame(p2, p1)
+                    x_vals[i + 1], y_vals[i + 1] = p2[0], p2[1]
+
+                i += 2
+
+        # The border drawer expects a list of lines.
+        # We only have one line here.
+        return [(x_vals, y_vals)]
+
+    @property
+    def all_detector_borders(self):
+        borders = {}
+        for det in self.images_dict.keys():
+            borders[det] = self.detector_borders(det)
+
+        return borders
+
     def create_warped_image(self, detector_id):
         img = self.images_dict[detector_id]
         panel = self.instr._detectors[detector_id]
-
-        if HexrdConfig().show_detector_borders:
-            # Draw a border around the detector panel
-            max_int = np.percentile(img, 99.95)
-            # 0.5% is big enough for cartesian mode
-            pbuf = int(0.005 * np.mean(img.shape))
-            img[:, :pbuf] = max_int
-            img[:, -pbuf:] = max_int
-            img[:pbuf, :] = max_int
-            img[-pbuf:, :] = max_int
 
         # map corners
         corners = np.vstack(
@@ -172,6 +247,8 @@ class InstrumentViewer:
         i_row = cellIndices(row_edges, mp[:, 1])
 
         src = np.vstack([j_col, i_row]).T
+        self.detector_corners[detector_id] = src
+
         dst = panel.cartToPixel(corners, pixels=True)
         dst = dst[:, ::-1]
 

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -47,6 +47,10 @@ class InstrumentViewer:
                                                 self.pixel_size)
 
     @property
+    def all_detector_borders(self):
+        return self.pv.all_detector_borders
+
+    @property
     def angular_grid(self):
         return self.pv.angular_grid
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -59,10 +59,14 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when a detector's transform is modified"""
     detector_transform_modified = Signal(str)
 
+    """Emitted when detector borders need to be re-rendered"""
+    rerender_detector_borders = Signal()
+
     """Emitted for any config changes EXCEPT detector transform changes
 
     Indicates that the image needs to be re-drawn from scratch.
 
+    Note that this does not do anything if "Show Live Updates" is off.
     """
     rerender_needed = Signal()
 
@@ -1143,8 +1147,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return self.config['image']['show_detector_borders']
 
     def set_show_detector_borders(self, v):
-        self.config['image']['show_detector_borders'] = v
-        self.rerender_needed.emit()
+        if v != self.show_detector_borders:
+            self.config['image']['show_detector_borders'] = v
+            self.rerender_detector_borders.emit()
 
     @property
     def colormap_min(self):


### PR DESCRIPTION
Previously, if "View" -> "Show Detector Borders" was checked, the
cartesian and polar images would be modified, with the detector borders
drawn in as the max pixel values. This meant that the borders would
affect the azimuthal integration plot in the polar plot.

Rather than drawing the detector borders into the images, plot them as
separate lines on top of the images. This way, the images and the
azimuthal integration plot are not affected by their presence.

This seems to work well, although drawing the detector borders for the
polar plot is time consuming. We are using
[hexrd.instrument.PlanarDetector.pixel_angles()](https://github.com/HEXRD/hexrd/blob/79ebd31e43ca4b96a7cad60ff61ff2cc4fb14fba/hexrd/instrument.py#L1636)
for this, and it appears to be slowing down the generation of the polar
plot by a lot. It would be good to figure out a way to get the polar
detector borders faster. The `pixel_angles()` function generates and
returns a lot of values we don't need (we only extract the first and
last rows/columns from the output). Maybe we can make a new function
that only generates the detector border values.

The drawing of the Cartesian borders seems to be fast, and it remains
very interactive with the slider widgets.

Some images of the new detector borders in action are here:
![cartesian](https://user-images.githubusercontent.com/9558430/73865210-e9f44d80-4810-11ea-9bea-48b6fa137a1d.png)
![polar](https://user-images.githubusercontent.com/9558430/73865212-e9f44d80-4810-11ea-99f9-5e51b3904ed0.png)

Fixes: #163