### PR TITLE
Move access to self.ui inside event type block

### DIFF
--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -357,15 +357,16 @@ class CalibrationConfigWidget(QObject):
         # focus here so it gets called only once.
         if type(target) == QComboBox:
             if target.objectName() == 'cal_det_current':
-                widget = self.ui.cal_det_current
                 enter_keys = [Qt.Key_Return, Qt.Key_Enter]
                 if type(event) == QKeyEvent and event.key() in enter_keys:
+                    widget = self.ui.cal_det_current
                     widget.lineEdit().clearFocus()
                     return True
 
                 if type(event) == QFocusEvent and event.lostFocus():
                     # This happens either if enter is pressed, or if the
                     # user tabs out.
+                    widget = self.ui.cal_det_current
                     items = [widget.itemText(i) for i in range(widget.count())]
                     text = widget.currentText()
                     idx = widget.currentIndex()

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -265,15 +265,16 @@ class MaterialsPanel(QObject):
         # We should keep this and CalibrationConfigWidget.eventFilter similar.
         if type(target) == QComboBox:
             if target.objectName() == 'materials_combo':
-                widget = self.ui.materials_combo
                 enter_keys = [Qt.Key_Return, Qt.Key_Enter]
                 if type(event) == QKeyEvent and event.key() in enter_keys:
+                    widget = self.ui.materials_combo
                     widget.lineEdit().clearFocus()
                     return True
 
                 if type(event) == QFocusEvent and event.lostFocus():
                     # This happens either if enter is pressed, or if the
                     # user tabs out.
+                    widget = self.ui.materials_combo
                     items = [widget.itemText(i) for i in range(widget.count())]
                     text = widget.currentText()
                     idx = widget.currentIndex()


### PR DESCRIPTION
On shutdown we were getting various AttributeError for self.ui access. Moving the access to the ui attribute inside the event type
check resolves this.

Fixes #478 