### PR TITLE
Replace all instances of detector in file name

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -90,7 +90,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
                 search.append(f)
             else:
                 for d in dets:
-                    search.append(d.join(f.rsplit(files[0], 1)))
+                    search.append(d.join(f.rsplit(files[0])))
         files = self.match_selected_files(fnames, search)
         if not self.check_success(files):
             # Look in sibling directories if the matching files were not

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -240,7 +240,7 @@ class LoadPanel(QObject):
         # Select the path if the file(s) are HDF5
         if (ImageFileManager().is_hdf(self.ext) and not
                 ImageFileManager().path_exists(selected_files[0])):
-            if ImageFileManager().path_prompt(selected_files[0]) is not None:
+            if ImageFileManager().path_prompt(selected_files[0]) is None:
                 return
 
         tmp_ims = []


### PR DESCRIPTION
In the case of implicit association of file names only one occurrence of the file name was being replaced. Replace all occurrences of the detector name. This will catch files with names like the `ff*` examples (`ff1_000002_ff1.hdf5`, `ff2_000002_ff2.hdf5`).

![file-association-fixed](https://user-images.githubusercontent.com/51238406/90646012-b1442080-e204-11ea-97d3-068d5a7704de.gif)
