### PR TITLE
apply offset corrections to overlays

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -96,7 +96,9 @@ DEFAULT_MONO_ROTATION_SERIES_STYLE = {
 DEFAULT_CRYSTAL_PARAMS = np.hstack(
     [constants.zeros_3, constants.zeros_3, constants.identity_6x1])
 
-DEFAULT_POWDER_OPTIONS = {}
+DEFAULT_POWDER_OPTIONS = {
+    'tvec': np.zeros(3)
+}
 
 DEFAULT_LAUE_OPTIONS = {
     'crystal_params': DEFAULT_CRYSTAL_PARAMS.copy(),

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -97,7 +97,7 @@ DEFAULT_CRYSTAL_PARAMS = np.hstack(
     [constants.zeros_3, constants.zeros_3, constants.identity_6x1])
 
 DEFAULT_POWDER_OPTIONS = {
-    'tvec': np.zeros(3)
+    'tvec': constants.zeros_3
 }
 
 DEFAULT_LAUE_OPTIONS = {

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -81,7 +81,7 @@ class LoadImagesDialog:
                 table.setItem(i, 0, d)
 
             trans_cb = QComboBox()
-            options = ["None", "Flip Vertically", "Flip Horizontally",
+            options = ["None", "Mirror about Vertical", "Mirror about Horizontal",
                 "Transpose", "Rotate 90°", "Rotate 180°", "Rotate 270°"]
             trans_cb.addItems(options)
             idx = 0

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -81,8 +81,13 @@ class LoadImagesDialog:
                 table.setItem(i, 0, d)
 
             trans_cb = QComboBox()
-            options = ["None", "Mirror about Vertical", "Mirror about Horizontal",
-                "Transpose", "Rotate 90°", "Rotate 180°", "Rotate 270°"]
+            options = ["None",
+                       "Mirror about Vertical",
+                       "Mirror about Horizontal",
+                       "Transpose",
+                       "Rotate 90°",
+                       "Rotate 180°",
+                       "Rotate 270°"]
             trans_cb.addItems(options)
             idx = 0
             if 'trans' in HexrdConfig().load_panel_state:

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -3,6 +3,7 @@ import copy
 import numpy as np
 
 from hexrd import constants
+from hexrd.transforms import xfcapi
 
 from hexrd.ui.constants import ViewType
 
@@ -102,16 +103,37 @@ class LaueSpotOverlay:
         keys = ['spots', 'ranges']
         for det_key, psim in sim_data.items():
             point_groups[det_key] = {key: [] for key in keys}
+
+            # grab panel and split out simulation results
+            # !!! note that the sim results are lists over number of grains
+            #     and here we explicitly have one.
+            panel = self.instrument.detectors[det_key]
             xy_det, hkls_in, angles, dspacing, energy = psim
-            idx = ~np.isnan(energy)
-            angles = angles[idx, :]
-            range_corners = self.range_corners(angles)
+
+            # find valid points
+            idx = ~np.isnan(energy[0])  # there is only one grain here
+
+            # filter (tth, eta) results
+            xy_data = xy_det[0][idx, :]
+            angles = angles[0][idx, :]  # these are in radians
+
+            # !!! apply offset corrections to angles
+            # convert to angles in LAB ref
+            angles_corr, _ = xfcapi.detectorXYToGvec(
+                xy_data, panel.rmat, self.sample_rmat,
+                panel.tvec, constants.zeros_3, constants.zeros_3,
+                beamVec=self.instrument.beam_vector,
+                etaVec=self.instrument.eta_vector
+            )
             if display_mode == ViewType.polar:
-                point_groups[det_key]['spots'] = np.degrees(angles)
+                range_corners = self.range_corners(angles_corr)
+                point_groups[det_key]['spots'] = np.degrees(angles_corr)
                 point_groups[det_key]['ranges'] = np.degrees(range_corners)
             elif display_mode in [ViewType.raw, ViewType.cartesian]:
+                # !!! verify this
+                range_corners = self.range_corners(angles)
                 panel = self.instrument.detectors[det_key]
-                data = xy_det[idx, :]
+                data = xy_data
                 if display_mode == ViewType.raw:
                     # Convert to pixel coordinates
                     data = panel.cartToPixel(data)
@@ -120,7 +142,8 @@ class LaueSpotOverlay:
 
                 point_groups[det_key]['spots'] = data
                 point_groups[det_key]['ranges'] = self.range_data(
-                    range_corners, display_mode, panel)
+                    range_corners, display_mode, panel
+                )
 
         return point_groups
 

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -125,6 +125,7 @@ class LaueSpotOverlay:
                 beamVec=self.instrument.beam_vector,
                 etaVec=self.instrument.eta_vector
             )
+            angles_corr = np.vstack(angles_corr).T
             if display_mode == ViewType.polar:
                 range_corners = self.range_corners(angles_corr)
                 point_groups[det_key]['spots'] = np.degrees(angles_corr)
@@ -153,14 +154,15 @@ class LaueSpotOverlay:
             return []
 
         widths = (self.tth_width, self.eta_width)
+        tol_box = np.array(
+            [[0.5, 0.5],
+             [0.5, -0.5],
+             [-0.5, -0.5],
+             [-0.5, 0.5]]
+        )
         ranges = []
         for spot in spots:
-            corners = [
-               (spot[0] + widths[0], spot[1] + widths[1]),
-               (spot[0] + widths[0], spot[1] - widths[1]),
-               (spot[0] - widths[0], spot[1] - widths[1]),
-               (spot[0] - widths[0], spot[1] + widths[1])
-            ]
+            corners = np.tile(spot, (4, 1)) + tol_box*np.tile(widths, (4, 1))
             # Put the first point at the end to complete the square
             corners.append(corners[0])
             ranges.append(corners)

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -15,6 +15,8 @@ class PowderLineOverlay:
                  eta_steps=360, eta_period=np.r_[-180., 180.]):
         self._plane_data = plane_data
         self._instrument = instr
+        tvec = np.asarray(tvec, float).flatten()
+        assert len(tvec) == 3, "tvec input must have exactly 3 elements"
         self._tvec = tvec
         self._eta_steps = eta_steps
         self._eta_period = eta_period

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -13,7 +13,7 @@ class PowderLineOverlay:
     def __init__(self, plane_data, instr, tvec=np.zeros(3), eta_steps=360):
         self._plane_data = plane_data
         self._instrument = instr
-        self._tvec = tvec
+        self.tvec = tvec
         self._eta_steps = eta_steps
 
     @property

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -13,7 +13,7 @@ class PowderLineOverlay:
     def __init__(self, plane_data, instr, tvec=np.zeros(3), eta_steps=360):
         self._plane_data = plane_data
         self._instrument = instr
-        self.tvec = tvec
+        self._tvec = tvec
         self._eta_steps = eta_steps
 
     @property

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -44,11 +44,16 @@ class PowderOverlayEditor:
             return
 
         blockers = [QSignalBlocker(w) for w in self.widgets]  # noqa: F841
+
         self.tth_width_gui = self.tth_width_config
+        self.offset_gui = self.offset_config
+
         self.update_enable_states()
 
     def update_config(self):
         self.tth_width_config = self.tth_width_gui
+        self.offset_config = self.offset_gui
+
         self.overlay['update_needed'] = True
         HexrdConfig().overlay_config_changed.emit()
 
@@ -82,8 +87,42 @@ class PowderOverlayEditor:
             self.ui.tth_width.setValue(np.degrees(v))
 
     @property
+    def offset_config(self):
+        if self.overlay is None:
+            return
+
+        options = self.overlay.get('options', {})
+        if 'tvec' not in options:
+            return
+
+        return options['tvec']
+
+    @offset_config.setter
+    def offset_config(self, v):
+        if self.overlay is None:
+            return
+
+        self.overlay['options']['tvec'] = v
+
+    @property
+    def offset_gui(self):
+        return [w.value() for w in self.offset_widgets]
+
+    @offset_gui.setter
+    def offset_gui(self, v):
+        if v is None:
+            return
+
+        for i, w in enumerate(self.offset_widgets):
+            w.setValue(v[i])
+
+    @property
+    def offset_widgets(self):
+        return [getattr(self.ui, f'offset_{i}') for i in range(3)]
+
+    @property
     def widgets(self):
         return [
             self.ui.enable_width,
             self.ui.tth_width
-        ]
+        ] + self.offset_widgets

