### PR TITLE
Remove "Apply Erosion?" checkbox, as it is unused

### DIFF
--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>409</width>
     <height>138</height>
    </rect>
   </property>
@@ -563,16 +563,6 @@
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QCheckBox" name="polar_apply_erosion">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="text">
-                 <string>Apply erosion?</string>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
This feature was removed earlier. The checkbox is not
connected to anything, and does not actually do anything.
Remove it from the polar view tab settings.