### PR TITLE
Do not allow the buffer to be refined

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -407,7 +407,7 @@ class CalTreeView(QTreeView):
             return
 
         # If the key is blacklisted, return
-        blacklisted_keys = ['saturation_level']
+        blacklisted_keys = ['saturation_level', 'buffer']
         if item.data(KEY_COL) in blacklisted_keys:
             return
 


### PR DESCRIPTION
Add it to the blacklist of unrefinable parameters.

Fixes: #331