### PR TITLE
Move materials table into a dialog

### DIFF
--- a/hexrd/ui/materials_table.py
+++ b/hexrd/ui/materials_table.py
@@ -1,0 +1,112 @@
+import math
+
+from PySide2.QtCore import Qt, QItemSelectionModel, QSignalBlocker
+from PySide2.QtWidgets import QTableWidgetItem
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class MaterialsTable:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('materials_table.ui', parent)
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.table.selectionModel().selectionChanged.connect(
+            self.update_ring_selections)
+
+    def show(self):
+        if not hasattr(self, 'already_shown'):
+            self.already_shown = True
+            self.move_dialog_to_left()
+
+        self.ui.show()
+
+    def update_material_name(self):
+        self.ui.setWindowTitle(HexrdConfig().active_material_name)
+
+    def update_ring_selections(self):
+        # This updates the exclusions based upon the table selections
+        plane_data = HexrdConfig().active_material.planeData
+        selection_model = self.ui.table.selectionModel()
+        selected_rows = [x.row() for x in selection_model.selectedRows()]
+
+        indices = range(len(plane_data.exclusions))
+        exclusions = [i not in selected_rows for i in indices]
+        plane_data.exclusions = exclusions
+        HexrdConfig().ring_config_changed.emit()
+
+    def update_table_selections(self):
+        # This updates the table selections based on the exclusions
+        material = HexrdConfig().active_material
+        selection_model = self.ui.table.selectionModel()
+        blocker = QSignalBlocker(selection_model)  # noqa: F841
+
+        selection_model.clear()
+        plane_data = material.planeData
+        for i, exclude in enumerate(plane_data.exclusions):
+            if exclude:
+                continue
+
+            # Add the row to the selections
+            model_index = selection_model.model().index(i, 0)
+            command = QItemSelectionModel.Select | QItemSelectionModel.Rows
+            selection_model.select(model_index, command)
+
+    def update_table(self):
+        material = HexrdConfig().active_material
+
+        block_list = [
+            self.ui.table,
+            self.ui.table.selectionModel()
+        ]
+        blockers = [QSignalBlocker(x) for x in block_list]  # noqa: F841
+
+        plane_data = material.planeData
+
+        # For the table, we will turn off exclusions so that all
+        # rows are displayed, even the excluded ones. The user
+        # picks the exclusions by selecting the rows.
+        previous_exclusions = plane_data.exclusions
+        plane_data.exclusions = [False] * len(plane_data.exclusions)
+
+        hkls = plane_data.getHKLs(asStr=True)
+        d_spacings = plane_data.getPlaneSpacings()
+        tth = plane_data.getTTh()
+
+        # Restore the previous exclusions
+        plane_data.exclusions = previous_exclusions
+
+        self.ui.table.clearContents()
+        self.ui.table.setRowCount(len(hkls))
+        for i, hkl in enumerate(hkls):
+            table_item = QTableWidgetItem(hkl)
+            table_item.setTextAlignment(Qt.AlignCenter)
+            self.ui.table.setItem(i, 0, table_item)
+
+            table_item = QTableWidgetItem('%.2f' % d_spacings[i])
+            table_item.setTextAlignment(Qt.AlignCenter)
+            self.ui.table.setItem(i, 1, table_item)
+
+            table_item = QTableWidgetItem('%.2f' % math.degrees(tth[i]))
+            table_item.setTextAlignment(Qt.AlignCenter)
+            self.ui.table.setItem(i, 2, table_item)
+
+        self.update_table_selections()
+        self.update_material_name()
+
+    def move_dialog_to_left(self):
+        # This moves the dialog to the left border of the parent
+        parent = self.ui.parent()
+        if not parent:
+            return
+
+        ph = parent.geometry().height()
+        px = parent.geometry().x()
+        py = parent.geometry().y()
+        dw = self.ui.width()
+        dh = self.ui.height()
+        self.ui.setGeometry(px, py + (ph - dh) / 2.0, dw, dh)

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>382</width>
-    <height>574</height>
+    <height>221</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -109,65 +109,8 @@
     </layout>
    </item>
    <item>
