### PR TITLE
Display dummy images when no images are loaded

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -311,9 +311,10 @@ class HexrdConfig(QObject, metaclass=Singleton):
                                      **kwargs)
 
     def clear_images(self):
-        self.imageseries_dict = {}
+        self.imageseries_dict.clear()
         self.hdf5_path = None
-        self.load_panel_state = {}
+        if self.load_panel_state is not None:
+            self.load_panel_state.clear()
 
     def load_instrument_config(self, yml_file):
         old_detectors = self.get_detector_names()

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -1,4 +1,5 @@
 import os
+import numpy as np
 import tempfile
 import yaml
 
@@ -31,6 +32,18 @@ class ImageFileManager(metaclass=Singleton):
 
         self.remember = True
         self.path = []
+
+    def load_dummy_images(self):
+        HexrdConfig().imageseries_dict.clear()
+        detectors = HexrdConfig().get_detector_names()
+        iconfig = HexrdConfig().instrument_config
+        for det in detectors:
+            cols = iconfig['detectors'][det]['pixels']['columns']
+            rows = iconfig['detectors'][det]['pixels']['rows']
+            shape = (rows, cols)
+            data = np.ones(shape, dtype=np.uint8)
+            ims = imageseries.open(None, 'array', data=data)
+            HexrdConfig().imageseries_dict[det] = ims
 
     def load_images(self, detectors, file_names):
         HexrdConfig().imageseries_dict.clear()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -35,7 +35,6 @@ class LoadPanel(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('load_panel.ui', parent)
 
-        self.ims = HexrdConfig().imageseries_dict
         self.parent_dir = HexrdConfig().images_dir
 
         self.files = []

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -18,7 +18,7 @@ def main():
     app = QApplication(sys.argv)
 
     window = MainWindow()
-    window.ui.show()
+    window.show()
 
     sys.exit(app.exec_())
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -82,7 +82,7 @@ class MainWindow(QObject):
 
         self.setup_connections()
 
-        self.calibration_config_widget.update_gui_from_config()
+        self.update_config_gui()
 
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
         self.live_update(HexrdConfig().live_update)
@@ -165,8 +165,7 @@ class MainWindow(QObject):
 
         if selected_file:
             HexrdConfig().load_instrument_config(selected_file)
-            self.cal_tree_view.rebuild_tree()
-            self.calibration_config_widget.update_gui_from_config()
+            self.update_config_gui()
             self.update_all(clear_canvases=True)
 
     def on_action_save_config_triggered(self):


### PR DESCRIPTION
When there are no images loaded, which happens either at the
start of the program or when changing to a different instrument
config, show dummy images, which are just arrays that have the
shape defined in the instrument config and all values of 1.

These dummy images get replaced with the real images when a user
loads real images.

Fixes: #240 
Fixes: #261

![raw_images](https://user-images.githubusercontent.com/9558430/74692589-f8018100-51b5-11ea-895e-538c08f37e90.png)
![cartesian](https://user-images.githubusercontent.com/9558430/74692591-fb950800-51b5-11ea-98f6-0c3bcf271642.png)
![polar](https://user-images.githubusercontent.com/9558430/74692593-fdf76200-51b5-11ea-8e80-b999644b1958.png)