### PR TITLE
Remove an unused dock widget

### DIFF
--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -190,7 +190,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>706</height>
+          <height>708</height>
          </rect>
         </property>
         <attribute name="label">
@@ -203,7 +203,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>706</height>
+          <height>708</height>
          </rect>
         </property>
         <attribute name="label">
@@ -216,7 +216,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>706</height>
+          <height>708</height>
          </rect>
         </property>
         <attribute name="label">
@@ -311,17 +311,6 @@
       <number>0</number>
      </property>
     </layout>
-   </widget>
-  </widget>
-  <widget class="QDockWidget" name="mask_manager_dock_widget">
-   <property name="windowTitle">
-    <string>Mask Manager</string>
-   </property>
-   <attribute name="dockWidgetArea">
-    <number>4</number>
-   </attribute>
-   <widget class="QWidget" name="mask_manager_dock_widgets">
-    <layout class="QHBoxLayout" name="horizontalLayout_3"/>
    </widget>
   </widget>
   <action name="action_tabbed_view">


### PR DESCRIPTION
Originally the design was to include the mask manager as a dock widget in the GUI, but this approach was discarded in favor of a more readable dialog without removing the old dock widget.