### PR TITLE
Do not clear load panel state on initial program load

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -319,10 +319,10 @@ class HexrdConfig(QObject, metaclass=Singleton):
         hexrd.imageseries.save.write(ims, write_file, selected_format,
                                      **kwargs)
 
-    def clear_images(self):
+    def clear_images(self, initial_load=False):
         self.imageseries_dict.clear()
         self.hdf5_path = None
-        if self.load_panel_state is not None:
+        if self.load_panel_state is not None and not initial_load:
             self.load_panel_state.clear()
             self.load_panel_state_reset.emit()
 

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -33,8 +33,8 @@ class ImageFileManager(metaclass=Singleton):
         self.remember = True
         self.path = []
 
-    def load_dummy_images(self):
-        HexrdConfig().clear_images()
+    def load_dummy_images(self, initial=False):
+        HexrdConfig().clear_images(initial)
         detectors = HexrdConfig().get_detector_names()
         iconfig = HexrdConfig().instrument_config
         for det in detectors:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -94,7 +94,7 @@ class MainWindow(QObject):
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
         self.live_update(HexrdConfig().live_update)
 
-        ImageFileManager().load_dummy_images()
+        ImageFileManager().load_dummy_images(True)
 
         # In order to avoid both a not very nice looking black window,
         # and a bug with the tabbed view


### PR DESCRIPTION
The initial loading of dummy images was clearing the load panel state. Do not
clear the load panel state until the configuration file or detectors have been
changed so that quick load transformations are remembered.

Signed-off-by: Brianna Major <brianna.major@kitware.com>