### PR TITLE
Update WPPF plot with each refinement

### DIFF
--- a/hexrd/ui/calibration/wppf_runner.py
+++ b/hexrd/ui/calibration/wppf_runner.py
@@ -95,8 +95,6 @@ class WppfRunner(QObject):
 
     def wppf_finished(self):
         HexrdConfig().wppf_data = list(self.wppf_object.spectrum_sim.data)
-        # Need to update x to match the tth_list for some reason...
-        # HexrdConfig().wppf_data[0] = self.wppf_object.tth_list
         HexrdConfig().rerender_needed.emit()
 
     def update_progress_text(self, text):

--- a/hexrd/ui/calibration/wppf_runner.py
+++ b/hexrd/ui/calibration/wppf_runner.py
@@ -1,6 +1,6 @@
 import numpy as np
 
-from PySide2.QtCore import QObject, QThreadPool, Signal
+from PySide2.QtCore import QCoreApplication, QObject, QThreadPool, Signal
 
 from hexrd.material import _angstroms
 from hexrd.WPPF import LeBail, Rietveld
@@ -92,10 +92,21 @@ class WppfRunner(QObject):
 
         for i in range(dialog.refinement_steps):
             self.wppf_object.RefineCycle()
+            self.rerender_wppf()
+
+    def rerender_wppf(self):
+        HexrdConfig().wppf_data = list(self.wppf_object.spectrum_sim.data)
+        HexrdConfig().rerender_wppf.emit()
+
+        # Process events to make sure it visually updates.
+        # If this causes issues, we can post self.wppf_object.RefineCycle()
+        # calls to the event loop in the future instead.
+        QCoreApplication.processEvents()
 
     def wppf_finished(self):
-        HexrdConfig().wppf_data = list(self.wppf_object.spectrum_sim.data)
-        HexrdConfig().rerender_needed.emit()
+        # Nothing to do currently, since we already re-render after each
+        # refinement.
+        pass
 
     def update_progress_text(self, text):
         self.progress_text.emit(text)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -70,6 +70,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when detector borders need to be re-rendered"""
     rerender_detector_borders = Signal()
 
+    """Emitted when wppf needs to be re-rendered"""
+    rerender_wppf = Signal()
+
     """Emitted for any config changes EXCEPT detector transform changes
 
     Indicates that the image needs to be re-drawn from scratch.

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -63,6 +63,7 @@ class ImageCanvas(FigureCanvas):
             self.on_detector_transform_modified)
         HexrdConfig().rerender_detector_borders.connect(
             self.draw_detector_borders)
+        HexrdConfig().rerender_wppf.connect(self.draw_wppf)
         HexrdConfig().beam_vector_changed.connect(self.beam_vector_changed)
 
     def __del__(self):
@@ -326,6 +327,10 @@ class ImageCanvas(FigureCanvas):
                 plot, = self.axis.plot(*line, color='y', lw=2)
                 self.cached_detector_borders.append(plot)
 
+        self.draw()
+
+    def draw_wppf(self):
+        self.update_wppf_plot()
         self.draw()
 
     def extract_ring_coords(self, data):

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -585,15 +585,6 @@ class ImageCanvas(FigureCanvas):
         if any(x is None for x in (wppf_data, axis, line)):
             return
 
-        # Make a copy that we will modify
-        wppf_data = copy.deepcopy(list(wppf_data))
-
-        # Scale the wppf data to match the scale of the azimuthal integral data
-        y = wppf_data[1]
-        old_range = (y.min(), y.max())
-        new_range = (line.get_data()[1].min(), line.get_data()[1].max())
-        wppf_data[1] = np.interp(y, old_range, new_range)
-
         style = {
             's': 30,
             'facecolors': 'none',

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -534,6 +534,9 @@
    </property>
   </action>
   <action name="action_run_wppf">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>WPPF</string>
    </property>


### PR DESCRIPTION
This will increase the amount of time needed for WPPF to finish since
re-rendering takes a little time. However, it gives live updates as
the refinement process occurs.

![wppf_refinement_updates](https://user-images.githubusercontent.com/9558430/93492575-f4171800-f8d8-11ea-8f49-b49082cb45d5.gif)

Fixes: #525