### PR TITLE
Update overlays only when needed

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -7,7 +7,7 @@ from hexrd.gridutil import cellIndices
 from hexrd.ui.constants import UI_CARTESIAN
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.overlays import overlay_generator
+from hexrd.ui.overlays import update_overlay_data
 
 from skimage import transform as tf
 
@@ -63,8 +63,6 @@ class InstrumentViewer:
         return -x_lim, x_lim, y_lim, -y_lim
 
     def update_overlay_data(self):
-        HexrdConfig().clear_overlay_data()
-
         if not HexrdConfig().show_overlays:
             # Nothing to do
             return
@@ -80,31 +78,7 @@ class InstrumentViewer:
         temp_instr._detectors.clear()
         temp_instr._detectors['dpanel'] = self.dpanel
 
-        for overlay in HexrdConfig().overlays:
-            overlay['data'].clear()
-            if not overlay['visible']:
-                # Skip over invisible overlays
-                continue
-
-            mat_name = overlay['material']
-            mat = HexrdConfig().material(mat_name)
-
-            if not mat:
-                # Print a warning, as this shouldn't happen
-                print('Warning in InstrumentViewer.update_overlay_data():',
-                      f'{mat_name} is not a valid material')
-                continue
-
-            type = overlay['type']
-            kwargs = {
-                'plane_data': mat.planeData,
-                'instr': temp_instr
-            }
-            # Add any options
-            kwargs.update(overlay.get('options', {}))
-
-            generator = overlay_generator(type)(**kwargs)
-            overlay['data'] = generator.overlay(UI_CARTESIAN)
+        update_overlay_data(temp_instr, self.type)
 
     def plot_dplane(self):
         # Cache the image max and min for later use

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -7,7 +7,7 @@ from .polarview import PolarView
 from hexrd.ui.constants import UI_POLAR
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.overlays import overlay_generator
+from hexrd.ui.overlays import update_overlay_data
 
 
 def polar_viewer():
@@ -49,36 +49,7 @@ class InstrumentViewer:
         self.snip1d_background = self.pv.snip1d_background
 
     def update_overlay_data(self):
-        HexrdConfig().clear_overlay_data()
-
-        if not HexrdConfig().show_overlays:
-            # Nothing to do
-            return
-
-        for overlay in HexrdConfig().overlays:
-            if not overlay['visible']:
-                # Skip over invisible overlays
-                continue
-
-            mat_name = overlay['material']
-            mat = HexrdConfig().material(mat_name)
-
-            if not mat:
-                # Print a warning, as this shouldn't happen
-                print('Warning in InstrumentViewer.update_overlay_data():',
-                      f'{mat_name} is not a valid material')
-                continue
-
-            type = overlay['type']
-            kwargs = {
-                'plane_data': mat.planeData,
-                'instr': self.instr
-            }
-            # Add any options
-            kwargs.update(overlay.get('options', {}))
-
-            generator = overlay_generator(type)(**kwargs)
-            overlay['data'] = generator.overlay(UI_POLAR)
+        update_overlay_data(self.instr, self.type)
 
     def update_detector(self, det):
         self.pv.update_detector(det)

--- a/hexrd/ui/calibration/raw_iviewer.py
+++ b/hexrd/ui/calibration/raw_iviewer.py
@@ -1,7 +1,6 @@
 from hexrd.ui.constants import UI_RAW
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
-from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.overlays import overlay_generator
+from hexrd.ui.overlays import update_overlay_data
 
 
 def raw_iviewer():
@@ -15,33 +14,4 @@ class InstrumentViewer:
         self.instr = create_hedm_instrument()
 
     def update_overlay_data(self):
-        HexrdConfig().clear_overlay_data()
-
-        if not HexrdConfig().show_overlays:
-            # Nothing to do
-            return
-
-        for overlay in HexrdConfig().overlays:
-            if not overlay['visible']:
-                # Skip over invisible overlays
-                continue
-
-            mat_name = overlay['material']
-            mat = HexrdConfig().material(mat_name)
-
-            if not mat:
-                # Print a warning, as this shouldn't happen
-                print('Warning in InstrumentViewer.update_overlay_data():',
-                      f'{mat_name} is not a valid material')
-                continue
-
-            type = overlay['type']
-            kwargs = {
-                'plane_data': mat.planeData,
-                'instr': self.instr
-            }
-            # Add any options
-            kwargs.update(overlay.get('options', {}))
-
-            generator = overlay_generator(type)(**kwargs)
-            overlay['data'] = generator.overlay(UI_RAW)
+        update_overlay_data(self.instr, self.type)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -800,8 +800,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
             raise Exception(name + ' is not in materials list!')
         self.config['materials']['materials'][name] = material
 
-        if self.material_is_visible(name):
-            self.overlay_config_changed.emit()
+        self.flag_overlay_updates_for_material(name)
+        self.overlay_config_changed.emit()
 
     def remove_material(self, name):
         if name not in self.materials:
