### PR TITLE
Specify Laue crystal orientation via Euler angles

### DIFF
--- a/hexrd/ui/calibration/line_picked_calibration.py
+++ b/hexrd/ui/calibration/line_picked_calibration.py
@@ -181,9 +181,8 @@ def run_line_picked_calibration(line_data):
 
     # Convert back to whatever convention we were using before
     eac = HexrdConfig().euler_angle_convention
-    if eac != (None, None):
-        old_conv = (None, None)
-        convert_tilt_convention(output_dict, old_conv, eac)
+    if eac is not None:
+        convert_tilt_convention(output_dict, None, eac)
 
     # Add the saturation levels, as they seem to be missing
     sl = 'saturation_level'

--- a/hexrd/ui/calibration/powder_calibration.py
+++ b/hexrd/ui/calibration/powder_calibration.py
@@ -310,9 +310,8 @@ def run_powder_calibration():
 
     # Convert back to whatever convention we were using before
     eac = HexrdConfig().euler_angle_convention
-    if eac != (None, None):
-        old_conv = (None, None)
-        convert_tilt_convention(output_dict, old_conv, eac)
+    if eac is not None:
+        convert_tilt_convention(output_dict, None, eac)
 
     # Add the saturation levels, as they seem to be missing
     sl = 'saturation_level'

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -33,6 +33,11 @@ UI_THRESHOLD_LESS_THAN = 0
 UI_THRESHOLD_GREATER_THAN = 1
 UI_THRESHOLD_EQUAL_TO = 2
 
