### PR TITLE
Add ability to specify crystal refinements

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -13,8 +13,8 @@ from hexrd.ui.tree_views.value_column_delegate import ValueColumnDelegate
 from hexrd.ui import constants
 
 # Global constants
-REFINED = 0
-FIXED = 1
+FIXED = 0
+REFINABLE = 1
 
 KEY_COL = BaseTreeItemModel.KEY_COL
 VALUE_COL = BaseTreeItemModel.VALUE_COL
@@ -25,7 +25,7 @@ class CalTreeItemModel(BaseTreeItemModel):
 
     def __init__(self, parent=None):
         super(CalTreeItemModel, self).__init__(parent)
-        self.root_item = TreeItem(['key', 'value', 'fixed'])
+        self.root_item = TreeItem(['key', 'value', 'refinable'])
         self.cfg = HexrdConfig()
         self.rebuild_tree()
 
@@ -117,7 +117,8 @@ class CalTreeItemModel(BaseTreeItemModel):
         # Rebuild the tree from scratch
         self.clear()
         for key in self.cfg.internal_instrument_config.keys():
-            tree_item = self.add_tree_item(key, None, REFINED, self.root_item)
+            tree_item = self.add_tree_item(key, None, REFINABLE,
+                                           self.root_item)
             self.recursive_add_tree_items(
                 self.cfg.internal_instrument_config[key], tree_item)
             self.update_parent_status(tree_item)
@@ -143,7 +144,7 @@ class CalTreeItemModel(BaseTreeItemModel):
             elif key == 'status':
                 tree_item = cur_tree_item
             else:
