### PR TITLE
Exit early in powder overlays if there is no data

### DIFF
--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -78,6 +78,10 @@ class PowderLineOverlay:
             )
         )
 
+        if tths.size == 0:
+            # No overlays
+            return {}
+
         if self.plane_data.tThWidth is not None:
             # Need to get width data as well
             indices, ranges = self.plane_data.getMergedRanges()


### PR DESCRIPTION
Check and exit early if there is no data when generating the powder
overlays.

Sometimes, there is no overlay data just because there are exclusions
on all of the hkls. Why this happens sometimes in currently unknown.
But this should alleviate that issue.

Sometimes, there is no overlay data because the max two theta in the
materials panel and the beam energy are both too small. This results
in no hkls appearing in the materials table.

This early exit prevents exceptions from occurring, and instead, no
powder overlays are drawn, which is more expected behavior.

Fixes: #500

This also helps the first part of #492