### PR TITLE
Disable run-indexing menu until an image series is loaded

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -142,6 +142,7 @@ class MainWindow(QObject):
         self.ui.action_run_indexing.triggered.connect(
             self.on_action_run_indexing_triggered)
         self.new_images_loaded.connect(self.update_color_map_bounds)
+        self.new_images_loaded.connect(self.update_indexing_menu)
         self.new_images_loaded.connect(self.color_map_editor.reset_range)
         self.new_images_loaded.connect(self.image_mode_widget.reset_masking)
         self.ui.image_tab_widget.update_needed.connect(self.update_all)
@@ -626,3 +627,13 @@ class MainWindow(QObject):
         self.image_mode_widget.reset_masking()
         td = TransformDialog(self.ui).exec_()
         self.image_mode_widget.reset_masking(mask_state)
+
+    def update_indexing_menu(self):
+        enabled = False
+        image_series_dict = ImageLoadManager().unaggregated_images
+        image_series_dict = HexrdConfig().imageseries_dict if image_series_dict is None else image_series_dict
+        if image_series_dict:
+            # Check length of first series
+            series = next(iter(image_series_dict.values()))
+            enabled = len(series) > 1
+        self.ui.action_run_indexing.setEnabled(enabled)

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -447,6 +447,9 @@
    </property>
   </action>
   <action name="action_run_indexing">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Indexing</string>
    </property>


### PR DESCRIPTION
Another tiny mod but all I have time for today. This branch disables the Run => Indexing menu at startup, and enables it after an image series has been loaded. This will fulfill #374 so we'll go ahead and close it, though more validation logic might become evident in the future.

Closes #374 