### PR TITLE
Use one default detector, with z == -1000

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -738,7 +738,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
     @property
     def default_detector(self):
         return copy.deepcopy(
-            self.default_config['instrument']['detectors']['ge1'])
+            self.default_config['instrument']['detectors']['detector_1'])
 
     def add_detector(self, detector_name, detector_to_copy=None):
         if detector_to_copy is not None:

--- a/hexrd/ui/resources/calibration/default_instrument_config.yml
+++ b/hexrd/ui/resources/calibration/default_instrument_config.yml
@@ -2,7 +2,7 @@ beam:
   energy: 55.6180
   vector: {azimuth: 90.0, polar_angle: 90.0}
 detectors:
-  ge1:
+  detector_1:
     distortion:
       function_name: None
       parameters: [0.0, 0.0, 0.0,
@@ -13,20 +13,7 @@ detectors:
       size: [1.0, 1.0]
     saturation_level: 14000.0
     transform:
-      translation: [0.0, 0.0, 0.0]
-      tilt: [0.0, 0.0, 0.0]
-  ge2:
-    distortion:
-      function_name: None
-      parameters: [0.0, 0.0, 0.0,
-        2.0, 2.0, 2.0]
-    pixels:
-      columns: 2048
-      rows: 2048
-      size: [1.0, 1.0]
-    saturation_level: 14000.0
-    transform:
-      translation: [0.0, 0.0, 0.0]
+      translation: [0.0, 0.0, -1000.0]
       tilt: [0.0, 0.0, 0.0]
 oscillation_stage:
   chi: 0.0

--- a/hexrd/ui/resources/ui/calibration_config_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_config_widget.ui
@@ -479,9 +479,12 @@
         <property name="editable">
          <bool>true</bool>
         </property>
+        <property name="currentText">
+         <string>detector_1</string>
+        </property>
         <item>
          <property name="text">
-          <string>ge1</string>
+          <string>detector_1</string>
          </property>
         </item>
        </widget>

--- a/hexrd/ui/resources/ui/load_panel.ui
+++ b/hexrd/ui/resources/ui/load_panel.ui
@@ -231,9 +231,12 @@
           <property name="enabled">
            <bool>true</bool>
           </property>
+          <property name="currentText">
+           <string>detector_1</string>
+          </property>
           <item>
            <property name="text">
-            <string>ge1</string>
+            <string>detector_1</string>
            </property>
           </item>
          </widget>


### PR DESCRIPTION
We only need one default detector. Delete the other, and
rename this to "detector_1".

Also, change the z to -1000. This prevents a NaN error when
trying to display the Cartesian plot with it.

Fixes: #409