### PR TITLE
Don't call clear from __del__

### DIFF
--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -39,9 +39,6 @@ class LinePickerDialog(QObject):
 
         self.setup_connections()
 
-    def __del__(self):
-        self.clear()
-
     def setup_connections(self):
         self.ui.accepted.connect(self.accepted)
         self.ui.rejected.connect(self.rejected)


### PR DESCRIPTION
The clear function accesses the canvas with will already be cleaned up my this time. Basically clear is already called by either  accept or reject.

Fixes: #376