### PR TITLE
Find files that contain detector name in extension

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -73,8 +73,9 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         for item in os.scandir(HexrdConfig().images_dir):
             if os.path.isfile(item):
                 file_name = os.path.splitext(item.name)[0]
+                ext = os.path.splitext(item.name)[1]
                 for det in dets:
-                    if (det in file_name) and (core_name == file_name.replace(det, '')):
+                    if (det in file_name or det in ext) and (core_name == file_name.replace(det, '')):
                         pos = dets.index(det)
                         files[pos].append(item.path)
         # Display error if equivalent files are not found for ea. detector

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -75,7 +75,8 @@ class ImageLoadManager(QObject, metaclass=Singleton):
                 file_name = os.path.splitext(item.name)[0]
                 ext = os.path.splitext(item.name)[1]
                 for det in dets:
-                    if (det in file_name or det in ext) and (core_name == file_name.replace(det, '')):
+                    if ((det in file_name or det in ext)
+                            and (core_name == file_name.replace(det, ''))):
                         pos = dets.index(det)
                         files[pos].append(item.path)
         # Display error if equivalent files are not found for ea. detector


### PR DESCRIPTION
This adds a check to see if the detector name exists in the file extension when the load panel is used to look for and load images. As discussed in #414 this code could be further simplified to simply use `in` to check for the detector name if there is no concern of having more than one file with the same detector name in the same directory.