### PR TITLE
Add ability to select materials for WPPF

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -592,7 +592,11 @@ class MainWindow(QObject):
 
     def run_wppf(self):
         self._wppf_runner = WppfRunner(self.ui)
-        self._wppf_runner.run()
+        try:
+            self._wppf_runner.run()
+        except Exception as e:
+            QMessageBox.critical(self.ui, 'HEXRD', str(e))
+            return
 
     def update_color_map_bounds(self):
         self.color_map_editor.update_bounds(

--- a/hexrd/ui/resources/ui/select_items_widget.ui
+++ b/hexrd/ui/resources/ui/select_items_widget.ui
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>select_items_widget</class>
+ <widget class="QWidget" name="select_items_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>265</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="table">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column/>
+     <column/>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/wppf_options_dialog.ui
+++ b/hexrd/ui/resources/ui/wppf_options_dialog.ui
@@ -11,24 +11,7 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="4" column="2">
-    <widget class="QPushButton" name="select_experiment_file_button">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Select File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="wppf_method_label">
-     <property name="text">
-      <string>WPPF Method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0" colspan="3">
+   <item row="8" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -38,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
+   <item row="3" column="1" colspan="2">
     <widget class="QComboBox" name="background_method">
      <item>
       <property name="text">
@@ -52,7 +35,7 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
+   <item row="1" column="1" colspan="2">
     <widget class="QComboBox" name="wppf_method">
      <item>
       <property name="text">
@@ -66,7 +49,75 @@
      </item>
     </widget>
    </item>
-   <item row="4" column="1">
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="refinement_steps">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000000</number>
+     </property>
+     <property name="value">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="refinement_steps_label">
+     <property name="text">
+      <string>Refinement Steps:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <layout class="QGridLayout" name="background_method_parameters_layout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="chebyshev_polynomial_degree_label">
+       <property name="text">
+        <string>Chebyshev Polynomial Degree:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="chebyshev_polynomial_degree">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>100000000</number>
+       </property>
+       <property name="value">
+        <number>6</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="select_experiment_file_button">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Select File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="use_experiment_file">
+     <property name="text">
+      <string>Use Experiment File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="wppf_method_label">
+     <property name="text">
+      <string>WPPF Method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
     <widget class="QLineEdit" name="experiment_file">
      <property name="enabled">
       <bool>false</bool>
@@ -76,14 +127,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="background_method_label">
      <property name="text">
       <string>Background Method:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="7" column="0" colspan="3">
     <widget class="QTableWidget" name="table">
      <property name="editTriggers">
       <set>QAbstractItemView::NoEditTriggers</set>
@@ -118,60 +169,20 @@
      </column>
     </widget>
    </item>
-   <item row="3" column="0" colspan="3">
-    <layout class="QGridLayout" name="background_method_parameters_layout">
-     <item row="1" column="0">
-      <widget class="QLabel" name="chebyshev_polynomial_degree_label">
-       <property name="text">
-        <string>Chebyshev Polynomial Degree:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QSpinBox" name="chebyshev_polynomial_degree">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>100000000</number>
-       </property>
-       <property name="value">
-        <number>6</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="refinement_steps_label">
+   <item row="0" column="0" colspan="3">
+    <widget class="QPushButton" name="select_materials_button">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Refinement Steps:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QSpinBox" name="refinement_steps">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10000000</number>
-     </property>
-     <property name="value">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QCheckBox" name="use_experiment_file">
-     <property name="text">
-      <string>Use Experiment File</string>
+      <string>Select Materials</string>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
  <tabstops>
+  <tabstop>select_materials_button</tabstop>
   <tabstop>wppf_method</tabstop>
   <tabstop>refinement_steps</tabstop>
   <tabstop>background_method</tabstop>

--- a/hexrd/ui/select_items_dialog.py
+++ b/hexrd/ui/select_items_dialog.py
@@ -1,0 +1,49 @@
+from PySide2.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
+
+from hexrd.ui.select_items_widget import SelectItemsWidget
+
+
+class SelectItemsDialog(QDialog):
+    def __init__(self, items, parent=None):
+        super().__init__(parent)
+
+        self.setLayout(QVBoxLayout(self))
+
+        self.select_items_widget = SelectItemsWidget(items, parent)
+        self.layout().addWidget(self.select_items_widget.ui)
+
+        buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        self.button_box = QDialogButtonBox(buttons, self)
+        self.layout().addWidget(self.button_box)
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+    @property
+    def selected_items(self):
+        return self.select_items_widget.selected_items
+
+
+if __name__ == '__main__':
+    from PySide2.QtWidgets import QApplication
+
+    app = QApplication()
+
+    items = [
+        ('Item1', True),
+        ('Item2', False),
+        ('Item3', True),
+        ('Item4', True)
+    ]
+
+    dialog = SelectItemsDialog(items)
+
+    def selection_changed():
+        print(f'Selection changed: {dialog.selected_items}')
+
+    dialog.select_items_widget.selection_changed.connect(selection_changed)
+    if dialog.exec_():
+        print(f'{dialog.selected_items=}')

--- a/hexrd/ui/select_items_widget.py
+++ b/hexrd/ui/select_items_widget.py
@@ -1,0 +1,75 @@
+from PySide2.QtCore import QObject, Qt, Signal
+from PySide2.QtWidgets import QCheckBox, QHBoxLayout, QTableWidgetItem, QWidget
+
+from hexrd.ui.ui_loader import UiLoader
+
+
+COLUMNS = {
+    'name': 0,
+    'checkbox': 1
+}
+
+
+class SelectItemsWidget(QObject):
+
+    selection_changed = Signal()
+
+    def __init__(self, items, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('select_items_widget.ui', parent)
+
+        # The items should be a list of tuples of length two, like
+        # (name, selected).
+        self.items = items
+
+        self.checkboxes = []
+
+        self.update_table()
+
+    def create_table_widget(self, w):
+        # These are required to center the widget...
+        tw = QWidget(self.ui.table)
+        layout = QHBoxLayout(tw)
+        layout.addWidget(w)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setContentsMargins(0, 0, 0, 0)
+        return tw
+
+    def create_label(self, v):
+        w = QTableWidgetItem(v)
+        w.setTextAlignment(Qt.AlignCenter)
+        return w
+
+    def create_checkbox(self, v):
+        cb = QCheckBox(self.ui.table)
+        cb.setChecked(v)
+        cb.toggled.connect(self.checkbox_toggled)
+        self.checkboxes.append(cb)
+        return self.create_table_widget(cb)
+
+    def clear_table(self):
+        self.checkboxes.clear()
+        self.ui.table.clearContents()
+
+    def update_table(self):
+        self.clear_table()
+        self.ui.table.setRowCount(len(self.items))
+        for i, (name, checked) in enumerate(self.items):
+            w = self.create_label(name)
+            self.ui.table.setItem(i, COLUMNS['name'], w)
+
+            w = self.create_checkbox(checked)
+            self.ui.table.setCellWidget(i, COLUMNS['checkbox'], w)
+
+    def checkbox_toggled(self):
+        # Go through and update the items
+        for i, (item, cb) in enumerate(zip(self.items, self.checkboxes)):
+            self.items[i] = (item[0], cb.isChecked())
+
+        self.selection_changed.emit()
+
+    @property
+    def selected_items(self):
+        return [x[0] for x in self.items if x[1] is True]


### PR DESCRIPTION
This adds a button the WPPF options dialog that will pop up a dialog
where the user can select which materials to use for WPPF.

Only materials with powder overlays can be used. Materials that are
both visible and have powder overlays are selected by default. Materials
that have powder overlays but are not visible can be selected in the
dialog.

These materials then get passed on to WPPF. Previously, only the currently
selected material was passed to WPPF. Multiple materials can now be passed.

![wppf_material_select](https://user-images.githubusercontent.com/9558430/94048445-89b31b80-fda1-11ea-82f4-82a574312583.gif)

Fixes: #554