### PR TITLE
Set load panel state defaults after clearing

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -86,6 +86,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """
     update_status_bar = Signal(str)
 
+    """Emitted when the load_panel_state has been cleared"""
+    load_panel_state_reset = Signal()
+
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)
@@ -321,6 +324,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.hdf5_path = None
         if self.load_panel_state is not None:
             self.load_panel_state.clear()
+            self.load_panel_state_reset.emit()
 
     def load_instrument_config(self, yml_file):
         old_detectors = self.get_detector_names()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -77,6 +77,9 @@ class LoadPanel(QObject):
         self.ui.file_options.resizeColumnsToContents()
 
     def setup_connections(self):
+        HexrdConfig().load_panel_state_reset.connect(
+            self.setup_processing_options)
+
         self.ui.image_folder.clicked.connect(self.select_folder)
         self.ui.image_files.clicked.connect(self.select_images)
         self.ui.selectDark.clicked.connect(self.select_dark_img)


### PR DESCRIPTION
The load panel was being initialized before the dummy images were loaded, resulting in the load panel state being set and then cleared. This caused key errors when the load panel settings were changed in any way. Instead, emit a signal any time the load panel state is cleared so that the defaults are reset.