### PR TITLE
Clean up materials panel

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -129,7 +129,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.polar_masks = []
         self.polar_masks_line_data = []
         self.backup_tth_maxes = {}
-        self.backup_tth_widths = {}
         self.overlays = []
         self.workflow = None
         self._threshold_data = {}
@@ -969,44 +968,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
             return []
 
         return list({x['material'] for x in self.overlays if x['visible']})
-
-    def _active_material_tth_width(self):
-        return self.active_material.planeData.tThWidth
-
-    def set_active_material_tth_width(self, v):
-        if v != self.active_material_tth_width:
-            if v is None:
-                self.backup_tth_width = self.active_material_tth_width
-
-            self.active_material.planeData.tThWidth = v
-            self.flag_overlay_updates_for_active_material()
-            self.overlay_config_changed.emit()
-
-    active_material_tth_width = property(_active_material_tth_width,
-                                         set_active_material_tth_width)
-
-    def _backup_tth_width(self):
-        return self.backup_tth_widths.setdefault(self.active_material_name,
-                                                 0.002182)
-
-    def _set_backup_tth_width(self, v):
-        self.backup_tth_widths[self.active_material_name] = v
-
-    backup_tth_width = property(_backup_tth_width, _set_backup_tth_width)
-
-    def _tth_width_enabled(self):
-        return self.active_material_tth_width is not None
-
-    def set_tth_width_enabled(self, v):
-        # This will restore the backup of tth width, or set tth width to None
-        if v != self.tth_width_enabled:
-            if v:
-                self.active_material_tth_width = self.backup_tth_width
-            else:
-                self.active_material_tth_width = None
-
-    tth_width_enabled = property(_tth_width_enabled,
-                                 set_tth_width_enabled)
 
     def _active_material_tth_max(self):
         return self.active_material.planeData.tThMax

--- a/hexrd/ui/laue_overlay_editor.py
+++ b/hexrd/ui/laue_overlay_editor.py
@@ -1,0 +1,128 @@
+import copy
+import numpy as np
+
+from PySide2.QtCore import QSignalBlocker
+from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
+
+from hexrd.ui.calibration_crystal_editor import CalibrationCrystalEditor
+from hexrd.ui.constants import DEFAULT_CRYSTAL_PARAMS
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class LaueOverlayEditor:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('laue_overlay_editor.ui', parent)
+
+        self._overlay = None
+
+        self.crystal_editor = CalibrationCrystalEditor(parent=self.ui)
+        self.ui.crystal_editor_layout.addWidget(self.crystal_editor.ui)
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        for w in self.widgets:
+            if isinstance(w, QDoubleSpinBox):
+                w.valueChanged.connect(self.update_config)
+            elif isinstance(w, QCheckBox):
+                w.toggled.connect(self.update_config)
+
+        self.ui.enable_widths.toggled.connect(self.update_enable_states)
+        self.crystal_editor.params_modified.connect(self.update_config)
+
+    @property
+    def overlay(self):
+        return self._overlay
+
+    @overlay.setter
+    def overlay(self, v):
+        self._overlay = v
+        self.update_gui()
+
+    def update_gui(self):
+        if self.overlay is None:
+            return
+
+        blockers = [QSignalBlocker(w) for w in self.widgets]  # noqa: F841
+
+        options = self.overlay.get('options', {})
+        if 'min_energy' in options:
+            self.ui.min_energy.setValue(options['min_energy'])
+        if 'max_energy' in options:
+            self.ui.max_energy.setValue(options['max_energy'])
+        if 'crystal_params' in options:
+            self.crystal_params = options['crystal_params']
+        else:
+            self.crystal_params = DEFAULT_CRYSTAL_PARAMS.copy()
+
+        if options.get('tth_width') is not None:
+            self.ui.tth_width.setValue(np.degrees(options['tth_width']))
+        if options.get('eta_width') is not None:
+            self.ui.eta_width.setValue(np.degrees(options['eta_width']))
+
+        widths = ['tth_width', 'eta_width']
+        enable_widths = all(options.get(x) is not None for x in widths)
+        self.ui.enable_widths.setChecked(enable_widths)
+
+        self.update_enable_states()
+
+    def update_enable_states(self):
+        enable_widths = self.enable_widths
+        names = [
+            'tth_width_label',
+            'tth_width',
+            'eta_width_label',
+            'eta_width'
+        ]
+        for name in names:
+            getattr(self.ui, name).setEnabled(enable_widths)
+
+    @property
+    def crystal_params(self):
+        return copy.deepcopy(self.crystal_editor.params)
+
+    @crystal_params.setter
+    def crystal_params(self, v):
+        self.crystal_editor.params = v
+
+    def update_config(self):
+        options = self.overlay.setdefault('options', {})
+        options['min_energy'] = self.ui.min_energy.value()
+        options['max_energy'] = self.ui.max_energy.value()
+        options['crystal_params'] = self.crystal_params
+        options['tth_width'] = self.tth_width
+        options['eta_width'] = self.eta_width
+
+        self.overlay['update_needed'] = True
+        HexrdConfig().overlay_config_changed.emit()
+
+    @property
+    def enable_widths(self):
+        return self.ui.enable_widths.isChecked()
+
+    @property
+    def tth_width(self):
+        if not self.enable_widths:
+            return None
+
+        return np.radians(self.ui.tth_width.value())
+
+    @property
+    def eta_width(self):
+        if not self.enable_widths:
+            return None
+
+        return np.radians(self.ui.eta_width.value())
+
+    @property
+    def widgets(self):
+        return [
+            self.ui.min_energy,
+            self.ui.max_energy,
+            self.ui.enable_widths,
+            self.ui.tth_width,
+            self.ui.eta_width
+        ]

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -1,6 +1,5 @@
 import copy
 import math
