### PR TITLE
fixed extents used in imshow

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -58,9 +58,10 @@ class InstrumentViewer:
     def extent(self):
         # We might want to use self.dpanel.col_edge_vec and
         # self.dpanel.row_edge_vec here instead.
+        # !!! recall that extents are (left, right, bottom, top)
         x_lim = self.dpanel.col_dim / 2
         y_lim = self.dpanel.row_dim / 2
-        return -x_lim, x_lim, y_lim, -y_lim
+        return -x_lim, x_lim, -y_lim, y_lim
 
     def update_overlay_data(self):
         if not HexrdConfig().show_overlays:

--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -102,9 +102,8 @@ class InstrumentViewer:
         corners = [[y, x] for x, y in corners]
         corners = self.dpanel.pixelToCart(corners)
 
-        # y is negative for some reason. I am not sure why right now.
         x_vals = [x[0] for x in corners]
-        y_vals = [-x[1] for x in corners]
+        y_vals = [x[1] for x in corners]
 
         if x_vals and y_vals:
             # Double each set of points.
@@ -121,7 +120,7 @@ class InstrumentViewer:
             # If there are points outside the frame, move them inside.
             extent = self.extent
             x_range = (extent[0], extent[1])
-            y_range = (extent[3], extent[2])
+            y_range = (extent[2], extent[3])
 
             def out_of_frame(p):
                 # Check if point p is out of the frame

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -107,10 +107,6 @@ class LaueSpotOverlay:
                     data = panel.cartToPixel(data)
                     # Swap x and y, they are flipped
                     data[:, [0, 1]] = data[:, [1, 0]]
-                else:
-                    # I'm not sure why, but the y axis is flipped for
-                    # Cartesian...
-                    data[:, 1] = -data[:, 1]
 
                 point_groups[det_key]['spots'] = data
                 point_groups[det_key]['ranges'] = self.range_data(
@@ -157,8 +153,6 @@ class LaueSpotOverlay:
             if display_mode == ViewType.raw:
                 data = panel.cartToPixel(data)
                 data[:, [0, 1]] = data[:, [1, 0]]
-            elif display_mode == ViewType.cartesian:
-                data[:, 1] = -data[:, 1]
 
             results.append(data)
 


### PR DESCRIPTION
Pyplot extents are [left, right, bottom, top] and the y-axis was flipped.
![Screen Shot 2020-08-17 at 5 37 39 PM](https://user-images.githubusercontent.com/1154130/90457447-66b18f80-e0b0-11ea-8b8d-d2d2c9df03da.png)
and after fix:
![Screen Shot 2020-08-17 at 5 42 51 PM](https://user-images.githubusercontent.com/1154130/90457701-27d00980-e0b1-11ea-8a23-532d867fcaf6.png)
Although after the fix something odd is happening with the detector borders (@psavery?)