### PR TITLE
Add default options for overlay types

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum
+import numpy as np
 
 from hexrd import constants
 
@@ -91,6 +92,22 @@ DEFAULT_MONO_ROTATION_SERIES_STYLE = {
         'lw': 1.0
     }
 }
+
+DEFAULT_CRYSTAL_PARAMS = np.hstack(
+    [constants.zeros_3, constants.zeros_3, constants.identity_6x1])
+
+DEFAULT_POWDER_OPTIONS = {}
+
+DEFAULT_LAUE_OPTIONS = {
+    'crystal_params': DEFAULT_CRYSTAL_PARAMS.copy(),
+    'sample_rmat': constants.identity_3x3.copy(),
+    'min_energy': 5,
+    'max_energy': 35,
+    'tth_width': None,
+    'eta_width': None
+}
+
+DEFAULT_MONO_ROTATION_SERIES_OPTIONS = {}
 
 WORKFLOW_HEDM = 'HEDM'
 WORKFLOW_LLNL = 'LLNL'

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1060,7 +1060,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             'type': type,
             'style': style,
             'visible': visible,
-            'options': {},
+            'options': overlays.default_overlay_options(type),
             'data': {}
         }
         self.overlays.append(overlay)
@@ -1078,7 +1078,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         overlay['type'] = type
         overlay['style'] = overlays.default_overlay_style(type)
-        overlay['options'].clear()
+        overlay['options'] = overlays.default_overlay_options(type)
         overlay['update_needed'] = True
 
     def clear_overlay_data(self):

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -5,7 +5,7 @@ from PySide2.QtCore import QSignalBlocker
 from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
 
 from hexrd.ui.calibration_crystal_editor import CalibrationCrystalEditor
-from hexrd.ui.constants import OverlayType
+from hexrd.ui.constants import DEFAULT_CRYSTAL_PARAMS, OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -81,7 +81,7 @@ class OverlayEditor:
         if 'crystal_params' in options:
             self.laue_crystal_params = options['crystal_params']
         else:
-            self.laue_crystal_params = [0]*12
+            self.laue_crystal_params = DEFAULT_CRYSTAL_PARAMS.copy()
 
         if options.get('tth_width') is not None:
             self.ui.laue_tth_width.setValue(np.degrees(options['tth_width']))

--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -37,6 +37,20 @@ def default_overlay_style(overlay_type):
     return copy.deepcopy(default_styles[overlay_type])
 
 
+def default_overlay_options(overlay_type):
+    default_options = {
+        OverlayType.powder: constants.DEFAULT_POWDER_OPTIONS,
+        OverlayType.laue: constants.DEFAULT_LAUE_OPTIONS,
+        OverlayType.mono_rotation_series: (
+            constants.DEFAULT_MONO_ROTATION_SERIES_OPTIONS)
+    }
+
+    if overlay_type not in default_options:
+        raise Exception(f'Unknown overlay type: {overlay_type}')
+
+    return copy.deepcopy(default_options[overlay_type])
+
+
 def update_overlay_data(instr, display_mode):
     from hexrd.ui.hexrd_config import HexrdConfig
 


### PR DESCRIPTION
Previously, if there were no options provided, the overlay generator
would set defaults. These defaults would be different from the GUI
defaults, which led to a mismatch.

To avoid this, create default options for the different overlay types,
and always set those default options when the overlay is created or
the type is changed. This ensures that the overlay generator and the
GUI both use these defaults, to avoid a mismatch.
