### PR TITLE
Increase the precision of floats in the tree view

### DIFF
--- a/hexrd/ui/scientificspinbox.py
+++ b/hexrd/ui/scientificspinbox.py
@@ -39,7 +39,7 @@ class ScientificDoubleSpinBox(QDoubleSpinBox):
     def format_float(value):
         """Modified form of the 'g' format specifier."""
 
-        string = '{:g}'.format(value).replace('e+', 'e')
+        string = '{:.10g}'.format(value).replace('e+', 'e')
         string = re.sub('e(-?)0*(\d+)', r'e\1\2', string)
 
         return string
@@ -68,7 +68,7 @@ class ScientificDoubleSpinBox(QDoubleSpinBox):
         groups = FLOAT_REGEX.search(text).groups()
         decimal = float(groups[1])
         decimal += steps
-        new_string = '{:g}'.format(decimal) + (groups[3] if groups[3] else '')
+        new_string = '{:.10g}'.format(decimal) + (groups[3] if groups[3] else '')
 
         # Set the value so that signals get emitted properly
         self.setValue(self.valueFromText(new_string))


### PR DESCRIPTION
Previously, when editing floating values in the tree view, the 
floats would immediately be truncated to 2 decimal places when editing
began, and it would not allow you to specify more than 2 decimal places
of precision.

To fix this, we are using our ScientificDoubleSpinBox class for floats,
which allows for scientific notation. Additionally, the previous commit
increased the precision of the scientific spinbox itself. These changes
will hopefully provide enough precision for the tree view.

Fixes: #302 