### PR TITLE
Fix Cartesian view exception when tThWidth is None

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -74,8 +74,17 @@ class InstrumentViewer:
         if not HexrdConfig().show_overlays or len(plane_data.getTTh()) == 0:
             return rings, rbnds, rbnd_indices
 
+        # A delta_tth is needed here, even if the plane data tThWidth
+        # is None. Default to 0.125 degrees if tThWidth is None.
+        # I don't see a difference in the output if different values for
+        # delta_tth are chosen here.
+        if plane_data.tThWidth:
+            delta_tth = np.degrees(plane_data.tThWidth)
+        else:
+            delta_tth = 0.125
         ring_angs, ring_xys = self.dpanel.make_powder_rings(
-            plane_data, delta_eta=1)
+            plane_data, delta_tth=delta_tth, delta_eta=1)
+
         for ring in ring_xys:
             rings.append(self.dpanel.cartToPixel(ring))
 

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -190,7 +190,7 @@
      <item row="4" column="0">
       <widget class="QCheckBox" name="enable_width">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the selected HKLs of the currently selected material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the currently selected material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
         <string>Enable Width</string>


### PR DESCRIPTION
A delta_tth value is required for PlanarDetector.make_powder_rings(),
even if the plane data tThWidth is None. Give it a default value
if the plane data tThWidth is None.

In my testing, it appears that different values of delta_tth here do
not affect the output, so perhaps an arbitrary delta_tth will work
fine.

Fixes: #271 