### PR TITLE
Add button to hide all materials

### DIFF
--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -72,6 +72,7 @@ class MaterialsPanel(QObject):
             self.on_min_d_spacing_changed)
 
         self.ui.edit_style_button.pressed.connect(self.edit_overlay_style)
+        self.ui.hide_all.pressed.connect(self.hide_all_materials)
 
         self.ui.material_visible.toggled.connect(
             self.material_visibility_toggled)
@@ -326,3 +327,7 @@ class MaterialsPanel(QObject):
         visible = self.ui.material_visible.isChecked()
         name = self.current_material()
         HexrdConfig().set_material_visibility(name, visible)
+
+    def hide_all_materials(self):
+        # This clears the list
+        HexrdConfig().visible_material_names = []

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -342,6 +342,13 @@
        </property>
       </spacer>
      </item>
+     <item row="0" column="5">
+      <widget class="QPushButton" name="hide_all">
+       <property name="text">
+        <string>Hide All</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -352,6 +359,7 @@
   <tabstop>materials_table</tabstop>
   <tabstop>material_visible</tabstop>
   <tabstop>edit_style_button</tabstop>
+  <tabstop>hide_all</tabstop>
   <tabstop>show_rings</tabstop>
   <tabstop>show_ranges</tabstop>
   <tabstop>tth_ranges</tabstop>


### PR DESCRIPTION
The "Hide All" button in the materials panel clears the visible
materials list, and makes all materials not visible.

Below is what the bottom of the materials panel looks like. We may want to re-design it at some point, since some of the widgets control global settings ("Show Rings", "Show Ranges", and the range width), and some of the widgets control individual materials settings (most other widgets).

![Screenshot from 2020-02-10 06-45-22](https://user-images.githubusercontent.com/9558430/74147317-f3930200-4bd0-11ea-8d44-85e6e08084d3.png)

Addresses part of [this comment](https://github.com/HEXRD/hexrdgui/issues/92#issuecomment-583136373) in #92.