### PR TITLE
Add calibration crystal editor with stretch matrix

### DIFF
--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -1,0 +1,212 @@
+import copy
+import numpy as np
+from numpy.linalg import LinAlgError
+
+from PySide2.QtCore import QObject, QSignalBlocker, Signal
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import convert_angle_convention
+
+
+class CalibrationCrystalEditor(QObject):
+
+    # Emitted when the params get modified
+    params_modified = Signal()
+
+    def __init__(self, params=None, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('calibration_crystal_editor.ui', parent)
+
+        self.params = params
+
+        self.update_gui()
+        self.update_orientation_suffixes()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        HexrdConfig().euler_angle_convention_changed.connect(
+            self.euler_angle_convention_changed)
+
+        for w in self.all_widgets:
+            w.valueChanged.connect(self.value_changed)
+
+    @property
+    def params(self):
+        return self._params
+
+    @params.setter
+    def params(self, v):
+        self._params = copy.deepcopy(v)
+        self.update_gui()
+
+    def value_changed(self):
+        sender = self.sender()
+
+        if sender in self.orientation_widgets:
+            self.params[:3] = self.orientation
+        elif sender in self.position_widgets:
+            self.params[3:6] = self.position
+        else:
+            # If the stretch matrix was modified, we may need to update
+            # a duplicate value in the matrix.
+            self.update_duplicate(sender)
+            try:
+                self.params[6:] = self.inverse_stretch
+            except LinAlgError:
+                self.set_matrix_invalid()
+                return
+
+            self.set_matrix_valid()
+
+        self.params_modified.emit()
+
+    def euler_angle_convention_changed(self):
+        self.update_gui()
+        self.update_orientation_suffixes()
+
+    def update_orientation_suffixes(self):
+        suffix = '' if HexrdConfig().euler_angle_convention is None else '°'
+        for w in self.orientation_widgets:
+            w.setSuffix(suffix)
+
+    def update_params(self):
+        if self.params is None:
+            return
+
+        self.params[:3] = self.orientation
+        self.params[3:6] = self.position
+        self.params[6:] = self.inverse_stretch
+        self.params_modified.emit()
+
+    def update_gui(self):
+        if self.params is None:
+            return
+
+        self.orientation = self.params[:3]
+        self.position = self.params[3:6]
+        self.inverse_stretch = self.params[6:]
+
+    @property
+    def stretch_matrix_duplicates(self):
+        return {
+            1: 3,
+            2: 6,
+            5: 7,
+            7: 5,
+            6: 2,
+            3: 1
+        }
+
+    def update_duplicate(self, w):
+        ind = int(w.objectName().replace('stretch_matrix_', ''))
+        dup_ind = self.stretch_matrix_duplicates.get(ind)
+        if dup_ind is not None:
+            dup = getattr(self.ui, f'stretch_matrix_{dup_ind}')
+            blocker = QSignalBlocker(dup)  # noqa: F841
+            dup.setValue(w.value())
+
+    def set_matrix_valid(self):
+        self.set_matrix_style_sheet('background-color: white')
+
+    def set_matrix_invalid(self):
+        self.set_matrix_style_sheet('background-color: red')
+
+    def set_matrix_style_sheet(self, s):
+        for w in self.stretch_matrix_widgets:
+            w.setStyleSheet(s)
+
+    @staticmethod
+    def convert_angle_convention(values, old_conv, new_conv):
+        values[:] = convert_angle_convention(values, old_conv, new_conv)
+
+    @property
+    def orientation(self):
+        # This automatically converts from Euler angle conventions
+        values = [x.value() for x in self.orientation_widgets]
+        if HexrdConfig().euler_angle_convention is not None:
+            convention = HexrdConfig().euler_angle_convention
+            self.convert_angle_convention(values, convention, None)
+
+        return values
+
+    @orientation.setter
+    def orientation(self, v):
+        # This automatically converts to Euler angle conventions
+        if HexrdConfig().euler_angle_convention is not None:
+            v = copy.deepcopy(v)
+            convention = HexrdConfig().euler_angle_convention
+            self.convert_angle_convention(v, None, convention)
+
+        for i, w in enumerate(self.orientation_widgets):
+            blocker = QSignalBlocker(w)  # noqa: F841
+            w.setValue(v[i])
+
+    @property
+    def position(self):
+        return [x.value() for x in self.position_widgets]
+
+    @position.setter
+    def position(self, v):
+        for i, w in enumerate(self.position_widgets):
+            blocker = QSignalBlocker(w)  # noqa: F841
+            w.setValue(v[i])
+
+    @property
+    def matrix_scaling(self):
+        scaling = np.array([np.sqrt(2)] * 9)
+        diagonal_indices = [0, 4, 8]
+        for i in diagonal_indices:
+            scaling[i] = 1
+
+        return scaling
+
+    @property
+    def inverse_stretch(self):
+        m = (self.stretch_matrix * self.matrix_scaling).reshape(3, 3)
+        m = np.linalg.inv(m).flatten()
+        indices = [0, 4, 8, 5, 2, 1]
+        return [m[i] for i in indices]
+
+    @inverse_stretch.setter
+    def inverse_stretch(self, v):
+        indices = [0, 5, 4, 5, 1, 3, 4, 3, 2]
+        m = np.array([v[i] for i in indices]).reshape(3, 3)
+        m = np.linalg.inv(m).flatten()
+        self.stretch_matrix = m / self.matrix_scaling
+
+    @property
+    def stretch_matrix(self):
+        return [x.value() for x in self.stretch_matrix_widgets]
+
+    @stretch_matrix.setter
+    def stretch_matrix(self, v):
+        for i, w in enumerate(self.stretch_matrix_widgets):
+            blocker = QSignalBlocker(w)  # noqa: F841
+            w.setValue(v[i])
+
+    @property
+    def orientation_widgets(self):
+        # Take advantage of the naming scheme
+        return [getattr(self.ui, f'orientation_{i}') for i in range(3)]
+
+    @property
+    def position_widgets(self):
+        # Take advantage of the naming scheme
+        return [getattr(self.ui, f'position_{i}') for i in range(3)]
+
+    @property
+    def stretch_matrix_widgets(self):
+        # Take advantage of the naming scheme
+        return [getattr(self.ui, f'stretch_matrix_{i}') for i in range(9)]
+
+    @property
+    def all_widgets(self):
+        return (
+            self.orientation_widgets +
+            self.position_widgets +
+            self.stretch_matrix_widgets
+        )

--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -58,8 +58,8 @@ class CalibrationCrystalEditor(QObject):
             self.update_duplicate(sender)
             try:
                 self.params[6:] = self.inverse_stretch
-            except LinAlgError:
-                self.set_matrix_invalid()
+            except LinAlgError as e:
+                self.set_matrix_invalid(str(e))
                 return
 
             self.set_matrix_valid()
@@ -113,13 +113,19 @@ class CalibrationCrystalEditor(QObject):
 
     def set_matrix_valid(self):
         self.set_matrix_style_sheet('background-color: white')
+        self.set_matrix_tooltips('')
 
-    def set_matrix_invalid(self):
+    def set_matrix_invalid(self, msg=''):
         self.set_matrix_style_sheet('background-color: red')
+        self.set_matrix_tooltips(msg)
 
     def set_matrix_style_sheet(self, s):
         for w in self.stretch_matrix_widgets:
             w.setStyleSheet(s)
+
+    def set_matrix_tooltips(self, s):
+        for w in self.stretch_matrix_widgets:
+            w.setToolTip(s)
 
     @staticmethod
     def convert_angle_convention(values, old_conv, new_conv):

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -1,0 +1,477 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>calibration_crystal_editor</class>
+ <widget class="QWidget" name="calibration_crystal_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>509</width>
+    <height>285</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0" colspan="2">
+    <spacer name="vertical_spacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="calibration_crystal_group_box">
+     <property name="title">
+      <string>Calibration Crystal</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="orientation_label">
+        <property name="text">
+         <string>Orientation:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QDoubleSpinBox" name="orientation_2">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="position_label">
+        <property name="text">
+         <string>Position:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="4">
+       <widget class="QGroupBox" name="stretch_matrix_group_box">
+        <property name="title">
+         <string>Stretch Matrix</string>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="1" column="0">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_3">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_0">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="suffix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_4">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_5">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_1">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_2">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>0.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_6">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="2">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_8">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="1">
+          <widget class="QDoubleSpinBox" name="stretch_matrix_7">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>5</number>
+           </property>
+           <property name="minimum">
+            <double>-10000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>10000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="orientation_0">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QDoubleSpinBox" name="orientation_1">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="prefix">
+         <string/>
+        </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QDoubleSpinBox" name="position_2">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QDoubleSpinBox" name="position_1">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="position_0">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>5</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>orientation_0</tabstop>
+  <tabstop>orientation_1</tabstop>
+  <tabstop>orientation_2</tabstop>
+  <tabstop>position_0</tabstop>
+  <tabstop>position_1</tabstop>
+  <tabstop>position_2</tabstop>
+  <tabstop>stretch_matrix_0</tabstop>
+  <tabstop>stretch_matrix_1</tabstop>
+  <tabstop>stretch_matrix_2</tabstop>
+  <tabstop>stretch_matrix_3</tabstop>
+  <tabstop>stretch_matrix_4</tabstop>
+  <tabstop>stretch_matrix_5</tabstop>
+  <tabstop>stretch_matrix_6</tabstop>
+  <tabstop>stretch_matrix_7</tabstop>
+  <tabstop>stretch_matrix_8</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>468</height>
+    <height>502</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -29,7 +29,7 @@
      <property name="minimumSize">
       <size>
        <width>0</width>
-       <height>380</height>
+       <height>450</height>
       </size>
      </property>
      <property name="currentIndex">
@@ -57,388 +57,6 @@
        <string>Laue</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="1">
-        <widget class="QDoubleSpinBox" name="laue_min_energy">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>5.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="QGroupBox" name="calibration_crystal_group_box">
-         <property name="title">
-          <string>Calibration Crystal</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_3">
-          <item row="3" column="1">
-           <widget class="QDoubleSpinBox" name="laue_cc_9">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QDoubleSpinBox" name="laue_cc_7">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QDoubleSpinBox" name="laue_cc_1">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="3">
-           <widget class="QDoubleSpinBox" name="laue_cc_5">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="3">
-           <widget class="QDoubleSpinBox" name="laue_cc_8">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="3">
-           <widget class="QDoubleSpinBox" name="laue_cc_11">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QDoubleSpinBox" name="laue_cc_4">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="2">
-           <widget class="QDoubleSpinBox" name="laue_cc_10">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="laue_cc_3">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="laue_cc_6">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="suffix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-            <property name="value">
-             <double>1.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QDoubleSpinBox" name="laue_cc_0">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="3">
-           <widget class="QDoubleSpinBox" name="laue_cc_2">
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="decimals">
-             <number>5</number>
-            </property>
-            <property name="minimum">
-             <double>-10000.000000000000000</double>
-            </property>
-            <property name="maximum">
-             <double>10000.000000000000000</double>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
-            <property name="text">
-             <string>Orientation:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>Position:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" rowspan="2">
-           <widget class="QLabel" name="label_4">
-            <property name="text">
-             <string>Inverse Stretch:</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QDoubleSpinBox" name="laue_max_energy">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>35.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="laue_max_energy_label">
-         <property name="text">
-          <string>Max Energy:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="laue_min_energy_label">
-         <property name="text">
-          <string>Min Energy:</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0" colspan="2">
         <widget class="QGroupBox" name="ranges_group_box">
          <property name="title">
@@ -525,6 +143,49 @@
          </layout>
         </widget>
        </item>
+       <item row="1" column="1">
+        <widget class="QDoubleSpinBox" name="laue_max_energy">
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
+         <property name="maximum">
+          <double>10000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>35.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="laue_max_energy_label">
+         <property name="text">
+          <string>Max Energy:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QDoubleSpinBox" name="laue_min_energy">
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
+         <property name="maximum">
+          <double>10000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>5.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="laue_min_energy_label">
+         <property name="text">
+          <string>Min Energy:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <layout class="QVBoxLayout" name="laue_crystal_editor_layout"/>
+       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="mono_rotation_series_tab">
@@ -561,18 +222,6 @@
   <tabstop>laue_enable_widths</tabstop>
   <tabstop>laue_tth_width</tabstop>
   <tabstop>laue_eta_width</tabstop>
-  <tabstop>laue_cc_0</tabstop>
-  <tabstop>laue_cc_1</tabstop>
-  <tabstop>laue_cc_2</tabstop>
-  <tabstop>laue_cc_3</tabstop>
-  <tabstop>laue_cc_4</tabstop>
-  <tabstop>laue_cc_5</tabstop>
-  <tabstop>laue_cc_6</tabstop>
-  <tabstop>laue_cc_7</tabstop>
-  <tabstop>laue_cc_8</tabstop>
-  <tabstop>laue_cc_9</tabstop>
-  <tabstop>laue_cc_10</tabstop>
-  <tabstop>laue_cc_11</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This separates out the calibration crystal editor as a stand-alone
widget, because it will be re-used for the mono rotation series.

Additionally, the stretch matrix is used instead of an inverse
stretch matrix. This is automatically converted to inverse stretch
values behind the scenes, which then get passed to hexrd.

If the user inputs values for a stretch matrix that is a noninvertible
(singular) matrix, the matrix boxes appear as red, and the values
are not set. But once the matrix is invertible, the values will
appear as white again.

Additionally, values across the diagonal are kept identical in the
stretch matrix automatically.

![calibration_crystal_editor](https://user-images.githubusercontent.com/9558430/87728677-960f6c80-c791-11ea-8689-75864ab2a5dd.gif)

Fixes: #387
