### PR TITLE
Do not reference ui before it has been loaded

### DIFF
--- a/hexrd/ui/load_hdf5_dialog.py
+++ b/hexrd/ui/load_hdf5_dialog.py
@@ -11,10 +11,11 @@ class LoadHDF5Dialog:
     self.file = f
     self.paths = []
 
-    self.get_paths(f)
-
     loader = UiLoader()
     self.ui = loader.load_file('load_hdf5_dialog.ui', parent)
+
+    self.get_paths(f)
+
     self.create_list()
 
   def get_HDF4_paths(self, f):


### PR DESCRIPTION
Fixes a reference before assignment bug when loading an hdf4 file through the import data panel