### PR TITLE
Bump python3 requirement to 3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Develop
 
-Requires Python 3.6+
+Requires Python 3.8+
 
 ```bash
 git clone git@github.com:/HEXRD/hexrd.git
@@ -19,6 +19,9 @@ pip install -e hexrdgui
 ## conda
 
 ```bash
+# First, make sure python3.8+ is installed.
+# If it is not, run the following command:
+conda install -c anaconda python=3.8
 # Install deps using conda package
 conda install -c cjh1 -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development

--- a/setup.py
+++ b/setup.py
@@ -35,11 +35,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6'
+        'Programming Language :: Python :: 3.8'
     ],
     packages=find_packages(),
     package_data={'hexrd': ['ui/resources/**/*']},
-    python_requires='>=3.6',
+    python_requires='>=3.8',
     install_requires=install_reqs,
     entry_points={
         'gui_scripts': [


### PR DESCRIPTION
Python 3.8 is [now required in hexrd](https://github.com/HEXRD/hexrd/blob/031d348dd27661d22d726dfdd4cc0838ca73a38b/setup.py#L81). As such, we need to bump our
python3 requirement to 3.8 as well.

Since miniconda doesn't come with python3.8 installed by default,
some instructions were also added as to how to install python3.8
in conda.