### PR TITLE
Overlay behavior improvements

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -850,6 +850,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         if name in self.materials:
             raise Exception(name + ' is already in materials list!')
         self.config['materials']['materials'][name] = material
+        self.reset_tth_max(name)
 
     def rename_material(self, old_name, new_name):
         if old_name != new_name:

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -197,7 +197,7 @@ class ImageModeWidget(QObject):
         HexrdConfig().config['image']['polar'].update(params)
 
         # Update all of the materials with the new tth_max
-        HexrdConfig().set_tth_max_all_materials(np.radians(params['tth_max']))
+        HexrdConfig().reset_tth_max_all_materials()
 
         # Get the GUI to update with the new values
         self.update_gui_from_config()

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -196,6 +196,9 @@ class ImageModeWidget(QObject):
 
         HexrdConfig().config['image']['polar'].update(params)
 
+        # Update all of the materials with the new tth_max
+        HexrdConfig().set_tth_max_all_materials(np.radians(params['tth_max']))
+
         # Get the GUI to update with the new values
         self.update_gui_from_config()
 

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -79,6 +79,9 @@ class MaterialsPanel(QObject):
         self.ui.limit_active.toggled.connect(self.update_material_limits)
         self.ui.limit_active.toggled.connect(self.update_table)
 
+        HexrdConfig().active_material_modified.connect(
+            self.update_gui_from_config)
+
     def update_enable_states(self):
         limit_active = self.ui.limit_active.isChecked()
         self.ui.max_tth.setEnabled(limit_active)

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 
 from hexrd import constants
@@ -10,7 +12,7 @@ class LaueSpotOverlay:
                  crystal_params=None, sample_rmat=None,
                  min_energy=5., max_energy=35.,
                  tth_width=None, eta_width=None):
-        self._plane_data = plane_data
+        self.plane_data = plane_data
         self._instrument = instr
         if crystal_params is None:
             self._crystal_params = np.hstack(
@@ -34,6 +36,14 @@ class LaueSpotOverlay:
     @property
     def plane_data(self):
         return self._plane_data
+
+    @plane_data.setter
+    def plane_data(self, v):
+        self._plane_data = v
+        # For Laue overlays, we will use all hkl values
+        if self._plane_data.exclusions is not None:
+            self._plane_data = copy.deepcopy(self._plane_data)
+            self._plane_data.exclusions = None
 
     @property
     def instrument(self):

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -185,6 +185,9 @@
        <property name="suffix">
         <string>°</string>
        </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
        <property name="singleStep">
         <double>0.100000000000000</double>
        </property>

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -82,9 +82,11 @@ def make_new_pdata(mat):
     # and the previous tthWidth
     prev_exclusions = mat.planeData.exclusions
     prev_tThWidth = mat.planeData.tThWidth
+    prev_tThMax = mat.planeData.tThMax
     mat._newPdata()
     mat.planeData.exclusions = prev_exclusions
     mat.planeData.tThWidth = prev_tThWidth
+    mat.planeData.tThMax = prev_tThMax
 
 
 def coords2index(im, x, y):


### PR DESCRIPTION
This PR is intends to add the following improvements:

1. Always use all hkl values for Laue overlays, rather than just the ones selected in the materials table
2. Reset materials' max two theta to match that of the polar resolution config at various places throughout the program

The places where max two theta are reset are:

1. When loading the default materials
2. When loading/resetting an instrument configuration
3. When adding a material

Fixes: #475 

I need to test and check this a little more before it is ready to go...