### PR TITLE
Rescale azimuthal integral plot on first draw

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -389,6 +389,9 @@ class ImageCanvas(FigureCanvas):
                 axis = self.figure.add_subplot(grid[2, 0], sharex=self.axis)
                 axis.plot(tth, np.sum(img, axis=0))
 
+                # Let the axes rescale one time
+                axis.autoscale_view()
+
                 # Turn off autoscale so modifying the rings does not
                 # rescale the y axis.
                 axis.autoscale(False)


### PR DESCRIPTION
On Linux, it appears that this plot rescales automatically. On Mac,
however, it does not.

Explicitly rescale the azimuthal integration plot when it is first
drawn.

Fixes: #295