### PR TITLE
Create new HEDMInstrument class from config dict

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -2,9 +2,9 @@ import warnings
 
 import numpy as np
 
-from hexrd import instrument
 from hexrd.gridutil import cellIndices
 
+from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 
 from skimage import transform as tf
@@ -15,15 +15,9 @@ from .display_plane import DisplayPlane
 
 
 def cartesian_viewer():
+    instr = create_hedm_instrument()
     images_dict = HexrdConfig().current_images_dict()
     pixel_size = HexrdConfig().cartesian_pixel_size
-
-    # HEDMInstrument expects None Euler angle convention for the
-    # config. Let's get it as such.
-    iconfig = HexrdConfig().instrument_config_none_euler_convention
-    rme = HexrdConfig().rotation_matrix_euler()
-    instr = instrument.HEDMInstrument(instrument_config=iconfig,
-                                      tilt_calibration_mapping=rme)
 
     # Make sure each key in the image dict is in the panel_ids
     if images_dict.keys() != instr._detectors.keys():

--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -1,5 +1,3 @@
-import warnings
-
 import numpy as np
 
 from hexrd.gridutil import cellIndices
@@ -8,8 +6,6 @@ from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 
 from skimage import transform as tf
-from skimage.exposure import equalize_adapthist
-from skimage.exposure import rescale_intensity
 
 from .display_plane import DisplayPlane
 

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -2,34 +2,25 @@ import h5py
 import os
 import numpy as np
 
-from hexrd import instrument
 from .polarview import PolarView
 
 from .display_plane import DisplayPlane
 
+from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 
 
 def polar_viewer():
+    instr = create_hedm_instrument()
     images_dict = HexrdConfig().current_images_dict()
-
-    # HEDMInstrument expects None Euler angle convention for the
-    # config. Let's get it as such.
-    iconfig = HexrdConfig().instrument_config_none_euler_convention
-    return InstrumentViewer(iconfig, images_dict)
-
-
-def load_instrument(config):
-    rme = HexrdConfig().rotation_matrix_euler()
-    return instrument.HEDMInstrument(instrument_config=config,
-                                     tilt_calibration_mapping=rme)
+    return InstrumentViewer(instr, images_dict)
 
 
 class InstrumentViewer:
 
-    def __init__(self, config, images_dict):
+    def __init__(self, instr, images_dict):
         self.type = 'polar'
-        self.instr = load_instrument(config)
+        self.instr = instr
         self.images_dict = images_dict
         self.dplane = DisplayPlane()
 

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -10,7 +10,7 @@ from hexrd.transforms.xfcapi import \
 from hexrd import constants as ct
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.utils import run_snip1d, snip_width_pixels
+from hexrd.ui.utils import run_snip1d
 
 tvec_c = ct.zeros_3
 

--- a/hexrd/ui/calibration/powder_calibration.py
+++ b/hexrd/ui/calibration/powder_calibration.py
@@ -5,7 +5,6 @@ from scipy.optimize import leastsq, least_squares
 from hexrd import instrument
 from hexrd.matrixutil import findDuplicateVectors
 from hexrd.fitting import fitpeak
-from hexrd.rotations import RotMatEuler
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.utils import convert_tilt_convention

