### PR TITLE
Update active material energy on instrument config load

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -260,6 +260,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.instrument_config_loaded.emit()
         self.deep_rerender_needed.emit()
         self.update_visible_material_energies()
+        self.update_active_material_energy()
 
     def set_images_dir(self, images_dir):
         self.images_dir = images_dir
@@ -382,6 +383,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         prev = self.show_overlays
         self.config['materials']['show_overlays'] = False
         self.update_visible_material_energies()
+        self.update_active_material_energy()
         self.config['materials']['show_overlays'] = prev
 
         self.instrument_config_loaded.emit()


### PR DESCRIPTION
Previously, only visible material energies were being updated
when an instrument config was loaded.

Ensure that the active material energy gets updated as well, so
that hkl values in the materials table will display the correct
information, even if the active material is not visible.

It should be okay if the active material is visible, and its energy
gets updated twice, because it only performs the expensive part
of the computation if the new energy doesn't match.

I did not actually test this, so it would be good if someone can
test it before merging.

Fixes: #435