### PR TITLE
Draw all detectors for polar view powder overlays

### DIFF
--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -105,12 +105,6 @@ class PowderLineOverlay:
                 for ind in indices:
                     point_groups[det_key]['rbnd_indices'] += [ind, ind]
 
-            # Currently, the polar mode draws lines over the whole image.
-            # Thus, we only need data from one detector.
-            # This can be changed in the future if needed.
-            if display_mode == ViewType.polar:
-                break
-
         return point_groups
 
     def generate_ring_points(self, tths, etas, panel, display_mode):


### PR DESCRIPTION
The other detectors were intentionally left out before since the
lines were assumed to all be vertical. Add them back in, since the
lines are not always vertical.

Here's an example image. It looks like there are still some vertical lines being drawn for some of the overlays.

![image](https://user-images.githubusercontent.com/9558430/93926303-53b06180-fce5-11ea-88d3-4a330e440e17.png)