### PR TITLE
Fix various bugs with form view detector editing

### DIFF
--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -1,6 +1,6 @@
 from PySide2.QtCore import QObject, Signal, QTimer
 from PySide2.QtWidgets import (
-    QAbstractSpinBox, QComboBox, QLineEdit, QPushButton
+    QAbstractSpinBox, QComboBox, QLineEdit, QMessageBox, QPushButton
 )
 
 import numpy as np
@@ -112,6 +112,11 @@ class CalibrationConfigWidget(QObject):
         self.cfg.rename_detector(old_name, new_name)
 
     def on_detector_remove_clicked(self):
+        if self.ui.cal_det_current.count() <= 1:
+            msg = 'Cannot remove last detector'
+            QMessageBox.critical(self.ui, 'HEXRD', msg)
+            return
+
         current_detector = self.get_current_detector()
         idx = self.ui.cal_det_current.currentIndex()
 

--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -36,7 +36,7 @@ class CalibrationConfigWidget(QObject):
 
         self.ui.cal_det_current.currentIndexChanged.connect(
             self.on_detector_changed)
-        self.ui.cal_det_current.editTextChanged.connect(
+        self.ui.cal_det_current.lineEdit().editingFinished.connect(
             self.on_detector_name_edited)
         self.ui.cal_det_remove.clicked.connect(self.on_detector_remove_clicked)
         self.ui.cal_det_add.clicked.connect(self.on_detector_add_clicked)

--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -26,6 +26,9 @@ class CalibrationConfigWidget(QObject):
 
         self.detector_widgets_disabled = False
 
+        # Turn off autocomplete for the QComboBox
+        self.ui.cal_det_current.setCompleter(None)
+
         self.setup_connections()
 
         self.timer = None

--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -122,6 +122,7 @@ class CalibrationConfigWidget(QObject):
             self.update_detector_from_config()
 
     def on_detector_add_clicked(self):
+        combo = self.ui.cal_det_current
         current_detector = self.get_current_detector()
         detector_names = self.cfg.get_detector_names()
         new_detector_name_base = 'detector_'
@@ -130,7 +131,8 @@ class CalibrationConfigWidget(QObject):
             if new_detector_name not in detector_names:
                 self.cfg.add_detector(new_detector_name, current_detector)
                 self.update_detector_from_config()
-                self.ui.cal_det_current.setCurrentText(new_detector_name)
+                new_ind = combo.findText(new_detector_name)
+                combo.setCurrentIndex(new_ind)
                 return
 
     def update_config_from_gui(self):
@@ -225,9 +227,11 @@ class CalibrationConfigWidget(QObject):
                 combo_items.append(self.ui.cal_det_current.itemText(i))
 
             if combo_items != detector_names:
-                self.ui.cal_det_current.clear()
-                self.ui.cal_det_current.addItems(detector_names)
-                self.ui.cal_det_current.setCurrentText(cur_detector)
+                combo_widget = self.ui.cal_det_current
+                combo_widget.clear()
+                combo_widget.addItems(detector_names)
+                new_ind = combo_widget.findText(cur_detector)
+                combo_widget.setCurrentIndex(new_ind)
 
         finally:
             self.unblock_all_signals(previously_blocked)


### PR DESCRIPTION
From the commits:

```
    Update detector name after editing finishes
    
    This fixes an issue where all of the detectors are re-rendered with
    every keystroke, when the detector name is being modified via the
    combo box in the form view.
    
    Now, the detectors are only re-rendered after editing finishes (i.e.,
    the widget loses focus, enter is pressed, etc.).
```
```
    Use setCurrentIndex instead of setCurrentText
    
    This combo box was originally not editable, so "setCurrentText"
    would change the index to the correct index.
    
    However, since the combo box is now editable, "setCurrentText"
    actually modifies the text rather than changing the index.
    
    Use "setCurrentIndex" to fix this.
```
```
    Do not allow user to remove the last detector
    
    If the user presses the minus button in the form view to try
    to remove the last detector, pop up an error stating that the
    user cannot remove the last detector. It then returns.
```

Fixes: #285 
Fixes: #287 