### PR TITLE
Transform menu

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -110,7 +110,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self._tab_images = False
         self.previous_active_material = None
         self.collapsed_state = []
-        self.load_panel_state = None
+        self.load_panel_state = {}
         self.polar_masks = []
         self.ring_styles = {}
         self.backup_tth_maxes = {}
@@ -191,7 +191,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         self.previous_active_material = settings.value('active_material', None)
         self.collapsed_state = settings.value('collapsed_state', [])
-        self.load_panel_state = settings.value('load_panel_state', None)
+        self.load_panel_state = settings.value('load_panel_state', {})
         self.ring_styles = settings.value('ring_styles', {})
 
         # Set this manually since we don't have any materials yet

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -162,7 +162,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         # Process the imageseries
         self.apply_operations(HexrdConfig().imageseries_dict)
         if self.data:
-            if self.state['agg']:
+            if 'agg' in self.state and self.state['agg']:
                 self.display_aggregation(HexrdConfig().imageseries_dict)
             else:
                 self.add_omega_metadata(HexrdConfig().imageseries_dict)
@@ -333,7 +333,8 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             if self.data and 'idx' in self.data:
                 idx = self.data['idx']
 
-            if self.state['dark'][idx] != UI_DARK_INDEX_NONE:
+            if ('dark' in self.state and
+                    self.state['dark'][idx] != UI_DARK_INDEX_NONE):
                 progress_macro_steps += 1
 
         if 'agg' in self.state and self.state['agg']:

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -17,7 +17,7 @@ class LoadImagesDialog:
         self.ui = loader.load_file('load_images_dialog.ui', parent)
 
         self.setup_connections()
-
+        self.setup_state()
         self.setup_table()
         self.update_table()
 
@@ -44,6 +44,12 @@ class LoadImagesDialog:
             else:
                 return False
 
+    def setup_state(self):
+        if 'trans' not in HexrdConfig().load_panel_state:
+            num_dets = len(HexrdConfig().detector_names)
+            HexrdConfig().load_panel_state = {
+                'trans': [0 for x in range(num_dets)]}
+
     def setup_table(self):
         table = self.ui.match_detectors_table
         table.clearContents()
@@ -56,7 +62,10 @@ class LoadImagesDialog:
             options = ["None", "Flip Vertically", "Flip Horizontally",
                 "Transpose", "Rotate 90°", "Rotate 180°", "Rotate 270°"]
             cb.addItems(options)
-            cb.setCurrentIndex(HexrdConfig().load_panel_state['trans'][i])
+            idx = 0
+            if 'trans' in HexrdConfig().load_panel_state:
+                idx = HexrdConfig().load_panel_state['trans'][i]
+            cb.setCurrentIndex(idx)
             table.setCellWidget(i, 1, cb)
 
             f = QTableWidgetItem(self.image_files[i])

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -4,7 +4,7 @@ import glob
 import numpy as np
 
 from PySide2.QtGui import QCursor
-from PySide2.QtCore import QObject, Qt, QPersistentModelIndex, QDir
+from PySide2.QtCore import QObject, Qt, QPersistentModelIndex, QDir, Signal
 from PySide2.QtWidgets import QTableWidgetItem, QFileDialog, QMenu, QMessageBox
 
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -21,6 +21,9 @@ from hexrd.ui.ui_loader import UiLoader
 
 
 class LoadPanel(QObject):
+
+    # Emitted when images are loaded
+    images_loaded = Signal()
 
     def __init__(self, parent=None):
         super(LoadPanel, self).__init__(parent)
@@ -516,3 +519,4 @@ class LoadPanel(QObject):
             data['yml_files'] = self.yml_files
 
         ImageLoadManager().read_data(self.files, data, self.parent())
+        self.images_loaded.emit()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import yaml
 import glob
@@ -51,10 +52,8 @@ class LoadPanel(QObject):
     def setup_gui(self):
         self.setup_processing_options()
 
-        if 'subdirs' in self.state:
-            self.ui.subdirectories.setChecked(self.state['subdirs'])
-        if 'apply_to_all' in self.state:
-            self.ui.all_detectors.setChecked(self.state['apply_to_all'])
+        self.ui.subdirectories.setChecked(self.state.get('subdirs', False))
+        self.ui.all_detectors.setChecked(self.state.get('apply_to_all', False))
         self.ui.image_folder.setEnabled(self.ui.subdirectories.isChecked())
         self.ui.aggregation.setCurrentIndex(self.state['agg'])
         self.ui.transform.setCurrentIndex(self.state['trans'][0])
@@ -97,16 +96,12 @@ class LoadPanel(QObject):
         self.ui.file_options.cellChanged.connect(self.enable_aggregations)
 
     def setup_processing_options(self):
+        self.state = copy.copy(HexrdConfig().load_panel_state)
         num_dets = len(HexrdConfig().detector_names)
