### PR TITLE
Apply to all selection

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -254,7 +254,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             # Apply dark subtraction
             if key in dark_images:
                 self.get_dark_op(ops, dark_images[key])
-            if 'trans' in self.state and self.state['trans'][idx]:
+            if 'trans' in self.state:
                 self.get_flip_op(ops, idx)
 
             frames = self.get_range(ims_dict[key])
@@ -304,6 +304,8 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             return range(self.empty_frames, len(ims))
 
     def get_flip_op(self, oplist, idx):
+        if self.data:
+            idx = self.data.get('idx', idx)
         # Change the image orientation
         if self.state['trans'][idx] == UI_TRANS_INDEX_NONE:
             return

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -157,8 +157,9 @@ class LoadPanel(QObject):
         self.idx = self.ui.detector.currentIndex()
         if not self.ui.all_detectors.isChecked():
             self.ui.transform.setCurrentIndex(self.state['trans'][self.idx])
-            self.ui.darkMode.setCurrentIndex(self.state['dark'][self.idx])
-            self.dark_mode_changed()
+            if self.ui.darkMode.isEnabled():
+                self.ui.darkMode.setCurrentIndex(self.state['dark'][self.idx])
+                self.dark_mode_changed()
         self.create_table()
 
     def apply_to_all_changed(self, checked):
@@ -238,7 +239,6 @@ class LoadPanel(QObject):
 
         if not enable:
             # Update dark mode settings
-            self.ui.all_detectors.setChecked(True)
             num_dets = len(HexrdConfig().detector_names)
             self.state['dark'] = [5 for x in range(num_dets)]
             self.ui.darkMode.setCurrentIndex(5)

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -163,7 +163,7 @@ class LoadPanel(QObject):
         self.create_table()
 
     def apply_to_all_changed(self, checked):
-        self.state['apply_to_all'] = checked
+        HexrdConfig().load_panel_state['apply_to_all'] = checked
         if not checked:
             self.switch_detector()
 
@@ -512,6 +512,6 @@ class LoadPanel(QObject):
             data['idx'] = self.idx
         if self.ext == '.yml':
             data['yml_files'] = self.yml_files
-        HexrdConfig().load_panel_state = copy.copy(self.state)
+        HexrdConfig().load_panel_state.update(copy.copy(self.state))
         ImageLoadManager().read_data(self.files, data, self.parent())
         self.images_loaded.emit()


### PR DESCRIPTION
Remember `Apply Selections to All Detectors` option on program exit.

This also fixes a bug that occurred when a single frame `ImageSeries` was loaded through the `Load Panel`. The `Apply Selections to All Detectors` option was automatically checked and could not be deselected. However, trying to deselect the option was still toggling the settings internally. This caused unexpected results when the `Read Files` option was selected. This has been fixed to allow toggling of the `Apply to all` selection which now produces the expected results.

Fixes #356