### PR TITLE
Load the correct image mode for new files

### DIFF
--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -57,7 +57,7 @@ class ImageSeriesToolbar(QWidget):
             if not size == self.slider.maximum():
                 self.slider.setMaximum(size)
                 self.frame.setMaximum(size)
-                self.slider.setValue(min(HexrdConfig().current_imageseries_idx, size))
+                self.slider.setValue(0)
                 self.frame.setValue(self.slider.value())
         else:
             self.show = False

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -92,13 +92,12 @@ class ImageTabWidget(QTabWidget):
 
     def load_images(self):
         self.update_image_names()
+        self.switch_toolbar(self.currentIndex())
 
         if HexrdConfig().tab_images:
             self.load_images_tabbed()
         else:
             self.load_images_untabbed()
-
-        self.switch_toolbar(self.currentIndex())
 
     def change_ims_image(self, pos):
         HexrdConfig().current_imageseries_idx = pos
@@ -154,6 +153,7 @@ class ImageTabWidget(QTabWidget):
 
     def show_cartesian(self):
         self.update_image_names()
+        self.switch_toolbar(self.currentIndex())
 
         # Make sure we actually have images
         if len(self.image_names) == 0:
@@ -168,6 +168,7 @@ class ImageTabWidget(QTabWidget):
 
     def show_polar(self):
         self.update_image_names()
+        self.switch_toolbar(self.currentIndex())
 
         # Make sure we actually have images
         if len(self.image_names) == 0:

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -28,6 +28,7 @@ from hexrd.ui.ui_loader import UiLoader
 class LoadPanel(QObject):
 
     # Emitted when new images are loaded
+    update_needed = Signal()
     new_images_loaded = Signal()
 
     def __init__(self, parent=None):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -139,6 +139,7 @@ class MainWindow(QObject):
         self.new_images_loaded.connect(self.color_map_editor.update_bounds)
         self.new_images_loaded.connect(self.color_map_editor.reset_range)
         self.ui.image_tab_widget.update_needed.connect(self.update_all)
+        self.load_widget.update_needed.connect(self.update_all)
         self.ui.image_tab_widget.new_mouse_position.connect(
             self.new_mouse_position)
         self.ui.image_tab_widget.clear_mouse_position.connect(


### PR DESCRIPTION
Whether using the load panel or the file menu, load the new images in the
currently select image mode (raw, cartesian, polar). Make sure that the slider
widget is updated in all modes.

Signed-off-by: Brianna Major <brianna.major@kitware.com>