### PR TITLE
Remove button defaults from dialog widgets

### DIFF
--- a/hexrd/ui/__init__.py
+++ b/hexrd/ui/__init__.py
@@ -1,0 +1,24 @@
+from PySide2.QtCore import QEvent, QObject, Qt
+from PySide2.QtWidgets import QDialog
+
+
+class EnterKeyFilter(QObject):
+    """An event filter to ignore <Enter> keys in QDialog instances.
+
+    QButtonBox will **always** assign a default button to the <Enter> key,
+    even if each button has its default and autoDefault properties explicitly
+    set False. So to prevent a QDialog with QButtonBox from responding
+    to the <Enter> key, install this filter on the QDialog instance.
+
+    Note that this filter **only** filters QDialog objects.
+    """
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.KeyPress and \
+                event.key() == Qt.Key_Return and \
+                isinstance(obj, QDialog):
+            return True
+        # (else) standard event processing
+        return QObject.eventFilter(self, obj, event)
+
+
+enter_key_filter = EnterKeyFilter()

--- a/hexrd/ui/calibration/panel_buffer_dialog.py
+++ b/hexrd/ui/calibration/panel_buffer_dialog.py
@@ -4,6 +4,8 @@ from PySide2.QtCore import Signal, QObject, QSignalBlocker
 from PySide2.QtWidgets import QFileDialog, QMessageBox
 import numpy as np
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -23,6 +25,7 @@ class PanelBufferDialog(QObject):
         self.detector = detector
         loader = UiLoader()
         self.ui = loader.load_file('panel_buffer_dialog.ui')
