### PR TITLE
Convert borders to degrees in a better location

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -137,10 +137,9 @@ class PolarView(object):
                 border, panel.rmat, ct.identity_3x3,
                 panel.tvec, ct.zeros_3, ct.zeros_3,
                 beamVec=panel.bvec, etaVec=panel.evec)
-            borders[i] = angles
-
-        # Convert to degrees. Keep as a list for easier modifications.
-        borders = np.degrees(borders).tolist()
+            # Convert to degrees, and keep them as lists for
+            # easier modification later
+            borders[i] = np.degrees(angles).tolist()
 
         # Here, we are going to remove points that are out-of-bounds,
         # and we are going to insert None in between points that are far


### PR DESCRIPTION
For the dexela instrument, I would be getting this error when
trying to draw the polar borders:

```
AttributeError: 'numpy.ndarray' object has no attribute 'degrees'
```

I'm not sure what was causing the error, but it was happening at
`np.degrees(borders)` where borders was a list of tuples of
np.ndarray objects.

It seems that the error does not occur if we convert to degrees
earlier, so let's just do that instead.