### PR TITLE
Crystal editor fixes

### DIFF
--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -160,6 +160,7 @@ class CalibrationCrystalEditor(QObject):
         # This automatically converts from Euler angle conventions
         values = [x.value() for x in self.orientation_widgets]
         if HexrdConfig().euler_angle_convention is not None:
+            values = np.radians(values)
             convention = HexrdConfig().euler_angle_convention
             self.convert_angle_convention(values, convention, None)
 
@@ -172,6 +173,7 @@ class CalibrationCrystalEditor(QObject):
             v = copy.deepcopy(v)
             convention = HexrdConfig().euler_angle_convention
             self.convert_angle_convention(v, None, convention)
+            v = np.degrees(v)
 
         for i, w in enumerate(self.orientation_widgets):
             blocker = QSignalBlocker(w)  # noqa: F841

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -539,6 +539,13 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>tab_widget</tabstop>
+  <tabstop>orientation_0</tabstop>
+  <tabstop>orientation_1</tabstop>
+  <tabstop>orientation_2</tabstop>
+  <tabstop>position_0</tabstop>
+  <tabstop>position_1</tabstop>
+  <tabstop>position_2</tabstop>
   <tabstop>stretch_matrix_0</tabstop>
   <tabstop>stretch_matrix_1</tabstop>
   <tabstop>stretch_matrix_2</tabstop>


### PR DESCRIPTION
Two parts:

1. Convert to degrees and back for Euler conversions

In the calibration crystal editor, convert to degrees/radians
when performing the conversions.

Although the GUI was displaying a degree sign, it was actually
displaying radians. It should now be truly displaying degrees.

2. Fix tab order for calibration crystal editor

Fixes: #518 