### PR TITLE
Floor number of pixels for polar plot

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -38,7 +38,7 @@ class InstrumentViewer:
 
     def draw_polar(self):
         """show polar view of rings"""
-        self.pv = PolarView(self.instr, eta_min=-180., eta_max=180.)
+        self.pv = PolarView(self.instr)
         self.pv.warp_all_images()
 
         tth_min = HexrdConfig().polar_res_tth_min

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -27,14 +27,10 @@ def log_scale_img(img):
     return np.log(fimg)
 
 
-class PolarView(object):
+class PolarView:
     """Create (two-theta, eta) plot of detectors
     """
-    def __init__(self, instrument, eta_min=0., eta_max=360.):
-
-        # etas
-        self._eta_min = np.radians(eta_min)
-        self._eta_max = np.radians(eta_max)
+    def __init__(self, instrument):
 
         self.instr = instrument
 
@@ -76,11 +72,11 @@ class PolarView(object):
 
     @property
     def eta_min(self):
-        return self._eta_min
+        return np.radians(HexrdConfig().polar_res_eta_min)
 
     @property
     def eta_max(self):
-        return self._eta_max
+        return np.radians(HexrdConfig().polar_res_eta_max)
 
     @property
     def eta_range(self):
@@ -98,11 +94,11 @@ class PolarView(object):
 
     @property
     def ntth(self):
-        return int(np.ceil(np.degrees(self.tth_range) / self.tth_pixel_size))
+        return int(np.degrees(self.tth_range) / self.tth_pixel_size)
 
     @property
     def neta(self):
-        return int(np.ceil(np.degrees(self.eta_range) / self.eta_pixel_size))
+        return int(np.degrees(self.eta_range) / self.eta_pixel_size)
 
     @property
     def shape(self):

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -2,32 +2,21 @@ import numpy as np
 
 from skimage.draw import polygon
 
-from hexrd.ui import constants
+from hexrd.ui.calibration.polarview import PolarView
 from hexrd.ui.hexrd_config import HexrdConfig
 
 
 def create_polar_mask(line_data):
     # Calculate current image dimensions
-    eta_min = constants.UI_ETA_MIN_DEGREES
-    eta_max = constants.UI_ETA_MAX_DEGREES
-    eta_range =  eta_max - eta_min
-    eta_pixel_size = HexrdConfig().polar_pixel_size_eta
-    neta = int(np.ceil(eta_range / eta_pixel_size))
-
-    tth_min = HexrdConfig().polar_res_tth_min
-    tth_max = HexrdConfig().polar_res_tth_max
-    tth_range = tth_max - tth_min
-    tth_pixel_size = HexrdConfig().polar_pixel_size_tth
-    ntth = int(np.ceil(tth_range / tth_pixel_size))
-
-    shape = (neta, ntth)
+    pv = PolarView(None)
+    shape = pv.shape
     # Generate masks from line data
     for line in line_data:
         tth = np.asarray([point[0] for point in line])
         eta = np.asarray([point[1] for point in line])
 
-        j_col = np.floor((tth - tth_min) / tth_pixel_size)
-        i_row = np.floor((eta - eta_min) / eta_pixel_size)
+        j_col = np.floor((tth - np.degrees(pv.tth_min)) / pv.tth_pixel_size)
+        i_row = np.floor((eta - np.degrees(pv.eta_min)) / pv.eta_pixel_size)
 
         rr, cc = polygon(i_row, j_col, shape=shape)
         mask = np.ones(shape, dtype=bool)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1122,6 +1122,16 @@ class HexrdConfig(QObject, metaclass=Singleton):
     polar_res_tth_max = property(_polar_res_tth_max,
                                  set_polar_res_tth_max)
 
+    @property
+    def polar_res_eta_min(self):
+        # This is constant for now...
+        return constants.UI_ETA_MIN_DEGREES
+
+    @property
+    def polar_res_eta_max(self):
+        # This is constant for now...
+        return constants.UI_ETA_MAX_DEGREES
+
     def _polar_apply_snip1d(self):
         return self.config['image']['polar']['apply_snip1d']
 


### PR DESCRIPTION
Previously, there would sometimes be white space on the right
side of the polar plot due to extra pixels being generated. Floor
the number of pixels so this doesn't happen. From our examples, it
looks like this doesn't remove any noticeable part of the plot.

This also gets the polar mask function to use the same logic as
the polar view, which is required to ensure that the numbers of
pixels are the same for both.