### PR TITLE
Add a default panel buffer to the detectors

### DIFF
--- a/hexrd/ui/resources/calibration/default_instrument_config.yml
+++ b/hexrd/ui/resources/calibration/default_instrument_config.yml
@@ -11,6 +11,7 @@ detectors:
       columns: 2048
       rows: 2048
       size: [1.0, 1.0]
+    buffer: 0.5
     saturation_level: 14000.0
     transform:
       translation: [0.0, 0.0, 0.0]
@@ -24,6 +25,7 @@ detectors:
       columns: 2048
       rows: 2048
       size: [1.0, 1.0]
+    buffer: 0.5
     saturation_level: 14000.0
     transform:
       translation: [0.0, 0.0, 0.0]


### PR DESCRIPTION
If a panel buffer is not specified, then default to 0.5. This is
required with some changes in hexrd master.

Fixes: #321