### PR TITLE
Remove dead code

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -567,9 +567,6 @@ class LoadPanel(QObject):
 
     def finish_processing_ims(self):
         # Display processed images on completion
-        # The setEnabled options will not be needed once the panel
-        # is complete - those dialogs will be removed.
-        self.parent().action_edit_angles.setEnabled(True)
         self.parent().image_tab_widget.load_images()
         self.new_images_loaded.emit()
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -122,7 +122,6 @@ class MainWindow(QObject):
         self.ui.action_calibration_line_picker.triggered.connect(
             self.on_action_calibration_line_picker_triggered)
         self.load_widget.new_images_loaded.connect(self.new_images_loaded)
-        self.new_images_loaded.connect(self.enable_editing_ims)
         self.new_images_loaded.connect(self.color_map_editor.update_bounds)
         self.ui.image_tab_widget.update_needed.connect(self.update_all)
         self.ui.image_tab_widget.new_mouse_position.connect(
@@ -222,8 +221,6 @@ class MainWindow(QObject):
             if dialog.exec_():
                 detector_names, image_files = dialog.results()
                 ImageFileManager().load_images(detector_names, image_files)
-                self.ui.action_edit_ims.setEnabled(True)
-                self.ui.action_edit_angles.setEnabled(True)
                 self.update_all()
                 self.new_images_loaded.emit()
 
@@ -242,8 +239,6 @@ class MainWindow(QObject):
             images_dir = os.path.dirname(d)
 
         ImageFileManager().load_aps_imageseries(detector_names, selected_dirs)
-        self.ui.action_edit_ims.setEnabled(True)
-        self.ui.action_edit_angles.setEnabled(True)
         self.update_all()
         self.new_images_loaded.emit()
 
@@ -362,9 +357,6 @@ class MainWindow(QObject):
         print('Updating the GUI')
         self.update_config_gui()
         self.update_all()
-
-    def enable_editing_ims(self):
-        self.ui.action_edit_ims.setEnabled(HexrdConfig().has_images())
 
     def on_action_edit_euler_angle_convention(self):
         allowed_conventions = [

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -364,14 +364,6 @@
     <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Show the saturation percentages of the images when in &amp;quot;Image View&amp;quot; mode. The saturation percentages will appear as white text in the bottom left corners of the images.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
    </property>
   </action>
-  <action name="action_edit_ims">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Process Image Series</string>
-   </property>
-  </action>
   <action name="action_save_materials">
    <property name="text">
     <string>&amp;Materials</string>
@@ -385,14 +377,6 @@
   <action name="action_edit_euler_angle_convention">
    <property name="text">
     <string>Euler Angle &amp;Convention</string>
-   </property>
-  </action>
-  <action name="action_edit_angles">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>&amp;Edit Angles</string>
    </property>
   </action>
   <action name="action_open_aps_imageseries">


### PR DESCRIPTION
Some code remained from before all the image loading had been combined into one
panel. Remove dead and unused code.

Signed-off-by: Brianna Major <brianna.major@kitware.com>