-import numpy as np
 
 from PySide2.QtCore import QObject, QSignalBlocker, Qt
 from PySide2.QtGui import QFocusEvent, QKeyEvent
@@ -67,11 +66,6 @@ class MaterialsPanel(QObject):
         self.ui.show_overlay_manager.pressed.connect(self.show_overlay_manager)
 
         self.ui.show_overlays.toggled.connect(HexrdConfig()._set_show_overlays)
-        self.ui.enable_width.toggled.connect(
-            HexrdConfig().set_tth_width_enabled)
-        self.ui.tth_width.valueChanged.connect(
-            lambda v: HexrdConfig().set_active_material_tth_width(
-                np.radians(v)))
 
         self.ui.limit_active.toggled.connect(
             HexrdConfig().set_limit_active_rings)
@@ -81,15 +75,11 @@ class MaterialsPanel(QObject):
 
         HexrdConfig().new_plane_data.connect(self.update_gui_from_config)
 
-        self.ui.enable_width.toggled.connect(self.update_enable_states)
         self.ui.limit_active.toggled.connect(self.update_enable_states)
         self.ui.limit_active.toggled.connect(self.update_material_limits)
         self.ui.limit_active.toggled.connect(self.update_table)
 
     def update_enable_states(self):
-        enable_width = self.ui.enable_width.isChecked()
-        self.ui.tth_width.setEnabled(enable_width)
-
         limit_active = self.ui.limit_active.isChecked()
         self.ui.max_tth.setEnabled(limit_active)
         self.ui.min_d_spacing.setEnabled(limit_active)
@@ -136,8 +126,6 @@ class MaterialsPanel(QObject):
             self.material_editor_widget,
             self.ui.materials_combo,
             self.ui.show_overlays,
-            self.ui.enable_width,
-            self.ui.tth_width,
             self.ui.min_d_spacing,
             self.ui.max_tth,
             self.ui.limit_active
@@ -158,11 +146,6 @@ class MaterialsPanel(QObject):
         self.ui.materials_combo.setCurrentIndex(
             materials_keys.index(HexrdConfig().active_material_name))
         self.ui.show_overlays.setChecked(HexrdConfig().show_overlays)
