### PR TITLE
Do not allow min to be 0 for log scale colormap

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -110,6 +110,8 @@ class ColorMapEditor:
         HexrdConfig().set_colormap_min(min)
 
         if self.ui.log_scale.isChecked():
+            # The min cannot be 0 here, or this will raise an exception
+            min = 1.e-8 if min < 1.e-8 else min
             norm = matplotlib.colors.LogNorm(vmin=min, vmax=max)
         else:
             norm = matplotlib.colors.Normalize(vmin=min, vmax=max)


### PR DESCRIPTION
Some images do indeed have a minimum value of 0. But a minimum value
of zero causes exceptions to be raised if a log scale is used. The
min value must be positive.

To avoid this, make the min value for the log scale a very small positive number when
it is zero.

Fixes: #184 