-    <widget class="QTableWidget" name="materials_table">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;left click a row to activate the hkl&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <property name="dragDropOverwriteMode">
-      <bool>false</bool>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="rowCount">
-      <number>5</number>
-     </property>
-     <attribute name="horizontalHeaderCascadingSectionResizes">
-      <bool>true</bool>
-     </attribute>
-     <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>85</number>
-     </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
-      <number>70</number>
-     </attribute>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <row/>
-     <row/>
-     <row/>
-     <row/>
-     <row/>
-     <column>
-      <property name="text">
-       <string>{hkl}</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>d-spacing (Å)</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>2θ (°)</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="5" column="0">
+     <item row="4" column="0">
       <widget class="QCheckBox" name="limit_active">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the allowed HKLs with the max 2θ or the minimum d spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -177,7 +120,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="1">
+     <item row="5" column="1">
       <widget class="QLabel" name="min_d_spacing_label">
        <property name="enabled">
         <bool>false</bool>
@@ -187,7 +130,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="3" column="0">
       <widget class="QCheckBox" name="enable_width">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the currently selected material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -197,7 +140,7 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="tth_width">
        <property name="enabled">
         <bool>false</bool>
@@ -234,7 +177,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QCheckBox" name="material_visible">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Make the currently selected material visible&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -244,7 +187,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QPushButton" name="edit_style_button">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Edit the overlay styles of the currently selected material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -254,7 +197,7 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="5">
+     <item row="5" column="2">
       <widget class="QDoubleSpinBox" name="min_d_spacing">
        <property name="enabled">
         <bool>false</bool>
@@ -276,7 +219,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <widget class="QLabel" name="max_tth_label">
        <property name="enabled">
         <bool>false</bool>
@@ -286,7 +229,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="5">
+     <item row="4" column="2">
       <widget class="QDoubleSpinBox" name="max_tth">
        <property name="enabled">
         <bool>false</bool>
@@ -308,7 +251,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="6">
+     <item row="4" column="3">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -321,7 +264,7 @@
        </property>
       </spacer>
      </item>
-     <item row="4" column="5" colspan="2">
+     <item row="3" column="2" colspan="2">
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -334,7 +277,7 @@
        </property>
       </spacer>
      </item>
-     <item row="9" column="6">
+     <item row="5" column="3">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -347,7 +290,7 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="5">
+     <item row="2" column="2">
       <widget class="QPushButton" name="hide_all">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide all material overlays&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -357,7 +300,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
+     <item row="1" column="0">
       <widget class="QCheckBox" name="show_overlays">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display overlays in the canvas for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -370,6 +313,13 @@
        </property>
       </widget>
      </item>
+     <item row="0" column="0" colspan="4">
+      <widget class="QPushButton" name="show_materials_table">
+       <property name="text">
+        <string>Show Materials Table</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
   </layout>
@@ -377,7 +327,7 @@
  <tabstops>
   <tabstop>materials_combo</tabstop>
   <tabstop>materials_tool_button</tabstop>
-  <tabstop>materials_table</tabstop>
+  <tabstop>show_materials_table</tabstop>
   <tabstop>show_overlays</tabstop>
   <tabstop>material_visible</tabstop>
   <tabstop>edit_style_button</tabstop>

--- a/hexrd/ui/resources/ui/materials_table.ui
+++ b/hexrd/ui/resources/ui/materials_table.ui
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>materials_table</class>
+ <widget class="QDialog" name="materials_table">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>468</width>
+    <height>173</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_7">
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item>
+    <widget class="QTableWidget" name="table">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;left click a row to activate the hkl&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="rowCount">
+      <number>5</number>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>150</number>
+     </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>70</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <column>
+      <property name="text">
+       <string>{hkl}</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>d-spacing (Å)</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>2θ (°)</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>table</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This moves the materials table into a dialog, which is not shown
by default. It can be shown by clicking the new "Show Materials Table"
button in the materials panel. The materials table can be hidden by
clicking on the "x" button in the top right corner.

All of the functionality should be the same. Rows are highlighted if
they are to not be excluded. The dialog will also automatically
update when settings are modified in the materials panel.

These changes were done to free up some space in the materials panel.

![materials_panel](https://user-images.githubusercontent.com/9558430/80539696-f7cfef80-8975-11ea-84df-c4cdcf619c27.png)

![with_table](https://user-images.githubusercontent.com/9558430/80539705-facae000-8975-11ea-8862-5107a89f98a3.png)

I am happy to move the button if anyone thinks it would look nicer somewhere else.

Fixes: #300 