### PR TITLE
box_overlay_line can be None so guard cleanup

### DIFF
--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -43,8 +43,9 @@ class ZoomCanvas(FigureCanvas):
             self.mne_id = None
 
     def remove_overlay_lines(self):
-        self.box_overlay_line.remove()
-        self.box_overlay_line = None
+        if self.box_overlay_line is not None:
+            self.box_overlay_line.remove()
+            self.box_overlay_line = None
 
     def mouse_moved(self, event):
         if event.inaxes is None:


### PR DESCRIPTION
Fixes exceptions for the form:

```
Traceback (most recent call last):
  File "/home/cjh/work/source/hexrdgui/hexrd/ui/zoom_canvas.py", line 34, in __del__
    self.cleanup()
  File "/home/cjh/work/source/hexrdgui/hexrd/ui/zoom_canvas.py", line 38, in cleanup
    self.remove_overlay_lines()
  File "/home/cjh/work/source/hexrdgui/hexrd/ui/zoom_canvas.py", line 47, in remove_overlay_lines
    self.box_overlay_line.remove()
AttributeError: 'NoneType' object has no attribute 'remove'
```