### PR TITLE
Draw material overlays in raw view

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -2,10 +2,10 @@ import warnings
 
 import numpy as np
 
-from hexrd import instrument
 from hexrd.gridutil import cellIndices
 
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui import utils
 
 from skimage import transform as tf
 from skimage.exposure import equalize_adapthist
@@ -18,12 +18,7 @@ def cartesian_viewer():
     images_dict = HexrdConfig().current_images_dict()
     pixel_size = HexrdConfig().cartesian_pixel_size
 
-    # HEDMInstrument expects None Euler angle convention for the
-    # config. Let's get it as such.
-    iconfig = HexrdConfig().instrument_config_none_euler_convention
-    rme = HexrdConfig().rotation_matrix_euler()
-    instr = instrument.HEDMInstrument(instrument_config=iconfig,
-                                      tilt_calibration_mapping=rme)
+    instr = utils.create_hedm_instrument()
 
     # Make sure each key in the image dict is in the panel_ids
     if images_dict.keys() != instr._detectors.keys():

--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -72,7 +72,7 @@ class InstrumentViewer:
         # A delta_tth is needed here, even if the plane data tThWidth
         # is None. Default to 0.125 degrees if tThWidth is None.
         # I don't see a difference in the output if different values for
-        # delta_tth are chosen here.
+        # delta_tth are chosen here, when plane_data.tThWidth is None.
         if plane_data.tThWidth:
             delta_tth = np.degrees(plane_data.tThWidth)
         else:

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -2,35 +2,23 @@ import h5py
 import os
 import numpy as np
 
-from hexrd import instrument
 from .polarview import PolarView
 
 from .display_plane import DisplayPlane
 
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui import utils
 
 
 def polar_viewer():
-    images_dict = HexrdConfig().current_images_dict()
-
-    # HEDMInstrument expects None Euler angle convention for the
-    # config. Let's get it as such.
-    iconfig = HexrdConfig().instrument_config_none_euler_convention
-    return InstrumentViewer(iconfig, images_dict)
-
-
-def load_instrument(config):
-    rme = HexrdConfig().rotation_matrix_euler()
-    return instrument.HEDMInstrument(instrument_config=config,
-                                     tilt_calibration_mapping=rme)
+    return InstrumentViewer()
 
 
 class InstrumentViewer:
 
-    def __init__(self, config, images_dict):
+    def __init__(self):
         self.type = 'polar'
-        self.instr = load_instrument(config)
-        self.images_dict = images_dict
+        self.instr = utils.create_hedm_instrument()
         self.dplane = DisplayPlane()
 
         # Resolution settings

