### PR TITLE
Use ViewType enum class for view types

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from hexrd.gridutil import cellIndices
 
-from hexrd.ui.constants import UI_CARTESIAN
+from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlays import update_overlay_data
@@ -21,7 +21,7 @@ def cartesian_viewer():
 class InstrumentViewer:
 
     def __init__(self):
-        self.type = UI_CARTESIAN
+        self.type = ViewType.cartesian
         self.instr = create_hedm_instrument()
         self.images_dict = HexrdConfig().current_images_dict()
 

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from .polarview import PolarView
 
-from hexrd.ui.constants import UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlays import update_overlay_data
@@ -17,7 +17,7 @@ def polar_viewer():
 class InstrumentViewer:
 
     def __init__(self):
-        self.type = UI_POLAR
+        self.type = ViewType.polar
         self.instr = create_hedm_instrument()
         self.images_dict = HexrdConfig().current_images_dict()
 

--- a/hexrd/ui/calibration/raw_iviewer.py
+++ b/hexrd/ui/calibration/raw_iviewer.py
@@ -1,4 +1,4 @@
-from hexrd.ui.constants import UI_RAW
+from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.overlays import update_overlay_data
 
@@ -10,7 +10,7 @@ def raw_iviewer():
 class InstrumentViewer:
 
     def __init__(self):
-        self.type = UI_RAW
+        self.type = ViewType.raw
         self.instr = create_hedm_instrument()
 
     def update_overlay_data(self):

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -2,7 +2,7 @@ from PySide2.QtCore import QObject, QTimer, Signal
 
 import numpy as np
 
-from hexrd.ui.constants import UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -281,7 +281,7 @@ class CalibrationSliderWidget(QObject):
             self._update_if_polar_timer = QTimer()
             self._update_if_polar_timer.setSingleShot(True)
             self._update_if_polar_timer.timeout.connect(
-                lambda: self.update_if_mode_matches.emit(UI_POLAR))
+                lambda: self.update_if_mode_matches.emit(ViewType.polar))
 
         self._update_if_polar_timer.start(500)
 

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -1,3 +1,5 @@
+from enum import Enum
+
 from hexrd import constants
 
 # Wavelength to kilo electron volt conversion
@@ -33,9 +35,12 @@ UI_THRESHOLD_LESS_THAN = 0
 UI_THRESHOLD_GREATER_THAN = 1
 UI_THRESHOLD_EQUAL_TO = 2
 
