### PR TITLE
Auto-generate Cartesian params from instrument config

### DIFF
--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -103,7 +103,7 @@ class CalibrationConfigWidget(QObject):
 
     def on_detector_name_edited(self):
         new_name = self.ui.cal_det_current.currentText()
-        detector_names = self.cfg.get_detector_names()
+        detector_names = self.cfg.detector_names
 
         # Ignore it if there is already a detector with this name
         if new_name in detector_names:
@@ -134,7 +134,7 @@ class CalibrationConfigWidget(QObject):
     def on_detector_add_clicked(self):
         combo = self.ui.cal_det_current
         current_detector = self.get_current_detector()
-        detector_names = self.cfg.get_detector_names()
+        detector_names = self.cfg.detector_names
         new_detector_name_base = 'detector_'
         for i in range(1000000):
             new_detector_name = new_detector_name_base + str(i + 1)
@@ -197,7 +197,7 @@ class CalibrationConfigWidget(QObject):
 
         try:
             combo_widget = self.ui.cal_det_current
-            detector_names = self.cfg.get_detector_names()
+            detector_names = self.cfg.detector_names
             if not detector_names:
                 # Disable detector widgets if there is no valid detector
                 if not self.detector_widgets_disabled:

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -65,7 +65,7 @@ class CalibrationSliderWidget(QObject):
         return self.ui.detector.currentText()
 
     def current_detector_dict(self):
-        return HexrdConfig().get_detector(self.current_detector())
+        return HexrdConfig().detector(self.current_detector())
 
     def translation_widgets(self):
         # Let's take advantage of the naming scheme

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -175,7 +175,7 @@ class CalibrationSliderWidget(QObject):
 
         old_detector = self.current_detector()
         old_detectors = [widget.itemText(x) for x in range(widget.count())]
-        detectors = HexrdConfig().get_detector_names()
+        detectors = HexrdConfig().detector_names
 
         if old_detectors == detectors:
             # The detectors didn't change. Nothing to update

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -285,7 +285,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # Find missing keys under detectors and set defaults for them
         default = self.get_default_detector()
         for name in self.detector_names:
-            self._recursive_set_defaults(self.get_detector(name), default)
+            self._recursive_set_defaults(self.detector(name), default)
 
     def _recursive_set_defaults(self, current, default):
         for key in default.keys():
@@ -698,12 +698,12 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return copy.deepcopy(
             self.default_config['instrument']['detectors']['ge1'])
 
-    def get_detector(self, detector_name):
+    def detector(self, detector_name):
         return self.config['instrument']['detectors'][detector_name]
 
     def add_detector(self, detector_name, detector_to_copy=None):
         if detector_to_copy is not None:
-            new_detector = copy.deepcopy(self.get_detector(detector_to_copy))
+            new_detector = copy.deepcopy(self.detector(detector_to_copy))
         else:
             new_detector = self.get_default_detector()
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1069,8 +1069,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return self.config['image']['cartesian']['pixel_size']
 
     def _set_cartesian_pixel_size(self, v):
-        self.config['image']['cartesian']['pixel_size'] = v
-        self.rerender_needed.emit()
+        if v != self.cartesian_pixel_size:
+            self.config['image']['cartesian']['pixel_size'] = v
+            self.rerender_needed.emit()
 
     cartesian_pixel_size = property(_cartesian_pixel_size,
                                     _set_cartesian_pixel_size)
@@ -1079,8 +1080,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return self.config['image']['cartesian']['virtual_plane_distance']
 
     def set_cartesian_virtual_plane_distance(self, v):