--- a/hexrd/ui/calibration/raw_iviewer.py
+++ b/hexrd/ui/calibration/raw_iviewer.py
@@ -1,0 +1,99 @@
+import numpy as np
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui import utils
+
+
+def raw_iviewer():
+    return InstrumentViewer()
+
+
+class InstrumentViewer:
+
+    def __init__(self):
+        self.type = 'images'
+        self.instr = utils.create_hedm_instrument()
+
+        # Callers should set this to indicate the detectors for which they
+        # would like to generate ring data
+        self.detectors = []
+
+    def clear_rings(self):
+        self.ring_data = {}
+
+    def generate_rings(self, plane_data, detector):
+        rings = []
+        rbnds = []
+        rbnd_indices = []
+
+        # If there are no rings, there is nothing to do
+        if not HexrdConfig().show_overlays or len(plane_data.getTTh()) == 0:
+            return rings, rbnds, rbnd_indices
+
+        # A delta_tth is needed here, even if the plane data tThWidth
+        # is None. Default to 0.125 degrees if tThWidth is None.
+        # I don't see a difference in the output if different values for
+        # delta_tth are chosen here, when plane_data.tThWidth is None.
+        if plane_data.tThWidth:
+            delta_tth = np.degrees(plane_data.tThWidth)
+        else:
+            delta_tth = 0.125
+        ring_angs, ring_xys = detector.make_powder_rings(
+            plane_data, delta_tth=delta_tth, delta_eta=1)
+
+        for ring in ring_xys:
+            rings.append(detector.cartToPixel(ring))
+
+        if plane_data.tThWidth is not None:
+            delta_tth = np.degrees(plane_data.tThWidth)
+            indices, ranges = plane_data.getMergedRanges()
+
+            r_lower = [r[0] for r in ranges]
+            r_upper = [r[1] for r in ranges]
+            l_angs, l_xyz = detector.make_powder_rings(
+                r_lower, delta_tth=delta_tth, delta_eta=1)
+            u_angs, u_xyz = detector.make_powder_rings(
+                r_upper, delta_tth=delta_tth, delta_eta=1)
+            for l, u in zip(l_xyz, u_xyz):
+                rbnds.append(detector.cartToPixel(l))
+                rbnds.append(detector.cartToPixel(u))
+            for ind in indices:
+                rbnd_indices.append(ind)
+                rbnd_indices.append(ind)
+
+        return rings, rbnds, rbnd_indices
+
+    def add_rings(self):
+        self.clear_rings()
+
+        if not HexrdConfig().show_overlays or not self.detectors:
+            # Nothing to do
+            return self.ring_data
+
+        for mat_name in HexrdConfig().visible_material_names:
+            mat = HexrdConfig().material(mat_name)
+            self.ring_data[mat_name] = {}
+
+            if not mat:
+                # Print a warning, as this shouldn't happen
+                print('Warning in InstrumentViewer.add_rings():',
+                      mat_name, 'is not a valid material')
+                continue
+
+            for det_name in self.detectors:
+                if det_name not in self.instr.detectors:
+                    # Print a warning, as this shouldn't happen
+                    print('Warning in InstrumentViewer.add_rings():',
+                          det_name, 'is not a valid detector')
+                    continue
+
+                detector = self.instr.detectors[det_name]
+                rings, rbnds, rbnd_indices = self.generate_rings(mat.planeData,
+                                                                 detector)
+                self.ring_data[mat_name][det_name] = {
+                    'ring_data': rings,
+                    'rbnd_data': rbnds,
+                    'rbnd_indices': rbnd_indices
+                }
+
+        return self.ring_data

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -6,6 +6,7 @@ import numpy as np
 import matplotlib.transforms as mtransforms
 
 from hexrd import imageutil
+from hexrd import instrument
 from hexrd.rotations import angleAxisOfRotMat, RotMatEuler
 from hexrd.transforms.xfcapi import makeRotMatOfExpMap
 
@@ -131,3 +132,15 @@ def remove_none_distortions(iconfig):
     for det in iconfig['detectors'].values():
         if det.get('distortion', {}).get('function_name', '').lower() == 'none':
             del det['distortion']
+
+
+def create_hedm_instrument():
+    # Takes the current config and creates an HEDMInstrument from it
+    from hexrd.ui.hexrd_config import HexrdConfig
+
+    # HEDMInstrument expects None Euler angle convention for the
+    # config. Let's get it as such.
+    iconfig = HexrdConfig().instrument_config_none_euler_convention
+    rme = HexrdConfig().rotation_matrix_euler()
+    return instrument.HEDMInstrument(instrument_config=iconfig,
+                                     tilt_calibration_mapping=rme)


### PR DESCRIPTION
This utilizes `PlanarDetector.make_powder_rings()` to draw the material
overlays on the raw view.

It looks good for the most part, except that some detectors produce
`ring_xys` values from `PlanarDetector.make_powder_rings()` that wrap
around to the other side, so that a line is drawn across the detector
connecting the ends. I am not sure if this is something that should
be fixed in hexrdgui, or in hexrd. See "ge2" below for an example.

Additionally, the values do not appear to go all the way to the image
borders for some reason.

![Screenshot from 2020-04-16 14-50-50](https://user-images.githubusercontent.com/9558430/79495276-5c905f00-7ff2-11ea-90e9-901faf3e7ee2.png)

![Screenshot from 2020-04-16 14-52-19](https://user-images.githubusercontent.com/9558430/79495296-60bc7c80-7ff2-11ea-8ee8-b961b08a77cd.png)

![Screenshot from 2020-04-16 14-52-51](https://user-images.githubusercontent.com/9558430/79495303-64e89a00-7ff2-11ea-9385-1935cbd436fb.png)

Fixes: #297