### PR TITLE
Add progress updates when loading files

### DIFF
--- a/hexrd/ui/async_worker.py
+++ b/hexrd/ui/async_worker.py
@@ -3,6 +3,7 @@
 
 from PySide2.QtCore import QObject, QRunnable, Signal, Slot
 
+import inspect
 import traceback
 import sys
 
@@ -56,9 +57,10 @@ class AsyncWorker(QRunnable):
         self.kwargs = kwargs
         self.signals = AsyncWorkerSignals()
 
-        # Add the callback to our kwargs
-        if 'progress_callback' in self.kwargs:
-            self.kwargs['progress_callback'] = self.signals.progress
+        # If the function signature accepts an 'update_progress'
+        # function, set it to emit the progress signal.
+        if 'update_progress' in inspect.getfullargspec(self.fn)[0]:
+            self.kwargs['update_progress'] = self.signals.progress.emit
 
     @Slot()
     def run(self):

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -12,7 +12,7 @@ from PySide2.QtCore import QObject, Qt, QPersistentModelIndex, QThreadPool, Sign
 from PySide2.QtWidgets import QTableWidgetItem, QFileDialog, QMenu, QMessageBox
 
 from hexrd.ui.async_worker import AsyncWorker
-from hexrd.ui.cal_progress_dialog import CalProgressDialog
+from hexrd.ui.progress_dialog import ProgressDialog
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_file_manager import ImageFileManager
 from hexrd.ui.ui_loader import UiLoader
@@ -527,8 +527,9 @@ class LoadPanel(QObject):
 
         # Create threads and loading dialog
         thread_pool = QThreadPool(self.parent())
-        progress_dialog = CalProgressDialog(self.parent())
+        progress_dialog = ProgressDialog(self.parent())
         progress_dialog.setWindowTitle('Loading Processed Imageseries')
+        progress_dialog.setRange(0, 0)
 
         # Start processing in background
         worker = AsyncWorker(self.process_ims)

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -45,6 +45,9 @@ class LoadPanel(QObject):
         self.omega_max = []
         self.idx = 0
         self.ext = ''
+        self.progress_dialog = None
+        self.current_progress_step = 0
+        self.progress_macro_steps = 0
 
         self.setup_gui()
         self.setup_connections()
@@ -529,18 +532,22 @@ class LoadPanel(QObject):
         thread_pool = QThreadPool(self.parent())
         progress_dialog = ProgressDialog(self.parent())
         progress_dialog.setWindowTitle('Loading Processed Imageseries')
-        progress_dialog.setRange(0, 0)
+        self.progress_dialog = progress_dialog
 
         # Start processing in background
         worker = AsyncWorker(self.process_ims)
         thread_pool.start(worker)
 
+        worker.signals.progress.connect(progress_dialog.setValue)
         # On completion load imageseries nd close loading dialog
         worker.signals.result.connect(self.finish_processing_ims)
         worker.signals.finished.connect(progress_dialog.accept)
         progress_dialog.exec_()
 
-    def process_ims(self):
+    def process_ims(self, update_progress):
+        self.update_progress = update_progress
+        self.update_progress(0)
+
         # Open selected images as imageseries
         det_names = HexrdConfig().get_detector_names()
 
@@ -555,12 +562,17 @@ class LoadPanel(QObject):
         else:
             ImageFileManager().load_images(det_names, self.files)
 
+        # Now that self.state is set, setup the progress variables
+        self.setup_progress_variables()
+
         # Process the imageseries
         self.apply_operations(HexrdConfig().imageseries_dict)
         if self.state['agg']:
             self.display_aggregation(HexrdConfig().imageseries_dict)
         elif '' not in self.omega_min:
             self.add_omega_metadata(HexrdConfig().imageseries_dict)
+
+        self.update_progress(100)
 
     def finish_processing_ims(self):
         # Display processed images on completion
@@ -591,22 +603,41 @@ class LoadPanel(QObject):
                 ims_dict[key], ops, frame_list=frames)
 
     def get_dark_op(self, oplist, ims, idx):
+        dark_idx = self.state['dark'][idx]
+        if dark_idx == 4:
+            ims = ImageFileManager().open_file(self.dark_files[idx])
+
         # Create or load the dark image if selected
-        if self.state['dark'][idx] != 4:
-            frames = len(ims)
-            if frames > 120:
-                frames = 120
-            if self.state['dark'][idx] == 0:
-                darkimg = imageseries.stats.median(ims, frames)
-            elif self.state['dark'][idx] == 1:
-                darkimg = imageseries.stats.average(ims, self.empty_frames)
-            elif self.state['dark'][idx] == 2:
-                darkimg = imageseries.stats.average(ims, frames)
-            else:
-                darkimg = imageseries.stats.max(ims, frames)
+        frames = len(ims)
+        if dark_idx != 4 and frames > 120:
+            frames = 120
+
+        if dark_idx == 0:
+            f = imageseries.stats.median_iter
+        elif dark_idx == 1:
+            f = imageseries.stats.average_iter
+            frames = self.empty_frames
+        elif dark_idx == 2:
+            f = imageseries.stats.average_iter
+        elif dark_idx == 3:
+            f = imageseries.stats.max_iter
         else:
