### PR TITLE
Overlays

### DIFF
--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -1,0 +1,84 @@
+import numpy as np
+
+from hexrd import constants
+
+
+class LaueSpotOverlay(object):
+    def __init__(self, plane_data, instr,
+                 crystal_params=None, sample_rmat=None,
+                 min_energy=5., max_energy=35.,
+                 ):
+        self._plane_data = plane_data
+        self._instrument = instr
+        if crystal_params is None:
+            self._crystal_params = np.hstack(
+                [constants.zeros_3,
+                 constants.zeros_3,
+                 constants.identity_6x1]
+            )
+        else:
+            assert len(crystal_params) == 12, \
+                "crystal parameters must have length 12"
+        self._min_energy = min_energy
+        self._max_energy = max_energy
+        if sample_rmat is None:
+            self._sample_rmat = constants.identity_3x3
+
+    @property
+    def plane_data(self):
+        return self._plane_data
+
+    @property
+    def instrument(self):
+        return self._instrument
+
+    @property
+    def crystal_params(self):
+        return self._crystal_params
+
+    @crystal_params.setter
+    def crystal_params(self, x):
+        assert len(x) == 12, 'input must be array-like with length 12'
+
+    @property
+    def min_energy(self):
+        return self._min_energy
+
+    @min_energy.setter
+    def min_energy(self, x):
+        assert x < self.max_energy
+        self._min_energy = x
+
+    @property
+    def max_energy(self):
+        return self._max_energy
+
+    @max_energy.setter
+    def max_energy(self, x):
+        assert x > self.min_energy
+        self._max_energy = x
+
+    @property
+    def sample_rmat(self):
+        return self._sample_rmat
+
+    @sample_rmat.setter
+    def sample_rmat(self, x):
+        assert isinstance(x, np.ndarray), 'input must be a (3, 3) array'
+
+    def overlay(self, display_mode='raw'):
+        sim_data = self.instrument.simulate_laue_pattern(
+            self.plane_data,
+            minEnergy=self.min_energy,
+            maxEnergy=self.max_energy,
+            rmat_s=self.sample_rmat,
+            grain_params=[self.crystal_params, ])
+        point_groups = dict.fromkeys(sim_data)
+        for det_key, psim in sim_data.items():
+            xy_det, hkls_in, angles, dspacing, energy = psim
+            idx = ~np.isnan(energy)
+            if display_mode == 'polar':
+                point_groups[det_key] = angles[idx, :]
+            elif display_mode in ['raw', 'cartesian']:
+                point_groups[det_key] = xy_det[idx, :]
+        return point_groups