-UI_RAW = 0
-UI_CARTESIAN = 1
-UI_POLAR = 2
+
+class ViewType(Enum):
+    raw = 'raw'
+    cartesian = 'cartesian'
+    polar = 'polar'
+
 
 DEFAULT_EULER_ANGLE_CONVENTION = {
     'axes_order': 'xyz',

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -14,7 +14,7 @@ from hexrd.ui.async_worker import AsyncWorker
 from hexrd.ui.calibration.cartesian_plot import cartesian_viewer
 from hexrd.ui.calibration.polar_plot import polar_viewer
 from hexrd.ui.calibration.raw_iviewer import raw_iviewer
-from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui import utils
 import hexrd.ui.constants
@@ -82,11 +82,12 @@ class ImageCanvas(FigureCanvas):
 
     def load_images(self, image_names):
         HexrdConfig().emit_update_status_bar('Loading image view...')
-        if self.mode != UI_RAW or len(image_names) != len(self.axes_images):
+        if (self.mode != ViewType.raw or
+                len(image_names) != len(self.axes_images)):
             # Either we weren't in image mode before, or we have a different
             # number of images. Clear and re-draw.
             self.clear()
-            self.mode = UI_RAW
+            self.mode = ViewType.raw
 
             cols = 1
             if len(image_names) > 1:
@@ -140,7 +141,7 @@ class ImageCanvas(FigureCanvas):
         if not overlay['data']:
             return []
 
-        if self.mode in [UI_CARTESIAN, UI_POLAR]:
+        if self.mode in [ViewType.cartesian, ViewType.polar]:
             # If it's cartesian or polar, there is only one axis
             # Use the same axis for all of the data
             return [(self.axis, x) for x in overlay['data'].values()]
@@ -312,7 +313,7 @@ class ImageCanvas(FigureCanvas):
         self.draw()
 
     def extract_ring_coords(self, data):
-        if self.mode == UI_CARTESIAN:
+        if self.mode == ViewType.cartesian:
             # These are in x, y coordinates. Do not swap them.
             return data[:, 0], data[:, 1]
 
@@ -335,7 +336,7 @@ class ImageCanvas(FigureCanvas):
             return
 
         # Do not show the saturation in calibration mode
-        if self.mode != UI_RAW:
+        if self.mode != ViewType.raw:
             return
 
         for img in self.axes_images:
@@ -373,9 +374,9 @@ class ImageCanvas(FigureCanvas):
 
     def show_cartesian(self):
         HexrdConfig().emit_update_status_bar('Loading Cartesian view...')
-        if self.mode != UI_CARTESIAN:
+        if self.mode != ViewType.cartesian:
             self.clear()
-            self.mode = UI_CARTESIAN
+            self.mode = ViewType.cartesian
 
         # Force a redraw when the pixel size changes.
         if (self.cartesian_res_config !=
@@ -427,15 +428,15 @@ class ImageCanvas(FigureCanvas):
 
     def show_polar(self):
         HexrdConfig().emit_update_status_bar('Loading polar view...')
-        if self.mode != UI_POLAR:
+        if self.mode != ViewType.polar:
             self.clear()
-            self.mode = UI_POLAR
+            self.mode = ViewType.polar
 
         polar_res_config = HexrdConfig().config['image']['polar']
         if self._polar_reset_needed(polar_res_config):
             # Reset the whole image when certain config items change
             self.clear()
-            self.mode = UI_POLAR
+            self.mode = ViewType.polar
 
         self.polar_res_config = polar_res_config.copy()
 
@@ -549,7 +550,7 @@ class ImageCanvas(FigureCanvas):
         self.draw()
 
     def update_azimuthal_integral_plot(self):
-        if self.mode != UI_POLAR:
+        if self.mode != ViewType.polar:
             # Nothing to do. Just return.
             return
 
@@ -572,7 +573,7 @@ class ImageCanvas(FigureCanvas):
         axis.axis('auto')
 
     def on_detector_transform_modified(self, det):
-        if self.mode not in [UI_CARTESIAN, UI_POLAR]:
+        if self.mode not in [ViewType.cartesian, ViewType.polar]:
             return
 
         self.iviewer.update_detector(det)
@@ -586,7 +587,7 @@ class ImageCanvas(FigureCanvas):
         self.draw_detector_borders()
 
     def export_polar_plot(self, filename):
-        if self.mode != UI_POLAR:
+        if self.mode != ViewType.polar:
             raise Exception('Not in polar mode. Cannot export polar plot')
 
         if not self.iviewer:
@@ -610,7 +611,7 @@ class ImageCanvas(FigureCanvas):
         return False
 
     def polar_show_snip1d(self):
-        if self.mode != UI_POLAR:
+        if self.mode != ViewType.polar:
             print('snip1d may only be shown in polar mode!')
             return
 

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -5,7 +5,7 @@ import numpy as np
 
 from PySide2.QtCore import QObject, QSignalBlocker, Signal
 
-from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.create_raw_mask import apply_raw_mask, remove_raw_mask
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -15,7 +15,7 @@ from hexrd.ui.ui_loader import UiLoader
 class ImageModeWidget(QObject):
 
     # The string indicates which tab was selected
-    tab_changed = Signal(int)
+    tab_changed = Signal(ViewType)
 
     # Tell the image canvas to show the snip1d
     polar_show_snip1d = Signal()
@@ -83,9 +83,9 @@ class ImageModeWidget(QObject):
 
     def currentChanged(self, index):
         modes = {
-            0: UI_RAW,
-            1: UI_CARTESIAN,
-            2: UI_POLAR
+            0: ViewType.raw,
+            1: ViewType.cartesian,
+            2: ViewType.polar
         }
         ind = self.ui.tab_widget.currentIndex()
         self.tab_changed.emit(modes[ind])

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -3,7 +3,7 @@ from PySide2.QtWidgets import QMessageBox, QTabWidget, QHBoxLayout
 
 import numpy as np
 
-from hexrd.ui.constants import UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_canvas import ImageCanvas
 from hexrd.ui.image_series_toolbar import ImageSeriesToolbar
@@ -264,11 +264,12 @@ class ImageTabWidget(QTabWidget):
 
         # intensity being None implies here that the mouse is on top of the
         # azimuthal integration plot in the polar view.
-        if mode in [UI_CARTESIAN, UI_POLAR] and intensity is not None:
+        if (mode in [ViewType.cartesian, ViewType.polar] and
+                intensity is not None):
 
             iviewer = self.image_canvases[0].iviewer
 
-            if mode == UI_CARTESIAN:
+            if mode == ViewType.cartesian:
                 xy_data = iviewer.dpanel.pixelToCart(np.vstack([i, j]).T)
                 ang_data, gvec = iviewer.dpanel.cart_to_angles(xy_data)
                 tth = ang_data[:, 0][0]

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -7,7 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Cursor
 
-from hexrd.ui.constants import UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.zoom_canvas import ZoomCanvas
 
@@ -84,7 +84,7 @@ class LinePickerDialog(QObject):
         self.zoom_canvas.render()
 
     def start(self):
-        if self.canvas.mode != UI_POLAR:
+        if self.canvas.mode != ViewType.polar:
             print('line picker only works in polar mode!')
             return
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -23,7 +23,7 @@ from hexrd.ui.calibration.line_picked_calibration import (
     run_line_picked_calibration
 )
 from hexrd.ui.create_polar_mask import create_polar_mask
-from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_file_manager import ImageFileManager
 from hexrd.ui.image_load_manager import ImageLoadManager
@@ -66,7 +66,7 @@ class MainWindow(QObject):
         self.ui.color_map_dock_widgets.layout().addWidget(
             self.color_map_editor.ui)
 
-        self.image_mode = UI_RAW
+        self.image_mode = ViewType.raw
         self.image_mode_widget = ImageModeWidget(self.ui.central_widget)
         self.ui.image_mode_dock_widgets.layout().addWidget(
             self.image_mode_widget.ui)
@@ -537,9 +537,9 @@ class MainWindow(QObject):
 
     def update_image_mode_enable_states(self):
         # This is for enable states that depend on the image mode
-        is_raw = self.image_mode == UI_RAW
-        is_cartesian = self.image_mode == UI_CARTESIAN
-        is_polar = self.image_mode == UI_POLAR
+        is_raw = self.image_mode == ViewType.raw
+        is_cartesian = self.image_mode == ViewType.cartesian
+        is_polar = self.image_mode == ViewType.polar
 
         has_images = HexrdConfig().has_images()
 
@@ -632,9 +632,9 @@ class MainWindow(QObject):
             for canvas in self.ui.image_tab_widget.image_canvases:
                 canvas.clear()
 
-        if self.image_mode == UI_CARTESIAN:
+        if self.image_mode == ViewType.cartesian:
             self.ui.image_tab_widget.show_cartesian()
-        elif self.image_mode == UI_POLAR:
+        elif self.image_mode == ViewType.polar:
             # Rebuild polar masks
             del HexrdConfig().polar_masks[:]
             for line_data in HexrdConfig().polar_masks_line_data:
@@ -671,7 +671,7 @@ class MainWindow(QObject):
         if intensity is not None:
             labels.append('value = {:8.3f}'.format(info['intensity']))
 
-            if info['mode'] in [UI_CARTESIAN, UI_POLAR]:
+            if info['mode'] in [ViewType.cartesian, ViewType.polar]:
                 labels.append('tth = {:8.3f}'.format(info['tth']))
                 labels.append('eta = {:8.3f}'.format(info['eta']))
                 labels.append('dsp = {:8.3f}'.format(info['dsp']))

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from hexrd import constants
 
-from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 
 
 class LaueSpotOverlay:
@@ -80,7 +80,7 @@ class LaueSpotOverlay:
         widths = ['tth_width', 'eta_width']
         return all(getattr(self, x) is not None for x in widths)
 
-    def overlay(self, display_mode=UI_RAW):
+    def overlay(self, display_mode=ViewType.raw):
         sim_data = self.instrument.simulate_laue_pattern(
             self.plane_data,
             minEnergy=self.min_energy,
@@ -96,13 +96,13 @@ class LaueSpotOverlay:
             idx = ~np.isnan(energy)
             angles = angles[idx, :]
             range_corners = self.range_corners(angles)
-            if display_mode == UI_POLAR:
+            if display_mode == ViewType.polar:
                 point_groups[det_key]['spots'] = np.degrees(angles)
                 point_groups[det_key]['ranges'] = np.degrees(range_corners)
-            elif display_mode in [UI_RAW, UI_CARTESIAN]:
+            elif display_mode in [ViewType.raw, ViewType.cartesian]:
                 panel = self.instrument.detectors[det_key]
                 data = xy_det[idx, :]
-                if display_mode == UI_RAW:
+                if display_mode == ViewType.raw:
                     # Convert to pixel coordinates
                     data = panel.cartToPixel(data)
                     # Swap x and y, they are flipped
@@ -154,10 +154,10 @@ class LaueSpotOverlay:
                 data.extend(panel.angles_to_cart(tmp))
 
             data = np.array(data)
-            if display_mode == UI_RAW:
+            if display_mode == ViewType.raw:
                 data = panel.cartToPixel(data)
                 data[:, [0, 1]] = data[:, [1, 0]]
-            elif display_mode == UI_CARTESIAN:
+            elif display_mode == ViewType.cartesian:
                 data[:, 1] = -data[:, 1]
 
             results.append(data)

--- a/hexrd/ui/overlays/mono_rotation_series.py
+++ b/hexrd/ui/overlays/mono_rotation_series.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from hexrd import constants
 
-from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 
 
 class MonoRotationSeriesSpotOverlay:
@@ -98,7 +98,7 @@ class MonoRotationSeriesSpotOverlay:
         else:
             self._aggregation_mode = x
 
-    def overlay(self, display_mode=UI_RAW, frame_aggregateion_mode=None):
+    def overlay(self, display_mode=ViewType.raw, frame_aggregateion_mode=None):
         """
         Returns appropriate point groups for displaying bragg reflection
         locations for a monochromatic rotation series.
@@ -106,7 +106,7 @@ class MonoRotationSeriesSpotOverlay:
         Parameters
         ----------
         display_mode : TYPE, optional
-            DESCRIPTION. The default is UI_RAW.
+            DESCRIPTION. The default is ViewType.raw.
         frame_aggregateion_mode : TYPE, optional
             DESCRIPTION. The default is None.
 
@@ -133,12 +133,12 @@ class MonoRotationSeriesSpotOverlay:
         point_groups = dict.fromkeys(sim_data)
         for det_key, psim in sim_data.items():
             valid_ids, valid_hkls, valid_angs, valid_xys, ang_pixel_size = psim
-            if display_mode == UI_POLAR:
+            if display_mode == ViewType.polar:
                 if self.aggregation_mode is None:
                     raise NotImplementedError
                 else:
                     point_groups[det_key] = valid_angs[0]
-            elif display_mode in [UI_RAW, UI_CARTESIAN]:
+            elif display_mode in [ViewType.raw, ViewType.cartesian]:
                 if self.aggregation_mode is None:
                     raise NotImplementedError
                 else:

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from hexrd.ui.constants import UI_RAW, UI_CARTESIAN, UI_POLAR
+from hexrd.ui.constants import ViewType
 
 
 nans_row = np.nan*np.ones((1, 2))
@@ -33,7 +33,7 @@ class PowderLineOverlay:
     def delta_eta(self):
         return 360./float(self.eta_steps)
 
-    def overlay(self, display_mode=UI_RAW):
+    def overlay(self, display_mode=ViewType.raw):
         tths = self.plane_data.getTTh()
         etas = np.radians(
             np.linspace(
@@ -69,7 +69,7 @@ class PowderLineOverlay:
             # Currently, the polar mode draws lines over the whole image.
             # Thus, we only need data from one detector.
             # This can be changed in the future if needed.
-            if display_mode == UI_POLAR:
+            if display_mode == ViewType.polar:
                 break
 
         return point_groups
@@ -78,17 +78,17 @@ class PowderLineOverlay:
         ring_pts = []
         for tth in tths:
             ang_crds = np.vstack([np.tile(tth, len(etas)), etas]).T
-            if display_mode == UI_POLAR:
+            if display_mode == ViewType.polar:
                 # Swap columns, convert to degrees
                 ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])
                 ring_pts.append(np.vstack([ang_crds, nans_row]))
-            elif display_mode in [UI_RAW, UI_CARTESIAN]:
+            elif display_mode in [ViewType.raw, ViewType.cartesian]:
                 xys_full = panel.angles_to_cart(ang_crds)
                 xys, on_panel = panel.clip_to_panel(
                     xys_full, buffer_edges=False
                 )
 
-                if display_mode == UI_RAW:
+                if display_mode == ViewType.raw:
                     # Convert to pixel coordinates
                     xys = panel.cartToPixel(xys)
 


### PR DESCRIPTION
This is a little more readable (to me at least), and it requires
fewer imports.

It also uses strings for the types, so they will be more readable
if printed.