### PR TITLE
Average x for azimuthal integral plot powder overlays

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -226,26 +226,24 @@ class ImageCanvas(FigureCanvas):
             az_axis = self.azimuthal_integral_axis
             for pr in rings:
                 x, _ = self.extract_ring_coords(pr)
-                # Don't plot duplicate vertical lines
-                x = np.unique(x.round(3))
-                for val in x:
-                    artist = az_axis.axvline(val, **data_style)
-                    artists.append(artist)
+                # Average the points together for the vertical line
+                x = np.nanmean(x)
+                artist = az_axis.axvline(x, **data_style)
+                artists.append(artist)
 
             # Add the rbnds too
             for ind, pr in zip(rbnd_indices, rbnds):
                 x, _ = self.extract_ring_coords(pr)
-                # Don't plot duplicate vertical lines
-                x = np.unique(x.round(3))
+                # Average the points together for the vertical line
+                x = np.nanmean(x)
 
                 current_style = copy.deepcopy(ranges_style)
                 if len(ind) > 1:
                     # If rbnds are combined, override the color to red
                     current_style['c'] = 'r'
 
-                for val in x:
-                    artist = az_axis.axvline(val, **current_style)
-                    artists.append(artist)
+                artist = az_axis.axvline(x, **current_style)
+                artists.append(artist)
 
     def draw_laue_overlay(self, axis, data, style):
         spots = data['spots']


### PR DESCRIPTION
This fixes an issue where there are overlays for every x value,
which is problematic if the powder offset is not at the origin,
because the line overlays are curved.

There may be alternatives to averaging that may be preferred. But
we'll do that if we find a better alternative. For now, this fixes
the extremely slow GUI when the line overlays are curved.

![example](https://user-images.githubusercontent.com/9558430/93640423-9104ae80-f9c8-11ea-8bf8-4bde6934c48c.gif)

@joelvbernier This should fix the slowness issue mentioned in https://github.com/HEXRD/hexrdgui/pull/527#issuecomment-694489708