-                tree_item = self.add_tree_item(key, None, REFINED,
+                tree_item = self.add_tree_item(key, None, REFINABLE,
                                                cur_tree_item)
             if tree_item is not None:
                 self.recursive_add_tree_items(cur_config[key], tree_item)

--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -299,10 +299,10 @@ class CalibrationConfigWidget(QObject):
         if isinstance(gui_object, QComboBox):
             gui_object.setCurrentText(value)
         else:
-            if flag == 1 and not gui_object.styleSheet():
+            if flag == 0 and not gui_object.styleSheet():
                 s = 'QSpinBox, QDoubleSpinBox { background-color: lightgray; }'
                 gui_object.setStyleSheet(s)
-            elif gui_object.styleSheet() and flag != 1:
+            elif gui_object.styleSheet() and flag != 0:
                 gui_object.setStyleSheet("")
             # If it is anything else, just assume setValue()
             gui_object.setValue(value)

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -120,3 +120,23 @@ BUFFER_KEY = 'buffer'
 # determine which mode has been set by the navigation bar
 ZOOM = 'zoom rect'
 PAN = 'pan/zoom'
+
+def default_crystal_refinements():
+    inverse_matrix_strings = [
+        '0_0',
+        '1_1',
+        '2_2',
+        '1_2',
+        '0_2',
+        '0_1'
+    ]
+
+    items = [f'orientation_{i}' for i in range(3)]
+    items += [f'position_{i}' for i in range(3)]
+    items += [f'stretch_{x}' for x
+              in inverse_matrix_strings]
+    default_refine = True
+    return [(x, default_refine) for x in items]
+
+
+DEFAULT_CRYSTAL_REFINEMENTS = default_crystal_refinements()

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -141,3 +141,12 @@ def default_crystal_refinements():
 
 
 DEFAULT_CRYSTAL_REFINEMENTS = default_crystal_refinements()
+
+
+def default_powder_refinements():
+    names = ['a', 'b', 'c', 'α', 'β', 'γ']
+    default_refine = True
+    return [(x, default_refine) for x in names]
+
+
+DEFAULT_POWDER_REFINEMENTS = default_powder_refinements()

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -121,6 +121,7 @@ BUFFER_KEY = 'buffer'
 ZOOM = 'zoom rect'
 PAN = 'pan/zoom'
 
+
 def default_crystal_refinements():
     inverse_matrix_strings = [
         '0_0',

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -505,9 +505,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 self.add_status(value)
             else:
                 if isinstance(value, list):
-                    stat_default = [1] * len(value)
+                    stat_default = [0] * len(value)
                 else:
-                    stat_default = 1
+                    stat_default = 0
                 current[key] = {'status': (stat_default), 'value': value}
 
     def remove_status(self, current, prev=None, parent=None):
@@ -565,9 +565,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 else:
                     statuses.append(status)
 
-        # Finally, reverse all booleans. We use "fixed", but they use
-        # "refinable".
-        statuses = [not x for x in statuses]
         return np.asarray(statuses)
 
     def set_statuses_from_prev_iconfig(self, prev_iconfig):
@@ -592,11 +589,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # currently using "set_statuses_from_prev_iconfig" instead.
         # If we ever want to use this function again, let's try to make
         # it much faster.
-
-        # First, make a deep copy, and then reverse all booleans. We
-        # use "fixed", but they use "refinable"
-        statuses = copy.deepcopy(statuses)
-        statuses = [not x for x in statuses]
 
         cur_ind = 0
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1088,6 +1088,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             'style': style,
             'visible': visible,
             'options': overlays.default_overlay_options(type),
+            'refinements': overlays.default_overlay_refinements(type),
             'data': {}
         }
         self.overlays.append(overlay)
@@ -1106,6 +1107,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         overlay['type'] = type
         overlay['style'] = overlays.default_overlay_style(type)
         overlay['options'] = overlays.default_overlay_options(type)
+        overlay['refinements'] = overlays.default_overlay_refinements(type)
         overlay['update_needed'] = True
 
     def clear_overlay_data(self):

--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -53,7 +53,7 @@ def default_overlay_options(overlay_type):
 
 def default_overlay_refinements(overlay_type):
     default_refinements = {
-        OverlayType.powder: [],
+        OverlayType.powder: constants.DEFAULT_POWDER_REFINEMENTS,
         OverlayType.laue: constants.DEFAULT_CRYSTAL_REFINEMENTS,
         OverlayType.mono_rotation_series: constants.DEFAULT_CRYSTAL_REFINEMENTS
     }

--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -51,6 +51,19 @@ def default_overlay_options(overlay_type):
     return copy.deepcopy(default_options[overlay_type])
 
 
+def default_overlay_refinements(overlay_type):
+    default_refinements = {
+        OverlayType.powder: [],
+        OverlayType.laue: constants.DEFAULT_CRYSTAL_REFINEMENTS,
+        OverlayType.mono_rotation_series: constants.DEFAULT_CRYSTAL_REFINEMENTS
+    }
+
+    if overlay_type not in default_refinements:
+        raise Exception(f'Unknown overlay type: {overlay_type}')
+
+    return copy.deepcopy(default_refinements[overlay_type])
+
+
 def update_overlay_data(instr, display_mode):
     from hexrd.ui.hexrd_config import HexrdConfig
 

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -1,9 +1,13 @@
+import copy
+
 import numpy as np
 
 from PySide2.QtCore import QSignalBlocker
 from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
 
+from hexrd.ui.constants import DEFAULT_POWDER_REFINEMENTS
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.select_items_widget import SelectItemsWidget
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -15,6 +19,11 @@ class PowderOverlayEditor:
 
         self._overlay = None
 
+        refinements = copy.deepcopy(DEFAULT_POWDER_REFINEMENTS)
+        self.refinements_selector = SelectItemsWidget(refinements, self.ui)
+        self.ui.refinements_selector_layout.addWidget(
+            self.refinements_selector.ui)
+
         self.setup_connections()
 
     def setup_connections(self):
@@ -25,6 +34,20 @@ class PowderOverlayEditor:
                 w.toggled.connect(self.update_config)
 
         self.ui.enable_width.toggled.connect(self.update_enable_states)
+        self.refinements_selector.selection_changed.connect(
+            self.update_refinements)
+
+    @property
+    def refinements(self):
+        return self.refinements_selector.items
+
+    @refinements.setter
+    def refinements(self, v):
+        self.refinements_selector.items = copy.deepcopy(v)
+        self.refinements_selector.update_table()
+
+    def update_refinements(self):
+        self.overlay['refinements'] = copy.deepcopy(self.refinements)
 
     @property
     def overlay(self):
@@ -47,6 +70,11 @@ class PowderOverlayEditor:
 
         self.tth_width_gui = self.tth_width_config
         self.offset_gui = self.offset_config
+
+        if 'refinements' in self.overlay:
+            self.refinements = self.overlay['refinements']
+        else:
+            self.refinements = DEFAULT_POWDER_REFINEMENTS
 
         self.update_enable_states()
 

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -531,6 +531,16 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="refinements_tab">
+         <attribute name="title">
+          <string>Refinements</string>
+         </attribute>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <layout class="QVBoxLayout" name="refinements_selector_layout"/>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
      </layout>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -24,43 +24,18 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="3">
-    <widget class="ScientificDoubleSpinBox" name="offset_1">
-     <property name="keyboardTracking">
-      <bool>false</bool>
+   <item row="4" column="1" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="offset_label">
-     <property name="text">
-      <string>Offset:</string>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
      </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="ScientificDoubleSpinBox" name="offset_0">
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QCheckBox" name="enable_width">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Enable Width</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="4">
-    <widget class="ScientificDoubleSpinBox" name="offset_2">
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-    </widget>
+    </spacer>
    </item>
    <item row="1" column="2" colspan="3">
     <widget class="QDoubleSpinBox" name="tth_width">
@@ -99,18 +74,55 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="4">
+    <widget class="ScientificDoubleSpinBox" name="offset_2">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3">
+    <widget class="ScientificDoubleSpinBox" name="offset_1">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="ScientificDoubleSpinBox" name="offset_0">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="enable_width">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Enable Width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="offset_label">
+     <property name="text">
+      <string>Offset:</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+    <widget class="QGroupBox" name="refinements_group">
+     <property name="title">
+      <string>Refinements</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QVBoxLayout" name="refinements_selector_layout"/>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -124,6 +136,9 @@
  <tabstops>
   <tabstop>enable_width</tabstop>
   <tabstop>tth_width</tabstop>
+  <tabstop>offset_0</tabstop>
+  <tabstop>offset_1</tabstop>
+  <tabstop>offset_2</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/select_items_widget.py
+++ b/hexrd/ui/select_items_widget.py
@@ -63,6 +63,8 @@ class SelectItemsWidget(QObject):
             w = self.create_checkbox(checked)
             self.ui.table.setCellWidget(i, COLUMNS['checkbox'], w)
 
+        self.ui.table.resizeColumnsToContents()
+
     def checkbox_toggled(self):
         # Go through and update the items
         for i, (item, cb) in enumerate(zip(self.items, self.checkboxes)):


### PR DESCRIPTION
This adds a "refinement" tab to the calibration crystal editor to
allow the user to specify which crystal parameters can be refined.

It is currently being used only in the Laue overlay editor.

The refinement statuses are saved in the overlays themselves. They
are currently not being used for anything, but they will be used when
the spot picked calibration will be performed.

All parameters default to being refinable.

![laue_refinements](https://user-images.githubusercontent.com/9558430/94091550-83935e00-fde6-11ea-91ca-e8c6b64799f2.gif)

Fixes: #561