### PR TITLE
Add Laue overlay widths to the polar view

### DIFF
--- a/hexrd/ui/calibration/raw_iviewer.py
+++ b/hexrd/ui/calibration/raw_iviewer.py
@@ -39,9 +39,8 @@ class InstrumentViewer:
                 'plane_data': mat.planeData,
                 'instr': self.instr
             }
-            if type == 'laue':
-                # Modify kwargs here
-                pass
+            # Add any options
+            kwargs.update(overlay.get('options', {}))
 
             generator = overlay_generator(type)(**kwargs)
             overlay['data'] = generator.overlay('raw')

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -133,7 +133,8 @@ class ImageCanvas(FigureCanvas):
 
         if self.mode in ['cartesian', 'polar']:
             # If it's cartesian or polar, there is only one axis
-            return [(self.axis, next(iter(overlay['data'].values())))]
+            # Use the same axis for all of the data
+            return [(self.axis, x) for x in overlay['data'].values()]
 
         # If it's raw, there is data for each axis.
         # The title of each axis should match the data key.

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -207,17 +207,18 @@ class ImageCanvas(FigureCanvas):
 
     def draw_laue_overlay(self, axis, data, style):
         spots = data['spots']
-
-        # FIXME: plot this when we start to generate it
-        ranges = data['ranges']  # noqa: F841
+        ranges = data['ranges']
 
         data_style = style['data']
-
-        # FIXME: plot this when we start to generate it
-        ranges_style = style['ranges']  # noqa: F841
+        ranges_style = style['ranges']
 
         for x, y in spots:
             artist = axis.scatter(x, y, **data_style)
+            self.overlay_artists.append(artist)
+
+        for range in ranges:
+            x, y = zip(*range)
+            artist, = axis.plot(x, y, **ranges_style)
             self.overlay_artists.append(artist)
 
     def draw_mono_rotation_series_overlay(self, axis, data, style):

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -23,7 +23,7 @@ class OverlayEditor:
     def setup_connections(self):
         for w in self.laue_widgets:
             if isinstance(w, QDoubleSpinBox):
-                w.editingFinished.connect(self.update_config)
+                w.valueChanged.connect(self.update_config)
             elif isinstance(w, QCheckBox):
                 w.toggled.connect(self.update_config)
 

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -73,9 +73,9 @@ class OverlayEditor:
             for i, w in enumerate(self.laue_cc_widgets):
                 w.setValue(options['crystal_params'][i])
 
-        if 'tth_width' in options:
+        if options.get('tth_width') is not None:
             self.ui.laue_tth_width.setValue(np.degrees(options['tth_width']))
-        if 'eta_width' in options:
+        if options.get('eta_width') is not None:
             self.ui.laue_eta_width.setValue(np.degrees(options['eta_width']))
 
         widths = ['tth_width', 'eta_width']

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -22,6 +22,8 @@ class OverlayManager:
 
         self.overlay_editor = OverlayEditor(self.ui)
         self.ui.overlay_editor_layout.addWidget(self.overlay_editor.ui)
+        flags = self.ui.windowFlags()
+        self.ui.setWindowFlags(flags | Qt.Tool)
 
         self.material_combos = []
         self.type_combos = []

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -7,7 +7,7 @@ class LaueSpotOverlay:
     def __init__(self, plane_data, instr,
                  crystal_params=None, sample_rmat=None,
                  min_energy=5., max_energy=35.,
-                 ):
+                 tth_width=None, eta_width=None):
         self._plane_data = plane_data
         self._instrument = instr
         if crystal_params is None:
@@ -25,6 +25,9 @@ class LaueSpotOverlay:
             self._sample_rmat = constants.identity_3x3
         else:
             self.sample_rmat = sample_rmat
+
+        self.tth_width = tth_width
+        self.eta_width = eta_width
 
     @property
     def plane_data(self):
@@ -70,6 +73,11 @@ class LaueSpotOverlay:
         assert isinstance(x, np.ndarray), 'input must be a (3, 3) array'
         self._sample_rmat = x
 
