### PR TITLE
Re-phrase transform flip labels

### DIFF
--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -81,7 +81,7 @@ class LoadImagesDialog:
                 table.setItem(i, 0, d)
 
             trans_cb = QComboBox()
-            options = ["None", "Flip Vertically", "Flip Horizontally",
+            options = ["None", "Flip about Vertical Axis", "Flip about Horizontal Axis",
                 "Transpose", "Rotate 90°", "Rotate 180°", "Rotate 270°"]
             trans_cb.addItems(options)
             idx = 0

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -81,8 +81,9 @@ class LoadImagesDialog:
                 table.setItem(i, 0, d)
 
             trans_cb = QComboBox()
-            options = ["None", "Flip about Vertical Axis", "Flip about Horizontal Axis",
-                "Transpose", "Rotate 90°", "Rotate 180°", "Rotate 270°"]
+            options = ["None", "Flip about Vertical Axis",
+                       "Flip about Horizontal Axis", "Transpose", "Rotate 90°",
+                       "Rotate 180°", "Rotate 270°"]
             trans_cb.addItems(options)
             idx = 0
             if 'trans' in HexrdConfig().load_panel_state:

--- a/hexrd/ui/resources/ui/load_panel.ui
+++ b/hexrd/ui/resources/ui/load_panel.ui
@@ -82,12 +82,12 @@
         </item>
         <item>
          <property name="text">
-          <string>Flip Vertically</string>
+          <string>Flip about Vertical Axis</string>
          </property>
         </item>
         <item>
          <property name="text">
-          <string>Flip Horizontally</string>
+          <string>Flip about Horizontal Axis</string>
          </property>
         </item>
         <item>

--- a/hexrd/ui/resources/ui/transforms_dialog.ui
+++ b/hexrd/ui/resources/ui/transforms_dialog.ui
@@ -66,12 +66,12 @@
        </item>
        <item>
         <property name="text">
-         <string>Flip Vertically</string>
+         <string>Flip about Vertical Axis</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>Flip Horizontally</string>
+         <string>Flip about Horizontal Axis</string>
         </property>
        </item>
        <item>

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -20,8 +20,8 @@ class TransformDialog:
 
     def update_gui(self):
         options = [
-            '(None)', 'Flip about Vertical Axis', 'Flip about Horizontal Axis', 'Transpose',
-            'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
+            '(None)', 'Flip about Vertical Axis', 'Flip about Horizontal Axis',
+            'Transpose', 'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
         for i, det in enumerate(HexrdConfig().detector_names):
             hbox = QHBoxLayout()
             # Add label

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -20,7 +20,7 @@ class TransformDialog:
 
     def update_gui(self):
         options = [
-            '(None)', 'Flip Vertically', 'Flip Horizontally', 'Transpose',
+            '(None)', 'Flip about Vertical Axis', 'Flip about Horizontal Axis', 'Transpose',
             'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
         for i, det in enumerate(HexrdConfig().detector_names):
             hbox = QHBoxLayout()


### PR DESCRIPTION
Re-name all instances of  `Flip Horizontally/Vertically` to `Flip about Horizontal/Vertical Axis`

@joelvbernier if there is a preferred way to re-word the transform labels than `Flip about Horizontal/Vertical Axis` let me know and we can use that instead.