-        self.ui.enable_width.setChecked(HexrdConfig().tth_width_enabled)
-
-        width = HexrdConfig().active_material_tth_width
-        width = width if width else HexrdConfig().backup_tth_width
-        self.ui.tth_width.setValue(np.degrees(width))
 
         self.ui.limit_active.setChecked(HexrdConfig().limit_active_rings)
 

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -79,8 +79,6 @@ class MaterialsPanel(QObject):
         self.ui.min_d_spacing.valueChanged.connect(
             self.on_min_d_spacing_changed)
 
-        self.ui.hide_all.pressed.connect(self.hide_all_overlays)
-
         HexrdConfig().new_plane_data.connect(self.update_gui_from_config)
 
         self.ui.enable_width.toggled.connect(self.update_enable_states)
@@ -247,17 +245,6 @@ class MaterialsPanel(QObject):
         old_name = HexrdConfig().active_material_name
         HexrdConfig().rename_material(old_name, new_name)
         self.update_gui_from_config()
-
-    def hide_all_overlays(self):
-        for overlay in HexrdConfig().overlays:
-            overlay['visible'] = False
-
-        # If there's an overlay manager, update it
-        if hasattr(self, '_overlay_manager'):
-            self._overlay_manager.update_table()
-
-        self.update_gui_from_config()
-        HexrdConfig().overlay_config_changed.emit()
 
     def show_materials_table(self):
         self.materials_table.show()

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -1,12 +1,4 @@
-import copy
-import numpy as np
-
-from PySide2.QtCore import QSignalBlocker
-from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
-
-from hexrd.ui.calibration_crystal_editor import CalibrationCrystalEditor
-from hexrd.ui.constants import DEFAULT_CRYSTAL_PARAMS, OverlayType
-from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.laue_overlay_editor import LaueOverlayEditor
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -16,28 +8,14 @@ class OverlayEditor:
         loader = UiLoader()
         self.ui = loader.load_file('overlay_editor.ui', parent)
 
-        self._overlay = None
-        self.update_type_tab()
+        self.laue_overlay_editor = LaueOverlayEditor(self.ui)
 
-        self.laue_crystal_editor = CalibrationCrystalEditor(parent=self.ui)
-        self.ui.laue_crystal_editor_layout.addWidget(
-            self.laue_crystal_editor.ui)
+        self.ui.laue_overlay_editor_layout.addWidget(
+            self.laue_overlay_editor.ui)
 
         self.ui.tab_widget.tabBar().hide()
 
-        self.setup_connections()
-
-    def setup_connections(self):
-        for w in self.laue_widgets:
-            if isinstance(w, QDoubleSpinBox):
-                w.valueChanged.connect(self.update_config)
-            elif isinstance(w, QCheckBox):
-                w.toggled.connect(self.update_config)
-
-        self.ui.laue_enable_widths.toggled.connect(
-            self.update_laue_enable_states)
-
-        self.laue_crystal_editor.params_modified.connect(self.update_config)
+        self.overlay = None
 
     @property
     def overlay(self):
@@ -46,10 +24,7 @@ class OverlayEditor:
     @overlay.setter
     def overlay(self, v):
         self._overlay = v
-        if self.overlay is not None:
-            self.update_gui()
-        else:
-            self.update_type_tab()
+        self.update_type_tab()
 
     @property
     def type(self):
@@ -64,121 +39,18 @@ class OverlayEditor:
 
         self.ui.tab_widget.setCurrentWidget(w)
 
