### PR TITLE
Fix color map editor tab order

### DIFF
--- a/hexrd/ui/resources/ui/color_map_editor.ui
+++ b/hexrd/ui/resources/ui/color_map_editor.ui
@@ -225,7 +225,13 @@
  </widget>
  <tabstops>
   <tabstop>color_map</tabstop>
+  <tabstop>reverse</tabstop>
   <tabstop>minimum</tabstop>
+  <tabstop>show_under</tabstop>
+  <tabstop>maximum</tabstop>
+  <tabstop>show_over</tabstop>
+  <tabstop>reset_range</tabstop>
+  <tabstop>log_scale</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This goes left to right, up to down.

Before, the order was somewhat random.