### PR TITLE
Add Cartesian feasibility checks and better error messages

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -25,12 +25,8 @@ class InstrumentViewer:
         self.instr = create_hedm_instrument()
         self.images_dict = HexrdConfig().current_images_dict()
 
-        # Make sure each key in the image dict is in the panel_ids
-        if self.images_dict.keys() != self.instr._detectors.keys():
-            msg = ('Images do not match the panel ids!\n' +
-                   'Images: ' + str(list(self.images_dict.keys())) + '\n' +
-                   'PanelIds: ' + str(list(self.instr._detectors.keys())))
-            raise Exception(msg)
+        # Perform some checks before proceeding
+        self.check_keys_match()
 
         self.pixel_size = HexrdConfig().cartesian_pixel_size
         self.warp_dict = {}
@@ -47,6 +43,14 @@ class InstrumentViewer:
         self.dplane = DisplayPlane(tvec=dplane_tvec, tilt=dplane_tilt)
         self.make_dpanel()
         self.plot_dplane()
+
+    def check_keys_match(self):
+        # Make sure each key in the image dict is in the panel_ids
+        if self.images_dict.keys() != self.instr._detectors.keys():
+            msg = ('Images do not match the panel ids!\n'
+                   f'Images: {str(list(self.images_dict.keys()))}\n'
+                   f'PanelIds: {str(list(self.instr._detectors.keys()))}')
+            raise Exception(msg)
 
     def make_dpanel(self):
         self.dpanel_sizes = self.dplane.panel_size(self.instr)

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -2,6 +2,7 @@ import copy
 import math
 
 from PySide2.QtCore import QThreadPool
+from PySide2.QtWidgets import QMessageBox
 
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 
@@ -72,6 +73,10 @@ class ImageCanvas(FigureCanvas):
 
     def clear(self):
         self.iviewer = None
+        self.mode = None
+        self.clear_figure()
+
+    def clear_figure(self):
         self.figure.clear()
         self.raw_axes.clear()
         self.axes_images.clear()
@@ -414,6 +419,7 @@ class ImageCanvas(FigureCanvas):
 
         # Get the results and close the progress dialog when finished
         worker.signals.result.connect(self.finish_show_cartesian)
+        worker.signals.error.connect(self.async_worker_error)
 
     def finish_show_cartesian(self, iviewer):
         self.iviewer = iviewer
@@ -467,6 +473,7 @@ class ImageCanvas(FigureCanvas):
 
         # Get the results and close the progress dialog when finished
         worker.signals.result.connect(self.finish_show_polar)
+        worker.signals.error.connect(self.async_worker_error)
 
     def finish_show_polar(self, iviewer):
         self.iviewer = iviewer
@@ -541,6 +548,14 @@ class ImageCanvas(FigureCanvas):
 
         msg = 'Polar view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
+
+    def async_worker_error(self, error):
+        QMessageBox.critical(self, 'HEXRD', str(error[1]))
+        msg = f'{str(self.mode)} view error!'
+        HexrdConfig().emit_update_status_bar(msg)
+
+        self.clear_figure()
+        self.draw()
 
     def set_cmap(self, cmap):
         self.cmap = cmap


### PR DESCRIPTION
This adds a few feasibility checks for the Cartesian plot, and it also adds better error messages for both polar and Cartesian modes. The following were added:

1. A memory check for the Cartesian view. If more memory will be used than the available memory, an exception is produced.
2. An angle check for the Cartesian view. If any two detectors have an angle between them greater than 120 degrees, an exception is produced.
3. Better error messages for Cartesian and polar views. Now, if an exception is raised when one is being performed, the message of the exception gets displayed in a QMessageBox for the user to see.

An example is provided below

![example](https://user-images.githubusercontent.com/9558430/90282807-023aca00-de3d-11ea-8901-b69710df3a89.gif)

Fixes: #33