-    def update_gui(self):
-        self.update_type_tab()
-
-        if self.type == OverlayType.laue:
-            self.update_gui_laue()
-
-    def update_gui_laue(self):
-        blockers = [QSignalBlocker(w) for w in self.all_widgets]  # noqa: F841
-
-        options = self.overlay.get('options', {})
-        if 'min_energy' in options:
-            self.ui.laue_min_energy.setValue(options['min_energy'])
-        if 'max_energy' in options:
-            self.ui.laue_max_energy.setValue(options['max_energy'])
-        if 'crystal_params' in options:
-            self.laue_crystal_params = options['crystal_params']
-        else:
-            self.laue_crystal_params = DEFAULT_CRYSTAL_PARAMS.copy()
-
-        if options.get('tth_width') is not None:
-            self.ui.laue_tth_width.setValue(np.degrees(options['tth_width']))
-        if options.get('eta_width') is not None:
-            self.ui.laue_eta_width.setValue(np.degrees(options['eta_width']))
-
-        widths = ['tth_width', 'eta_width']
-        enable_widths = all(options.get(x) is not None for x in widths)
-        self.ui.laue_enable_widths.setChecked(enable_widths)
-
-        self.update_laue_enable_states()
-
-    def update_laue_enable_states(self):
-        enable_widths = self.laue_enable_widths
-        names = [
-            'laue_tth_width_label',
-            'laue_tth_width',
-            'laue_eta_width_label',
-            'laue_eta_width'
-        ]
-        for name in names:
-            getattr(self.ui, name).setEnabled(enable_widths)
+        if self.active_widget is not None:
+            self.active_widget.overlay = self.overlay
 
     @property
-    def laue_crystal_params(self):
-        return copy.deepcopy(self.laue_crystal_editor.params)
+    def active_widget(self):
+        widgets = {
+            'powder': None,
+            'laue': self.laue_overlay_editor,
+            'mono_rotation_series': None
+        }
 
-    @laue_crystal_params.setter
-    def laue_crystal_params(self, v):
-        self.laue_crystal_editor.params = v
-
-    def update_config(self):
-        if self.type == OverlayType.laue:
-            self.update_config_laue()
-
-        self.overlay['update_needed'] = True
-        HexrdConfig().overlay_config_changed.emit()
-
-    def update_config_laue(self):
-        options = self.overlay.setdefault('options', {})
-        options['min_energy'] = self.ui.laue_min_energy.value()
-        options['max_energy'] = self.ui.laue_max_energy.value()
-        options['crystal_params'] = self.laue_crystal_params
-        options['tth_width'] = self.laue_tth_width
-        options['eta_width'] = self.laue_eta_width
-
-    @property
-    def laue_enable_widths(self):
-        return self.ui.laue_enable_widths.isChecked()
-
-    @property
-    def laue_tth_width(self):
-        if not self.laue_enable_widths:
+        if self.type is None or self.type.value not in widgets:
             return None
 
-        return np.radians(self.ui.laue_tth_width.value())
-
-    @property
-    def laue_eta_width(self):
-        if not self.laue_enable_widths:
-            return None
-
-        return np.radians(self.ui.laue_eta_width.value())
-
-    @property
-    def powder_widgets(self):
-        return []
-
-    @property
-    def laue_widgets(self):
-        return [
-            self.ui.laue_min_energy,
-            self.ui.laue_max_energy,
-            self.ui.laue_enable_widths,
-            self.ui.laue_tth_width,
-            self.ui.laue_eta_width
-        ]
-
-    @property
-    def mono_rotation_series_widgets(self):
-        return []
-
-    @property
-    def tab_widgets(self):
-        return [
-            self.ui.tab_widget,
-            self.ui.powder_tab,
-            self.ui.laue_tab,
-            self.ui.mono_rotation_series_tab,
-            self.ui.blank_tab
-        ]
-
-    @property
-    def all_widgets(self):
-        return (
-            self.powder_widgets +
-            self.laue_widgets +
-            self.mono_rotation_series_widgets +
-            self.tab_widgets
-        )
+        return widgets[self.type.value]

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -1,4 +1,5 @@
 from hexrd.ui.laue_overlay_editor import LaueOverlayEditor
+from hexrd.ui.powder_overlay_editor import PowderOverlayEditor
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -8,8 +9,11 @@ class OverlayEditor:
         loader = UiLoader()
         self.ui = loader.load_file('overlay_editor.ui', parent)
 
-        self.laue_overlay_editor = LaueOverlayEditor(self.ui)
+        self.powder_overlay_editor = PowderOverlayEditor(self.ui)
+        self.ui.powder_overlay_editor_layout.addWidget(
+            self.powder_overlay_editor.ui)
 