-            darkimg = imageseries.stats.median(
-                ImageFileManager().open_file(self.dark_files[idx]))
+            f = imageseries.stats.median_iter
+
+        self.update_progress_text('Aggregating dark images...')
+
+        step = int(frames * len(HexrdConfig().imageseries_dict) / 100)
+        step = step if step > 2 else 2
+        nchunk = int(frames / step)
+        if nchunk > frames or nchunk < 1:
+            # One last sanity check
+            nchunk = frames
+
+        for i, darkimg in enumerate(f(ims, nchunk, nframes=frames)):
+            progress = self.calculate_progress(i, nchunk)
+            self.update_progress(progress)
+
+        self.increment_progress_step()
 
         oplist.append(('dark', darkimg))
 
@@ -637,20 +668,32 @@ class LoadPanel(QObject):
             return range(self.empty_frames, len(ims))
 
     def display_aggregation(self, ims_dict):
+        self.update_progress_text('Aggregating images...')
         # Remember unaggregated images
         self.unaggregated_images = copy.copy(ims_dict)
-
         # Display aggregated image from imageseries
-        for key in ims_dict.keys():
+        for key, ims in ims_dict.items():
+            frames = len(ims)
+            step = int(frames * len(ims_dict) / 100)
+            step = step if step > 2 else 2
+            nchunk = int(frames / step)
+            if nchunk > frames or nchunk < 1:
+                # One last sanity check
+                nchunk = frames
+
             if self.state['agg'] == 1:
-                ims_dict[key] = [imageseries.stats.max(
-                    ims_dict[key], len(ims_dict[key]))]
+                f = imageseries.stats.max_iter
             elif self.state['agg'] == 2:
-                ims_dict[key] = [imageseries.stats.median(
-                    ims_dict[key], len(ims_dict[key]))]
+                f = imageseries.stats.median_iter
             else:
-                ims_dict[key] = [imageseries.stats.average(
-                    ims_dict[key], len(ims_dict[key]))]
+                f = imageseries.stats.average_iter
+
+            for i, img in enumerate(f(ims, nchunk)):
+                progress = self.calculate_progress(i, nchunk)
+                self.update_progress(progress)
+
+            self.increment_progress_step()
+            ims_dict[key] = [img]
 
     def add_omega_metadata(self, ims_dict):
         # Add on the omega metadata if there is any
@@ -670,3 +713,33 @@ class LoadPanel(QObject):
                 omw.addwedge(start, stop, nsteps)
 
             ims_dict[key].metadata['omega'] = omw.omegas
+
+    def setup_progress_variables(self):
+        self.current_progress_step = 0
+
+        ims_dict = HexrdConfig().imageseries_dict
+        num_ims = len(ims_dict)
+
+        progress_macro_steps = 0
+        for idx in range(num_ims):
+            if self.ui.all_detectors.isChecked():
+                idx = self.idx
+
+            if self.state['dark'][idx] != 5:
+                progress_macro_steps += 1
+
+        if self.state['agg']:
+            progress_macro_steps += num_ims
+
+        self.progress_macro_steps = progress_macro_steps
+
+    def calculate_progress(self, i, nchunk):
+        numerator = self.current_progress_step + i / nchunk
+        return numerator / self.progress_macro_steps * 100
+
+    def increment_progress_step(self):
+        self.current_progress_step += 1
+
+    def update_progress_text(self, text):
+        if self.progress_dialog is not None:
+            self.progress_dialog.setLabelText(text)

--- a/hexrd/ui/progress_dialog.py
+++ b/hexrd/ui/progress_dialog.py
@@ -2,16 +2,14 @@ from PySide2.QtCore import Qt
 from PySide2.QtWidgets import QProgressDialog
 
 
-class CalProgressDialog(QProgressDialog):
+class ProgressDialog(QProgressDialog):
 
     def __init__(self, parent=None):
-        super(CalProgressDialog, self).__init__(parent)
+        super(ProgressDialog, self).__init__(parent)
 
-        self.setWindowTitle('Calibration Running')
+        # Some default window title and text
+        self.setWindowTitle('Hexrd')
         self.setLabelText('Please wait...')
-
-        # Indeterminate state
-        self.setRange(0, 0)
 
         # No cancel button
         self.setCancelButton(None)
@@ -27,4 +25,4 @@ class CalProgressDialog(QProgressDialog):
     def keyPressEvent(self, e):
         # Do not let the user close the dialog by pressing escape
         if e.key() != Qt.Key_Escape:
-            super(CalProgressDialog, self).keyPressEvent(e)
+            super(ProgressDialog, self).keyPressEvent(e)


### PR DESCRIPTION
This adds two main parts of progress updates:

1. Performing aggregations on dark images.
2. Performing aggregations on the loaded images.

The progress bar will steadily move from 0 to 100 percent
until both of these parts are completed. It will usually move
a little slower during the second part since that step typically
takes longer.

No progress updates are currently being performed at other steps,
such as flip operations.

![progress_updates](https://user-images.githubusercontent.com/9558430/75282895-cbfe8500-57df-11ea-8ac1-9209d670051d.png)

Depends on: hexrd/hexrd#12
Fixes: #239