+    @property
+    def widths_enabled(self):
+        widths = ['tth_width', 'eta_width']
+        return all(getattr(self, x) is not None for x in widths)
+
     def overlay(self, display_mode='raw'):
         sim_data = self.instrument.simulate_laue_pattern(
             self.plane_data,
@@ -85,7 +93,9 @@ class LaueSpotOverlay:
             xy_det, hkls_in, angles, dspacing, energy = psim
             idx = ~np.isnan(energy)
             if display_mode == 'polar':
-                point_groups[det_key]['spots'] = np.degrees(angles[idx, :])
+                spots = np.degrees(angles[idx, :])
+                point_groups[det_key]['spots'] = spots
+                point_groups[det_key]['ranges'] = self.polar_ranges(spots)
             elif display_mode in ['raw', 'cartesian']:
                 panel = self.instrument.detectors[det_key]
 
@@ -96,3 +106,22 @@ class LaueSpotOverlay:
 
                 point_groups[det_key]['spots'] = data
         return point_groups
+
+    def polar_ranges(self, spots):
+        # spots should be in degrees
+        if not self.widths_enabled:
+            return []
+
+        widths = np.degrees([self.tth_width, self.eta_width])
+        ranges = []
+        for spot in spots:
+            corners = [
+               (spot[0] + widths[0], spot[1] + widths[1]),
+               (spot[0] + widths[0], spot[1] - widths[1]),
+               (spot[0] - widths[0], spot[1] - widths[1]),
+               (spot[0] - widths[0], spot[1] + widths[1])
+            ]
+            # Put the first point at the end to complete the square
+            corners.append(corners[0])
+            ranges.append(corners)
+        return ranges

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -105,6 +105,10 @@ class LaueSpotOverlay:
                     data = panel.cartToPixel(data)
                     # Swap x and y, they are flipped
                     data[:, [0, 1]] = data[:, [1, 0]]
+                else:
+                    # I'm not sure why, but the y axis is flipped for
+                    # Cartesian...
+                    data[:, 1] = -data[:, 1]
 
                 point_groups[det_key]['spots'] = data
         return point_groups

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -103,6 +103,8 @@ class LaueSpotOverlay:
                 if display_mode == 'raw':
                     # Convert to pixel coordinates
                     data = panel.cartToPixel(data)
+                    # Swap x and y, they are flipped
+                    data[:, [0, 1]] = data[:, [1, 0]]
 
                 point_groups[det_key]['spots'] = data
         return point_groups

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -64,6 +64,12 @@ class PowderLineOverlay:
                 for ind in indices:
                     point_groups[det_key]['rbnd_indices'] += [ind, ind]
 
+            # Currently, the polar mode draws lines over the whole image.
+            # Thus, we only need data from one detector.
+            # This can be changed in the future if needed.
+            if display_mode == 'polar':
+                break
+
         return point_groups
 
     def generate_ring_points(self, tths, etas, panel, display_mode):

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>299</height>
+    <height>468</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -29,7 +29,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>275</height>
+       <height>380</height>
       </size>
      </property>
      <property name="currentIndex">
@@ -57,33 +57,6 @@
        <string>Laue</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="1" column="1">
-        <widget class="QDoubleSpinBox" name="laue_max_energy">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>35.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="laue_min_energy_label">
-         <property name="text">
-          <string>Min Energy:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="laue_max_energy_label">
-         <property name="text">
-          <string>Max Energy:</string>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="1">
         <widget class="QDoubleSpinBox" name="laue_min_energy">
          <property name="keyboardTracking">
@@ -97,7 +70,7 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="0" colspan="2">
+       <item row="3" column="0" colspan="2">
         <widget class="QGroupBox" name="calibration_crystal_group_box">
          <property name="title">
           <string>Calibration Crystal</string>
@@ -430,6 +403,113 @@
          </layout>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QDoubleSpinBox" name="laue_max_energy">
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
+         <property name="maximum">
+          <double>10000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>35.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="laue_max_energy_label">
+         <property name="text">
+          <string>Max Energy:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="laue_min_energy_label">
+         <property name="text">
+          <string>Min Energy:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QGroupBox" name="ranges_group_box">
+         <property name="title">
+          <string>Widths</string>
+         </property>
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="2" column="1">
+           <widget class="QLabel" name="laue_eta_width_label">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>η</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="laue_tth_width_label">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>2θ</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="laue_enable_widths">
+            <property name="text">
+             <string>Enable Widths</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QDoubleSpinBox" name="laue_tth_width">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>180.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.050000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="2">
+           <widget class="QDoubleSpinBox" name="laue_eta_width">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="decimals">
+             <number>3</number>
+            </property>
+            <property name="maximum">
+             <double>180.000000000000000</double>
+            </property>
+            <property name="value">
+             <double>5.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="mono_rotation_series_tab">
@@ -463,6 +543,9 @@
   <tabstop>tab_widget</tabstop>
   <tabstop>laue_min_energy</tabstop>
   <tabstop>laue_max_energy</tabstop>
+  <tabstop>laue_enable_widths</tabstop>
+  <tabstop>laue_tth_width</tabstop>
+  <tabstop>laue_eta_width</tabstop>
   <tabstop>laue_cc_0</tabstop>
   <tabstop>laue_cc_1</tabstop>
   <tabstop>laue_cc_2</tabstop>

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -483,6 +483,9 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
             <property name="suffix">
              <string>°</string>
             </property>
@@ -500,6 +503,9 @@
           <item row="2" column="2">
            <widget class="QDoubleSpinBox" name="laue_eta_width">
             <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="keyboardTracking">
              <bool>false</bool>
             </property>
             <property name="suffix">

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -124,6 +124,9 @@
             <property name="singleStep">
              <double>0.100000000000000</double>
             </property>
+            <property name="value">
+             <double>1.000000000000000</double>
+            </property>
            </widget>
           </item>
           <item row="0" column="2">
@@ -195,6 +198,9 @@
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -317,6 +323,9 @@
             </property>
             <property name="singleStep">
              <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>1.000000000000000</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
This adds an option in the overlay editor to enable widths for the Laue
overlays, and it also adds options for tth_width and eta_width.

If this is enabled, these options get passed on to the Laue overlay
generator. For the polar view, these are used to construct range data,
which appear as rectangles around the Laue spots.

Currently, these options are ignored for the raw and cartesian views.
They will need to be added at a later time.

![image](https://user-images.githubusercontent.com/9558430/87074539-03009080-c1ed-11ea-9f77-88edeea6486d.png)

![laue_widths](https://user-images.githubusercontent.com/9558430/87074418-d5b3e280-c1ec-11ea-8bbf-ed994a0b56a5.png)

This also fixes issues with our plotting of the Laue spots.

Fixes part of: #31
Fixes part of: #381 

Fixes: #391