### PR TITLE
Toggle zoom/pan off

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -115,3 +115,8 @@ WORKFLOWS = [WORKFLOW_HEDM, WORKFLOW_LLNL]
 HEXRD_DIRECTORY_SUFFIX = '.hexrd'
 
 BUFFER_KEY = 'buffer'
+
+# Used to access matplotlib internals in backend_bases and
+# determine which mode has been set by the navigation bar
+ZOOM = 'zoom rect'
+PAN = 'pan/zoom'

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -171,6 +171,14 @@ class ImageTabWidget(QTabWidget):
             self.toolbars[idx]['sb'].update_name(self.image_names[idx])
             self.toolbars[idx]['sb'].update_range(True)
 
+    def toggle_off_toolbar(self):
+        toolbars = [bars['tb'] for bars in self.toolbars]
+        for tb in toolbars:
+            if tb.mode == 'zoom rect':
+                tb.zoom()
+            if tb.mode == 'pan/zoom':
+                tb.pan()
+
     def show_cartesian(self):
         self.update_image_names()
         self.update_ims_toolbar()

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -3,7 +3,7 @@ from PySide2.QtWidgets import QMessageBox, QTabWidget, QHBoxLayout
 
 import numpy as np
 
-from hexrd.ui.constants import ViewType
+from hexrd.ui.constants import ViewType, ZOOM, PAN
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_canvas import ImageCanvas
 from hexrd.ui.image_series_toolbar import ImageSeriesToolbar
@@ -174,9 +174,9 @@ class ImageTabWidget(QTabWidget):
     def toggle_off_toolbar(self):
         toolbars = [bars['tb'] for bars in self.toolbars]
         for tb in toolbars:
-            if tb.mode == 'zoom rect':
+            if tb.mode == ZOOM:
                 tb.zoom()
-            if tb.mode == 'pan/zoom':
+            if tb.mode == PAN:
                 tb.pan()
 
     def show_cartesian(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -151,10 +151,14 @@ class MainWindow(QObject):
             self.on_action_edit_euler_angle_convention)
         self.ui.action_edit_apply_polar_mask.triggered.connect(
             self.on_action_edit_apply_polar_mask_triggered)
+        self.ui.action_edit_apply_polar_mask.triggered.connect(
+            self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_edit_apply_laue_mask_to_polar.triggered.connect(
             self.on_action_edit_apply_laue_mask_to_polar_triggered)
         self.ui.action_edit_apply_polygon_mask.triggered.connect(
             self.on_action_edit_apply_polygon_mask_triggered)
+        self.ui.action_edit_apply_polygon_mask.triggered.connect(
+            self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_edit_reset_instrument_config.triggered.connect(
             self.on_action_edit_reset_instrument_config)
         self.ui.action_transform_detectors.triggered.connect(
@@ -173,6 +177,8 @@ class MainWindow(QObject):
             self.start_powder_calibration)
         self.ui.action_calibration_line_picker.triggered.connect(
             self.on_action_calibration_line_picker_triggered)
+        self.ui.action_calibration_line_picker.triggered.connect(
+            self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_run_indexing.triggered.connect(
             self.on_action_run_indexing_triggered)
         self.ui.action_run_wppf.triggered.connect(self.run_wppf)

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -64,6 +64,7 @@ class MaskRegionsDialog(QObject):
     def setup_ui_connections(self):
         self.ui.button_box.accepted.connect(self.apply_masks)
         self.ui.button_box.rejected.connect(self.cancel)
+        self.ui.rejected.connect(self.cancel)
         self.ui.shape.currentIndexChanged.connect(self.select_shape)
         self.ui.undo.clicked.connect(self.undo_selection)
         HexrdConfig().tab_images_changed.connect(self.tabbed_view_changed)

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -155,7 +155,7 @@ class MaskRegionsDialog(QObject):
         if not self.axes:
             return
 
-        self.press = [int(event.xdata), int(event.ydata)]
+        self.press = [event.xdata, event.ydata]
         self.det = self.axes.get_title()
         if not self.det:
             self.det = self.image_mode
@@ -196,7 +196,7 @@ class MaskRegionsDialog(QObject):
         if not self.axes or not self.press:
             return
 
-        self.end = [int(event.xdata), int(event.ydata)]
+        self.end = [event.xdata, event.ydata]
         self.save_line_data()
 
         self.press.clear()

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -222,6 +222,10 @@ class MaskRegionsDialog(QObject):
 
         if hasattr(self.canvas, 'axis'):
             self.canvas.axis.patches.clear()
+        else:
+            for canvas in self.parent.image_tab_widget.active_canvases():
+                for axes in canvas.raw_axes:
+                    axes.patches.clear()
 
         self.disconnect()
         self.canvas.draw()


### PR DESCRIPTION
When the calibration line picker, polygon mask tool, or polar mask tool are selected make sure that the navigation bar `Zoom` and `Pan` options are toggled off.

Fixes: #552