### PR TITLE
Change ViewType to not subclass Enum

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -1,5 +1,3 @@
-from enum import Enum
-
 from hexrd import constants
 
 # Wavelength to kilo electron volt conversion
@@ -36,7 +34,7 @@ UI_THRESHOLD_GREATER_THAN = 1
 UI_THRESHOLD_EQUAL_TO = 2
 
 
-class ViewType(Enum):
+class ViewType:
     raw = 'raw'
     cartesian = 'cartesian'
     polar = 'polar'


### PR DESCRIPTION
PR #427 fixed the segfault on macos/conda but left a mismatch in signal argument types. This PR resolves that by undoing the ViewType as an Enum so that the signals are emitted as strings.