### PR TITLE
Dark sub

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -217,7 +217,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         else:
             f = imageseries.stats.median_iter
 
-        return (f, frames)
+        return (f, frames, ims)
 
     def get_dark_aggr_ops(self, ims_dict):
         """
@@ -256,7 +256,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         self.update_progress_text('Aggregating dark images...')
         dark_images = {}
         if dark_aggr_ops:
-            dark_images = self.aggregate_dark_multithread(dark_aggr_ops, ims_dict)
+            dark_images = self.aggregate_dark_multithread(dark_aggr_ops)
 
         # Apply the operations to the imageseries
         for idx, key in enumerate(ims_dict.keys()):
@@ -441,7 +441,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         return (key, darkimg)
 
 
-    def aggregate_dark_multithread(self, aggr_op_dict, ims_dict):
+    def aggregate_dark_multithread(self, aggr_op_dict):
         """
         Use ThreadPoolExecutor to dark aggregation. Returns a dict mapping the
         detector name to dark image.
@@ -452,10 +452,10 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         :param ims_dict: The dict of image series
         """
         futures = []
-        progress_dict = {key: 0.0 for key in ims_dict.keys()}
+        progress_dict = {key: 0.0 for key in aggr_op_dict.keys()}
         with ThreadPoolExecutor() as tp:
-            for (key, (op, frames)) in aggr_op_dict.items():
-                futures.append(tp.submit(self.aggregate_dark, key, op, ims_dict[key], frames, progress_dict))
+            for (key, (op, frames, ims)) in aggr_op_dict.items():
+                futures.append(tp.submit(self.aggregate_dark, key, op, ims, frames, progress_dict))
 
             self.wait_with_progress(futures, progress_dict)
 

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -440,7 +440,6 @@ class ImageLoadManager(QObject, metaclass=Singleton):
 
         return (key, darkimg)
 
-
     def aggregate_dark_multithread(self, aggr_op_dict):
         """
         Use ThreadPoolExecutor to dark aggregation. Returns a dict mapping the
@@ -455,7 +454,8 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         progress_dict = {key: 0.0 for key in aggr_op_dict.keys()}
         with ThreadPoolExecutor() as tp:
             for (key, (op, frames, ims)) in aggr_op_dict.items():
-                futures.append(tp.submit(self.aggregate_dark, key, op, ims, frames, progress_dict))
+                futures.append(tp.submit(
+                    self.aggregate_dark, key, op, ims, frames, progress_dict))
 
             self.wait_with_progress(futures, progress_dict)
 

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -446,9 +446,9 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         detector name to dark image.
 
         :param aggr_op_dict: A dict mapping the detector name to a tuple of the form
-                            (func, frames), where func is the function to use to do
-                            the aggregation and frames is number of images to aggregate.
-        :param ims_dict: The dict of image series
+                            (func, frames, ims), where func is the function to use to do
+                            the aggregation, frames is number of images to aggregate, and
+                            ims is the image series to perform the aggregation on.
         """
         futures = []
         progress_dict = {key: 0.0 for key in aggr_op_dict.keys()}

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -344,7 +344,8 @@ class LoadPanel(QObject):
     def enable_read(self):
         if (self.ext == '.tiff'
                 or '' not in self.omega_min and '' not in self.omega_max):
-            if self.state['dark'][self.idx] == 4 and self.dark_files is not None:
+            if (self.state['dark'][self.idx] == 4
+                    and self.dark_files[self.idx] is not None):
                 self.ui.read.setEnabled(len(self.files))
                 return
             elif self.state['dark'][self.idx] != 4 and len(self.files):


### PR DESCRIPTION
Dark subtraction uses functions from the `stats` package in `HEXRD` and requires an `ImageSeries` object to operate on. Typically this is the loaded `ImageSeries`, but in the case of dark subtraction using a file the selected file is what needs to be used. This branch fixes that appropriate `ImageSeries` is used in each case.

During testing I noticed that files could be loaded even when the `File` option was selected for dark subtraction but no file had been selected. This branch also fixes that by disabling the `Read Files` option until a dark file is loaded.

Fixes #424 