### PR TITLE
Improve speed of line picked calibration GUI interaction

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -36,6 +36,9 @@ class InstrumentViewer:
     def angular_grid(self):
         return self.pv.angular_grid
 
+    def update_angular_grid(self):
+        self.pv.update_angular_grid()
+
     def draw_polar(self):
         """show polar view of rings"""
         self.pv = PolarView(self.instr)

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -38,6 +38,8 @@ class PolarView:
 
         self.snip1d_background = None
 
+        self.update_angular_grid()
+
     @property
     def detectors(self):
         return self.instr.detectors
@@ -106,13 +108,16 @@ class PolarView:
     def shape(self):
         return (self.neta, self.ntth)
 
-    @property
-    def angular_grid(self):
+    def update_angular_grid(self):
         tth_vec = np.radians(self.tth_pixel_size * (np.arange(self.ntth)))\
             + self.tth_min + 0.5 * np.radians(self.tth_pixel_size)
         eta_vec = np.radians(self.eta_pixel_size * (np.arange(self.neta)))\
             + self.eta_min + 0.5 * np.radians(self.eta_pixel_size)
-        return np.meshgrid(eta_vec, tth_vec, indexing='ij')
+        self._angular_grid = np.meshgrid(eta_vec, tth_vec, indexing='ij')
+
+    @property
+    def angular_grid(self):
+        return self._angular_grid
 
     def detector_borders(self, det):
         panel = self.detectors[det]


### PR DESCRIPTION
This improves speed via a few ways:

1. Caches the angular grid results for the polar view (which also speeds up interactions with the polar view)
2. Skips drawing a polygon for the zoom box (it now just uses direct slicing of the data)
3. Rather than modifying the data and extents of the zoom box on a re-draw, just change the x and y limits.