@@ -841,7 +841,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         self.config['materials']['active_material'] = name
         self.update_active_material_energy()
-        self.overlay_config_changed.emit()
 
     active_material = property(_active_material, _set_active_material)
 
@@ -875,6 +874,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         mat.beamEnergy = energy
         utils.make_new_pdata(mat)
+        self.flag_overlay_updates_for_material(mat.name)
 
     def update_active_material_energy(self):
         self.update_material_energy(self.active_material)
@@ -912,6 +912,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 self.backup_tth_width = self.active_material_tth_width
 
             self.active_material.planeData.tThWidth = v
+            self.flag_overlay_updates_for_active_material()
             self.overlay_config_changed.emit()
 
     active_material_tth_width = property(_active_material_tth_width,
@@ -949,6 +950,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 self.backup_tth_max = self.active_material_tth_max
 
             self.active_material.planeData.tThMax = v
+            self.flag_overlay_updates_for_active_material()
             self.overlay_config_changed.emit()
 
     active_material_tth_max = property(_active_material_tth_max,
@@ -1019,10 +1021,21 @@ class HexrdConfig(QObject, metaclass=Singleton):
         overlay['type'] = type
         overlay['style'] = overlays.default_overlay_style(type)
         overlay['options'].clear()
+        overlay['update_needed'] = True
 
     def clear_overlay_data(self):
         for overlay in self.overlays:
             overlay['data'].clear()
+            if 'update_needed' in overlay:
+                del overlay['update_needed']
+
+    def flag_overlay_updates_for_active_material(self):
+        self.flag_overlay_updates_for_material(self.active_material_name)
+
+    def flag_overlay_updates_for_material(self, material_name):
+        for overlay in self.overlays:
+            if overlay['material'] == material_name:
+                overlay['update_needed'] = True
 
     def _polar_pixel_size_tth(self):
         return self.config['image']['polar']['pixel_size_tth']

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -368,7 +368,12 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # Create a backup
         self.backup_instrument_config()
 
+        # Temporarily turn off overlays. They will be updated later.
+        self.clear_overlay_data()
+        prev = self.show_overlays
+        self.config['materials']['show_overlays'] = False
         self.update_visible_material_energies()
+        self.config['materials']['show_overlays'] = prev
 
         self.instrument_config_loaded.emit()
 
@@ -982,8 +987,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
         return self.config['materials'].get('show_overlays')
 
     def _set_show_overlays(self, b):
-        self.config['materials']['show_overlays'] = b
-        self.overlay_config_changed.emit()
+        if b != self.show_overlays:
+            self.config['materials']['show_overlays'] = b
+            self.overlay_config_changed.emit()
 
     show_overlays = property(_show_overlays, _set_show_overlays)
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -175,7 +175,6 @@ class ImageCanvas(FigureCanvas):
             self.overlay_draw_func(type)(axis, data, style)
 
     def draw_powder_overlay(self, axis, data, style):
-        print('Drawing powder...')
         rings = data['rings']
         rbnds = data['rbnds']
         rbnd_indices = data['rbnd_indices']
@@ -226,7 +225,6 @@ class ImageCanvas(FigureCanvas):
                     artists.append(artist)
 
     def draw_laue_overlay(self, axis, data, style):
-        print('Drawing laue...')
         spots = data['spots']
         ranges = data['ranges']
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -80,6 +80,9 @@ class ImageCanvas(FigureCanvas):
         self.azimuthal_line_artist = None
         self.mode = None
 
+        # Force a re-draw of the overlays
+        HexrdConfig().clear_overlay_data()
+
     def load_images(self, image_names):
         HexrdConfig().emit_update_status_bar('Loading image view...')
         if self.mode != UI_RAW or len(image_names) != len(self.axes_images):
@@ -233,10 +236,15 @@ class ImageCanvas(FigureCanvas):
             return
 
         self.clear_overlays()
+        if not HexrdConfig().show_overlays:
+            self.draw()
+            return
+
         self.iviewer.update_overlay_data()
 
         for overlay in HexrdConfig().overlays:
-            self.draw_overlay(overlay)
+            if overlay['visible']:
+                self.draw_overlay(overlay)
 
         self.draw()
 
@@ -319,6 +327,9 @@ class ImageCanvas(FigureCanvas):
     def beam_vector_changed(self):
         if not self.iviewer or not hasattr(self.iviewer, 'instr'):
             return
+
+        # Re-draw all overlays from scratch
+        HexrdConfig().clear_overlay_data()
 
         bvec = HexrdConfig().instrument_config['beam']['vector']
         self.iviewer.instr.beam_vector = (bvec['azimuth'], bvec['polar_angle'])

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -169,8 +169,7 @@ class MainWindow(QObject):
             self.ui.status_bar.showMessage)
         HexrdConfig().detectors_changed.connect(
             self.on_detectors_changed)
-        HexrdConfig().deep_rerender_needed.connect(
-            lambda: self.update_all(clear_canvases=True))
+        HexrdConfig().deep_rerender_needed.connect(self.deep_rerender)
 
         ImageLoadManager().update_needed.connect(self.update_all)
         ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)
