### PR TITLE
Add -c anaconda to conda instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install -e hexrdgui
 
 ```bash
 # Install deps using conda package
-conda install -c cjh1 -c conda-forge hexrdgui
+conda install -c cjh1 -c anaconda -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 pip install --no-deps -U -e hexrd
 CONDA_BUILD=1 pip install --no-deps -U -e hexrdgui

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -25,7 +25,6 @@ requirements:
     - fabio
     - pyyaml
     - hexrd
-    - libopenblas==0.3.7
 
 test:
   imports:


### PR DESCRIPTION
`-c anaconda` is added before `-c conda-forge` to give preference to
packages on anaconda if they are there, and then conda-forge if they
are not.

Hopefully, the packages on anaconda are more stable because they are
maintained by anaconda, rather than the community.

Additionally, numpy on anaconda uses mkl, and numpy on conda-forge
uses libopenblas. We have had problems with libopenblas on the mac,
so maybe mkl will be more stable.

Fixes: #298
Fixes: #299