### PR TITLE
Update overlays when beam vector is changed

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -50,7 +50,8 @@ class InstrumentViewer:
     def make_dpanel(self):
         self.dpanel_sizes = self.dplane.panel_size(self.instr)
         self.dpanel = self.dplane.display_panel(self.dpanel_sizes,
-                                                self.pixel_size)
+                                                self.pixel_size,
+                                                self.instr.beam_vector)
 
     def clear_rings(self):
         self.ring_data = {}

--- a/hexrd/ui/calibration/display_plane.py
+++ b/hexrd/ui/calibration/display_plane.py
@@ -43,7 +43,7 @@ class DisplayPlane:
 
         return (del_x, del_y)
 
-    def display_panel(self, sizes, mps):
+    def display_panel(self, sizes, mps, bvec=None):
 
         del_x = sizes[0]
         del_y = sizes[1]
@@ -54,6 +54,7 @@ class DisplayPlane:
         display_panel = instrument.PlanarDetector(
             rows=nrows_map, cols=ncols_map,
             pixel_size=(mps, mps),
-            tvec=self.tvec, tilt=self.tilt)
+            tvec=self.tvec, tilt=self.tilt,
+            bvec=bvec)
 
         return display_panel

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -226,9 +226,11 @@ class CalibrationSliderWidget(QObject):
                 HexrdConfig().update_visible_material_energies()
             elif key == 'polar':
                 iconfig['beam']['vector']['polar_angle']['value'] = val
+                HexrdConfig().beam_vector_changed.emit()
                 self.emit_update_if_polar()
             else:
                 iconfig['beam']['vector'][key]['value'] = val
+                HexrdConfig().beam_vector_changed.emit()
                 self.emit_update_if_polar()
 
     def update_widget_value(self, widget):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -50,6 +50,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when ring configuration has changed"""
     ring_config_changed = Signal()
 
+    """Emitted when beam vector has changed"""
+    beam_vector_changed = Signal()
+
     """Emitted when the option to show the saturation level is changed"""
     show_saturation_level_changed = Signal()
 
@@ -636,6 +639,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # If the beam energy was modified, update the visible materials
         if path == ['beam', 'energy', 'value']:
             self.update_visible_material_energies()
+            return
+
+        if path[:2] == ['beam', 'vector']:
+            # Beam vector has been modified. Indicate so.
+            self.beam_vector_changed.emit()
             return
 
         if path[0] == 'detectors' and path[2] == 'transform':

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -66,6 +66,7 @@ class ImageCanvas(FigureCanvas):
             self.on_detector_transform_modified)
         HexrdConfig().rerender_detector_borders.connect(
             self.draw_detector_borders)
+        HexrdConfig().beam_vector_changed.connect(self.beam_vector_changed)
 
     def __del__(self):
         # This is so that the figure can be cleaned up
@@ -318,6 +319,14 @@ class ImageCanvas(FigureCanvas):
             self.saturation_texts.append(t)
 
         self.draw()
+
+    def beam_vector_changed(self):
+        if not self.iviewer or not hasattr(self.iviewer, 'instr'):
+            return
+
+        bvec = HexrdConfig().instrument_config['beam']['vector']
+        self.iviewer.instr.beam_vector = (bvec['azimuth'], bvec['polar_angle'])
+        self.redraw_rings()
 
     def show_cartesian(self):
         HexrdConfig().emit_update_status_bar('Loading Cartesian view...')


### PR DESCRIPTION
When the beam vector is changed, update the beam vector on the
instrument that the overlay has, and then redraw the overlays.

![Peek 2020-06-17 14-03](https://user-images.githubusercontent.com/9558430/84936184-e1a5fc00-b0a7-11ea-8ba4-c270e8a8024e.gif)

Fixes: #341 