### PR TITLE
Calibration widget

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -76,6 +76,11 @@ class CalTreeItemModel(BaseTreeItemModel):
         item.set_data(index.column(), value)
 
         if item.child_count() == 0:
+            parent = item.parent_item.data(KEY_COL)
+            if (parent == 'tilt' and
+                    HexrdConfig().rotation_matrix_euler() is not None):
+                # Convert tilt values to radians before saving
+                value = np.radians(value).item()
             self.cfg.set_instrument_config_val(path, value)
             dist_func_path = ['distortion', 'function_name', 'value']
             if len(path) > 4 and path[2:5] == dist_func_path:
@@ -130,7 +135,8 @@ class CalTreeItemModel(BaseTreeItemModel):
         for key in keys:
             if key == 'value':
                 data = cur_config[key]
-                if cur_tree_item.data(0) == 'tilt':
+                if (cur_tree_item.data(KEY_COL) == 'tilt' and
+                        HexrdConfig().rotation_matrix_euler() is not None):
                     data = [np.degrees(rad).item() for rad in cur_config[key]]
                 self.set_value(key, data, cur_tree_item)
                 continue

--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -129,7 +129,10 @@ class CalTreeItemModel(BaseTreeItemModel):
 
         for key in keys:
             if key == 'value':
-                self.set_value(key, cur_config[key], cur_tree_item)
+                data = cur_config[key]
+                if cur_tree_item.data(0) == 'tilt':
+                    data = [np.degrees(rad).item() for rad in cur_config[key]]
+                self.set_value(key, data, cur_tree_item)
                 continue
             elif key == 'status':
                 tree_item = cur_tree_item

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -175,6 +175,7 @@ class CalibrationSliderWidget(QObject):
             self.unblock_all_signals(previously_blocked)
 
         self.update_ranges()
+        self.update_labels()
 
     def update_detectors_from_config(self):
         widget = self.ui.detector
@@ -295,10 +296,11 @@ class CalibrationSliderWidget(QObject):
         self.update_gui_from_config()
 
     def update_labels(self):
+        # Make sure tilt labels reflect current euler convention
         if HexrdConfig().euler_angle_convention is None:
-            return
-
-        a, b, c = HexrdConfig().euler_angle_convention['axes_order']
+            a, b, c = 'xyz'
+        else:
+            a, b, c = HexrdConfig().euler_angle_convention['axes_order']
         self.ui.label_tilt_2.setText(str.upper(a + ':'))
         self.ui.label_tilt_0.setText(str.upper(b + ':'))
         self.ui.label_tilt_1.setText(str.upper(c + ':'))

--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -42,6 +42,9 @@ class CalibrationSliderWidget(QObject):
 
         self.ui.push_reset_config.pressed.connect(self.reset_config)
 
+        HexrdConfig().euler_angle_convention_changed.connect(
+            self.update_labels)
+
     def update_ranges(self):
         r = self.ui.sb_translation_range.value()
         slider_r = r * self.CONF_VAL_TO_SLIDER_VAL
@@ -290,3 +293,12 @@ class CalibrationSliderWidget(QObject):
     def reset_config(self):
         HexrdConfig().restore_instrument_config_backup()
         self.update_gui_from_config()
+
+    def update_labels(self):
+        if HexrdConfig().euler_angle_convention is None:
+            return
+
+        a, b, c = HexrdConfig().euler_angle_convention['axes_order']
+        self.ui.label_tilt_2.setText(str.upper(a + ':'))
+        self.ui.label_tilt_0.setText(str.upper(b + ':'))
+        self.ui.label_tilt_1.setText(str.upper(c + ':'))


### PR DESCRIPTION
Addresses some of the issues discussed in #493:
- Updates the labels for tilt to match selected parameterization
- Change the units to degrees for tilts in tree view if parameterization is not None

Not yet fixed:
- Possibly use `ScientificSpinBox` to allow for more than two decimal places in spin controller widgets
- Possibly recalculate slider range if value is entered into the spin controller widget is outside of the current range
- Make sure form view fields update when detector selector is changed*
- Make sure edits made in the form view are not lost when calibration view tabs are toggled*
*May be Mac-specific issues