### PR TITLE
Transform menu images

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -319,10 +319,10 @@ class HexrdConfig(QObject, metaclass=Singleton):
         hexrd.imageseries.save.write(ims, write_file, selected_format,
                                      **kwargs)
 
-    def clear_images(self):
+    def clear_images(self, initial_load=False):
         self.imageseries_dict.clear()
         self.hdf5_path = None
-        if self.load_panel_state is not None:
+        if self.load_panel_state is not None and not initial_load:
             self.load_panel_state.clear()
             self.load_panel_state_reset.emit()
 

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -33,8 +33,8 @@ class ImageFileManager(metaclass=Singleton):
         self.remember = True
         self.path = []
 
-    def load_dummy_images(self):
-        HexrdConfig().clear_images()
+    def load_dummy_images(self, initial=False):
+        HexrdConfig().clear_images(initial)
         detectors = HexrdConfig().get_detector_names()
         iconfig = HexrdConfig().instrument_config
         for det in detectors:

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -148,8 +148,8 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         self.setup_progress_variables()
 
         # Process the imageseries
+        self.apply_operations(HexrdConfig().imageseries_dict)
         if self.data:
-            self.apply_operations(HexrdConfig().imageseries_dict)
             if self.state['agg']:
                 self.display_aggregation(HexrdConfig().imageseries_dict)
             else:
@@ -165,10 +165,10 @@ class ImageLoadManager(QObject, metaclass=Singleton):
     def apply_operations(self, ims_dict):
         # Apply the operations to the imageseries
         for idx, key in enumerate(ims_dict.keys()):
+            ops = []
             if self.data:
                 if 'idx' in self.data:
                     idx = self.data['idx']
-                ops = []
                 if self.state['dark'][idx] != 5:
                     if (self.state['dark'][idx] == 1
                             and self.empty_frames == 0):

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -1,7 +1,7 @@
 from collections import Counter  # To compare two lists' contents
 import re
 
-from PySide2.QtWidgets import QMessageBox, QTableWidgetItem
+from PySide2.QtWidgets import QMessageBox, QTableWidgetItem, QComboBox
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
@@ -52,8 +52,15 @@ class LoadImagesDialog:
             d = QTableWidgetItem(self.detectors[i])
             table.setItem(i, 0, d)
 
+            cb = QComboBox()
+            options = ["None", "Flip Vertically", "Flip Horizontally",
+                "Transpose", "Rotate 90°", "Rotate 180°", "Rotate 270°"]
+            cb.addItems(options)
+            cb.setCurrentIndex(HexrdConfig().load_panel_state['trans'][i])
+            table.setCellWidget(i, 1, cb)
+
             f = QTableWidgetItem(self.image_files[i])
-            table.setItem(i, 1, f)
+            table.setItem(i, 2, f)
 
     def update_combo_state(self):
         enable = len(self.ui.regex_line_edit.text()) == 0
@@ -72,7 +79,7 @@ class LoadImagesDialog:
 
         for i in range(len(detectors)):
             f = QTableWidgetItem(image_files[i])
-            table.setItem(i, 1, f)
+            table.setItem(i, 2, f)
 
     def results(self):
         table = self.ui.match_detectors_table
@@ -80,7 +87,8 @@ class LoadImagesDialog:
         image_files = []
         for i in range(table.rowCount()):
             detectors.append(table.item(i, 0).text())
-            image_files.append(table.item(i, 1).text())
+            image_files.append(table.item(i, 2).text())
+            HexrdConfig().load_panel_state['trans'][i] = table.cellWidget(i, 1).currentIndex()
 
         return detectors, image_files
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -94,7 +94,7 @@ class MainWindow(QObject):
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
         self.live_update(HexrdConfig().live_update)
 
-        ImageFileManager().load_dummy_images()
+        ImageFileManager().load_dummy_images(True)
 
         # In order to avoid both a not very nice looking black window,
         # and a bug with the tabbed view

--- a/hexrd/ui/resources/ui/load_images_dialog.ui
+++ b/hexrd/ui/resources/ui/load_images_dialog.ui
@@ -53,6 +53,9 @@
      <property name="rowCount">
       <number>2</number>
      </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
      <attribute name="horizontalHeaderMinimumSectionSize">
       <number>100</number>
      </attribute>
@@ -79,6 +82,11 @@
      <column>
       <property name="text">
        <string>Detector</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Transform</string>
       </property>
      </column>
      <column>


### PR DESCRIPTION
Add the option to transform images that have been selected through the file menu, as detectors may need to perform a simple rotation but not need all of the options or steps of the load panel.

This addresses #264 

![transform](https://user-images.githubusercontent.com/51238406/76859905-85290b80-6830-11ea-8d4f-0146b030e389.png)
