### PR TITLE
Clear images when a new configuration is loaded

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -309,6 +309,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
         hexrd.imageseries.save.write(ims, write_file, selected_format,
                                      **kwargs)
 
+    def clear_images(self):
+        self.imageseries_dict = {}
+        self.hdf5_path = None
+        self.load_panel_state = {}
+
     def load_instrument_config(self, yml_file):
         with open(yml_file, 'r') as f:
             self.config['instrument'] = yaml.load(f, Loader=yaml.FullLoader)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -315,6 +315,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.load_panel_state = {}
 
     def load_instrument_config(self, yml_file):
+        old_detectors = self.get_detector_names()
         with open(yml_file, 'r') as f:
             self.config['instrument'] = yaml.load(f, Loader=yaml.FullLoader)
 
@@ -333,7 +334,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.backup_instrument_config()
 
         self.update_visible_material_energies()
-        self.instrument_config_loaded.emit()
+
+        new_detectors = self.get_detector_names()
+        if old_detectors != new_detectors:
+            self.instrument_config_loaded.emit()
+
         return self.config['instrument']
 
     def save_instrument_config(self, output_file):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -76,9 +76,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """
     update_status_bar = Signal(str)
 
-    """Emitted when a new instrument configuration file has been loaded"""
-    instrument_config_loaded = Signal()
-
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)
@@ -337,7 +334,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         new_detectors = self.get_detector_names()
         if old_detectors != new_detectors:
-            self.instrument_config_loaded.emit()
+            self.detectors_changed.emit()
 
         return self.config['instrument']
 

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -147,8 +147,9 @@ class LoadPanel(QObject):
         self.ui.file_options.setRowCount(0)
         self.reset_data()
         self.enable_read()
-        HexrdConfig().load_panel_state = {}
-        self.state = self.setup_processing_options()
+        HexrdConfig().clear_images()
+        self.setup_gui()
+        self.parent().image_tab_widget.load_images()
 
     def switch_detector(self):
         self.idx = self.ui.detector.currentIndex()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -89,7 +89,7 @@ class LoadPanel(QObject):
         self.ui.file_options.customContextMenuRequested.connect(
             self.contextMenuEvent)
         self.ui.file_options.cellChanged.connect(self.omega_data_changed)
-        HexrdConfig().detectors_changed.connect(self.detectors_changed)
+        HexrdConfig().detectors_changed.connect(self.config_changed)
         HexrdConfig().instrument_config_loaded.connect(self.config_changed)
 
     def setup_processing_options(self):

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -90,7 +90,6 @@ class LoadPanel(QObject):
             self.contextMenuEvent)
         self.ui.file_options.cellChanged.connect(self.omega_data_changed)
         HexrdConfig().detectors_changed.connect(self.config_changed)
-        HexrdConfig().instrument_config_loaded.connect(self.config_changed)
 
     def setup_processing_options(self):
         num_dets = len(HexrdConfig().get_detector_names())

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -148,7 +148,6 @@ class LoadPanel(QObject):
         self.enable_read()
         HexrdConfig().clear_images()
         self.setup_gui()
-        self.parent().image_tab_widget.load_images()
 
     def switch_detector(self):
         self.idx = self.ui.detector.currentIndex()


### PR DESCRIPTION
When a new configuration file is loaded, remove any loaded images and reset the
load panel editing options.

Signed-off-by: Brianna Major <brianna.major@kitware.com>