### PR TITLE
Remove "buffer" from default instrument config

### DIFF
--- a/hexrd/ui/resources/calibration/default_instrument_config.yml
+++ b/hexrd/ui/resources/calibration/default_instrument_config.yml
@@ -11,7 +11,6 @@ detectors:
       columns: 2048
       rows: 2048
       size: [1.0, 1.0]
-    buffer: 0.5
     saturation_level: 14000.0
     transform:
       translation: [0.0, 0.0, 0.0]
@@ -25,7 +24,6 @@ detectors:
       columns: 2048
       rows: 2048
       size: [1.0, 1.0]
-    buffer: 0.5
     saturation_level: 14000.0
     transform:
       translation: [0.0, 0.0, 0.0]


### PR DESCRIPTION
The issue on hexrd master that was requiring this option is now
fixed. There isn't an acceptable default option for the buffer,
either, so just remove it.

Done in response to [this comment](https://github.com/HEXRD/hexrdgui/pull/326#issuecomment-640922896).