### PR TITLE
Add ability to export polar plot to HDF5

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -343,7 +343,7 @@ class MainWindow(QObject):
     def on_action_export_polar_plot_triggered(self):
         selected_file, selected_filter = QFileDialog.getSaveFileName(
             self.ui, 'Save Polar Image', HexrdConfig().working_dir,
-            'NPZ files (*.npz)')
+            'HDF5 files (*.h5 *.hdf5);; NPZ files (*.npz)')
 
         if selected_file:
             return self.ui.image_tab_widget.export_polar_plot(selected_file)


### PR DESCRIPTION
When the polar plot is being displayed, the user can export the
polar plot data via "File"->"Export"->"Polar Plot". Now, the user may
choose between HDF5 (default) or npz for the export. If the file
name ends with ".npz", a ".npz" file will be written. Otherwise,
an HDF5 file will be written.

The data that is written out is as follows:
```
tth_coordinates
eta_coordinates
intensities
extent
```

They are all written out as datasets in the root in the HDF5 file.

Currently, no material overlays are written out and no borders are
written out. But that is potentially changeable.

Fixes: #241