### PR TITLE
Add a structure tab to the materials panel

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -450,6 +450,7 @@ class MainWindow(QObject):
             HexrdConfig().working_dir = os.path.dirname(selected_file)
             HexrdConfig().load_materials(selected_file)
             self.materials_panel.update_gui_from_config()
+            self.materials_panel.update_structure_tab()
 
     def on_action_save_imageseries_triggered(self):
         if not HexrdConfig().has_images():

--- a/hexrd/ui/material_site_editor.py
+++ b/hexrd/ui/material_site_editor.py
@@ -1,0 +1,282 @@
+import numpy as np
+
+from PySide2.QtCore import QObject, QSignalBlocker, Signal
+from PySide2.QtWidgets import QSizePolicy, QTableWidgetItem
+
+from hexrd.material import Material
+
+from hexrd.ui.periodic_table_dialog import PeriodicTableDialog
+from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
+from hexrd.ui.ui_loader import UiLoader
+
+
+COLUMNS = {
+    'symbol': 0,
+    'occupancy': 1,
+    'thermal_factor': 2
+}
+
+DEFAULT_U = Material.DFLT_U[0]
+
+OCCUPATION_MIN = 0
+OCCUPATION_MAX = 1000
+
+THERMAL_FACTOR_MIN = -1.e7
+THERMAL_FACTOR_MAX = 1.e7
+
+U_TO_B = 8 * np.pi ** 2
+B_TO_U = 1 / U_TO_B
+
+
+class MaterialSiteEditor(QObject):
+
+    site_modified = Signal()
+
+    def __init__(self, site, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('material_site_editor.ui', parent)
+
+        self._site = site
+
+        self.occupancy_spinboxes = []
+        self.thermal_factor_spinboxes = []
+
+        self.update_gui()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.select_atom_types.pressed.connect(self.select_atom_types)
+        self.ui.thermal_factor_type.currentIndexChanged.connect(
+            self.update_thermal_factor_header)
+        self.ui.thermal_factor_type.currentIndexChanged.connect(
+            self.update_gui)
+        for w in self.site_settings_widgets:
+            w.valueChanged.connect(self.update_config)
+        self.ui.total_occupancy.valueChanged.connect(
+            self.update_occupancy_validity)
+
+    def select_atom_types(self):
+        dialog = PeriodicTableDialog(self.atom_types, self.ui)
+        if not dialog.exec_():
+            return
+
+        self.atom_types = dialog.selected_atoms
+
+    @property
+    def site(self):
+        return self._site
+
+    @site.setter
+    def site(self, v):
+        self._site = v
+        self.update_gui()
+
+    @property
+    def atoms(self):
+        return self.site['atoms']
+
+    @property
+    def total_occupancy(self):
+        return self.site['total_occupancy']
+
+    @total_occupancy.setter
+    def total_occupancy(self, v):
+        self.site['total_occupancy'] = v
+
+    @property
+    def fractional_coords(self):
+        return self.site['fractional_coords']
+
+    @property
+    def thermal_factor_type(self):
+        return self.ui.thermal_factor_type.currentText()
+
+    def U(self, val):
+        # Take a thermal factor from a spin box and convert it to U
+        type = self.thermal_factor_type
+        if type == 'U':
+            multiplier = 1
+        elif type == 'B':
+            multiplier = B_TO_U
+        else:
+            raise Exception(f'Unknown type: {type}')
+
+        return val * multiplier
+
+    def B(self, val):
+        # Take a thermal factor from a spin box and convert it to B
+        type = self.thermal_factor_type
+        if type == 'U':
+            multiplier = U_TO_B
+        elif type == 'B':
+            multiplier = 1
+        else:
+            raise Exception(f'Unknown type: {type}')
+
+        return val * multiplier
+
+    def thermal_factor(self, atom):
+        # Given an atom, return the thermal factor in either B or U
+        type = self.thermal_factor_type
+        if type == 'U':
+            multiplier = 1
+        elif type == 'B':
+            multiplier = U_TO_B
+        else:
+            raise Exception(f'Unknown type: {type}')
+
+        return atom['U'] * multiplier
+
+    @property
+    def atom_types(self):
+        return [x['symbol'] for x in self.site['atoms']]
+
+    @atom_types.setter
+    def atom_types(self, v):
+        if v == self.atom_types:
+            # No changes needed...
+            return
+
+        # Reset all the occupancies
+        atoms = self.atoms
+        atoms.clear()
+        atoms += [{'symbol': x, 'U': DEFAULT_U} for x in v]
+        self.reset_occupancies()
+
+        self.update_table()
+        self.emit_site_modified_if_valid()
+
+    def create_symbol_label(self, v):
+        w = QTableWidgetItem(v)
+        return w
+
+    def create_occupancy_spinbox(self, v):
+        sb = ScientificDoubleSpinBox(self.ui.table)
+        sb.setKeyboardTracking(False)
+        sb.setMinimum(OCCUPATION_MIN)
+        sb.setMaximum(OCCUPATION_MAX)
+        sb.setValue(v)
+        sb.valueChanged.connect(self.update_config)
+
+        size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        sb.setSizePolicy(size_policy)
+
+        self.occupancy_spinboxes.append(sb)
+        return sb
+
+    def create_thermal_factor_spinbox(self, v):
+        sb = ScientificDoubleSpinBox(self.ui.table)
+        sb.setKeyboardTracking(False)
+        sb.setMinimum(THERMAL_FACTOR_MIN)
+        sb.setMaximum(THERMAL_FACTOR_MAX)
+        sb.setValue(v)
+        sb.valueChanged.connect(self.update_config)
+
+        size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        sb.setSizePolicy(size_policy)
+
+        self.thermal_factor_spinboxes.append(sb)
+        return sb
+
+    def clear_table(self):
+        self.occupancy_spinboxes.clear()
+        self.thermal_factor_spinboxes.clear()
+        self.ui.table.clearContents()
+
+    def update_gui(self):
+        widgets = self.site_settings_widgets
+        blockers = [QSignalBlocker(w) for w in widgets]  # noqa: F841
+
+        self.ui.total_occupancy.setValue(self.total_occupancy)
+        for i, w in enumerate(self.fractional_coords_widgets):
+            w.setValue(self.fractional_coords[i])
+
+        self.update_table()
+
+    def update_table(self):
+        blocker = QSignalBlocker(self.ui.table)  # noqa: F841
+
+        atoms = self.site['atoms']
+        self.clear_table()
+        self.ui.table.setRowCount(len(atoms))
+        for i, atom in enumerate(atoms):
+            w = self.create_symbol_label(atom['symbol'])
+            self.ui.table.setItem(i, COLUMNS['symbol'], w)
+
+            w = self.create_occupancy_spinbox(atom['occupancy'])
+            self.ui.table.setCellWidget(i, COLUMNS['occupancy'], w)
+
+            w = self.create_thermal_factor_spinbox(self.thermal_factor(atom))
+            self.ui.table.setCellWidget(i, COLUMNS['thermal_factor'], w)
+
+        self.update_occupancy_validity()
+
+    def update_thermal_factor_header(self):
+        w = self.ui.table.horizontalHeaderItem(COLUMNS['thermal_factor'])
+        w.setText(self.thermal_factor_type)
+
+    def update_config(self):
+        self.total_occupancy = self.ui.total_occupancy.value()
+        for i, w in enumerate(self.fractional_coords_widgets):
+            self.fractional_coords[i] = w.value()
+
+        for atom, spinbox in zip(self.atoms, self.occupancy_spinboxes):
+            atom['occupancy'] = spinbox.value()
+
+        for atom, spinbox in zip(self.atoms, self.thermal_factor_spinboxes):
+            atom['U'] = self.U(spinbox.value())
+
+        self.update_occupancy_validity()
+
+        self.emit_site_modified_if_valid()
+
+    def reset_occupancies(self):
+        total = self.total_occupancy
+        atoms = self.atoms
+        num_atoms = len(atoms)
+        for atom in atoms:
+            atom['occupancy'] = total / num_atoms
+
+        self.update_occupancy_validity()
+
+    @property
+    def site_valid(self):
+        return self.occupancies_valid
+
+    @property
+    def occupancies_valid(self):
+        total_occupancy = sum(x['occupancy'] for x in self.atoms)
+        tol = 1.e-6
+        return abs(total_occupancy - self.site['total_occupancy']) < tol
+
+    def update_occupancy_validity(self):
+        valid = self.occupancies_valid
+        color = 'white' if valid else 'red'
+        msg = '' if valid else 'Sum of occupancies must equal total occupancy'
+
+        for w in self.occupancy_spinboxes + [self.ui.total_occupancy]:
+            w.setStyleSheet(f'background-color: {color}')
+            w.setToolTip(msg)
+
+    def emit_site_modified_if_valid(self):
+        if not self.site_valid:
+            return
+
+        self.site_modified.emit()
+
+    @property
+    def fractional_coords_widgets(self):
+        return [
+            self.ui.coords_x,
+            self.ui.coords_y,
+            self.ui.coords_z
+        ]
+
+    @property
+    def site_settings_widgets(self):
+        return [
+            self.ui.total_occupancy
+        ] + self.fractional_coords_widgets

--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -1,0 +1,331 @@
+import copy
+import re
+
+import numpy as np
+
+from PySide2.QtCore import Qt, QItemSelectionModel, QSignalBlocker
+from PySide2.QtWidgets import (
+    QItemEditorFactory, QStyledItemDelegate, QTableWidgetItem
+)
+
+from hexrd.constants import ptable, ptableinverse
+from hexrd.unitcell import unitcell
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.material_site_editor import MaterialSiteEditor
+from hexrd.ui.ui_loader import UiLoader
+
+
+class MaterialStructureEditor:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('material_structure_editor.ui', parent)
+
+        # Hide the tab bar
+        self.ui.site_editor_tab_widget.tabBar().hide()
+
+        # Center the text when it is edited...
+        self.ui.table.setItemDelegate(Delegate(self.ui.table))
+
+        self.sites = []
+
+        self.setup_connections()
+
+        self.update_gui()
+
+    def setup_connections(self):
+        self.ui.add_site.pressed.connect(self.add_site)
+        self.ui.remove_site.pressed.connect(self.remove_site)
+
+        self.ui.table.cellChanged.connect(self.name_changed)
+        self.ui.table.selectionModel().selectionChanged.connect(
+            self.selection_changed)
+
+    def site_modified(self):
+        site = copy.deepcopy(self.material_site_editor.site)
+        self.sites[self.selected_row] = site
+        self.update_material()
+
+    def name_changed(self, row, column):
+        new_name = self.ui.table.item(row, column).text()
+
+        # If there are any sites that already have this name, ignore it
+        if any(x['name'] == new_name for x in self.sites):
+            return
+
+        self.sites[row]['name'] = new_name
+
+    def selection_changed(self):
+        self.update_enable_states()
+        self.update_tab()
+        self.update_site_editor()
+
+    def update_gui(self):
+        self.generate_sites()
+        self.update_table()
+
+    def update_enable_states(self):
+        enable_remove = self.num_rows > 1 and self.selected_row is not None
+        self.ui.remove_site.setEnabled(enable_remove)
+
+    def update_tab(self):
+        tab = 'empty' if self.selected_row is None else 'site_editor'
+        w = self.ui.site_editor_tab_widget
+        w.setCurrentWidget(getattr(self.ui, f'{tab}_tab'))
+
+    def update_site_editor(self):
+        site = copy.deepcopy(self.active_site)
+        if site is None:
+            return
+
+        if not hasattr(self, 'material_site_editor'):
+            self.material_site_editor = MaterialSiteEditor(site, self.ui)
+            self.ui.material_site_editor_layout.addWidget(
+                self.material_site_editor.ui)
+            self.material_site_editor.site_modified.connect(self.site_modified)
+        else:
+            self.material_site_editor.site = site
+
+    @property
+    def material(self):
+        return HexrdConfig().active_material
+
+    @property
+    def num_rows(self):
+        return self.ui.table.rowCount()
+
+    @property
+    def active_site(self):
+        row = self.selected_row
+        return self.sites[row] if row is not None else None
+
+    @property
+    def selected_row(self):
+        selected = self.ui.table.selectionModel().selectedRows()
+        return selected[0].row() if selected else None
+
+    def select_row(self, i):
+        if i is None or i >= self.num_rows:
+            # Out of range. Don't do anything.
+            return
+
+        # Select the row
+        selection_model = self.ui.table.selectionModel()
+        selection_model.clearSelection()
+
+        model_index = selection_model.model().index(i, 0)
+        command = QItemSelectionModel.Select | QItemSelectionModel.Rows
+        selection_model.select(model_index, command)
+
+    @staticmethod
+    def trailing_integer(s):
+        last = re.split(r'[^\d]', s)[-1]
+        return int(last) if last else None
+
+    def next_name(self, s):
+        # Get a name with a trailing number at the end
+        # If that name already exists, it increments the trailing number
+        trailing_int = self.trailing_integer(s)
+        if trailing_int is None:
+            next_int = 1
+        else:
+            # Chop off the trailing int
+            s = s[:-len(str(trailing_int))]
+            next_int = trailing_int + 1
+
+        new_name = s + str(next_int)
+        if any(x['name'] == new_name for x in self.sites):
+            # Try again...
+            return self.next_name(new_name)
+
+        return new_name
+
+    def new_site(self, site):
+        new = copy.deepcopy(site)
+        new['name'] = self.next_name(site['name'])
+        return new
+
+    def add_site(self):
+        # Copy if the active site if there is one. Otherwise, copy the
+        # last row.
+        site = self.active_site
+        if site is None:
+            site = self.sites[-1]
+
+        self.sites.append(self.new_site(site))
+        self.update_table()
+
+        # Select the newly added row
+        self.select_row(len(self.sites) - 1)
+
+        self.update_material()
+
+    def remove_site(self):
+        selected_row = self.selected_row
+        if selected_row is None:
+            return
+
+        del self.sites[selected_row]
+        self.update_table()
+
+        if self.selected_row is None:
+            # Select the last row
+            self.select_row(len(self.sites) - 1)
+
+        self.update_material()
+
+    def create_table_widget(self, v):
+        w = QTableWidgetItem(v)
+        w.setTextAlignment(Qt.AlignCenter)
+        return w
+
+    def clear_table(self):
+        self.ui.table.clearContents()
+
+    def update_table(self):
+        prev_selected = self.selected_row
+
+        self.clear_table()
+        if not self.sites:
+            return
+
+        block_list = [
+            self.ui.table,
+            self.ui.table.selectionModel()
+        ]
+        blockers = [QSignalBlocker(x) for x in block_list]  # noqa: F841
+
+        self.ui.table.setRowCount(len(self.sites))
+        for i, site in enumerate(self.sites):
+            w = self.create_table_widget(site['name'])
+            self.ui.table.setItem(i, 0, w)
+
+        if prev_selected is not None:
+            select_row = (prev_selected if prev_selected < len(self.sites)
+                          else len(self.sites) - 1)
+            self.select_row(select_row)
+
+        # Just in case the selection actually changed...
+        self.selection_changed()
+
+    def update_material(self):
+        # Convert the sites back to the material data format
+        info_array = []
+        type_array = []
+        U_array = []
+
+        for site in self.sites:
+            for atom in site['atoms']:
+                info_array.append((*site['fractional_coords'],
+                                   atom['occupancy']))
+                type_array.append(ptable[atom['symbol']])
+                U_array.append(atom['U'])
+
+        mat = self.material
+        mat._atominfo = np.array(info_array)
+        mat._atomtype = np.array(type_array)
+        mat._U = np.array(U_array)
+
+        # Re-create the unit cell from scratch. This is easier to do
+        # right now than setting the variables and figuring out which
+        # properties need to be updated and in what order...
+        mat.unitcell = unitcell(mat._lparms, mat.sgnum, mat._atomtype,
+                                mat._atominfo, mat._U, mat._dmin.getVal('nm'),
+                                mat._beamEnergy.value, mat._sgsetting)
+
+        # Update the structure factor of the PData
+        mat.update_structure_factor()
+
+    def generate_sites(self):
+        """The sites have a structure like the following:
+        {
+            'name': 'NaBr1',
+            'total_occupancy': 1.0,
+            'fractional_coords': [0.25, 0.25, 0.25],
+            'atoms': [
+                {
+                    'symbol': 'Na',
+                    'occupancy': 0.5,
+                    'U': 4.18e-7
+                },
+                {
+                    'symbol': 'Br',
+                    'occupancy': 0.5,
+                    'U': 4.18e-7
+                }
+            ],
+        }
+        """
+        self.sites.clear()
+
+        mat = self.material
+        site_indices = []
+
+        def coords_equal(v1, v2, tol=1.e-5):
+            return (
+                len(v1) == len(v2) and
+                all(abs(x - y) < tol for x, y in zip(v1, v2))
+            )
+
+        info_array = mat._atominfo
+        type_array = mat._atomtype
+        U_array = mat._U
+
+        for i, atom in enumerate(info_array):
+            atom_coords = atom[:3]
+            # Check if this one has coords that match any others before it
+            match_found = False
+            for indices, coords in site_indices:
+                if coords_equal(atom_coords, coords):
+                    indices.append(i)
+                    match_found = True
+                    break
+
+            if match_found:
+                continue
+
+            # No match was found. Append this one.
+            site_indices.append(([i], atom_coords))
+
+        for indices, coords in site_indices:
+            site = {}
+            symbols = [ptableinverse[type_array[i]] for i in indices]
+
+            # Combine the symbols for a basic name
+            site['name'] = self.next_name(''.join(symbols))
+            site['total_occupancy'] = sum(info_array[i][3] for i in indices)
+            site['fractional_coords'] = coords
+            site['atoms'] = []
+
+            for i in indices:
+                atom = {
+                    'symbol': ptableinverse[type_array[i]],
+                    'occupancy': info_array[i][3],
+                    'U': U_array[i]
+                }
+                site['atoms'].append(atom)
+
+            self.sites.append(site)
+
+
+class Delegate(QStyledItemDelegate):
+    # This is only needed to center the text when we edit it...
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        editor_factory = EditorFactory(parent)
+        self.setItemEditorFactory(editor_factory)
+
+
+class EditorFactory(QItemEditorFactory):
+    # This is only needed to center the text when we edit it...
+
+    def __init__(self, parent=None):
+        super().__init__(self, parent)
+
+    def createEditor(self, user_type, parent):
+        editor = super().createEditor(user_type, parent)
+        editor.setAlignment(Qt.AlignCenter)
+        return editor

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -9,6 +9,7 @@ from PySide2.QtWidgets import QComboBox, QFileDialog, QMenu, QMessageBox
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.materials_table import MaterialsTable
 from hexrd.ui.material_editor_widget import MaterialEditorWidget
+from hexrd.ui.material_structure_editor import MaterialStructureEditor
 from hexrd.ui.overlay_manager import OverlayManager
 from hexrd.ui.ui_loader import UiLoader
 
@@ -25,7 +26,12 @@ class MaterialsPanel(QObject):
         self.material_editor_widget = MaterialEditorWidget(m, self.ui)
         self.materials_table = MaterialsTable(self.ui)
 
-        self.ui.layout().insertWidget(2, self.material_editor_widget.ui)
+        self.ui.material_editor_layout.addWidget(
+            self.material_editor_widget.ui)
+
+        self.material_structure_editor = MaterialStructureEditor(self.ui)
+        self.ui.material_structure_editor_layout.addWidget(
+            self.material_structure_editor.ui)
 
         # Turn off autocomplete for the QComboBox
         self.ui.materials_combo.setCompleter(None)
@@ -162,6 +168,9 @@ class MaterialsPanel(QObject):
         self.update_table()
         self.update_enable_states()
 
+    def update_structure_tab(self):
+        self.material_structure_editor.update_gui()
+
     def update_material_limits(self):
         max_tth = HexrdConfig().active_material_tth_max
         if max_tth is None:
@@ -189,6 +198,7 @@ class MaterialsPanel(QObject):
     def set_active_material(self):
         HexrdConfig().active_material = self.current_material()
         self.material_editor_widget.material = HexrdConfig().active_material
+        self.update_structure_tab()
 
     def current_material(self):
         return self.ui.materials_combo.currentText()

--- a/hexrd/ui/periodic_table_dialog.py
+++ b/hexrd/ui/periodic_table_dialog.py
@@ -1,0 +1,61 @@
+from PySide2.QtWidgets import (
+    QDialog, QDialogButtonBox, QMessageBox, QPushButton, QVBoxLayout
+)
+
+from silx.gui.widgets.PeriodicTable import PeriodicTable
+
+
+class PeriodicTableDialog(QDialog):
+
+    def __init__(self, atoms_selected=None, parent=None):
+        super().__init__(parent)
+
+        self.setLayout(QVBoxLayout(self))
+
+        self.periodic_table = PeriodicTable(self, selectable=True)
+        self.layout().addWidget(self.periodic_table)
+
+        self.clear_selection_button = QPushButton('Clear Selection', self)
+        self.layout().addWidget(self.clear_selection_button)
+
+        buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        self.button_box = QDialogButtonBox(buttons, self)
+        self.layout().addWidget(self.button_box)
+
+        if atoms_selected:
+            self.periodic_table.setSelection(atoms_selected)
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.clear_selection_button.pressed.connect(self.clear_selection)
+
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+    def accept(self):
+        if not self.selected_atoms:
+            msg = 'Please select at least one element'
+            QMessageBox.critical(self, 'HEXRD', msg)
+            return
+
+        super().accept()
+
+    @property
+    def selected_atoms(self):
+        return [x.symbol for x in self.periodic_table.getSelection()]
+
+    def clear_selection(self):
+        for item in self.periodic_table.getSelection():
+            self.periodic_table.elementToggle(item)
+
+
+if __name__ == '__main__':
+    from PySide2.QtWidgets import QApplication
+
+    app = QApplication()
+
+    dialog = PeriodicTableDialog(['H', 'Ni', 'Ta'])
+    dialog.exec_()
+
+    print(f'{dialog.selected_atoms=}')

--- a/hexrd/ui/resources/ui/material_site_editor.ui
+++ b/hexrd/ui/resources/ui/material_site_editor.ui
@@ -1,0 +1,204 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>material_site_editor</class>
+ <widget class="QWidget" name="material_site_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>511</width>
+    <height>502</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0" colspan="4">
+    <widget class="QGroupBox" name="site_atom_types_group">
+     <property name="title">
+      <string>Site Atom Types</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="1" colspan="2">
+       <widget class="QPushButton" name="select_atom_types">
+        <property name="text">
+         <string>Select Atom Types</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QTableWidget" name="table">
+        <property name="editTriggers">
+         <set>QAbstractItemView::NoEditTriggers</set>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::NoSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectItems</enum>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>120</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Symbol</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Occupancy</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>U</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="4">
+    <widget class="QGroupBox" name="site_settings_group">
+     <property name="title">
+      <string>Site Settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="1" colspan="3">
+       <widget class="QDoubleSpinBox" name="total_occupancy">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="coords_x">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="thermal_factor_label">
+        <property name="text">
+         <string>Thermal Factor Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QDoubleSpinBox" name="coords_y">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QDoubleSpinBox" name="coords_z">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>3</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="total_occupancy_label">
+        <property name="text">
+         <string>Total Occupancy:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="fractional_coordinates_label">
+        <property name="text">
+         <string>Fractional Coords:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="thermal_factor_type">
+        <item>
+         <property name="text">
+          <string>U</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>B</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>total_occupancy</tabstop>
+  <tabstop>coords_x</tabstop>
+  <tabstop>coords_y</tabstop>
+  <tabstop>coords_z</tabstop>
+  <tabstop>thermal_factor_type</tabstop>
+  <tabstop>table</tabstop>
+  <tabstop>select_atom_types</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/material_structure_editor.ui
+++ b/hexrd/ui/resources/ui/material_structure_editor.ui
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>material_structure_editor</class>
+ <widget class="QWidget" name="material_structure_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>502</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="0">
+    <widget class="QPushButton" name="add_site">
+     <property name="text">
+      <string>+</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QTabWidget" name="site_editor_tab_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="site_editor_tab">
+      <attribute name="title">
+       <string>Site Editor</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="material_site_editor_layout"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="empty_tab">
+      <attribute name="title">
+       <string>Empty</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>No Site Selected</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="remove_site">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTableWidget" name="table">
+     <property name="editTriggers">
+      <set>QAbstractItemView::AnyKeyPressed|QAbstractItemView::DoubleClicked|QAbstractItemView::EditKeyPressed</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Site</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>table</tabstop>
+  <tabstop>add_site</tabstop>
+  <tabstop>remove_site</tabstop>
+  <tabstop>site_editor_tab_widget</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -7,13 +7,10 @@
     <x>0</x>
     <y>0</y>
     <width>382</width>
-    <height>221</height>
+    <height>241</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7">
-   <property name="spacing">
-    <number>0</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout_3">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,12 +23,197 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_7">
-     <property name="spacing">
-      <number>0</number>
-     </property>
-     <item>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout_2">
+     <item row="2" column="0" colspan="2">
+      <widget class="QTabWidget" name="tab_widget">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <widget class="QWidget" name="general_tab">
+        <attribute name="title">
+         <string>General</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout">
+         <item row="4" column="2">
+          <widget class="QDoubleSpinBox" name="min_d_spacing">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum d spacing for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string> Å</string>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="show_overlays">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display overlays in the canvas for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Show Overlays</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="1">
+          <widget class="QLabel" name="max_tth_label">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Max 2θ:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="3">
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>32</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="3" column="0">
+          <widget class="QCheckBox" name="limit_active">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the allowed HKLs with the max 2θ or the minimum d spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Limit Active</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="4">
+          <widget class="QPushButton" name="show_overlay_manager">
+           <property name="text">
+            <string>Overlay Manager</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="4">
+          <widget class="QPushButton" name="show_materials_table">
+           <property name="text">
+            <string>Materials Table</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="1">
+          <widget class="QLabel" name="min_d_spacing_label">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="text">
+            <string>Min d-spacing:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="QDoubleSpinBox" name="max_tth">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The max 2θ for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="maximum">
+            <double>360.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="3">
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>32</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="5" column="0" colspan="4">
+          <layout class="QVBoxLayout" name="material_editor_layout"/>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="structure_tab">
+        <attribute name="title">
+         <string>Structure</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="0" column="0">
+          <layout class="QVBoxLayout" name="material_structure_editor_layout"/>
+         </item>
+        </layout>
+       </widget>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QToolButton" name="materials_tool_button">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to add, modify, or delete material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">QToolButton::menu-indicator { image: none; }</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>16</width>
+         <height>16</height>
+        </size>
+       </property>
+       <property name="popupMode">
+        <enum>QToolButton::InstantPopup</enum>
+       </property>
+       <property name="toolButtonStyle">
+        <enum>Qt::ToolButtonIconOnly</enum>
+       </property>
+       <property name="autoRaise">
+        <bool>false</bool>
+       </property>
+       <property name="arrowType">
+        <enum>Qt::DownArrow</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
       <widget class="QComboBox" name="materials_combo">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -75,171 +257,6 @@
        </item>
       </widget>
      </item>
-     <item>
-      <widget class="QToolButton" name="materials_tool_button">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Click to add, modify, or delete material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QToolButton::menu-indicator { image: none; }</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>16</width>
-         <height>16</height>
-        </size>
-       </property>
-       <property name="popupMode">
-        <enum>QToolButton::InstantPopup</enum>
-       </property>
-       <property name="toolButtonStyle">
-        <enum>Qt::ToolButtonIconOnly</enum>
-       </property>
-       <property name="autoRaise">
-        <bool>false</bool>
-       </property>
-       <property name="arrowType">
-        <enum>Qt::DownArrow</enum>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="4" column="3">
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="limit_active">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the allowed HKLs with the max 2θ or the minimum d spacing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Limit Active</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="show_overlays">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display overlays in the canvas for each material&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Show Overlays</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="2">
-      <widget class="QDoubleSpinBox" name="min_d_spacing">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The minimum d spacing for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="suffix">
-        <string> Å</string>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QDoubleSpinBox" name="max_tth">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The max 2θ for the HKLs.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0" colspan="4">
-      <widget class="QPushButton" name="show_overlay_manager">
-       <property name="text">
-        <string>Overlay Manager</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QLabel" name="max_tth_label">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Max 2θ:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="3">
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="5" column="1">
-      <widget class="QLabel" name="min_d_spacing_label">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>Min d-spacing:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="4">
-      <widget class="QPushButton" name="show_materials_table">
-       <property name="text">
-        <string>Materials Table</string>
-       </property>
-      </widget>
-     </item>
     </layout>
    </item>
   </layout>
@@ -247,6 +264,7 @@
  <tabstops>
   <tabstop>materials_combo</tabstop>
   <tabstop>materials_tool_button</tabstop>
+  <tabstop>tab_widget</tabstop>
   <tabstop>show_materials_table</tabstop>
   <tabstop>show_overlay_manager</tabstop>
   <tabstop>show_overlays</tabstop>

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,8 @@ install_reqs = [
     'importlib-resources',
     'fabio@git+https://github.com/joelvbernier/fabio.git@master',
     'pyyaml',
-    'hexrd@git+https://github.com/hexrd/hexrd.git@master'
+    'hexrd@git+https://github.com/hexrd/hexrd.git@master',
+    'silx'
 ]
 
 # This is a hack to get around the fact that pyside2 on conda-forge doesn't install


### PR DESCRIPTION
The structure tab modifies sites and atomic properties for the
material.

Only a single U value for each atom type is currently allowed. However,
in the near future, we may need to allow for a symmetric tensor for
the U values for each atom type.

Currently, to update the `hexrd` objects, it updates the attributes directly
on the `Material` class, and then re-creates the `unitcell` from scratch, since
that seems to be easier than updating all the properties inside the `unitcell`.
It then calls a function to update the structure factor on the `PlaneData` object.

![example](https://user-images.githubusercontent.com/9558430/92938638-cb93a780-f41a-11ea-8a25-9af2a09ca95a.gif)

Depends on: hexrd/hexrd#97
Fixes: #483