--- a/hexrd/ui/resources/calibration/default_tardis_config.yml
+++ b/hexrd/ui/resources/calibration/default_tardis_config.yml
@@ -1,6 +1,6 @@
 beam:
   energy: 10.2505
-  vector: {azimuth: 62.94883531793789, polar_angle: 86.08781021594156}
+  vector: {azimuth: 119., polar_angle: 90.}
 detectors:
   default:
     pixels:

--- a/hexrd/ui/resources/ui/import_data_panel.ui
+++ b/hexrd/ui/resources/ui/import_data_panel.ui
@@ -6,27 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>491</width>
-    <height>711</height>
+    <width>514</width>
+    <height>717</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_3">
-   <item>
-    <spacer name="verticalSpacer_4">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
    <item>
     <widget class="QGroupBox" name="association">
      <property name="title">
@@ -101,10 +88,13 @@
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Expanding</enum>
+     </property>
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>10</height>
       </size>
      </property>
     </spacer>
@@ -213,7 +203,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>123</height>
+       <height>10</height>
       </size>
      </property>
     </spacer>
@@ -314,7 +304,7 @@
      <property name="sizeHint" stdset="0">
       <size>
        <width>20</width>
-       <height>40</height>
+       <height>10</height>
       </size>
      </property>
     </spacer>

