### PR TITLE
Allow each material its own tThWidth

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -71,16 +71,15 @@ class InstrumentViewer:
         rbnd_indices = []
 
         # If there are no rings, there is nothing to do
-        if len(plane_data.getTTh()) == 0:
+        if not HexrdConfig().show_overlays or len(plane_data.getTTh()) == 0:
             return rings, rbnds, rbnd_indices
 
-        if HexrdConfig().show_rings:
-            ring_angs, ring_xys = self.dpanel.make_powder_rings(
-                plane_data, delta_eta=1)
-            for ring in ring_xys:
-                rings.append(self.dpanel.cartToPixel(ring))
+        ring_angs, ring_xys = self.dpanel.make_powder_rings(
+            plane_data, delta_eta=1)
+        for ring in ring_xys:
+            rings.append(self.dpanel.cartToPixel(ring))
 
-        if HexrdConfig().show_ring_ranges:
+        if plane_data.tThWidth is not None:
             delta_tth = np.degrees(plane_data.tThWidth)
             indices, ranges = plane_data.getMergedRanges()
 
@@ -102,7 +101,7 @@ class InstrumentViewer:
     def add_rings(self):
         self.clear_rings()
 
-        if not HexrdConfig().show_rings and not HexrdConfig().show_ring_ranges:
+        if not HexrdConfig().show_overlays:
             # Nothing to do
             return self.ring_data
 

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -75,14 +75,13 @@ class InstrumentViewer:
         rbnd_indices = []
 
         # If there are no rings, there is nothing to do
-        if len(plane_data.getTTh()) == 0:
+        if not HexrdConfig().show_overlays or len(plane_data.getTTh()) == 0:
             return rings, rbnds, rbnd_indices
 
-        if HexrdConfig().show_rings:
-            for tth in np.degrees(plane_data.getTTh()):
-                rings.append(np.array([[-180, tth], [180, tth]]))
+        for tth in np.degrees(plane_data.getTTh()):
+            rings.append(np.array([[-180, tth], [180, tth]]))
 
-        if HexrdConfig().show_ring_ranges:
+        if plane_data.tThWidth is not None:
             indices, ranges = plane_data.getMergedRanges()
 
             for ind, r in zip(indices, np.degrees(ranges)):

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -1,5 +1,6 @@
 import copy
 import math
+import numpy as np
 
 from PySide2.QtCore import QItemSelectionModel, QObject, Qt
 from PySide2.QtWidgets import QMenu, QMessageBox, QTableWidgetItem
@@ -59,10 +60,12 @@ class MaterialsPanel(QObject):
         self.ui.materials_table.selectionModel().selectionChanged.connect(
             self.update_ring_selection)
 
-        self.ui.show_rings.toggled.connect(HexrdConfig()._set_show_rings)
-        self.ui.show_ranges.toggled.connect(
-            HexrdConfig()._set_show_ring_ranges)
-        self.ui.tth_ranges.valueChanged.connect(HexrdConfig()._set_ring_ranges)
+        self.ui.show_overlays.toggled.connect(HexrdConfig()._set_show_overlays)
+        self.ui.enable_width.toggled.connect(
+            HexrdConfig().set_tth_width_enabled)
+        self.ui.tth_width.valueChanged.connect(
+            lambda v: HexrdConfig().set_active_material_tth_width(
+                np.radians(v)))
 
         self.ui.limit_active.toggled.connect(
             HexrdConfig().set_limit_active_rings)
@@ -79,14 +82,14 @@ class MaterialsPanel(QObject):
 
         HexrdConfig().new_plane_data.connect(self.update_gui_from_config)
 
-        self.ui.show_ranges.toggled.connect(self.update_enable_states)
+        self.ui.enable_width.toggled.connect(self.update_enable_states)
         self.ui.limit_active.toggled.connect(self.update_enable_states)
         self.ui.limit_active.toggled.connect(self.update_material_limits)
         self.ui.limit_active.toggled.connect(self.update_table)
 
     def update_enable_states(self):