-        self.config['image']['cartesian']['virtual_plane_distance'] = v
-        self.rerender_needed.emit()
+        if v != self.cartesian_virtual_plane_distance:
+            self.config['image']['cartesian']['virtual_plane_distance'] = v
+            self.rerender_needed.emit()
 
     cartesian_virtual_plane_distance = property(
         _cartesian_virtual_plane_distance,
@@ -1090,8 +1092,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return self.config['image']['cartesian']['plane_normal_rotate_x']
 
     def set_cartesian_plane_normal_rotate_x(self, v):
-        self.config['image']['cartesian']['plane_normal_rotate_x'] = v
-        self.rerender_needed.emit()
+        if v != self.cartesian_plane_normal_rotate_x:
+            self.config['image']['cartesian']['plane_normal_rotate_x'] = v
+            self.rerender_needed.emit()
 
     cartesian_plane_normal_rotate_x = property(
         _cartesian_plane_normal_rotate_x,
@@ -1101,8 +1104,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return self.config['image']['cartesian']['plane_normal_rotate_y']
 
     def set_cartesian_plane_normal_rotate_y(self, v):
-        self.config['image']['cartesian']['plane_normal_rotate_y'] = v
-        self.rerender_needed.emit()
+        if v != self.cartesian_plane_normal_rotate_y:
+            self.config['image']['cartesian']['plane_normal_rotate_y'] = v
+            self.rerender_needed.emit()
 
     cartesian_plane_normal_rotate_y = property(
         _cartesian_plane_normal_rotate_y,

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -79,6 +79,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when detectors have been added or removed"""
     detectors_changed = Signal()
 
+    """Emitted when an instrument config has been loaded"""
+    instrument_config_loaded = Signal()
+
     """Convenience signal to update the main window's status bar
 
     Arguments are: message (str)
@@ -238,6 +241,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         self.deep_rerender_needed.emit()
         self.update_visible_material_energies()
+        self.instrument_config_loaded.emit()
 
     def set_images_dir(self, images_dir):
         self.images_dir = images_dir
@@ -354,6 +358,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             # Still need a deep rerender
             self.deep_rerender_needed.emit()
 
+        self.instrument_config_loaded.emit()
         return self.config['instrument']
 
     def save_instrument_config(self, output_file):
@@ -695,12 +700,16 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return list(self.config['instrument'].get('detectors', {}).keys())
 
     @property
-    def default_detector(self):
-        return copy.deepcopy(
-            self.default_config['instrument']['detectors']['ge1'])
+    def detectors(self):
+        return self.config['instrument'].get('detectors', {})
 
     def detector(self, detector_name):
         return self.config['instrument']['detectors'][detector_name]
+
+    @property
+    def default_detector(self):
+        return copy.deepcopy(
+            self.default_config['instrument']['detectors']['ge1'])
 
     def add_detector(self, detector_name, detector_to_copy=None):
         if detector_to_copy is not None:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -284,7 +284,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
     def set_detector_defaults_if_missing(self):
         # Find missing keys under detectors and set defaults for them
         default = self.get_default_detector()
-        for name in self.get_detector_names():
+        for name in self.detector_names:
             self._recursive_set_defaults(self.get_detector(name), default)
 
     def _recursive_set_defaults(self, current, default):
@@ -327,7 +327,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             self.load_panel_state_reset.emit()
 
     def load_instrument_config(self, yml_file):
-        old_detectors = self.get_detector_names()
+        old_detectors = self.detector_names
         with open(yml_file, 'r') as f:
             self.config['instrument'] = yaml.load(f, Loader=yaml.FullLoader)
 
@@ -347,7 +347,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         self.update_visible_material_energies()
 
-        new_detectors = self.get_detector_names()
+        new_detectors = self.detector_names
         if old_detectors != new_detectors:
             self.detectors_changed.emit()
         else:
@@ -450,8 +450,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 statuses.append(status)
 
         # Get the detector flags
-        det_names = self.get_detector_names()
-        for name in det_names:
+        for name in self.detector_names:
             for path in dflags_order:
                 full_path = ['detectors', name] + path
                 status = self.get_instrument_config_val(full_path)
@@ -526,8 +525,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 cur_ind += 1
 
         # Set the detector flags
-        det_names = self.get_detector_names()
-        for name in det_names:
+        for name in self.detector_names:
             for path in dflags_order:
                 full_path = ['detectors', name] + path
 
@@ -692,7 +690,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
         res += self.get_gui_yaml_paths(['detectors'])
         return [x[0] for x in res]
 
-    def get_detector_names(self):
+    @property
+    def detector_names(self):
         return list(self.config['instrument'].get('detectors', {}).keys())
 
     def get_default_detector(self):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -283,7 +283,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
     def set_detector_defaults_if_missing(self):
         # Find missing keys under detectors and set defaults for them
-        default = self.get_default_detector()
+        default = self.default_detector
         for name in self.detector_names:
             self._recursive_set_defaults(self.detector(name), default)
 
@@ -694,7 +694,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
     def detector_names(self):
         return list(self.config['instrument'].get('detectors', {}).keys())
 
-    def get_default_detector(self):
+    @property
+    def default_detector(self):
         return copy.deepcopy(
             self.default_config['instrument']['detectors']['ge1'])
 
@@ -705,7 +706,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         if detector_to_copy is not None:
             new_detector = copy.deepcopy(self.detector(detector_to_copy))
         else:
-            new_detector = self.get_default_detector()
+            new_detector = self.default_detector
 
         self.config['instrument']['detectors'][detector_name] = new_detector
         self.detectors_changed.emit()

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -303,7 +303,7 @@ class ImageCanvas(FigureCanvas):
             # our method for getting the saturation level as well.
             ax = img.axes
             detector_name = ax.get_title()
-            detector = HexrdConfig().get_detector(detector_name)
+            detector = HexrdConfig().detector(detector_name)
             saturation_level = detector['saturation_level']['value']
 
             array = img.get_array()

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -35,7 +35,7 @@ class ImageFileManager(metaclass=Singleton):
 
     def load_dummy_images(self, initial=False):
         HexrdConfig().clear_images(initial)
-        detectors = HexrdConfig().get_detector_names()
+        detectors = HexrdConfig().detector_names
         iconfig = HexrdConfig().instrument_config
         for det in detectors:
             cols = iconfig['detectors'][det]['pixels']['columns']

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -40,7 +40,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         self.unaggregated_images = None
 
     def check_images(self, fnames):
-        dets = HexrdConfig().get_detector_names()
+        dets = HexrdConfig().detector_names
         files = [[] for i in range(len(dets))]
         core_name = os.path.split(fnames[0])[1]
         for det in dets:
@@ -63,7 +63,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             return files
 
     def match_images(self, fnames):
-        dets = HexrdConfig().get_detector_names()
+        dets = HexrdConfig().detector_names
         files = [[] for i in range(len(dets))]
         core_name = fnames[0]
         for det in dets:
@@ -86,7 +86,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             return files
 
     def match_dirs_images(self, fnames, directories):
-        dets = HexrdConfig().get_detector_names()
+        dets = HexrdConfig().detector_names
         files = [[] for i in range(len(dets))]
         # Find the images with the same name for the remaining detectors
         for i, dir in enumerate(directories):
@@ -136,7 +136,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
 
         # Open selected images as imageseries
         self.parent_dir = HexrdConfig().images_dir
-        det_names = HexrdConfig().get_detector_names()
+        det_names = HexrdConfig().detector_names
 
         if len(self.files[0]) > 1:
             for i, det in enumerate(det_names):

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QObject, Signal
+from PySide2.QtCore import QObject, QSignalBlocker, Signal
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
@@ -79,41 +79,27 @@ class ImageModeWidget(QObject):
 
         return widgets
 
-    def block_widgets(self):
-        previous = []
-        for widget in self.all_widgets():
-            previous.append(widget.blockSignals(True))
-
-        return previous
-
-    def unblock_widgets(self, previous):
-        for widget, block in zip(self.all_widgets(), previous):
-            widget.blockSignals(block)
-
     def update_gui_from_config(self):
-        block_list = self.block_widgets()
-        try:
-            self.ui.cartesian_pixel_size.setValue(
-                HexrdConfig().cartesian_pixel_size)
-            self.ui.cartesian_virtual_plane_distance.setValue(
-                HexrdConfig().cartesian_virtual_plane_distance)
-            self.ui.cartesian_plane_normal_rotate_x.setValue(
-                HexrdConfig().cartesian_plane_normal_rotate_x)
-            self.ui.cartesian_plane_normal_rotate_y.setValue(
-                HexrdConfig().cartesian_plane_normal_rotate_y)
-            self.ui.polar_pixel_size_tth.setValue(
-                HexrdConfig().polar_pixel_size_tth)
-            self.ui.polar_pixel_size_eta.setValue(
-                HexrdConfig().polar_pixel_size_eta)
-            self.ui.polar_res_tth_min.setValue(
-                HexrdConfig().polar_res_tth_min)
-            self.ui.polar_res_tth_max.setValue(
-                HexrdConfig().polar_res_tth_max)
-            self.ui.polar_apply_snip1d.setChecked(
-                HexrdConfig().polar_apply_snip1d)
-            self.ui.polar_snip1d_width.setValue(
-                HexrdConfig().polar_snip1d_width)
-            self.ui.polar_snip1d_numiter.setValue(
-                HexrdConfig().polar_snip1d_numiter)
-        finally:
-            self.unblock_widgets(block_list)
+        blocked = [QSignalBlocker(x) for x in self.all_widgets()]  # noqa: F841
+        self.ui.cartesian_pixel_size.setValue(
+            HexrdConfig().cartesian_pixel_size)
+        self.ui.cartesian_virtual_plane_distance.setValue(
+            HexrdConfig().cartesian_virtual_plane_distance)
+        self.ui.cartesian_plane_normal_rotate_x.setValue(
+            HexrdConfig().cartesian_plane_normal_rotate_x)
+        self.ui.cartesian_plane_normal_rotate_y.setValue(
+            HexrdConfig().cartesian_plane_normal_rotate_y)
+        self.ui.polar_pixel_size_tth.setValue(
+            HexrdConfig().polar_pixel_size_tth)
+        self.ui.polar_pixel_size_eta.setValue(
+            HexrdConfig().polar_pixel_size_eta)
+        self.ui.polar_res_tth_min.setValue(
+            HexrdConfig().polar_res_tth_min)
+        self.ui.polar_res_tth_max.setValue(
+            HexrdConfig().polar_res_tth_max)
+        self.ui.polar_apply_snip1d.setChecked(
+            HexrdConfig().polar_apply_snip1d)
+        self.ui.polar_snip1d_width.setValue(
+            HexrdConfig().polar_snip1d_width)
+        self.ui.polar_snip1d_numiter.setValue(
+            HexrdConfig().polar_snip1d_numiter)

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -10,7 +10,7 @@ from hexrd.ui.ui_loader import UiLoader
 class LoadImagesDialog:
 
     def __init__(self, image_files, parent=None):
-        self.detectors = HexrdConfig().get_detector_names()
+        self.detectors = HexrdConfig().detector_names
         self.image_files = image_files
 
         loader = UiLoader()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -94,7 +94,7 @@ class LoadPanel(QObject):
         self.ui.file_options.cellChanged.connect(self.enable_aggregations)
 
     def setup_processing_options(self):
-        num_dets = len(HexrdConfig().get_detector_names())
+        num_dets = len(HexrdConfig().detector_names)
         if (not HexrdConfig().load_panel_state
                 or not isinstance(HexrdConfig().load_panel_state['trans'], list)):
             HexrdConfig().load_panel_state = {
@@ -126,7 +126,7 @@ class LoadPanel(QObject):
 
     def detectors_changed(self):
         self.ui.detector.clear()
-        self.ui.detector.addItems(HexrdConfig().get_detector_names())
+        self.ui.detector.addItems(HexrdConfig().detector_names)
 
     def agg_changed(self):
         self.state['agg'] = self.ui.aggregation.currentIndex()
@@ -241,7 +241,7 @@ class LoadPanel(QObject):
         if not enable:
             # Update dark mode settings
             self.ui.all_detectors.setChecked(True)
-            num_dets = len(HexrdConfig().get_detector_names())
+            num_dets = len(HexrdConfig().detector_names)
             self.state['dark'] = [5 for x in range(num_dets)]
             self.ui.darkMode.setCurrentIndex(5)
             # Update aggregation settings
@@ -340,10 +340,10 @@ class LoadPanel(QObject):
 
     def find_directories(self):
         # Find all detector directories
-        num_det = len(HexrdConfig().get_detector_names())
+        num_det = len(HexrdConfig().detector_names)
         for sub_dir in os.scandir(os.path.dirname(self.parent_dir)):
             if (os.path.isdir(sub_dir)
-                    and sub_dir.name in HexrdConfig().get_detector_names()):
+                    and sub_dir.name in HexrdConfig().detector_names):
                 self.directories.append(sub_dir.path)
         # Show error if expected detector directories are not found
         if len(self.directories) != num_det:
@@ -352,7 +352,7 @@ class LoadPanel(QObject):
                 for path in self.directories:
                     dir_names.append(os.path.basename(path))
             diff = list(
-                set(HexrdConfig().get_detector_names()) - set(dir_names))
+                set(HexrdConfig().detector_names) - set(dir_names))
             msg = (
                 'ERROR - No directory found for the following detectors: \n'
                 + str(diff)[1:-1])

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -246,7 +246,7 @@ class MainWindow(QObject):
 
             # Make sure the names and number of files and
             # names and number of detectors match
-            num_detectors = len(HexrdConfig().get_detector_names())
+            num_detectors = len(HexrdConfig().detector_names)
             if len(selected_files) != num_detectors:
                 msg = ('Number of files must match number of detectors: ' +
                        str(num_detectors))
@@ -273,7 +273,7 @@ class MainWindow(QObject):
     def open_aps_imageseries(self):
         # Get the most recent images dir
         images_dir = HexrdConfig().images_dir
-        detector_names = HexrdConfig().get_detector_names()
+        detector_names = HexrdConfig().detector_names
         selected_dirs = []
         for name in detector_names:
             caption = 'Select directory for detector: ' + name


### PR DESCRIPTION
When a new instrument config is loaded (either by
"File"->"Open"->"Configuration", or by resetting the instrument
configuration), automatically generate Cartesian parameters based
upon the config.

The parameters are currently calculated as follows:

1. Distance: absolute value of the average of detector z translation values
2. Pixel size: 5x the average of the detector pixel sizes

I ended up using 5x the average for the pixel size because that gave me a
reasonably interactive setup for my personal computer. But we can adjust it
if something else is better. Less than 5x, such as 3x, made for much slower
interaction for me.

I did a little bit of re-formatting int his PR as well. But the main changes of
interest are [here](https://github.com/HEXRD/hexrdgui/compare/master...psavery:auto-generate-cartesian-params?expand=1#diff-30bfcc80b3692dfa8947f36bbec62f14R109-R130).

Fixes: #305