-        if (not HexrdConfig().load_panel_state
-                or not isinstance(HexrdConfig().load_panel_state['trans'], list)):
-            HexrdConfig().load_panel_state = {
-                'agg': 0,
-                'trans': [0 for x in range(num_dets)],
-                'dark': [0 for x in range(num_dets)],
-                'dark_files': [None for x in range(num_dets)]}
-
-        self.state = HexrdConfig().load_panel_state
+        self.state.setdefault('agg', 0)
+        self.state.setdefault('trans', [0 for x in range(num_dets)])
+        self.state.setdefault('dark', [0 for x in range(num_dets)])
+        self.state.setdefault('dark_files', [None for x in range(num_dets)])
 
     # Handle GUI changes
 
@@ -517,6 +512,6 @@ class LoadPanel(QObject):
             data['idx'] = self.idx
         if self.ext == '.yml':
             data['yml_files'] = self.yml_files
-
+        HexrdConfig().load_panel_state = copy.copy(self.state)
         ImageLoadManager().read_data(self.files, data, self.parent())
         self.images_loaded.emit()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -183,7 +183,7 @@ class LoadPanel(QObject):
                 self.ui, caption, dir=self.parent_dir)
 
         # Only update if a new directory is selected
-        if new_dir and new_dir != self.parent_dir:
+        if new_dir and new_dir != HexrdConfig().images_dir:
             self.ui.image_files.setEnabled(True)
             HexrdConfig().set_images_dir(new_dir)
             self.parent_dir = new_dir

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -30,6 +30,7 @@ from hexrd.ui.load_images_dialog import LoadImagesDialog
 from hexrd.ui.load_panel import LoadPanel
 from hexrd.ui.materials_panel import MaterialsPanel
 from hexrd.ui.powder_calibration_dialog import PowderCalibrationDialog
+from hexrd.ui.transform_dialog import TransformDialog
 from hexrd.ui.image_mode_widget import ImageModeWidget
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui import resource_loader
@@ -126,6 +127,8 @@ class MainWindow(QObject):
             self.on_action_edit_apply_polar_mask_triggered)
         self.ui.action_edit_reset_instrument_config.triggered.connect(
             self.on_action_edit_reset_instrument_config)
+        self.ui.action_transform_detectors.triggered.connect(
+            self.on_action_transform_detectors_triggered)
         self.ui.action_show_live_updates.toggled.connect(
             self.live_update)
         self.ui.action_show_detector_borders.toggled.connect(
@@ -218,6 +221,7 @@ class MainWindow(QObject):
     def load_dummy_images(self):
         ImageFileManager().load_dummy_images()
         self.update_all(clear_canvases=True)
+        self.ui.action_transform_detectors.setEnabled(False)
         self.new_images_loaded.emit()
 
     def open_image_file(self):
@@ -269,6 +273,7 @@ class MainWindow(QObject):
             if dialog.exec_():
                 detector_names, image_files = dialog.results()
                 ImageLoadManager().read_data(files, parent=self.ui)
+                self.ui.action_transform_detectors.setEnabled(True)
 
     def open_aps_imageseries(self):
         # Get the most recent images dir
@@ -607,3 +612,6 @@ class MainWindow(QObject):
 
         msg = delimiter.join(labels)
         self.ui.status_bar.showMessage(msg)
+
+    def on_action_transform_detectors_triggered(self):
+        td = TransformDialog(self.ui).exec_()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -149,6 +149,7 @@ class MainWindow(QObject):
             self.ui.status_bar.clearMessage)
         self.calibration_slider_widget.update_if_mode_matches.connect(
             self.update_if_mode_matches)
+        self.load_widget.images_loaded.connect(self.images_loaded)
 
         self.image_mode_widget.polar_show_snip1d.connect(
             self.ui.image_tab_widget.polar_show_snip1d)
@@ -273,7 +274,10 @@ class MainWindow(QObject):
             if dialog.exec_():
                 detector_names, image_files = dialog.results()
                 ImageLoadManager().read_data(files, parent=self.ui)
-                self.ui.action_transform_detectors.setEnabled(True)
+                self.images_loaded()
+
+    def images_loaded(self):
+        self.ui.action_transform_detectors.setEnabled(True)
 
     def open_aps_imageseries(self):
         # Get the most recent images dir

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -93,6 +93,7 @@
     <addaction name="action_edit_calibration_crystal"/>
     <addaction name="action_edit_apply_polar_mask"/>
     <addaction name="action_edit_reset_instrument_config"/>
+    <addaction name="action_transform_detectors"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -176,8 +177,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>98</width>
-          <height>28</height>
+          <width>550</width>
+          <height>708</height>
          </rect>
         </property>
         <attribute name="label">
@@ -189,8 +190,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>127</width>
-          <height>49</height>
+          <width>550</width>
+          <height>708</height>
          </rect>
         </property>
         <attribute name="label">
@@ -435,6 +436,14 @@
   <action name="action_edit_reset_instrument_config">
    <property name="text">
     <string>Reset Instrument Config</string>
