### PR TITLE
Raw drawn masks

### DIFF
--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -14,12 +14,12 @@ def convert_raw_to_polar(det, line):
     return [np.degrees(tth)]
 
 
-def create_polar_mask(name, line_data):
+def create_polar_mask(line_data, names):
     # Calculate current image dimensions
     pv = PolarView(None)
     shape = pv.shape
     # Generate masks from line data
-    for line in line_data:
+    for line, name in zip(line_data, names):
         tth = np.asarray([point[0] for point in line])
         eta = np.asarray([point[1] for point in line])
 

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -30,4 +30,3 @@ def create_polar_mask(line_data, names):
         mask = np.ones(shape, dtype=bool)
         mask[rr, cc] = False
         HexrdConfig().polar_masks[name] = mask
-        HexrdConfig().visible_masks.append(name)

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -14,12 +14,13 @@ def convert_raw_to_polar(det, line):
     return [np.degrees(tth)]
 
 
-def create_polar_mask(line_data, names):
+def create_polar_mask(line_data, name):
     # Calculate current image dimensions
     pv = PolarView(None)
     shape = pv.shape
     # Generate masks from line data
-    for line, name in zip(line_data, names):
+    final_mask = np.ones(shape, dtype=bool)
+    for line in line_data:
         tth = np.asarray([point[0] for point in line])
         eta = np.asarray([point[1] for point in line])
 
@@ -29,4 +30,5 @@ def create_polar_mask(line_data, names):
         rr, cc = polygon(i_row, j_col, shape=shape)
         mask = np.ones(shape, dtype=bool)
         mask[rr, cc] = False
-        HexrdConfig().polar_masks[name] = mask
+        final_mask = np.logical_and(final_mask, mask)
+    HexrdConfig().polar_masks[name] = final_mask

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -56,4 +56,3 @@ def create_raw_mask(name, line_data):
         mask = np.ones(img.shape, dtype=bool)
         mask[rr, cc] = False
         HexrdConfig().raw_masks[name] = (det, mask)
-        HexrdConfig().visible_masks.append(name)

--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -1,0 +1,127 @@
+from PySide2.QtCore import QObject, Signal
+
+from itertools import cycle
+
+import numpy as np
+
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Cursor
+
+from hexrd.ui import enter_key_filter
+
+from hexrd.ui.line_picker_dialog import LineBuilder
+from hexrd.ui.constants import ViewType
+from hexrd.ui.ui_loader import UiLoader
+
+
+class HandDrawnMaskDialog(QObject):
+
+    # Emits the ring data that was selected
+    finished = Signal(list)
+
+    def __init__(self, canvas, parent):
+        super(HandDrawnMaskDialog, self).__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('hand_drawn_mask_dialog.ui', parent)
+        self.ui.installEventFilter(enter_key_filter)
+
+        self.canvas = canvas
+        self.ring_data = []
+        self.linebuilder = None
+        self.lines = []
+
+        prop_cycle = plt.rcParams['axes.prop_cycle']
+        self.color_cycler = cycle(prop_cycle.by_key()['color'])
+
+        self.move_dialog_to_left()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.accepted.connect(self.accepted)
+        self.ui.rejected.connect(self.rejected)
+        self.bp_id = self.canvas.mpl_connect('button_press_event',
+                                             self.button_pressed)
+
+    def move_dialog_to_left(self):
+        # This moves the dialog to the left border of the parent
+        ph = self.ui.parent().geometry().height()
+        px = self.ui.parent().geometry().x()
+        py = self.ui.parent().geometry().y()
+        dw = self.ui.width()
+        dh = self.ui.height()
+        self.ui.setGeometry(px, py + (ph - dh) / 2.0, dw, dh)
+
+    def clear(self):
+        self.ring_data.clear()
+
+        while self.lines:
+            self.lines.pop(0).remove()
+
+        if self.linebuilder:
+            self.linebuilder.disconnect()
+
+        self.linebuilder = None
+        self.cursor = None
+
+        self.canvas.mpl_disconnect(self.bp_id)
+        self.bp_id = None
+        self.canvas.draw()
+
+    def start(self):
+        if self.canvas.mode != ViewType.polar:
+            print('line picker only works in polar mode!')
+            return
+
+        ax = self.canvas.axis
+
+        # list for set of rings 'picked'
+        self.ring_data.clear()
+
+        # fire up the cursor for this tool
+        self.cursor = Cursor(ax, useblit=True, color='red', linewidth=1)
+        self.add_line()
+        self.show()
+
+    def add_line(self):
+        ax = self.canvas.axis
+        color = next(self.color_cycler)
+        marker = '.'
+        linestyle = 'None'
+
+        # empty line
+        line, = ax.plot([], [], color=color, marker=marker,
+                        linestyle=linestyle)
+        self.linebuilder = LineBuilder(line)
+        self.lines.append(line)
+        self.canvas.draw()
+
+    def line_finished(self):
+        # append to ring_data
+        linebuilder = self.linebuilder
+        ring_data = np.vstack([linebuilder.xs, linebuilder.ys]).T
+
+        if len(ring_data) == 0:
+            # Don't do anything if there is no ring data
+            return
+
+        linebuilder.disconnect()
+        self.ring_data.append(ring_data)
+        self.add_line()
+
+    def button_pressed(self, event):
+        if event.button == 3:
+            self.line_finished()
+
+    def accepted(self):
+        # Finish the current line
+        self.line_finished()
+        self.finished.emit(self.ring_data)
+        self.clear()
+
+    def rejected(self):
+        self.clear()
+
+    def show(self):
+        self.ui.show()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -647,6 +647,7 @@ class MainWindow(QObject):
                 HexrdConfig().polar_masks_line_data, 'polar_mask_0')
             names.append(name)
             HexrdConfig().polar_masks_line_data[name] = line.copy()