--- a/hexrd/ui/create_hedm_instrument.py
+++ b/hexrd/ui/create_hedm_instrument.py
@@ -1,0 +1,133 @@
+from hexrd.instrument.beam import Beam
+from hexrd.instrument.detector import PlanarDetector
+from hexrd.instrument.instrument import HEDMInstrument
+from hexrd.instrument.oscillation_stage import OscillationStage
+
+from hexrd.instrument.instrument import eta_vec_DFLT
+
+from hexrd.ui.hexrd_config import HexrdConfig
+
+
+def create_hedm_instrument():
+    # Takes the current config and creates an HEDMInstrument from it
+    kwargs = {}
+
+    # HEDMInstrument expects None Euler angle convention for the
+    # config. Let's get it as such.
+    iconfig = HexrdConfig().instrument_config_none_euler_convention
+    kwargs['tilt_calibration_mapping'] = HexrdConfig().rotation_matrix_euler()
+
+    kwargs['beam'] = create_beam(iconfig)
+    kwargs['eta_vector'] = eta_vec_DFLT
+    kwargs['detector_dict'] = create_detector_dict(
+        iconfig, beam=kwargs['beam'], eta_vector=kwargs['eta_vector'])
+
+    kwargs['oscillation_stage'] = create_oscillation_stage(iconfig)
+    kwargs['instrument_name'] = None
+
+    return HEDMInstrument(**kwargs)
+
+
+def create_beam(iconfig):
+    # Use kwargs so the default is used when unspecified.
+    kwargs = {}
+
+    # EAFP
+    try:
+        kwargs['energy'] = iconfig['beam']['energy']
+    except KeyError:
+        pass
+
+    try:
+        azimuth = iconfig['beam']['vector']['azimuth']
+        polar_angle = iconfig['beam']['vector']['polar_angle']
+    except KeyError:
+        pass
+    else:
+        kwargs['vector'] = Beam.calc_beam_vec(azimuth, polar_angle)
+
+    return Beam(**kwargs)
+
+
+def create_oscillation_stage(iconfig):
+    kwargs = {}
+
+    # EAFP
+    try:
+        kwargs['tvec'] = iconfig['oscillation_stage']['translation']
+    except KeyError:
+        pass
+
+    try:
+        kwargs['chi'] = iconfig['oscillation_stage']['chi']
+    except KeyError:
+        pass
+
+    return OscillationStage(**kwargs)
+
+
+def create_distortion_dict(iconfig):
+    detectors = iconfig.get('detectors', {})
+
+    # This might need to be changed in the future...
+    from hexrd.distortion import GE_41RT
+
+    dist_func_map = {
+        'GE41RT': GE_41RT,
+        'GE_41RT': GE_41RT
+    }
+
+    # Have default values of None
+    distortion_dict = {key: None for key in detectors.keys()}
+    for key, det in detectors.items():
+        try:
+            func_name = det['distortion']['function_name']
+            parameters = det['distortion']['parameters']
+
+            if func_name == 'None':
+                continue
+
+            if func_name not in dist_func_map:
+                print('Warning:', func_name, 'is not a known distortion'
+                      'function. Skipping it')
+                continue
+
+            distortion_dict[key] = [dist_func_map[func_name], parameters]
+
+        except KeyError:
+            continue
+
+    return distortion_dict
+
+
+def create_detector_dict(iconfig, beam, eta_vector=eta_vec_DFLT):
+    distortion_dict = create_distortion_dict(iconfig)
+    detectors = iconfig.get('detectors', {})
+
+    ret = {}
+    for key, det in detectors.items():
+        try:
+            pix = det['pixels']
+            xform = det['transform']
+
+            kwargs = {
+                'rows': pix['rows'],
+                'cols': pix['columns'],
+                'pixel_size': pix['size'],
+                'tvec': xform['translation'],
+                'tilt': xform['tilt'],
+                'name': key,
+                'evec': eta_vector,
+                'saturation_level': det.get('saturation_level'),
+                'panel_buffer': det.get('buffer'),
+                'roi': None,
+                'distortion': distortion_dict[key],
+                'beam': beam
+            }
+        except KeyError as e:
+            print('Warning: key', e, 'was missing in the detector config for',
+                  key, '\nSkipping over it in instrument creation.')
+        else:
+            ret[key] = PlanarDetector(**kwargs)
+
+    return ret


### PR DESCRIPTION
A [new HEDMInstrument class](https://github.com/HEXRD/hexrd/blob/eb2f5ffd288287df9c331755b240d90a9bb7ea25/hexrd/instrument/instrument.py#L167) was added as a part of hexrd v0.8.
This HEDMInstrument class does not currently accept an instrument
config for initializing it, and this causes errors in hexrdgui
for the cartesian and polar viewers.

To adjust our code for this, add a new function for creating an
HEDMInstrument from the config, and use this when we need to create
an instrument.

hexrd/hexrd#19 is also needed for the Cartesian viewer to work with
hexrd v0.8.