+        self.ui.installEventFilter(enter_key_filter)
 
         # Hide the tab bar. It gets selected by changes to the combo box.
         self.ui.tab_widget.tabBar().hide()

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -2,6 +2,8 @@ from PySide2.QtCore import (
     QItemSelectionModel, QObject, QSignalBlocker, Qt, Signal, Slot)
 from PySide2.QtWidgets import QDialogButtonBox, QHeaderView
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -24,6 +26,7 @@ class FitGrainsOptionsDialog(QObject):
         self.ui = loader.load_file('fit_grains_options_dialog.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
+        self.ui.installEventFilter(enter_key_filter)
 
         ok_button = self.ui.button_box.button(QDialogButtonBox.Ok)
         ok_button.setText('Fit Grains')

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -3,6 +3,8 @@ import os
 from PySide2.QtCore import Signal, QObject, QSignalBlocker
 from PySide2.QtWidgets import QFileDialog, QMessageBox
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -18,6 +20,7 @@ class OmeMapsSelectDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('ome_maps_select_dialog.ui', parent)
         self.ui.setWindowTitle('Load/Generate Eta Omega Maps')
+        self.ui.installEventFilter(enter_key_filter)
 
         # Hide the tab bar. It gets selected by changes to the combo box.
         self.ui.tab_widget.tabBar().hide()

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -11,7 +11,7 @@ import yaml
 from PySide2.QtCore import Signal, QObject, QSignalBlocker, Qt
 from PySide2.QtWidgets import QComboBox, QFileDialog, QSizePolicy
 
-from hexrd.ui import resource_loader
+from hexrd.ui import enter_key_filter, resource_loader
 
 from hexrd.ui.color_map_editor import ColorMapEditor
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -32,6 +32,7 @@ class OmeMapsViewerDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('ome_maps_viewer_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
 
         self.data = data
         self.cmap = hexrd.ui.constants.DEFAULT_CMAP

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -7,6 +7,8 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Cursor
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.zoom_canvas import ZoomCanvas
@@ -24,6 +26,7 @@ class LinePickerDialog(QObject):
         self.ui = loader.load_file('line_picker_dialog.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
+        self.ui.installEventFilter(enter_key_filter)
 
         self.canvas = canvas
         self.ring_data = []

--- a/hexrd/ui/load_hdf5_dialog.py
+++ b/hexrd/ui/load_hdf5_dialog.py
@@ -3,6 +3,8 @@ import os
 
 from PySide2.QtWidgets import QDialog, QListWidgetItem, QMessageBox
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.ui_loader import UiLoader
 
 class LoadHDF5Dialog:
@@ -13,6 +15,7 @@ class LoadHDF5Dialog:
 
     loader = UiLoader()
     self.ui = loader.load_file('load_hdf5_dialog.ui', parent)
+    self.ui.installEventFilter(enter_key_filter)
 
     self.get_paths(f)
 

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -4,6 +4,8 @@ import os
 
 from PySide2.QtWidgets import QMessageBox, QTableWidgetItem, QComboBox
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -15,6 +17,8 @@ class LoadImagesDialog:
 
         loader = UiLoader()
         self.ui = loader.load_file('load_images_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
+
         self.setup_connections()
         self.setup_state()
         self.setup_table(manual_assign)

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -5,6 +5,9 @@ from PySide2.QtCore import QObject, Signal
 from PySide2.QtWidgets import (
     QCheckBox, QFileDialog, QMenu, QPushButton, QTableWidgetItem)
 from PySide2.QtGui import QCursor
+
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -20,6 +23,7 @@ class MaskManagerDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('mask_manager_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
         self.create_masks_list()
         self.threshold = False
 

--- a/hexrd/ui/overlay_style_picker.py
+++ b/hexrd/ui/overlay_style_picker.py
@@ -4,6 +4,8 @@ from PySide2.QtCore import QObject, QSignalBlocker
 from PySide2.QtGui import QColor
 from PySide2.QtWidgets import QColorDialog
 
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
@@ -16,6 +18,7 @@ class OverlayStylePicker(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('overlay_style_picker.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
 
         self.original_style = copy.deepcopy(overlay['style'])
         self.overlay = overlay

--- a/hexrd/ui/powder_calibration_dialog.py
+++ b/hexrd/ui/powder_calibration_dialog.py
@@ -1,3 +1,5 @@
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -7,6 +9,7 @@ class PowderCalibrationDialog:
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('powder_calibration_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
 
         self.update_gui_from_config()
         self.setup_connections()

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>697</height>
+    <height>725</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -573,6 +573,9 @@
       <widget class="QPushButton" name="export_button">
        <property name="text">
         <string>Export</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
        </property>
       </widget>
      </item>

--- a/hexrd/ui/resources/ui/overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/overlay_style_picker.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>468</width>
-    <height>212</height>
+    <width>476</width>
+    <height>214</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -65,6 +65,9 @@
         <property name="text">
          <string/>
         </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
        </widget>
       </item>
       <item row="0" column="5">
@@ -106,6 +109,9 @@
        <widget class="QPushButton" name="range_color">
         <property name="text">
          <string/>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
         </property>
        </widget>
       </item>

--- a/hexrd/ui/resources/ui/panel_buffer_dialog.ui
+++ b/hexrd/ui/resources/ui/panel_buffer_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>478</width>
-    <height>157</height>
+    <height>235</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -94,6 +94,9 @@
         <widget class="QPushButton" name="select_file_button">
          <property name="text">
           <string>Select NumPy Array File</string>
+         </property>
+         <property name="autoDefault">
+          <bool>false</bool>
          </property>
         </widget>
        </item>

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -1,3 +1,5 @@
+from hexrd.ui import enter_key_filter
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_load_manager import ImageLoadManager
 from hexrd.ui.ui_loader import UiLoader
@@ -9,6 +11,7 @@ class TransformDialog:
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('transforms_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
         self.det_labels = []
         self.det_cboxes = []
 

--- a/hexrd/ui/workflow_selection_dialog.py
+++ b/hexrd/ui/workflow_selection_dialog.py
@@ -1,6 +1,6 @@
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
-from hexrd.ui import constants
+from hexrd.ui import constants, enter_key_filter
 
 
 class WorkflowSelectionDialog:
@@ -8,6 +8,7 @@ class WorkflowSelectionDialog:
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('workflow_selection_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
         self.init_gui()
         self.update_gui_from_config()
         self.setup_connections()


### PR DESCRIPTION
Filters `<Enter>` key events from dialogs so that there is no default behavior for that key.

* For buttons in the .ui file, this PR clears autoDefault flag
* For QButtonBox buttons, this PR adds an EnterKeyFilter class to filter  <Enter> key events.

resolves #472 