+        self.laue_overlay_editor = LaueOverlayEditor(self.ui)
         self.ui.laue_overlay_editor_layout.addWidget(
             self.laue_overlay_editor.ui)
 
@@ -45,7 +49,7 @@ class OverlayEditor:
     @property
     def active_widget(self):
         widgets = {
-            'powder': None,
+            'powder': self.powder_overlay_editor,
             'laue': self.laue_overlay_editor,
             'mono_rotation_series': None
         }
@@ -54,3 +58,10 @@ class OverlayEditor:
             return None
 
         return widgets[self.type.value]
+
+    def update_active_widget_gui(self):
+        w = self.active_widget
+        if w is None:
+            return
+
+        w.update_gui()

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -181,6 +181,9 @@ class OverlayManager:
                 overlay['material'] = w.currentData()
                 overlay['update_needed'] = True
 
+                # In case the active widget depends on material settings
+                self.overlay_editor.update_active_widget_gui()
+
         HexrdConfig().overlay_config_changed.emit()
 
     def update_config_types(self):

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -1,0 +1,89 @@
+import numpy as np
+
+from PySide2.QtCore import QSignalBlocker
+from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class PowderOverlayEditor:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('powder_overlay_editor.ui', parent)
+
+        self._overlay = None
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        for w in self.widgets:
+            if isinstance(w, QDoubleSpinBox):
+                w.valueChanged.connect(self.update_config)
+            elif isinstance(w, QCheckBox):
+                w.toggled.connect(self.update_config)
+
+        self.ui.enable_width.toggled.connect(self.update_enable_states)
+
+    @property
+    def overlay(self):
+        return self._overlay
+
+    @overlay.setter
+    def overlay(self, v):
+        self._overlay = v
+        self.update_gui()
+
+    def update_enable_states(self):
+        enable_width = self.ui.enable_width.isChecked()
+        self.ui.tth_width.setEnabled(enable_width)
+
+    def update_gui(self):
+        if self.overlay is None:
+            return
+
+        blockers = [QSignalBlocker(w) for w in self.widgets]  # noqa: F841
+        self.tth_width_gui = self.tth_width_config
+        self.update_enable_states()
+
+    def update_config(self):
+        self.tth_width_config = self.tth_width_gui
+        self.overlay['update_needed'] = True
+        HexrdConfig().overlay_config_changed.emit()
+
+    @property
+    def tth_width_config(self):
+        if self.overlay is None:
+            return None
+
+        name = self.overlay['material']
+        return HexrdConfig().material(name).planeData.tThWidth
+
+    @tth_width_config.setter
+    def tth_width_config(self, v):
+        if self.overlay is None:
+            return
+
+        name = self.overlay['material']
+        HexrdConfig().material(name).planeData.tThWidth = v
+
+    @property
+    def tth_width_gui(self):
+        if not self.ui.enable_width.isChecked():
+            return None
+        return np.radians(self.ui.tth_width.value())
+
+    @tth_width_gui.setter
+    def tth_width_gui(self, v):
+        enable_width = v is not None
+        self.ui.enable_width.setChecked(enable_width)
+        if enable_width:
+            self.ui.tth_width.setValue(np.degrees(v))
+
+    @property
+    def widgets(self):
+        return [
+            self.ui.enable_width,
+            self.ui.tth_width
+        ]

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>laue_overlay_editor</class>
+ <widget class="QWidget" name="laue_overlay_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>502</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="ranges_group_box">
+     <property name="title">
+      <string>Widths</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="2" column="1">
+       <widget class="QLabel" name="eta_width_label">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>η</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLabel" name="tth_width_label">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>2θ</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enable_widths">
+        <property name="text">
+         <string>Enable Widths</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QDoubleSpinBox" name="tth_width">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>180.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.200000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QDoubleSpinBox" name="eta_width">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>180.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>2.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QDoubleSpinBox" name="max_energy">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="maximum">
+      <double>10000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>35.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="min_energy_label">
+     <property name="text">
+      <string>Min Energy:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="max_energy_label">
+     <property name="text">
+      <string>Max Energy:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QDoubleSpinBox" name="min_energy">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="maximum">
+      <double>10000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>5.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="crystal_editor_layout"/>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>min_energy</tabstop>
+  <tabstop>max_energy</tabstop>
+  <tabstop>enable_widths</tabstop>
+  <tabstop>tth_width</tabstop>
+  <tabstop>eta_width</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -110,17 +110,7 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="5" column="0">
-      <widget class="QCheckBox" name="limit_active">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the allowed HKLs with the max 2θ or the minimum d spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Limit Active</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="3">
+     <item row="4" column="3">
       <spacer name="horizontalSpacer_2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -134,98 +124,29 @@
       </spacer>
      </item>
      <item row="4" column="0">
