### PR TITLE
Update images when detectors are added/removed

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -70,6 +70,12 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """
     rerender_needed = Signal()
 
+    """Emitted for any changes that need a re-render from scratch
+
+    This causes all canvases to be cleared and re-rendered.
+    """
+    deep_rerender_needed = Signal()
+
     """Emitted when detectors have been added or removed"""
     detectors_changed = Signal()
 
@@ -227,7 +233,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             utils.convert_tilt_convention(self.config['instrument'], old_eac,
                                           new_eac)
 
-        self.rerender_needed.emit()
+        self.deep_rerender_needed.emit()
         self.update_visible_material_energies()
 
     def set_images_dir(self, images_dir):
@@ -340,6 +346,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         new_detectors = self.get_detector_names()
         if old_detectors != new_detectors:
             self.detectors_changed.emit()
+        else:
+            # Still need a deep rerender
+            self.deep_rerender_needed.emit()
 
         return self.config['instrument']
 

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -34,7 +34,7 @@ class ImageFileManager(metaclass=Singleton):
         self.path = []
 
     def load_dummy_images(self):
-        HexrdConfig().imageseries_dict.clear()
+        HexrdConfig().clear_images()
         detectors = HexrdConfig().get_detector_names()
         iconfig = HexrdConfig().instrument_config
         for det in detectors:

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -52,7 +52,7 @@ class LoadPanel(QObject):
     # Setup GUI
 
     def setup_gui(self):
-        self.state = self.setup_processing_options()
+        self.setup_processing_options()
 
         if 'subdirs' in self.state:
             self.ui.subdirectories.setChecked(self.state['subdirs'])
@@ -91,7 +91,6 @@ class LoadPanel(QObject):
         self.ui.file_options.customContextMenuRequested.connect(
             self.contextMenuEvent)
         self.ui.file_options.cellChanged.connect(self.omega_data_changed)
-        HexrdConfig().detectors_changed.connect(self.config_changed)
 
     def setup_processing_options(self):
         num_dets = len(HexrdConfig().get_detector_names())
@@ -103,7 +102,7 @@ class LoadPanel(QObject):
                 'dark': [0 for x in range(num_dets)],
                 'dark_files': [None for x in range(num_dets)]}
 
-        return HexrdConfig().load_panel_state
+        self.state = HexrdConfig().load_panel_state
 
     # Handle GUI changes
 
@@ -146,11 +145,11 @@ class LoadPanel(QObject):
         self.state['subdirs'] = checked
 
     def config_changed(self):
+        self.setup_processing_options()
         self.detectors_changed()
         self.ui.file_options.setRowCount(0)
         self.reset_data()
         self.enable_read()
-        HexrdConfig().clear_images()
         self.setup_gui()
 
     def switch_detector(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -150,6 +150,10 @@ class MainWindow(QObject):
             self.open_aps_imageseries)
         HexrdConfig().update_status_bar.connect(
             self.ui.status_bar.showMessage)
+        HexrdConfig().detectors_changed.connect(
+            self.on_detectors_changed)
+        HexrdConfig().deep_rerender_needed.connect(
+            lambda: self.update_all(clear_canvases=True))
 
     def show(self):
         self.ui.show()
@@ -177,18 +181,8 @@ class MainWindow(QObject):
             'YAML files (*.yml)')
 
         if selected_file:
-            prev_detectors = HexrdConfig().get_detector_names()
-
             HexrdConfig().load_instrument_config(selected_file)
             self.update_config_gui()
-
-            new_detectors = HexrdConfig().get_detector_names()
-            if new_detectors != prev_detectors:
-                # Load the dummy images. The new config probably isn't
-                # for the current images.
-                self.load_dummy_images()
-            else:
-                self.update_all(clear_canvases=True)
 
     def on_action_save_config_triggered(self):
         selected_file, selected_filter = QFileDialog.getSaveFileName(
@@ -197,6 +191,11 @@ class MainWindow(QObject):
 
         if selected_file:
             return HexrdConfig().save_instrument_config(selected_file)
+
+    def on_detectors_changed(self):
+        self.load_dummy_images()
+        # Update the load widget
+        self.load_widget.config_changed()
 
     def load_dummy_images(self):
         ImageFileManager().load_dummy_images()


### PR DESCRIPTION
This causes the dummy images to be updated when detectors
are removed/added. It also adds a new signal in the hexrd
config that causes a deep re-render to occur.

Currently, there are many things that can cause a deep re-render
to occur, but most of them occur due to internal checks in the
ImageCanvas class (such as "_polar_reset_needed()"). This adds
the ability for other parts of the code to force a deep re-render
as well. It is needed, for instance, if the user switches to a
config that has the same number of detectors (because the ImageCanvas
class will not automatically perform a deep re-render in this case).

Fixes: #265