@@ -223,6 +222,7 @@ class MainWindow(QObject):
             return HexrdConfig().save_instrument_config(selected_file)
 
     def on_detectors_changed(self):
+        HexrdConfig().clear_overlay_data()
         HexrdConfig().current_imageseries_idx = 0
         self.load_dummy_images()
         self.ui.image_tab_widget.switch_toolbar(0)
@@ -493,6 +493,10 @@ class MainWindow(QObject):
     def change_image_mode(self, mode):
         self.image_mode = mode
         self.update_image_mode_enable_states()
+
+        # Clear the overlays
+        HexrdConfig().clear_overlay_data()
+
         self.update_all()
 
     def update_image_mode_enable_states(self):
@@ -566,6 +570,13 @@ class MainWindow(QObject):
     def update_if_mode_matches(self, mode):
         if self.image_mode == mode:
             self.update_all()
+
+    def deep_rerender(self):
+        # Clear all overlays
+        HexrdConfig().clear_overlay_data()
+
+        # Update all and clear the canvases
+        self.update_all(clear_canvases=True)
 
     def update_all(self, clear_canvases=False):
         # If there are no images loaded, skip the request

--- a/hexrd/ui/material_editor_widget.py
+++ b/hexrd/ui/material_editor_widget.py
@@ -34,6 +34,11 @@ class MaterialEditorWidget(QObject):
 
         self.ui.max_hkl.valueChanged.connect(self.set_max_hkl)
 
+        # Flag overlays using this material for an update
+        self.material_modified.connect(
+            lambda: HexrdConfig().flag_overlay_updates_for_material(
+                self.material.name))
+
         # Emit that the ring config changed when the material is modified
         self.material_modified.connect(
             HexrdConfig().overlay_config_changed.emit)

--- a/hexrd/ui/materials_table.py
+++ b/hexrd/ui/materials_table.py
@@ -39,6 +39,7 @@ class MaterialsTable:
         indices = range(len(plane_data.exclusions))
         exclusions = [i not in selected_rows for i in indices]
         plane_data.exclusions = exclusions
+        HexrdConfig().flag_overlay_updates_for_active_material()
         HexrdConfig().overlay_config_changed.emit()
 
     def update_table_selections(self):

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -105,9 +105,8 @@ class OverlayEditor:
         if self.type == 'laue':
             self.update_config_laue()
 
-        if self.overlay['visible']:
-            # Only cause a re-render if the overlay is visible
-            HexrdConfig().overlay_config_changed.emit()
+        self.overlay['update_needed'] = True
+        HexrdConfig().overlay_config_changed.emit()
 
     def update_config_laue(self):
         options = self.overlay.setdefault('options', {})

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -174,7 +174,10 @@ class OverlayManager:
     def update_config_materials(self):
         for i in range(self.ui.table.rowCount()):
             w = self.material_combos[i]
-            HexrdConfig().overlays[i]['material'] = w.currentData()
+            overlay = HexrdConfig().overlays[i]
+            if overlay['material'] != w.currentData():
+                overlay['material'] = w.currentData()
+                overlay['update_needed'] = True
 
         HexrdConfig().overlay_config_changed.emit()
 

--- a/hexrd/ui/overlay_style_picker.py
+++ b/hexrd/ui/overlay_style_picker.py
@@ -93,7 +93,12 @@ class OverlayStylePicker(QObject):
         ]
 
     def reset_style(self):
+        if self.overlay['style'] == self.original_style:
+            # Nothing really to do...
+            return
+
         self.overlay['style'] = copy.deepcopy(self.original_style)
+        self.overlay['update_needed'] = True
         self.update_gui()
         HexrdConfig().overlay_config_changed.emit()
 
@@ -126,6 +131,7 @@ class OverlayStylePicker(QObject):
         ranges[keys['range_color']] = self.ui.range_color.text()
         ranges[keys['range_style']] = self.ui.range_style.currentData()
         ranges[keys['range_size']] = self.ui.range_size.value()
+        self.overlay['update_needed'] = True
         HexrdConfig().overlay_config_changed.emit()
 
     def pick_color(self):


### PR DESCRIPTION
Rather than re-generating and re-drawing the overlays from scratch every time, only re-generate and re-draw them when they are needed. This provides a few benefits:

1. Significant speedup for generating and drawing a single overlay when multiple overlays are visible.
2. Big speedups for hide/show operations (the overlay data is not re-generated, but only re-drawn).
3. Big speedup in tabbed view (previously, each tab was re-generating the data from scratch).
4. More resilience against accidentally re-creating overlays multiple times in the code.

This PR additionally combines some common code into a function to reduce repetition.

It keeps track of the artists used for drawing via the id of the data that was used to to draw them.

Fixes: #405