### PR TITLE
Live update fixes

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -184,7 +184,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.images_dir = settings.value('images_dir', None)
         self.hdf5_path = settings.value('hdf5_path', None)
         # All QSettings come back as strings.
-        self.live_update = bool(settings.value('live_update', True) == 'true')
+        self.live_update = settings.value('live_update', 'true') == 'true'
 
         conv = settings.value('euler_angle_convention', ('xyz', True))
         self.set_euler_angle_convention(conv[0], conv[1], convert_config=False)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -585,6 +585,8 @@ class MainWindow(QObject):
 
         if enabled:
             HexrdConfig().rerender_needed.connect(self.update_all)
+            # Go ahead and trigger an update as well
+            self.update_all()
         # Only disconnect if we were previously enabled. i.e. the signal was connected
         elif previous:
             HexrdConfig().rerender_needed.disconnect(self.update_all)


### PR DESCRIPTION
Default live update to True

It is almost always used, so make sure the default is True.

This fixes a bug where `True == 'true'` was returning `False`.


Also, trigger re-render when live update is enabled
    
This is so the user won't need to switch to another image mode
and then back.

Fixes: #333