+            HexrdConfig().visible_masks.append(name)
         create_polar_mask(line_data.copy(), names)
         HexrdConfig().polar_masks_changed.emit()
         self.new_mask_added.emit(self.image_mode)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -635,7 +635,8 @@ class MainWindow(QObject):
     def on_action_edit_apply_polar_mask_triggered(self):
         # Make the dialog
         canvas = self.ui.image_tab_widget.image_canvases[0]
-        self._apply_polar_mask_line_picker = HandDrawnMaskDialog(canvas, self.ui)
+        self._apply_polar_mask_line_picker = (
+            HandDrawnMaskDialog(canvas, self.ui))
         self._apply_polar_mask_line_picker.start()
         self._apply_polar_mask_line_picker.finished.connect(
             self.run_apply_polar_mask)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -16,6 +16,7 @@ from hexrd.ui.async_worker import AsyncWorker
 from hexrd.ui.color_map_editor import ColorMapEditor
 from hexrd.ui.progress_dialog import ProgressDialog
 from hexrd.ui.cal_tree_view import CalTreeView
+from hexrd.ui.hand_drawn_mask_dialog import HandDrawnMaskDialog
 from hexrd.ui.line_picker_dialog import LinePickerDialog
 from hexrd.ui.indexing.run import IndexingRunner
 from hexrd.ui.calibration.powder_calibration import run_powder_calibration
@@ -634,7 +635,7 @@ class MainWindow(QObject):
     def on_action_edit_apply_polar_mask_triggered(self):
         # Make the dialog
         canvas = self.ui.image_tab_widget.image_canvases[0]
-        self._apply_polar_mask_line_picker = LinePickerDialog(canvas, self.ui)
+        self._apply_polar_mask_line_picker = HandDrawnMaskDialog(canvas, self.ui)
         self._apply_polar_mask_line_picker.start()
         self._apply_polar_mask_line_picker.finished.connect(
             self.run_apply_polar_mask)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -641,11 +641,13 @@ class MainWindow(QObject):
             self.run_apply_polar_mask)
 
     def run_apply_polar_mask(self, line_data):
-        name = create_unique_name(
-            HexrdConfig().polar_masks_line_data, 'polar_mask_0')
-        ld = line_data.copy()
-        HexrdConfig().polar_masks_line_data[name] = ld
-        create_polar_mask(name, ld)
+        names = []
+        for line in line_data:
+            name = create_unique_name(
+                HexrdConfig().polar_masks_line_data, 'polar_mask_0')
+            names.append(name)
+            HexrdConfig().polar_masks_line_data[name] = line.copy()
+        create_polar_mask(line_data.copy(), names)
         HexrdConfig().polar_masks_changed.emit()
         self.new_mask_added.emit(self.image_mode)
 
@@ -802,10 +804,10 @@ class MainWindow(QObject):
             # Rebuild polar masks
             HexrdConfig().polar_masks.clear()
             for name, line_data in HexrdConfig().polar_masks_line_data.items():
