### PR TITLE
Restrict reasons slider visibility can be toggled on

### DIFF
--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -75,7 +75,8 @@ class ImageSeriesToolbar(QWidget):
             self.name = name
 
     def set_visible(self, b=False):
-        self.widget.setVisible(b)
+        size = len(self.ims) - 1 if self.ims else 0
+        self.widget.setVisible(b and size)
 
     def val_changed(self, pos):
         self.parent().change_ims_image(pos)

--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -75,8 +75,7 @@ class ImageSeriesToolbar(QWidget):
             self.name = name
 
     def set_visible(self, b=False):
-        size = len(self.ims) - 1 if self.ims else 0
-        self.widget.setVisible(b and size)
+        self.widget.setVisible(b and len(self.ims)>1)
 
     def val_changed(self, pos):
         self.parent().change_ims_image(pos)


### PR DESCRIPTION
Visibility was being toggled on, only to be toggled off again, causing unnecessary clearing of the image canvas. This was causing a blank canvas to flash before loading the current image mode, which didn't look very nice.