### PR TITLE
Provide tvec_c for Laue widths for raw, cart

### DIFF
--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -138,11 +138,18 @@ class LaueSpotOverlay:
 
         return ranges
 
-    @staticmethod
-    def range_data(range_corners, display_mode, panel):
+    @property
+    def tvec_c(self):
+        if self.crystal_params is None:
+            return None
+        return self.crystal_params[3:6].reshape(3, 1)
+
+    def range_data(self, range_corners, display_mode, panel):
         # This function is only for raw and cartesian views
         if not range_corners:
             return []
+
+        tvec_c = self.tvec_c
 
         # The range data is curved for raw and cartesian.
         # Get more intermediate points so the data reflects this.
@@ -151,7 +158,7 @@ class LaueSpotOverlay:
             data = []
             for i in range(len(corners) - 1):
                 tmp = np.linspace(corners[i], corners[i + 1])
-                data.extend(panel.angles_to_cart(tmp))
+                data.extend(panel.angles_to_cart(tmp, tvec_c=tvec_c))
 
             data = np.array(data)
             if display_mode == ViewType.raw:


### PR DESCRIPTION
This is required for the widths to be computed correctly when
the crystal's position is not at the origin.

Depends on: hexrd/hexrd#66

Fixes: #448