+DEFAULT_EULER_ANGLE_CONVENTION = {
+    'axes_order': 'xyz',
+    'extrinsic': True
+}
+
 DEFAULT_POWDER_STYLE = {
     'data': {
         'c': '#00ffff',  # Cyan

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -99,6 +99,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when the workflow has been changed"""
     workflow_changed = Signal()
 
+    """Emitted when the Euler angle convention changes"""
+    euler_angle_convention_changed = Signal()
+
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)
@@ -1187,6 +1190,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         # Set the variable
         self._euler_angle_convention = copy.deepcopy(new_conv)
+        self.euler_angle_convention_changed.emit()
 
     @property
     def instrument_config_none_euler_convention(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -445,14 +445,19 @@ class MainWindow(QObject):
             'Extrinsic XYZ',
             'Intrinsic ZXZ'
         ]
+        corresponding_values = [
+            None,
+            {
+                'axes_order': 'xyz',
+                'extrinsic': True
+            },
+            {
+                'axes_order': 'zxz',
+                'extrinsic': False
+            }
+        ]
         current = HexrdConfig().euler_angle_convention
-        ind = 0
-        if current[0] is not None and current[1] is not None:
-            for i, convention in enumerate(allowed_conventions):
-                is_extr = 'Extrinsic' in convention
-                if current[0].upper() in convention and current[1] == is_extr:
-                    ind = i
-                    break
+        ind = corresponding_values.index(current)
 
         name, ok = QInputDialog.getItem(self.ui, 'HEXRD',
                                         'Select Euler Angle Convention',
@@ -462,14 +467,8 @@ class MainWindow(QObject):
             # User canceled...
             return
 
-        if name == 'None':
-            chosen = None
-            extrinsic = None
-        else:
-            chosen = name.split()[1].lower()
-            extrinsic = 'Extrinsic' in name
-
-        HexrdConfig().set_euler_angle_convention(chosen, extrinsic)
+        chosen = corresponding_values[allowed_conventions.index(name)]
+        HexrdConfig().set_euler_angle_convention(chosen)
 
         self.update_all()
         self.update_config_gui()

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -1,3 +1,4 @@
+import copy
 import numpy as np
 
 from PySide2.QtCore import QSignalBlocker
@@ -5,6 +6,7 @@ from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import convert_angle_convention
 
 
 class OverlayEditor:
@@ -18,6 +20,8 @@ class OverlayEditor:
 
         self.ui.tab_widget.tabBar().hide()
 
+        self.update_orientation_suffixes()
+
         self.setup_connections()
 
     def setup_connections(self):
@@ -29,6 +33,9 @@ class OverlayEditor:
 
         self.ui.laue_enable_widths.toggled.connect(
             self.update_laue_enable_states)
+
+        HexrdConfig().euler_angle_convention_changed.connect(
+            self.euler_angle_convention_changed)
 
     @property
     def overlay(self):
@@ -70,8 +77,7 @@ class OverlayEditor:
         if 'max_energy' in options:
             self.ui.laue_max_energy.setValue(options['max_energy'])
         if 'crystal_params' in options:
-            for i, w in enumerate(self.laue_cc_widgets):
-                w.setValue(options['crystal_params'][i])
+            self.laue_crystal_params = options['crystal_params']
 
         if options.get('tth_width') is not None:
             self.ui.laue_tth_width.setValue(np.degrees(options['tth_width']))
@@ -111,9 +117,49 @@ class OverlayEditor:
         options['tth_width'] = self.laue_tth_width
         options['eta_width'] = self.laue_eta_width
 
+    def euler_angle_convention_changed(self):
+        self.update_orientation_suffixes()
+        self.update_gui()
+
+    def update_orientation_suffixes(self):
+        suffix = '' if HexrdConfig().euler_angle_convention is None else '°'
+        widgets = self.laue_cc_widgets
+        for i in self.laue_orientation_indices:
+            widgets[i].setSuffix(suffix)
+
+    def convert_orientation_angle_convention(self, values, old_conv,
+                                             new_conv):
+        # Converts the angle convention of crystal params in place
+        indices = self.laue_orientation_indices
+        angles = [values[i] for i in indices]
+        angles = convert_angle_convention(angles, old_conv, new_conv)
+        for i, angle in zip(indices, angles):
+            values[i] = angle
+
+    @property
+    def laue_orientation_indices(self):
+        return [0, 1, 2]
+
     @property
     def laue_crystal_params(self):
-        return [x.value() for x in self.laue_cc_widgets]
+        values = [x.value() for x in self.laue_cc_widgets]
+        if HexrdConfig().euler_angle_convention is not None:
+            # Convert the angles to None
+            convention = HexrdConfig().euler_angle_convention
+            self.convert_orientation_angle_convention(values, convention, None)
+
+        return values
+
+    @laue_crystal_params.setter
+    def laue_crystal_params(self, v):
+        if HexrdConfig().euler_angle_convention is not None:
+            # Convert the angles
+            v = copy.deepcopy(v)
+            convention = HexrdConfig().euler_angle_convention
+            self.convert_orientation_angle_convention(v, None, convention)
+
+        for i, w in enumerate(self.laue_cc_widgets):
+            w.setValue(v[i])
 
     @property
     def laue_enable_widths(self):

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -34,25 +34,22 @@ def convert_tilt_convention(iconfig, old_convention,
             data.clear()
             data.extend(val)
 
-    old_axes, old_extrinsic = old_convention
-    new_axes, new_extrinsic = new_convention
-
     det_keys = iconfig['detectors'].keys()
-    if old_axes is not None and old_extrinsic is not None:
+    if old_convention is not None:
         # First, convert these to the matrix invariants
-        rme = RotMatEuler(np.zeros(3), old_axes, old_extrinsic)
+        rme = RotMatEuler(np.zeros(3), **old_convention)
         for key in det_keys:
             tilts = iconfig['detectors'][key]['transform']['tilt']
             rme.angles = np.array(_get_tilt_array(tilts))
             phi, n = angleAxisOfRotMat(rme.rmat)
             _set_tilt_array(tilts, (phi * n.flatten()).tolist())
 
-        if new_axes is None or new_extrinsic is None:
+        if new_convention is None:
             # We are done
             return
 
     # Update to the new mapping
-    rme = RotMatEuler(np.zeros(3), new_axes, new_extrinsic)
+    rme = RotMatEuler(np.zeros(3), **new_convention)
     for key in det_keys:
         tilts = iconfig['detectors'][key]['transform']['tilt']
         tilt = np.array(_get_tilt_array(tilts))


### PR DESCRIPTION
When specifying the Laue crystal orientation, use whatever Euler angle
convention the user has chosen in "Edit"->"Euler Angle Convention".

In the internal config, a Euler angle convention of `None` is always
being used. But in the GUI, the convention that is displayed is
whatever the user chose.

Fixes: #390

Note that this PR also changed our setup to store the Euler angle
convention as a dict instead of a tuple, since it is easier to work with
this way.