### PR TITLE
Prevent post crop flip

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -284,6 +284,8 @@ class ImportDataPanel(QObject):
 
         ilm = ImageLoadManager()
         self.cmap.block_updates(True)
+        # Do not re-apply transform if selected in load file dialog
+        HexrdConfig().load_panel_state.clear()
         ilm.read_data([[img]], parent=self.ui)
         if self.instrument == 'PXRDIP':
             ilm.set_state({'trans': [UI_TRANS_INDEX_ROTATE_90]})
@@ -291,7 +293,6 @@ class ImportDataPanel(QObject):
             img = HexrdConfig().image(self.detector, 0)
         self.cmap.block_updates(False)
 
-        self.it.update_image(img)
         self.edited_images[self.detector] = {
             'img': img,
             'height': img.shape[0],

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -167,14 +167,14 @@ class ImportDataPanel(QObject):
 
             if not self.canvas.raw_axes[0].get_autoscale_on():
                 self.canvas.raw_axes[0].set_autoscale_on(True)
-            if hasattr(self, 'prev_extent'):
-                self.canvas.axes_images[0].set_extent(self.prev_extent)
 
             if self.completed_detectors:
                 # Only reset the color map range for first detector processed
                 self.cmap.block_updates(True)
             ImageLoadManager().read_data(files, parent=self.ui)
-            self.prev_extent = self.canvas.axes_images[0].get_extent()
+            img_shape = HexrdConfig().image(self.detector, 0).shape
+            self.canvas.axes_images[0].set_extent(
+                (-0.5, img_shape[1], img_shape[0], -0.5))
             self.cmap.block_updates(False)
 
             file_names = [os.path.split(f[0])[1] for f in files]

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -6,6 +6,7 @@ from matplotlib.transforms import Affine2D
 
 from skimage.draw import polygon
 
+from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui import resource_loader
 
@@ -15,7 +16,7 @@ class InteractiveTemplate:
         self.parent = parent.image_tab_widget.image_canvases[0]
         self.ax = self.parent.axes_images[0]
         self.raw_axes = self.parent.raw_axes[0]
-        self.panels = self.parent.iviewer.instr.detectors
+        self.panels = create_hedm_instrument().detectors
         self.img = img
         self.shape = None
         self.press = None


### PR DESCRIPTION
This branch:
- Prevents the cropped image from being rotated back to its original position
- Resizes the canvas to the loaded image (ex. the case of loading a processed tif)

Fixes #551 