### PR TITLE
Overlay fixes for powder offset and eta period

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from skimage.exposure import rescale_intensity
 
-from hexrd.transforms.xfcapi import detectorXYToGvec
+from hexrd.transforms.xfcapi import detectorXYToGvec, mapAngle
 
 from hexrd import constants as ct
 from hexrd.xrdutil import _project_on_detector_plane
@@ -145,6 +145,10 @@ class PolarView:
                 border, panel.rmat, ct.identity_3x3,
                 panel.tvec, ct.zeros_3, ct.zeros_3,
                 beamVec=panel.bvec, etaVec=panel.evec)
+            angles = np.array(angles)
+            angles[1:, :] = mapAngle(
+                angles[1:, :], np.radians(self.eta_period), units='radians'
+            )
             # Convert to degrees, and keep them as lists for
             # easier modification later
             borders[i] = np.degrees(angles).tolist()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1163,6 +1163,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
         if rerender:
             self.rerender_needed.emit()
 
+            # If we are drawing outside of the previous extents,
+            # we will need to update the overlays as well.
+            self.flag_overlay_updates_for_all_materials()
+            self.overlay_config_changed.emit()
+
     polar_res_eta_min = property(_polar_res_eta_min,
                                  set_polar_res_eta_min)
 
@@ -1173,6 +1178,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
         self.config['image']['polar']['eta_max'] = v
         if rerender:
             self.rerender_needed.emit()
+
+            # If we are drawing outside of the previous extents,
+            # we will need to update the overlays as well.
+            self.flag_overlay_updates_for_all_materials()
+            self.overlay_config_changed.emit()
 
     polar_res_eta_max = property(_polar_res_eta_max,
                                  set_polar_res_eta_max)

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -25,7 +25,11 @@
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="2" column="3">
-    <widget class="ScientificDoubleSpinBox" name="offset_1"/>
+    <widget class="ScientificDoubleSpinBox" name="offset_1">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item row="2" column="1">
     <widget class="QLabel" name="offset_label">
@@ -35,7 +39,11 @@
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="ScientificDoubleSpinBox" name="offset_0"/>
+    <widget class="ScientificDoubleSpinBox" name="offset_0">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item row="1" column="1">
     <widget class="QCheckBox" name="enable_width">
@@ -48,7 +56,11 @@
     </widget>
    </item>
    <item row="2" column="4">
-    <widget class="ScientificDoubleSpinBox" name="offset_2"/>
+    <widget class="ScientificDoubleSpinBox" name="offset_2">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
    </item>
    <item row="1" column="2" colspan="3">
     <widget class="QDoubleSpinBox" name="tth_width">


### PR DESCRIPTION
The changes are summarized below:

* Turn off keyboard tracking for powder offsets
* Update overlays when eta extents change
* Map angles to eta period for detector borders

See full commit messages for more details. Here is a before and after for the overlays and detector border fixes.

### Before:
![before](https://user-images.githubusercontent.com/9558430/93643672-7cc3b000-f9ce-11ea-81ef-d3544b8b48d5.gif)

### After:
![after](https://user-images.githubusercontent.com/9558430/93643684-80efcd80-f9ce-11ea-99f1-08d0dd123364.gif)