-      <widget class="QCheckBox" name="enable_width">
+      <widget class="QCheckBox" name="limit_active">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the currently selected material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the allowed HKLs with the max 2θ or the minimum d spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Enable Width</string>
+        <string>Limit Active</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="tth_width">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="show_overlays">
        <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;2θ width for the currently selected material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="prefix">
-        <string/>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="minimum">
-        <double>0.000000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>10.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.005000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.125000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2" colspan="2">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="6" column="1">
-      <widget class="QLabel" name="min_d_spacing_label">
-       <property name="enabled">
-        <bool>false</bool>
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display overlays in the canvas for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
        <property name="text">
-        <string>Min d-spacing:</string>
+        <string>Show Overlays</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
      <item row="5" column="2">
-      <widget class="QDoubleSpinBox" name="max_tth">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The max 2θ for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="2">
       <widget class="QDoubleSpinBox" name="min_d_spacing">
        <property name="enabled">
         <bool>false</bool>
@@ -247,7 +168,36 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="2">
+      <widget class="QDoubleSpinBox" name="max_tth">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The max 2θ for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="suffix">
+        <string>°</string>
+       </property>
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="4">
+      <widget class="QPushButton" name="show_overlay_manager">
+       <property name="text">
+        <string>Overlay Manager</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
       <widget class="QLabel" name="max_tth_label">
        <property name="enabled">
         <bool>false</bool>
@@ -257,14 +207,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="0" colspan="4">
-      <widget class="QPushButton" name="show_materials_table">
-       <property name="text">
-        <string>Materials Table</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="3">
+     <item row="5" column="3">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -277,23 +220,20 @@
        </property>
       </spacer>
      </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="show_overlays">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display overlays in the canvas for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     <item row="5" column="1">
+      <widget class="QLabel" name="min_d_spacing_label">
+       <property name="enabled">
+        <bool>false</bool>
        </property>
        <property name="text">
-        <string>Show Overlays</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
+        <string>Min d-spacing:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0" colspan="4">
-      <widget class="QPushButton" name="show_overlay_manager">
+     <item row="0" column="0" colspan="4">
+      <widget class="QPushButton" name="show_materials_table">
        <property name="text">
-        <string>Overlay Manager</string>
+        <string>Materials Table</string>
        </property>
       </widget>
      </item>
@@ -307,8 +247,6 @@
   <tabstop>show_materials_table</tabstop>
   <tabstop>show_overlay_manager</tabstop>
   <tabstop>show_overlays</tabstop>
-  <tabstop>enable_width</tabstop>
-  <tabstop>tth_width</tabstop>
   <tabstop>limit_active</tabstop>
   <tabstop>max_tth</tabstop>
   <tabstop>min_d_spacing</tabstop>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -180,16 +180,6 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
-      <widget class="QPushButton" name="hide_all">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Hide all material overlays&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Hide All</string>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="2" colspan="2">
       <spacer name="horizontalSpacer">
        <property name="orientation">
@@ -317,7 +307,6 @@
   <tabstop>show_materials_table</tabstop>
   <tabstop>show_overlay_manager</tabstop>
   <tabstop>show_overlays</tabstop>
