### PR TITLE
Use unaggregated images for indexing if possible

### DIFF
--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -36,8 +36,13 @@ def create_indexing_config():
     mconfig.materials = HexrdConfig().materials
     config.material = mconfig
 
-    # Set the image series dict
-    ims_dict = HexrdConfig().imageseries_dict
+    # Use unaggregated images if possible
+    ims_dict = ImageLoadManager().unaggregated_images
+    if ims_dict is None:
+        # This probably means the image series was never aggregated.
+        # Try using the imageseries dict.
+        ims_dict = HexrdConfig().imageseries_dict
+
     # Load omega data if it is missing
     load_omegas_dict = {
         k: ims for k, ims in ims_dict.items() if 'omega' not in ims.metadata


### PR DESCRIPTION
If there are unaggregated images set on the image load manager, use
those for the indexing.

This fixes an issues where, if the user had aggregated images, they
could not perform indexing. Now, the user can perform indexing
whether they aggregated the data or not.

I tested this with images loaded via the load panel, once with a maximum
aggregation, and once with no aggregation, and I was able to generate the
eta omega maps and perform the indexing in both cases.