### PR TITLE
Remove need to rescale points in Cartesian view

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -242,9 +242,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
             utils.convert_tilt_convention(self.config['instrument'], old_eac,
                                           new_eac)
 
+        self.instrument_config_loaded.emit()
         self.deep_rerender_needed.emit()
         self.update_visible_material_energies()
-        self.instrument_config_loaded.emit()
 
     def set_images_dir(self, images_dir):
         self.images_dir = images_dir
@@ -354,6 +354,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         self.update_visible_material_energies()
 
+        self.instrument_config_loaded.emit()
+
         new_detectors = self.detector_names
         if old_detectors != new_detectors:
             self.detectors_changed.emit()
@@ -361,7 +363,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
             # Still need a deep rerender
             self.deep_rerender_needed.emit()
 
-        self.instrument_config_loaded.emit()
         return self.config['instrument']
 
     def save_instrument_config(self, output_file):

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -345,6 +345,7 @@ class ImageCanvas(FigureCanvas):
             self.axes_images[0].set_extent(iviewer.extent)
             self.axis.relim()
             self.axis.autoscale_view()
+            self.axis.autoscale(False)
             self.figure.tight_layout()
 
         self.redraw_rings()

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -109,7 +109,9 @@ class ImageModeWidget(QObject):
     def auto_generate_cartesian_params(self):
         # This will automatically generate and set values for the
         # Cartesian pixel size and virtual plane distance based upon
-        # values in the instrument config
+        # values in the instrument config.
+        # The calling function should ensure a re-render occurs. This function
+        # will not perform a re-render.
         detectors = list(HexrdConfig().detectors.values())
         distances = [
             x['transform']['translation']['value'][2] for x in detectors
@@ -119,12 +121,12 @@ class ImageModeWidget(QObject):
         average_dist = sum(distances) / len(distances)
         average_size = sum([x[0] + x[1] for x in sizes]) / (2 * len(sizes))
 
-        # Set one of these without triggerring a re-render, so we will only
-        # re-render one time.
         HexrdConfig().config['image']['cartesian']['pixel_size'] = (
             5 * average_size
         )
-        HexrdConfig().cartesian_virtual_plane_distance = abs(average_dist)
+        HexrdConfig().config['image']['cartesian']['virtual_plane_distance'] = (
+            abs(average_dist)
+        )
 
         # Get the GUI to update with the new values
         self.update_gui_from_config()

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -80,8 +80,9 @@ class PowderLineOverlay(object):
                     xys_full, buffer_edges=False
                 )
 
-                # Convert to pixel coordinates
-                xys = panel.cartToPixel(xys)
+                if display_mode == 'raw':
+                    # Convert to pixel coordinates
+                    xys = panel.cartToPixel(xys)
 
                 diff_tol = np.radians(self.delta_eta) + 1e-4
                 ring_breaks = np.where(


### PR DESCRIPTION
Instead of plotting detector borders and overlays in pixel coordinates
and then rescaling them to the Cartesian coordinates, just plot them in
Cartesian coordinates.

This removes the need to rescale the points.

This also fixes a couple of other bugs that were noticed as a result
of these changes.

The powder rings in particular are now more well-behaved as a result
of these changes. They do not depend on the original extents of
the image anymore, since Cartesian coordinates are used.

Additionally, (0, 0) is now at the center of the Cartesian image, which
was changed as a result of [this comment](https://github.com/HEXRD/hexrdgui/issues/337#issuecomment-646376601).

![image](https://user-images.githubusercontent.com/9558430/85435875-20c7c780-b556-11ea-9971-1c55e74f7170.png)

Fixes: #337