--- a/hexrd/ui/resources/ui/import_data_panel.ui
+++ b/hexrd/ui/resources/ui/import_data_panel.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>514</width>
-    <height>717</height>
+    <width>491</width>
+    <height>472</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -145,17 +145,17 @@
           </property>
           <item>
            <property name="text">
-            <string/>
+            <string>None</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Flip about Vertical Axis</string>
+            <string>Mirror about Vertical</string>
            </property>
           </item>
           <item>
            <property name="text">
-            <string>Flip about Horizontal Axis</string>
+            <string>Mirror about Horizontal</string>
            </property>
           </item>
           <item>

--- a/hexrd/ui/resources/ui/load_panel.ui
+++ b/hexrd/ui/resources/ui/load_panel.ui
@@ -82,12 +82,12 @@
         </item>
         <item>
          <property name="text">
-          <string>Flip Vertically</string>
+          <string>Mirror about Vertical</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Flip Horizontally</string>
+          <string>Mirror about Horizontal</string>
          </property>
         </item>
         <item>
@@ -128,6 +128,9 @@
       </item>
       <item row="2" column="1">
        <widget class="QComboBox" name="darkMode">
+        <property name="currentIndex">
+         <number>5</number>
+        </property>
         <item>
          <property name="text">
           <string>Median</string>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -24,7 +24,33 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="2">
+   <item row="2" column="3">
+    <widget class="ScientificDoubleSpinBox" name="offset_1"/>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="offset_label">
+     <property name="text">
+      <string>Offset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="ScientificDoubleSpinBox" name="offset_0"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="enable_width">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Enable Width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="4">
+    <widget class="ScientificDoubleSpinBox" name="offset_2"/>
+   </item>
+   <item row="1" column="2" colspan="3">
     <widget class="QDoubleSpinBox" name="tth_width">
      <property name="enabled">
       <bool>false</bool>
@@ -61,17 +87,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QCheckBox" name="enable_width">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Enable Width</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="2">
+   <item row="3" column="1" colspan="4">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -86,6 +102,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.py</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>enable_width</tabstop>
   <tabstop>tth_width</tabstop>

--- a/hexrd/ui/resources/ui/transforms_dialog.ui
+++ b/hexrd/ui/resources/ui/transforms_dialog.ui
@@ -61,17 +61,17 @@
       <widget class="QComboBox" name="transform_all_menu">
        <item>
         <property name="text">
-         <string>(None)</string>
+         <string>None</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Flip Vertically</string>
+         <string>Mirror about Vertical</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Flip Horizontally</string>
+         <string>Mirror about Horizontal</string>
         </property>
        </item>
        <item>


### PR DESCRIPTION
see issue #516

This PR contains the same relevant commits as #517, but this PR rebases on master to avoid introducing all of the extra commits.

The commits were cherry-picked via `git cherry-pick ...`. In the future, we can rebase on master to avoid the extra commits, like the following:

```bash
git checkout master
git pull origin master
git checkout overlay-fixes
git rebase origin/master
```