-        show_ranges = self.ui.show_ranges.isChecked()
-        self.ui.tth_ranges.setEnabled(show_ranges)
+        enable_width = self.ui.enable_width.isChecked()
+        self.ui.tth_width.setEnabled(enable_width)
 
         limit_active = self.ui.limit_active.isChecked()
         self.ui.max_bragg_angle.setEnabled(limit_active)
@@ -132,9 +135,9 @@ class MaterialsPanel(QObject):
         block_list = [
             self.material_editor_widget,
             self.ui.materials_combo,
-            self.ui.show_rings,
-            self.ui.show_ranges,
-            self.ui.tth_ranges,
+            self.ui.show_overlays,
+            self.ui.enable_width,
+            self.ui.tth_width,
             self.ui.material_visible,
             self.ui.min_d_spacing,
             self.ui.max_bragg_angle,
@@ -158,9 +161,13 @@ class MaterialsPanel(QObject):
             self.material_editor_widget.material = HexrdConfig().active_material
             self.ui.materials_combo.setCurrentIndex(
                 materials_keys.index(HexrdConfig().active_material_name))
-            self.ui.show_rings.setChecked(HexrdConfig().show_rings)
-            self.ui.show_ranges.setChecked(HexrdConfig().show_ring_ranges)
-            self.ui.tth_ranges.setValue(HexrdConfig().ring_ranges)
+            self.ui.show_overlays.setChecked(HexrdConfig().show_overlays)
+            self.ui.enable_width.setChecked(HexrdConfig().tth_width_enabled)
+
+            width = HexrdConfig().active_material_tth_width
+            width = width if width else HexrdConfig().backup_tth_width
+            self.ui.tth_width.setValue(np.degrees(width))
+
             self.ui.material_visible.setChecked(
                 HexrdConfig().material_is_visible(self.current_material()))
             self.ui.limit_active.setChecked(HexrdConfig().limit_active_rings)

--- a/hexrd/ui/resources/materials/materials_panel_defaults.yml
+++ b/hexrd/ui/resources/materials/materials_panel_defaults.yml
@@ -1,4 +1,2 @@
 active_material: 'ceo2'
-show_rings: true
-show_ring_ranges: false
-ring_ranges: 0.125
+show_overlays: true

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -167,14 +167,14 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QCheckBox" name="limit_active">
        <property name="text">
         <string>Limit Active</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
+     <item row="9" column="1">
       <widget class="QLabel" name="min_d_spacing_label">
        <property name="enabled">
         <bool>false</bool>
@@ -184,31 +184,18 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QCheckBox" name="show_ranges">
+     <item row="4" column="0">
+      <widget class="QCheckBox" name="enable_width">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show 2θ ranges for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Show Ranges</string>
+        <string>Enable Width</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="show_rings">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show powder rings for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Show Rings</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="tth_ranges">
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="tth_width">
        <property name="enabled">
         <bool>false</bool>
        </property>
@@ -218,8 +205,11 @@
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
        <property name="prefix">
-        <string>±</string>
+        <string/>
        </property>
        <property name="suffix">
         <string>°</string>
@@ -241,21 +231,21 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
+     <item row="1" column="0">
       <widget class="QCheckBox" name="material_visible">
        <property name="text">
         <string>Visible</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="1">
+     <item row="1" column="1">
       <widget class="QPushButton" name="edit_style_button">
        <property name="text">
         <string>Edit Style...</string>
        </property>
       </widget>
      </item>
-     <item row="8" column="5">
+     <item row="9" column="5">
       <widget class="QDoubleSpinBox" name="min_d_spacing">
        <property name="enabled">
         <bool>false</bool>
@@ -274,7 +264,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QLabel" name="max_bragg_angle_label">
        <property name="enabled">
         <bool>false</bool>
@@ -284,7 +274,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="5">
+     <item row="5" column="5">
       <widget class="QDoubleSpinBox" name="max_bragg_angle">
        <property name="enabled">
         <bool>false</bool>
@@ -303,7 +293,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="6">
+     <item row="5" column="6">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -316,7 +306,7 @@
        </property>
       </spacer>
      </item>
-     <item row="3" column="5" colspan="2">
+     <item row="4" column="5" colspan="2">
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -329,7 +319,7 @@
        </property>
       </spacer>
      </item>
-     <item row="8" column="6">
+     <item row="9" column="6">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -342,10 +332,23 @@
        </property>
       </spacer>
      </item>
-     <item row="0" column="5">
+     <item row="1" column="5">
       <widget class="QPushButton" name="hide_all">
        <property name="text">
         <string>Hide All</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="show_overlays">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;display overlays for the selected HKLs for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Show Overlays</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -357,12 +360,12 @@
   <tabstop>materials_combo</tabstop>
   <tabstop>materials_tool_button</tabstop>
   <tabstop>materials_table</tabstop>
+  <tabstop>show_overlays</tabstop>
   <tabstop>material_visible</tabstop>
   <tabstop>edit_style_button</tabstop>
   <tabstop>hide_all</tabstop>
-  <tabstop>show_rings</tabstop>
-  <tabstop>show_ranges</tabstop>
-  <tabstop>tth_ranges</tabstop>
+  <tabstop>enable_width</tabstop>
+  <tabstop>tth_width</tabstop>
   <tabstop>limit_active</tabstop>
   <tabstop>max_bragg_angle</tabstop>
   <tabstop>min_d_spacing</tabstop>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -169,6 +169,9 @@
     <layout class="QGridLayout" name="gridLayout">
      <item row="5" column="0">
       <widget class="QCheckBox" name="limit_active">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the allowed HKLs with the max Bragg angle or the minimum d spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string>Limit Active</string>
        </property>
@@ -187,7 +190,7 @@
      <item row="4" column="0">
       <widget class="QCheckBox" name="enable_width">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;show 2θ ranges for the selected HKLs for the active material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the selected HKLs of the currently selected material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Enable Width</string>
@@ -200,7 +203,7 @@
         <bool>false</bool>
        </property>
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;±2θ range&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;2θ width for the currently selected material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -233,6 +236,9 @@
      </item>
      <item row="1" column="0">
       <widget class="QCheckBox" name="material_visible">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make the currently selected material visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string>Visible</string>
        </property>
@@ -240,6 +246,9 @@
      </item>
      <item row="1" column="1">
       <widget class="QPushButton" name="edit_style_button">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit the overlay styles of the currently selected material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string>Edit Style...</string>
        </property>
@@ -249,6 +258,9 @@
       <widget class="QDoubleSpinBox" name="min_d_spacing">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum d spacing for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -278,6 +290,9 @@
       <widget class="QDoubleSpinBox" name="max_bragg_angle">
        <property name="enabled">
         <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The max Bragg angle, θ, for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -334,6 +349,9 @@
      </item>
      <item row="1" column="5">
       <widget class="QPushButton" name="hide_all">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide all material overlays&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string>Hide All</string>
        </property>
@@ -342,7 +360,7 @@
      <item row="0" column="0">
       <widget class="QCheckBox" name="show_overlays">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;display overlays for the selected HKLs for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display overlays in the canvas for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Show Overlays</string>


### PR DESCRIPTION
Rather than forcing all materials to have the same tThWidth,
as was done previously, allow each material to have their own
tThWidths. The "Show Ranges" checkbox was renamed to "Enable Width",
and this toggles setting `None` on the material's tThWidth. The
spinbox displays the tThWidth on the material. And, when the active
material in the materials panel is changed, the checkbox and spinbox
update to the newly selected material.

This also changes a little naming in the materials panel, including
renaming "Show Rings" to a more general "Show Overlays".

Additionally, the plus or minus prefix on the width was removed.

Finally, this also enables saving/loading of the `tThWidth`s via the `materials.hexrd` file.

Fixes: #237