### PR TITLE
Draw Laue widths for raw and cartesian views also

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -104,7 +104,7 @@ class InstrumentViewer:
             kwargs.update(overlay.get('options', {}))
 
             generator = overlay_generator(type)(**kwargs)
-            overlay['data'] = generator.overlay('cartesian')
+            overlay['data'] = generator.overlay(UI_CARTESIAN)
 
     def plot_dplane(self):
         # Cache the image max and min for later use

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -78,7 +78,7 @@ class InstrumentViewer:
             kwargs.update(overlay.get('options', {}))
 
             generator = overlay_generator(type)(**kwargs)
-            overlay['data'] = generator.overlay('polar')
+            overlay['data'] = generator.overlay(UI_POLAR)
 
     def update_detector(self, det):
         self.pv.update_detector(det)

--- a/hexrd/ui/calibration/raw_iviewer.py
+++ b/hexrd/ui/calibration/raw_iviewer.py
@@ -44,4 +44,4 @@ class InstrumentViewer:
             kwargs.update(overlay.get('options', {}))
 
             generator = overlay_generator(type)(**kwargs)
-            overlay['data'] = generator.overlay('raw')
+            overlay['data'] = generator.overlay(UI_RAW)

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from hexrd import constants
 
+from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+
 
 class LaueSpotOverlay:
     def __init__(self, plane_data, instr,
@@ -78,7 +80,7 @@ class LaueSpotOverlay:
         widths = ['tth_width', 'eta_width']
         return all(getattr(self, x) is not None for x in widths)
 
-    def overlay(self, display_mode='raw'):
+    def overlay(self, display_mode=UI_RAW):
         sim_data = self.instrument.simulate_laue_pattern(
             self.plane_data,
             minEnergy=self.min_energy,
@@ -94,13 +96,13 @@ class LaueSpotOverlay:
             idx = ~np.isnan(energy)
             angles = angles[idx, :]
             range_corners = self.range_corners(angles)
-            if display_mode == 'polar':
+            if display_mode == UI_POLAR:
                 point_groups[det_key]['spots'] = np.degrees(angles)
                 point_groups[det_key]['ranges'] = np.degrees(range_corners)
-            elif display_mode in ['raw', 'cartesian']:
+            elif display_mode in [UI_RAW, UI_CARTESIAN]:
                 panel = self.instrument.detectors[det_key]
                 data = xy_det[idx, :]
-                if display_mode == 'raw':
+                if display_mode == UI_RAW:
                     # Convert to pixel coordinates
                     data = panel.cartToPixel(data)
                     # Swap x and y, they are flipped
@@ -152,10 +154,10 @@ class LaueSpotOverlay:
                 data.extend(panel.angles_to_cart(tmp))
 
             data = np.array(data)
-            if display_mode == 'raw':
+            if display_mode == UI_RAW:
                 data = panel.cartToPixel(data)
                 data[:, [0, 1]] = data[:, [1, 0]]
-            elif display_mode == 'cartesian':
+            elif display_mode == UI_CARTESIAN:
                 data[:, 1] = -data[:, 1]
 
             results.append(data)

--- a/hexrd/ui/overlays/mono_rotation_series.py
+++ b/hexrd/ui/overlays/mono_rotation_series.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from hexrd import constants
 
+from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+
 
 class MonoRotationSeriesSpotOverlay:
     def __init__(self, plane_data, instr,
@@ -96,7 +98,7 @@ class MonoRotationSeriesSpotOverlay:
         else:
             self._aggregation_mode = x
 
-    def overlay(self, display_mode='raw', frame_aggregateion_mode=None):
+    def overlay(self, display_mode=UI_RAW, frame_aggregateion_mode=None):
         """
         Returns appropriate point groups for displaying bragg reflection
         locations for a monochromatic rotation series.
@@ -104,7 +106,7 @@ class MonoRotationSeriesSpotOverlay:
         Parameters
         ----------
         display_mode : TYPE, optional
-            DESCRIPTION. The default is 'raw'.
+            DESCRIPTION. The default is UI_RAW.
         frame_aggregateion_mode : TYPE, optional
             DESCRIPTION. The default is None.
 
@@ -131,12 +133,12 @@ class MonoRotationSeriesSpotOverlay:
         point_groups = dict.fromkeys(sim_data)
         for det_key, psim in sim_data.items():
             valid_ids, valid_hkls, valid_angs, valid_xys, ang_pixel_size = psim
-            if display_mode == 'polar':
+            if display_mode == UI_POLAR:
                 if self.aggregation_mode is None:
                     raise NotImplementedError
                 else:
                     point_groups[det_key] = valid_angs[0]
-            elif display_mode in ['raw', 'cartesian']:
+            elif display_mode in [UI_RAW, UI_CARTESIAN]:
                 if self.aggregation_mode is None:
                     raise NotImplementedError
                 else:

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+
 
 nans_row = np.nan*np.ones((1, 2))
 
@@ -31,7 +33,7 @@ class PowderLineOverlay:
     def delta_eta(self):
         return 360./float(self.eta_steps)
 
-    def overlay(self, display_mode='raw'):
+    def overlay(self, display_mode=UI_RAW):
         tths = self.plane_data.getTTh()
         etas = np.radians(
             np.linspace(
@@ -67,7 +69,7 @@ class PowderLineOverlay:
             # Currently, the polar mode draws lines over the whole image.
             # Thus, we only need data from one detector.
             # This can be changed in the future if needed.
-            if display_mode == 'polar':
+            if display_mode == UI_POLAR:
                 break
 
         return point_groups
@@ -76,17 +78,17 @@ class PowderLineOverlay:
         ring_pts = []
         for tth in tths:
             ang_crds = np.vstack([np.tile(tth, len(etas)), etas]).T
-            if display_mode == 'polar':
+            if display_mode == UI_POLAR:
                 # Swap columns, convert to degrees
                 ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])
                 ring_pts.append(np.vstack([ang_crds, nans_row]))
-            elif display_mode in ['raw', 'cartesian']:
+            elif display_mode in [UI_RAW, UI_CARTESIAN]:
                 xys_full = panel.angles_to_cart(ang_crds)
                 xys, on_panel = panel.clip_to_panel(
                     xys_full, buffer_edges=False
                 )
 
-                if display_mode == 'raw':
+                if display_mode == UI_RAW:
                     # Convert to pixel coordinates
                     xys = panel.cartToPixel(xys)
 

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -496,7 +496,7 @@
              <double>180.000000000000000</double>
             </property>
             <property name="value">
-             <double>0.050000000000000</double>
+             <double>0.200000000000000</double>
             </property>
            </widget>
           </item>
@@ -518,7 +518,7 @@
              <double>180.000000000000000</double>
             </property>
             <property name="value">
-             <double>5.000000000000000</double>
+             <double>2.000000000000000</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Previously, Laue widths would only be drawn for polar views.

This draws them in raw and cartesian views as well.

![raw](https://user-images.githubusercontent.com/9558430/87338727-9a2e5680-c513-11ea-868e-3cd9a008b826.png)

![cartesian](https://user-images.githubusercontent.com/9558430/87338729-9c90b080-c513-11ea-9e16-37e276086afb.png)

Fixes: #395