### PR TITLE
Remember un-aggregated images

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -304,8 +304,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         return ret
 
-    def save_imageseries(self, name, write_file, selected_format, **kwargs):
-        ims = self.imageseries(name)
+    def save_imageseries(self, ims, name, write_file, selected_format, **kwargs):
         hexrd.imageseries.save.write(ims, write_file, selected_format,
                                      **kwargs)
 

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -3,6 +3,7 @@ import yaml
 import glob
 import re
 import numpy as np
+import copy
 
 from hexrd import imageseries
 
@@ -36,7 +37,8 @@ class LoadPanel(QObject):
         self.ui = loader.load_file('load_panel.ui', parent)
 
         self.ims = HexrdConfig().imageseries_dict
-        self.parent_dir = HexrdConfig().images_dir
+        self.parent_dir = HexrdConfig().images_dir if HexrdConfig().images_dir else ''
+        self.unaggregated_images = None
 
         self.files = []
         self.omega_min = []
@@ -127,6 +129,8 @@ class LoadPanel(QObject):
 
     def agg_changed(self):
         self.state['agg'] = self.ui.aggregation.currentIndex()
+        if self.ui.aggregation.currentIndex() == 0:
+            self.unaggregated_images = None
 
     def trans_changed(self):
         self.state['trans'][self.idx] = self.ui.transform.currentIndex()
@@ -643,6 +647,9 @@ class LoadPanel(QObject):
             return range(self.empty_frames, len(ims))
 
     def display_aggregation(self, ims_dict):
+        # Remember unaggregated images
+        self.unaggregated_images = copy.copy(ims_dict)
+
         # Display aggregated image from imageseries
         for key in ims_dict.keys():
             if self.state['agg'] == 1:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -262,9 +262,14 @@ class MainWindow(QObject):
             QMessageBox.warning(self.ui, 'HEXRD', msg)
             return
 
-        if len(HexrdConfig().imageseries_dict) > 1:
+        if self.load_widget.unaggregated_images:
+            ims_dict = self.load_widget.unaggregated_images
+        else:
+            ims_dict = HexrdConfig().imageseries_dict
+
+        if len(ims_dict) > 1:
             # Have the user choose an imageseries to save
-            names = list(HexrdConfig().imageseries_dict.keys())
+            names = list(ims_dict.keys())
             name, ok = QInputDialog.getItem(self.ui, 'HEXRD',
                                             'Select ImageSeries', names, 0,
                                             False)
@@ -272,7 +277,7 @@ class MainWindow(QObject):
                 # User canceled...
                 return
         else:
-            name = list(HexrdConfig().imageseries_dict.keys())[0]
+            name = list(ims_dict.keys())[0]
 
         selected_file, selected_filter = QFileDialog.getSaveFileName(
             self.ui, 'Save ImageSeries', HexrdConfig().working_dir,
@@ -303,7 +308,7 @@ class MainWindow(QObject):
                 # to be the same as the file name...
                 kwargs['cache_file'] = selected_file
 
-            HexrdConfig().save_imageseries(name, selected_file,
+            HexrdConfig().save_imageseries(ims_dict.get(name), name, selected_file,
                                            selected_format, **kwargs)
 
     def on_action_save_materials_triggered(self):


### PR DESCRIPTION
When saving an ImageSeries, use the un-aggregated images. When displaying
aggregated images, remember the processed but un-aggregated ImageSeries.

Signed-off-by: Brianna Major <brianna.major@kitware.com>