### PR TITLE
Use Qt::Tool window flag to keep popup panels on top

### DIFF
--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import QObject, Signal
+from PySide2.QtCore import Qt, QObject, Signal
 
 from itertools import cycle
 
@@ -21,6 +21,8 @@ class LinePickerDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('line_picker_dialog.ui', parent)
+        flags = self.ui.windowFlags()
+        self.ui.setWindowFlags(flags | Qt.Tool)
 
         self.canvas = canvas
         self.ring_data = []

--- a/hexrd/ui/materials_table.py
+++ b/hexrd/ui/materials_table.py
@@ -12,6 +12,8 @@ class MaterialsTable:
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('materials_table.ui', parent)
+        flags = self.ui.windowFlags()
+        self.ui.setWindowFlags(flags | Qt.Tool)
         self.setup_connections()
 
     def setup_connections(self):


### PR DESCRIPTION
On macOS, the line picker and materials table weren't staying on top of the main window. This PR adds the Qt::Tool window flag so that they do.

Closes #335 