### PR TITLE
Do not disconnect signals more than once

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -245,12 +245,12 @@ class ImportDataPanel(QObject):
         self.ui.trans.setChecked(True)
 
     def setup_translate(self):
-        if self.it is not None and self.ui.rotate.isChecked():
+        if self.it is not None:
             self.it.disconnect_rotate()
             self.it.connect_translate()
 
     def setup_rotate(self):
-        if self.it is not None and self.ui.trans.isChecked():
+        if self.it is not None:
             self.it.disconnect_translate()
             self.it.connect_rotate()
 

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -164,6 +164,9 @@ class InteractiveTemplate:
         self.redraw()
 
     def disconnect_translate(self):
+        if not self.button_press_cid:
+            return
+
         self.parent.mpl_disconnect(self.button_press_cid)
         self.parent.mpl_disconnect(self.button_release_cid)
         self.parent.mpl_disconnect(self.motion_cid)
@@ -247,6 +250,9 @@ class InteractiveTemplate:
         self.redraw()
 
     def disconnect_rotate(self):
+        if not self.button_press_cid:
+            return
+
         self.parent.mpl_disconnect(self.button_press_cid)
         self.parent.mpl_disconnect(self.button_drag_cid)
         self.parent.mpl_disconnect(self.button_release_cid)


### PR DESCRIPTION
The fix added in #567 cleared up the error message but broke the rotation option. This branch fixes that.