+   </property>
+  </action>
+  <action name="action_transform_detectors">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Transform Detectors</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/transforms_dialog.ui
+++ b/hexrd/ui/resources/ui/transforms_dialog.ui
@@ -1,0 +1,165 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>transform_dialog</class>
+ <widget class="QDialog" name="transform_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>410</width>
+    <height>140</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Transform Detectors</string>
+  </property>
+  <layout class="QVBoxLayout" name="dialog_layout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="update_all">
+       <property name="text">
+        <string>Update All Detectors</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="update_each">
+       <property name="text">
+        <string>Update Individual Detectors</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="all_label">
+       <property name="text">
+        <string>All Detectors</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QComboBox" name="transform_all_menu">
+       <item>
+        <property name="text">
+         <string>(None)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Flip Vertically</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Flip Horizontally</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Transpose</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Rotate 90°</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Rotate 180°</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Rotate 270°</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>transform_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>transform_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -63,6 +63,6 @@ class TransformDialog:
             for combo in self.det_cboxes:
                 trans.append(combo.currentIndex())
         ilm = ImageLoadManager()
-        ilm.set_state({ 'trans': trans })
-        ilm.apply_operations(HexrdConfig().imageseries_dict)
-        ilm.finish_processing_ims()
+        state = HexrdConfig().load_panel_state
+        ilm.set_state({ 'trans': trans , 'agg': state.get('agg', 0) })
+        ilm.begin_processing(postprocess=True)

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -1,0 +1,68 @@
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.image_load_manager import ImageLoadManager
+from hexrd.ui.ui_loader import UiLoader
+
+from PySide2.QtWidgets import QComboBox, QHBoxLayout, QLabel, QSpacerItem
+
+class TransformDialog:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('transforms_dialog.ui', parent)
+        self.det_labels = []
+        self.det_cboxes = []
+
+        self.update_gui()
+        self.setup_connections()
+
+    def update_gui(self):
+        options = [
+            '(None)', 'Flip Vertically', 'Flip Horizontally', 'Transpose',
+            'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
+        for i, det in enumerate(HexrdConfig().get_detector_names()):
+            hbox = QHBoxLayout()
+            # Add label
+            label = QLabel(det)
+            hbox.addWidget(label)
+            self.det_labels.append(label)
+            # Add spacer
+            hbox.addSpacerItem(QSpacerItem(40, 20))
+            # Add combo box
+            cb = QComboBox()
+            hbox.addWidget(cb)
+            self.det_cboxes.append(cb)
+            cb.addItems(options)
+            self.ui.dialog_layout.insertLayout(i + 2, hbox)
+        for label, cbox in zip(self.det_labels, self.det_cboxes):
+            label.setEnabled(False)
+            cbox.setEnabled(False)
+
+    def setup_connections(self):
+        self.ui.update_all.clicked.connect(self.toggle_options)
+        self.ui.update_each.clicked.connect(self.toggle_options)
+        self.ui.accepted.connect(self.apply_transforms)
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    def toggle_options(self):
+        enabled = self.ui.update_all.isChecked()
+        self.ui.all_label.setEnabled(enabled)
+        self.ui.transform_all_menu.setEnabled(enabled)
+        for label, cbox in zip(self.det_labels, self.det_cboxes):
+            label.setEnabled(not enabled)
+            cbox.setEnabled(not enabled)
+
+    def apply_transforms(self):
+        num_dets = len(HexrdConfig().get_detector_names())
+        trans = []
+        if self.ui.update_all.isChecked():
+            idx = self.ui.transform_all_menu.currentIndex()
+            trans = [idx for x in range(num_dets)]
+        else:
+            for combo in self.det_cboxes:
+                trans.append(combo.currentIndex())
+        ilm = ImageLoadManager()
+        ilm.set_state({ 'trans': trans })
+        ilm.apply_operations(HexrdConfig().imageseries_dict)
+        ilm.finish_processing_ims()

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -19,7 +19,7 @@ class TransformDialog:
         options = [
             '(None)', 'Flip Vertically', 'Flip Horizontally', 'Transpose',
             'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
-        for i, det in enumerate(HexrdConfig().get_detector_names()):
+        for i, det in enumerate(HexrdConfig().detector_names):
             hbox = QHBoxLayout()
             # Add label
             label = QLabel(det)
@@ -54,7 +54,7 @@ class TransformDialog:
             cbox.setEnabled(not enabled)
 
     def apply_transforms(self):
-        num_dets = len(HexrdConfig().get_detector_names())
+        num_dets = len(HexrdConfig().detector_names)
         trans = []
         if self.ui.update_all.isChecked():
             idx = self.ui.transform_all_menu.currentIndex()


### PR DESCRIPTION
Allow detector images to be transformed after load. Although the transform can be set for each detector for quick load, mistakes may accidentally be made. This adds an option in the `Edit` menu to `Transform Detectors`. The default option is to apply the transform to all detectors, but if `Update Individual Detectors` is selected each detector can be adjusted separately.

![transform_dialog](https://user-images.githubusercontent.com/51238406/84937148-53cb1080-b0a9-11ea-8281-8ef0985ab073.png)