-                create_polar_mask(name, line_data)
+                create_polar_mask(line_data, [name])
             for name, (det, data) in HexrdConfig().raw_masks_line_data.items():
                 line_data = convert_raw_to_polar(det, data)
-                create_polar_mask(name, line_data)
+                create_polar_mask(line_data, [name])
             self.ui.image_tab_widget.show_polar()
         else:
             # Rebuild raw masks

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -642,14 +642,12 @@ class MainWindow(QObject):
             self.run_apply_polar_mask)
 
     def run_apply_polar_mask(self, line_data):
-        names = []
         for line in line_data:
             name = create_unique_name(
                 HexrdConfig().polar_masks_line_data, 'polar_mask_0')
-            names.append(name)
             HexrdConfig().polar_masks_line_data[name] = line.copy()
             HexrdConfig().visible_masks.append(name)
-        create_polar_mask(line_data.copy(), names)
+            create_polar_mask([line.copy()], name)
         HexrdConfig().polar_masks_changed.emit()
         self.new_mask_added.emit(self.image_mode)
 
@@ -679,9 +677,11 @@ class MainWindow(QObject):
             return
         name = create_unique_name(
             HexrdConfig().polar_masks_line_data, 'laue_mask')
+        create_polar_mask(data, name)
         HexrdConfig().polar_masks_line_data[name] = data
+        HexrdConfig().visible_masks.append(name)
         self.new_mask_added.emit(self.image_mode)
-        self.update_all()
+        HexrdConfig().polar_masks_changed.emit()
 
     def on_action_edit_apply_polygon_mask_triggered(self):
         mrd = MaskRegionsDialog(self.ui)
@@ -806,10 +806,10 @@ class MainWindow(QObject):
             # Rebuild polar masks
             HexrdConfig().polar_masks.clear()
             for name, line_data in HexrdConfig().polar_masks_line_data.items():
-                create_polar_mask(line_data, [name])
+                create_polar_mask(line_data, name)
             for name, (det, data) in HexrdConfig().raw_masks_line_data.items():
                 line_data = convert_raw_to_polar(det, data)
-                create_polar_mask(line_data, [name])
+                create_polar_mask(line_data, name)
             self.ui.image_tab_widget.show_polar()
         else:
             # Rebuild raw masks

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -190,7 +190,7 @@ class MaskRegionsDialog(QObject):
             name = create_unique_name(
                 HexrdConfig().polar_masks_line_data, 'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = [data_coords]
-            create_polar_mask(data_coords, [name])
+            create_polar_mask(data_coords, name)
             HexrdConfig().visible_masks.append(name)
             HexrdConfig().polar_masks_changed.emit()
 

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -189,7 +189,7 @@ class MaskRegionsDialog(QObject):
             name = create_unique_name(
                 HexrdConfig().polar_masks_line_data, 'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = [data_coords]
-            create_polar_mask(name, data_coords)
+            create_polar_mask(data_coords, [name])
             HexrdConfig().polar_masks_changed.emit()
 
     def button_released(self, event):

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -183,6 +183,7 @@ class MaskRegionsDialog(QObject):
                 HexrdConfig().raw_masks_line_data, 'raw_mask_0')
             HexrdConfig().raw_masks_line_data[name] = data
             create_raw_mask(name, data)
+            HexrdConfig().visible_masks.append(name)
             HexrdConfig().raw_masks_changed.emit()
 
         for data_coords in self.polar_masks_line_data:
@@ -190,6 +191,7 @@ class MaskRegionsDialog(QObject):
                 HexrdConfig().polar_masks_line_data, 'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = [data_coords]
             create_polar_mask(data_coords, [name])
+            HexrdConfig().visible_masks.append(name)
             HexrdConfig().polar_masks_changed.emit()
 
     def button_released(self, event):

--- a/hexrd/ui/resources/ui/hand_drawn_mask_dialog.ui
+++ b/hexrd/ui/resources/ui/hand_drawn_mask_dialog.ui
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>247</width>
+    <height>181</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Add a point with left-click.</string>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Start a new line with right-click.</string>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Click &quot;Ok&quot; to finish.</string>
+     </property>
+    </widget>
+   </item>
+   <item alignment="Qt::AlignHCenter">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>Dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
This has three parts:

- Does not use the zoom canvas when the hand drawn masks are created in polar view (this is a part of #474)
- Fixes a bug that caused lists of masks to be overwritten with the same key - affected laue masks and when multiple masks are drawn by hand
- Fixes a bug that reset visibility on masks when toggling between views