-  <tabstop>hide_all</tabstop>
   <tabstop>enable_width</tabstop>
   <tabstop>tth_width</tabstop>
   <tabstop>limit_active</tabstop>

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -23,8 +23,8 @@
    <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
 </string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="2">
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
     <widget class="QTabWidget" name="tab_widget">
      <property name="minimumSize">
       <size>
@@ -39,16 +39,9 @@
       <attribute name="title">
        <string>Powder</string>
       </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>No Custom Settings for Powder</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="powder_overlay_editor_layout"/>
        </item>
       </layout>
      </widget>
@@ -74,7 +67,7 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item>
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -57,134 +57,8 @@
        <string>Laue</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="2" column="0" colspan="2">
-        <widget class="QGroupBox" name="ranges_group_box">
-         <property name="title">
-          <string>Widths</string>
-         </property>
-         <layout class="QGridLayout" name="gridLayout_4">
-          <item row="2" column="1">
-           <widget class="QLabel" name="laue_eta_width_label">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>η</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="laue_tth_width_label">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>2θ</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QCheckBox" name="laue_enable_widths">
-            <property name="text">
-             <string>Enable Widths</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QDoubleSpinBox" name="laue_tth_width">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="suffix">
-             <string>°</string>
-            </property>
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>180.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>0.200000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="2">
-           <widget class="QDoubleSpinBox" name="laue_eta_width">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="keyboardTracking">
-             <bool>false</bool>
-            </property>
-            <property name="suffix">
-             <string>°</string>
-            </property>
-            <property name="decimals">
-             <number>3</number>
-            </property>
-            <property name="maximum">
-             <double>180.000000000000000</double>
-            </property>
-            <property name="value">
-             <double>2.000000000000000</double>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QDoubleSpinBox" name="laue_max_energy">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>35.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="laue_max_energy_label">
-         <property name="text">
-          <string>Max Energy:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QDoubleSpinBox" name="laue_min_energy">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="maximum">
-          <double>10000.000000000000000</double>
-         </property>
-         <property name="value">
-          <double>5.000000000000000</double>
-         </property>
-        </widget>
-       </item>
        <item row="0" column="0">
-        <widget class="QLabel" name="laue_min_energy_label">
-         <property name="text">
-          <string>Min Energy:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0" colspan="2">
-        <layout class="QVBoxLayout" name="laue_crystal_editor_layout"/>
+        <layout class="QVBoxLayout" name="laue_overlay_editor_layout"/>
        </item>
       </layout>
      </widget>
@@ -217,11 +91,6 @@
  </widget>
  <tabstops>
   <tabstop>tab_widget</tabstop>
-  <tabstop>laue_min_energy</tabstop>
-  <tabstop>laue_max_energy</tabstop>
-  <tabstop>laue_enable_widths</tabstop>
-  <tabstop>laue_tth_width</tabstop>
-  <tabstop>laue_eta_width</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -1,0 +1,95 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>powder_overlay_editor</class>
+ <widget class="QWidget" name="powder_overlay_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>502</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="2">
+    <widget class="QDoubleSpinBox" name="tth_width">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="prefix">
+      <string/>
+     </property>
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="decimals">
+      <number>3</number>
+     </property>
+     <property name="minimum">
+      <double>0.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10.000000000000000</double>
+     </property>
+     <property name="singleStep">
+      <double>0.005000000000000</double>
+     </property>
+     <property name="value">
+      <double>0.125000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="enable_width">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Enable Width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>enable_width</tabstop>
+  <tabstop>tth_width</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This changes a few things:

1. 6de3d9c6f614a0c2fe0da988372d60805a5e5668 from #450 was cherry-picked.
2. Remove "Hide All" button (no longer needed).
3. Move material tth width editor into powder overlay editor.

Rather than having the material tth width editor be on the 
materials panel, move it into the powder overlay editor, because
it currently only impacts the powder overlays.

This tth width is still set on the material, so two powder overlays
with the same material will have the same tth width, but that is
most likely not an issue.