--- a/hexrd/ui/overlays/mono_rotation_series.py
+++ b/hexrd/ui/overlays/mono_rotation_series.py
@@ -1,0 +1,104 @@
+import numpy as np
+
+eta_range_DFLT = 
+class MonoRotationSeriesSpotOverlay(object):
+    def __init__(self, plane_data, instr,
+                 crystal_params=None,
+                 eta_ranges=None,
+                 
+                                 ome_ranges=[(-np.pi, np.pi), ],
+                                 ome_period=(-np.pi, np.pi)
+                 ):
+        self._plane_data = plane_data
+        self._instrument = instr
+        if crystal_params is None:
+            self._crystal_params = np.hstack(
+                [constants.zeros_3,
+                 constants.zeros_3,
+                 constants.identity_6x1]
+            )
+        else:
+            assert len(crystal_params) == 12, \
+                "crystal parameters must have length 12"
+
+        if eta_ranges is None:
+            self._eta_ranges = [(-np.pi, np.pi), ]
+        else:
+            assert hasattr(eta_ranges, '__len__'), \
+                'eta ranges must be a list of 2-tuples'
+            # !!! need better check
+            self._eta_ranges = eta_ranges
+
+        if ome_ranges is None:
+            self._ome_ranges = [(-np.pi, np.pi), ]
+        else:
+            assert hasattr(ome_ranges, '__len__'), \
+                'ome ranges must be a list of 2-tuples'
+            # !!! need better check
+            self._ome_ranges = ome_ranges
+
+        if ome_period is None:
+            self._ome_period = self._ome_ranges[0][0] + np.r_[0., 2*np.pi]
+        else:
+            self._ome_period = ome_period
+
+    @property
+    def plane_data(self):
+        return self._plane_data
+
+    @property
+    def instrument(self):
+        return self._instrument
+
+    @property
+    def crystal_params(self):
+        return self._crystal_params
+
+    @crystal_params.setter
+    def crystal_params(self, x):
+        assert len(x) == 12, 'input must be array-like with length 12'
+
+    @property
+    def eta_ranges(self):
+        return self._eta_ranges
+
+    @eta_ranges.setter
+    def eta_ranges(self, x):
+        # FIXME: need a check here
+        self._eta_ranges = x
+
+    @property
+    def ome_ranges(self):
+        return self._ome_ranges
+
+    @ome_ranges.setter
+    def ome_ranges(self, x):
+        # FIXME: need a check here
+        self._ome_ranges = x
+
+    @property
+    def ome_period(self):
+        return self._ome_ranges[0][0] + np.r_[0., 2*np.pi]
+    
+    def overlay(self, display_mode='raw', frame_aggregateion_mode=None):
+        sim_data = self.instrument.simulate_rotation_series(
+            self.plane_data,
+            grain_params=[self.crystal_params, ],
+            eta_ranges=self.eta_ranges,
+            ome_ranges=self.ome_ranges,
+            ome_period=self.ome_period
+        )
+        point_groups = dict.fromkeys(sim_data)
+        for det_key, psim in sim_data.items():
+            valid_ids, valid_hkls, valid_angs, valid_xys, ang_pixel_size = psim
+            if display_mode == 'polar':
+                if self.aggregation mode is None:
+                    raise NotImplementedError
+                else:
+                    point_groups[det_key] = valid_angs
+            elif display_mode in ['raw', 'cartesian']:
+                if self.aggregation mode is None:
+                    raise NotImplementedError
+                else:
+                    point_groups[det_key] = valid_xys
+        return point_groups

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -1,0 +1,76 @@
+import numpy as np
+
+
+nans_row = np.nan*np.ones((1, 2))
+
+
+class PowderLineOverlay(object):
+    def __init__(self, plane_data, instr, eta_steps=360):
+        self._plane_data = plane_data
+        self._instrument = instr
+        self._eta_steps = eta_steps
+
+    @property
+    def plane_data(self):
+        return self._plane_data
+
+    @property
+    def instrument(self):
+        return self._instrument
+
+    @property
+    def eta_steps(self):
+        return self._eta_steps
+
+    @eta_steps.setter
+    def eta_steps(self, x):
+        assert isinstance(x, int), 'input must be an int'
+        self._eta_steps = x
+
+    @property
+    def delta_eta(self):
+        return 360./float(self.eta_steps)
+
+    def overlay(self, display_mode='raw'):
+        """
+        """
+        tths = self.plane_data.getTTh()
+
+        etas = np.radians(
+            self.delta_eta*np.linspace(
+                0., self.eta_steps, num=self.eta_steps + 1
+            )
+        )
+        point_groups = dict.fromkeys(self.instrument.detectors)
+        for det_key, panel in self.instrument.detectors.items():
+            ring_pts = []
+            for tth in tths:
+                ang_crds = np.vstack([np.tile(tth, len(etas)), etas]).T
+                if display_mode == 'polar':
+                    ring_pts.append(np.vstack([ang_crds, nans_row]))
+                elif display_mode in ['raw', 'cartesian']:
+                    xys_full = panel.angles_to_cart(ang_crds)
+                    xys, on_panel = panel.clip_to_panel(
+                        xys_full, buffer_edges=False
+                    )
+                    diff_tol = np.radians(self.delta_eta) + 1e-4
+                    ring_breaks = np.where(
+                        np.abs(np.diff(etas[on_panel])) > diff_tol
+                    )[0] + 1
+                    n_segments = len(ring_breaks) + 1
+                    if n_segments == 1:
+                        ring_pts.append(np.vstack([xys, nans_row]))
+                    else:
+                        src_len = sum(on_panel)
+                        dst_len = src_len + len(ring_breaks)
+                        nxys = np.nan*np.ones((dst_len, 2))
+                        ii = 0
+                        for i in range(n_segments - 1):
+                            jj = ring_breaks[i]
+                            nxys[ii + i:jj + i, :] = xys[ii:jj, :]
+                            ii = jj
+                        i = n_segments - 1
+                        nxys[ii + i:, :] = xys[ii:, :]
+                        ring_pts.append(np.vstack([nxys, nans_row]))
+            point_groups[det_key] = np.vstack(ring_pts)
+        return point_groups


### PR DESCRIPTION
adds a ui package `overlays` containing the prototype classes yielding the overlay point groups for:
- Powder diffraction (Debye-Scherrer rings\line)
- Laue diffraction
- Monochromatic rotation series

The current API for obtaining the point group for each class is via the `OverlayClass.overlay()` method, which yields a dictionary of (x, y) or (2θ, η) points to plot, depending on the kwarg `display_mode=<'raw'> or 'cartesian' or 'polar'`.  The return type is a dictionary, with keys for each detector panel.  In the usage case for the `cartesian` display mode, the intention is to instantiate the overlay class with the synthetic instrument used to generate the display plane.  Ranges are currenly _not* output, but this is an easy fix -- most likely to be access via a `'ranges'` kwarg to the `overlay()` method.  

The instantiation API for each takes a planeData object and an instrument as the two positional args, then type-specific kwargs.  Tested them, and they work; this is start, at least.
![Screenshot 2020-05-26 13 50 09](https://user-images.githubusercontent.com/1154130/83073293-0d900d80-a025-11ea-9eb2-7d630b33a468.png)
![Screen Shot 2020-05-27 at 2 21 06 PM](https://user-images.githubusercontent.com/1154130/83073447-51831280-a025-11ea-97d1-fc3c6ceae520.png)

