### PR TITLE
Add ability to mask polar view via Laue overlays

### DIFF
--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -94,6 +94,7 @@
     <addaction name="action_edit_reset_instrument_config"/>
     <addaction name="action_transform_detectors"/>
     <addaction name="action_switch_workflow"/>
+    <addaction name="action_edit_apply_laue_mask_to_polar"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -458,6 +459,14 @@
   <action name="action_switch_workflow">
    <property name="text">
     <string>Switch Workflow</string>
+   </property>
+  </action>
+  <action name="action_edit_apply_laue_mask_to_polar">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Apply Laue Masks to Polar</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -89,12 +89,18 @@
     <property name="title">
      <string>E&amp;dit</string>
     </property>
+    <widget class="QMenu" name="menu_masks">
+     <property name="title">
+      <string>Masks</string>
+     </property>
+     <addaction name="action_edit_apply_polar_mask"/>
+     <addaction name="action_edit_apply_laue_mask_to_polar"/>
+    </widget>
     <addaction name="action_edit_euler_angle_convention"/>
-    <addaction name="action_edit_apply_polar_mask"/>
     <addaction name="action_edit_reset_instrument_config"/>
+    <addaction name="menu_masks"/>
     <addaction name="action_transform_detectors"/>
     <addaction name="action_switch_workflow"/>
-    <addaction name="action_edit_apply_laue_mask_to_polar"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -427,14 +433,6 @@
     <string>Calibration Line Picker</string>
    </property>
   </action>
-  <action name="action_edit_apply_polar_mask">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Apply Mask to Polar</string>
-   </property>
-  </action>
   <action name="action_edit_reset_instrument_config">
    <property name="text">
     <string>Reset Instrument Config</string>
@@ -461,12 +459,20 @@
     <string>Switch Workflow</string>
    </property>
   </action>
+  <action name="action_edit_apply_polar_mask">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Apply Mask to Polar</string>
+   </property>
+  </action>
   <action name="action_edit_apply_laue_mask_to_polar">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Apply Laue Masks to Polar</string>
+    <string>Apply Laue Mask to Polar</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
If the polar view is displayed, and there are Laue overlays displayed
with widths (boxes are drawn around them), the user may mask the polar
view with these Laue widths via "Edit"->"Apply Laue Masks to Polar".

Note: there currently isn't a way to remove masks...

![apply_laue_masks](https://user-images.githubusercontent.com/9558430/87412973-a956e800-c597-11ea-987e-551ab47783a3.gif)

Fixes: #381