### PR TITLE
Add general calibration runner

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -125,7 +125,22 @@ class CalibrationRunner:
         self.pick_next_line()
 
     def finish(self):
-        print(f'{self.all_overlay_picks=}')
+        # Temporary
+        import json
+
+        pick_results = []
+        for i, val in self.all_overlay_picks.items():
+            overlay = self.overlays[i]
+            pick_results.append({
+                'material': overlay['material'],
+                'type': overlay['type'].value,
+                'picks': val
+            })
+
+        out_file = 'calibration_picks.json'
+        print(f'Writing out picks to {out_file}')
+        with open(out_file, 'w') as wf:
+            json.dump(pick_results, wf)
 
     def set_exclusive_overlay_visibility(self, overlay):
         self.overlay_visibilities = [overlay is x for x in self.overlays]

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -1,0 +1,220 @@
+import numpy as np
+
+from hexrd.ui.constants import OverlayType
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.line_picker_dialog import LinePickerDialog
+
+
+class CalibrationRunner:
+    def __init__(self, canvas, parent=None):
+        self.canvas = canvas
+        self.parent = parent
+        self.current_overlay_ind = -1
+        self.all_overlay_picks = {}
+
+    def run(self):
+        self.validate()
+        self.clear_all_overlay_picks()
+        self.pick_next_line()
+
+    def validate(self):
+        # Do a quick check for refinable paramters, which are required
+        flags = HexrdConfig().get_statuses_instrument_format()
+        if np.count_nonzero(flags) == 0:
+            raise Exception('There are no refinable parameters')
+
+        visible_overlays = self.visible_overlays
+        if not visible_overlays:
+            raise Exception('No visible overlays')
+
+        if not all(self.has_widths(x) for x in visible_overlays):
+            raise Exception('All visible overlays must have widths')
+
+    def clear_all_overlay_picks(self):
+        self.all_overlay_picks.clear()
+
+    @staticmethod
+    def has_widths(overlay):
+        type = overlay['type']
+        if type == OverlayType.powder:
+            # Make sure the material has a two-theta width
+            name = overlay['material']
+            return HexrdConfig().material(name).planeData.tThWidth is not None
+        elif type == OverlayType.laue:
+            options = overlay.get('options', {})
+            width_params = ['tth_width', 'eta_width']
+            return all(options.get(x) is not None for x in width_params)
+        elif type == OverlayType.mono_rotation_series:
+            raise NotImplementedError('mono_rotation_series not implemented')
+        else:
+            raise Exception(f'Unknown overlay type: {type}')
+
+    @property
+    def overlays(self):
+        return HexrdConfig().overlays
+
+    @property
+    def visible_overlays(self):
+        return [x for x in self.overlays if x['visible']]
+
+    @staticmethod
+    def overlay_name(overlay):
+        return f'{overlay["material"]} {overlay["type"].name}'
+
+    def next_overlay(self):
+        ind = self.current_overlay_ind
+        ind += 1
+        for i in range(ind, len(self.overlays)):
+            if self.overlays[i]['visible']:
+                self.current_overlay_ind = i
+                return self.overlays[i]
+
+    @property
+    def active_overlay(self):
+        if not 0 <= self.current_overlay_ind < len(self.overlays):
+            return None
+
+        return self.overlays[self.current_overlay_ind]
+
+    @property
+    def active_overlay_type(self):
+        return self.active_overlay['type']
+
+    def pick_next_line(self):
+        overlay = self.next_overlay()
+        if overlay is None:
+            # No more overlays to do. Move on.
+            self.finish()
+            return
+
+        # Create a backup of the visibilities that we will restore later
+        self.backup_overlay_visibilities = self.overlay_visibilities
+
+        # Only make the current overlay we are selecting visible
+        self.set_exclusive_overlay_visibility(overlay)
+
+        title = self.overlay_name(overlay)
+
+        self.reset_overlay_picks()
+        self.reset_overlay_data_index_map()
+        self.increment_overlay_data_index()
+
+        kwargs = {
+            'canvas': self.canvas,
+            'parent': self.canvas,
+            'single_line_mode': overlay['type'] == OverlayType.laue
+        }
+
+        self._calibration_line_picker = LinePickerDialog(**kwargs)
+        self._calibration_line_picker.ui.setWindowTitle(title)
+        self._calibration_line_picker.start()
+        self._calibration_line_picker.point_picked.connect(
+            self.point_picked)
+        self._calibration_line_picker.line_completed.connect(
+            self.line_completed)
+        self._calibration_line_picker.finished.connect(
+            self.restore_backup_overlay_visibilities)
+        self._calibration_line_picker.finished.connect(
+            self.remove_all_highlighting)
+        self._calibration_line_picker.result.connect(self.finish_line)
+
+    def finish_line(self):
+        self.save_overlay_picks()
+        self.pick_next_line()
+
+    def finish(self):
+        print(f'{self.all_overlay_picks=}')
+
+    def set_exclusive_overlay_visibility(self, overlay):
+        self.overlay_visibilities = [overlay is x for x in self.overlays]
+
+    def restore_backup_overlay_visibilities(self):
+        self.overlay_visibilities = self.backup_overlay_visibilities
+        HexrdConfig().overlay_config_changed.emit()
+
+    def remove_all_highlighting(self):
+        for overlay in self.overlays:
+            if 'highlights' in overlay:
+                del overlay['highlights']
+        HexrdConfig().flag_overlay_updates_for_all_materials()
+        HexrdConfig().overlay_config_changed.emit()
+
+    @property
+    def overlay_visibilities(self):
+        return [x['visible'] for x in self.overlays]
+
+    @overlay_visibilities.setter
+    def overlay_visibilities(self, visibilities):
+        for o, v in zip(self.overlays, visibilities):
+            o['visible'] = v
+        HexrdConfig().overlay_config_changed.emit()
+
+    def reset_overlay_picks(self):
+        self.overlay_picks = {}
+
+    def reset_overlay_data_index_map(self):
+        self.overlay_data_index = -1
+
+        if self.active_overlay_type == OverlayType.powder:
+            data_key = 'rings'
+        elif self.active_overlay_type == OverlayType.laue:
+            data_key = 'spots'
+        else:
+            raise Exception(f'{self.active_overlay_type} not implemented')
+
+        data_map = {}
+        ind = 0
+        for key, value in self.active_overlay['data'].items():
+            for i in range(len(value[data_key])):
+                data_map[ind] = (key, data_key, i)
+                ind += 1
+
+        self.overlay_data_index_map = data_map
+
+    def save_overlay_picks(self):
+        self.all_overlay_picks[self.current_overlay_ind] = self.overlay_picks
+
+    @property
+    def current_data_path(self):
+        idx = self.overlay_data_index
+        if not 0 <= idx < len(self.overlay_data_index_map):
+            return None
+
+        return self.overlay_data_index_map[idx]
+
+    @property
+    def current_data_list(self):
+        key, _, val = self.current_data_path
+        root_list = self.overlay_picks.setdefault(key, [])
+        if self.active_overlay_type == OverlayType.powder:
+            while len(root_list) <= val:
+                root_list.append([])
+            return root_list[val]
+        elif self.active_overlay_type == OverlayType.laue:
+            # Only a single list for each Laue key
+            return root_list
+
+        raise Exception(f'Not implemented: {self.active_overlay_type}')
+
+    def increment_overlay_data_index(self):
+        self.overlay_data_index += 1
+        data_path = self.current_data_path
+        if data_path is None:
+            # We are done picking for this overlay.
+            if hasattr(self, '_calibration_line_picker'):
+                self._calibration_line_picker.ui.accept()
+            return
+
+        self.active_overlay['highlights'] = [data_path]
+        HexrdConfig().flag_overlay_updates_for_all_materials()
+        HexrdConfig().overlay_config_changed.emit()
+
+    def point_picked(self):
+        linebuilder = self._calibration_line_picker.linebuilder
+        data = (linebuilder.xs[-1], linebuilder.ys[-1])
+        self.current_data_list.append(data)
+        if self.active_overlay_type == OverlayType.laue:
+            self.increment_overlay_data_index()
+
+    def line_completed(self):
+        self.increment_overlay_data_index()

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -90,6 +90,45 @@ DEFAULT_MONO_ROTATION_SERIES_STYLE = {
     }
 }
 
+HIGHLIGHT_POWDER_STYLE = {
+    'data': {
+        'c': '#fce94f',  # Yellow
+        'ls': 'solid',
+        'lw': 2.0
+    },
+    'ranges': {
+        'c': '#fce94f',  # Yellow
+        'ls': 'dotted',
+        'lw': 2.0
+    }
+}
+
+HIGHLIGHT_LAUE_STYLE = {
+    'data': {
+        'c': '#fce94f',  # Yellow
+        'marker': 'o',
+        's': 4.0
+    },
+    'ranges': {
+        'c': '#fce94f',  # Yellow
+        'ls': 'dotted',
+        'lw': 2.0
+    }
+}
+
+HIGHLIGHT_MONO_ROTATION_SERIES_STYLE = {
+    'data': {
+        'c': '#fce94f',  # Yellow
+        'ls': 'solid',
+        'lw': 2.0
+    },
+    'ranges': {
+        'c': '#fce94f',  # Yellow
+        'ls': 'dotted',
+        'lw': 2.0
+    }
+}
+
 DEFAULT_CRYSTAL_PARAMS = np.hstack(
     [constants.zeros_3, constants.zeros_3, constants.identity_6x1])
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1107,6 +1107,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
             overlay['data'].clear()
             if 'update_needed' in overlay:
                 del overlay['update_needed']
+            if 'highlights' in overlay:
+                del overlay['highlights']
 
     def flag_overlay_updates_for_active_material(self):
         self.flag_overlay_updates_for_material(self.active_material_name)

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -70,8 +70,18 @@ class LinePickerDialog(QObject):
         self.ui.zoom_tth_width.valueChanged.connect(self.zoom_width_changed)
         self.ui.zoom_eta_width.valueChanged.connect(self.zoom_width_changed)
         self.ui.back_button.pressed.connect(self.back_button_pressed)
+        self.point_picked.connect(self.update_enable_states)
+        self.last_point_removed.connect(self.update_enable_states)
         self.bp_id = self.canvas.mpl_connect('button_press_event',
                                              self.button_pressed)
+
+    def update_enable_states(self):
+        linebuilder = self.linebuilder
+        enable_back_button = (
+            linebuilder is not None and
+            all(z for z in [linebuilder.xs, linebuilder.ys])
+        )
+        self.ui.back_button.setEnabled(enable_back_button)
 
     def move_dialog_to_left(self):
         # This moves the dialog to the left border of the parent
@@ -149,6 +159,8 @@ class LinePickerDialog(QObject):
         self.linebuilder = LineBuilder(line)
 
         self.linebuilder.point_picked.connect(self.point_picked.emit)
+
+        self.update_enable_states()
 
         self.lines.append(line)
         self.canvas.draw()

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -156,7 +156,11 @@ class LaueSpotOverlay:
 
             if display_mode == ViewType.polar:
                 range_corners = self.range_corners(angles_corr)
-                point_groups[det_key]['spots'] = np.degrees(angles_corr)
+                # Save the Laue spots as a list instead of a numpy array,
+                # so that we can predictably get the id() of spots inside.
+                # Numpy arrays do fancy optimizations that break this.
+                spots = np.degrees(angles_corr).tolist()
+                point_groups[det_key]['spots'] = spots
                 point_groups[det_key]['ranges'] = np.degrees(range_corners)
             elif display_mode in [ViewType.raw, ViewType.cartesian]:
                 # !!! verify this

--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -13,10 +13,24 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="2" column="0" colspan="2">
-      <widget class="QLabel" name="finish_label">
+     <item row="4" column="0">
+      <widget class="QLabel" name="zoom_eta_width_label">
        <property name="text">
-        <string>Click &quot;Ok&quot; to finish.</string>
+        <string>Zoom η Width:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="start_new_line_label">
+       <property name="text">
+        <string>Start a new line with right-click.</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="add_point_label">
+       <property name="text">
+        <string>Add a point with left-click.</string>
        </property>
       </widget>
      </item>
@@ -77,24 +91,20 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="zoom_eta_width_label">
+     <item row="2" column="0" colspan="2">
+      <widget class="QLabel" name="finish_label">
        <property name="text">
-        <string>Zoom η Width:</string>
+        <string>Click &quot;Ok&quot; to finish.</string>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="add_point_label">
-       <property name="text">
-        <string>Add a point with left-click.</string>
+     <item row="5" column="1">
+      <widget class="QPushButton" name="back_button">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the most recently picked point&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="start_new_line_label">
        <property name="text">
-        <string>Start a new line with right-click.</string>
+        <string>Back</string>
        </property>
       </widget>
      </item>

--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -14,14 +14,14 @@
    <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="2" column="0" colspan="2">
-      <widget class="QLabel" name="label_3">
+      <widget class="QLabel" name="finish_label">
        <property name="text">
         <string>Click &quot;Ok&quot; to finish.</string>
        </property>
       </widget>
      </item>
      <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
+      <widget class="QLabel" name="zoom_tth_width_label">
        <property name="text">
         <string>Zoom 2θ Width:</string>
        </property>
@@ -78,21 +78,21 @@
       </widget>
      </item>
      <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
+      <widget class="QLabel" name="zoom_eta_width_label">
        <property name="text">
         <string>Zoom η Width:</string>
        </property>
       </widget>
      </item>
      <item row="0" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="add_point_label">
        <property name="text">
         <string>Add a point with left-click.</string>
        </property>
       </widget>
      </item>
      <item row="0" column="1">
-      <widget class="QLabel" name="label_2">
+      <widget class="QLabel" name="start_new_line_label">
        <property name="text">
         <string>Start a new line with right-click.</string>
        </property>

--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -100,6 +100,9 @@
      </item>
      <item row="5" column="1">
       <widget class="QPushButton" name="back_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the most recently picked point&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -123,7 +123,7 @@
      <string>R&amp;un</string>
     </property>
     <addaction name="action_run_powder_calibration"/>
-    <addaction name="action_calibration_line_picker"/>
+    <addaction name="action_run_calibration"/>
     <addaction name="action_run_indexing"/>
     <addaction name="action_run_wppf"/>
    </widget>
@@ -437,12 +437,12 @@
     <string>Polar Plot</string>
    </property>
   </action>
-  <action name="action_calibration_line_picker">
+  <action name="action_run_calibration">
    <property name="enabled">
     <bool>false</bool>
    </property>
    <property name="text">
-    <string>Calibration Line Picker</string>
+    <string>Calibration</string>
    </property>
   </action>
   <action name="action_edit_reset_instrument_config">


### PR DESCRIPTION
This generalizes the line picked calibration into a general calibration
runner, with several helpful features.

First of all, the calibration runner loops through all of the visible
overlays, and has the user pick points for each one. While the user
is picking points for an overlay, all of the other overlays are hidden,
and the line/spot of interest is highlighted.

For powder overlays, the user can move on to the next line by
right-clicking. For laue overlays, right-clicking is disabled and
left click automatically moves on to the next spot. If a spot in the
laue overlays needs to be skipped, the user may do so by middle clicking,
which inserts NaN's instead of regular values.

The user may click on the "Ok" button on the dialog to move on to the next
overlay. Alternatively, if there are no more points available for picking,
the dialog will automatically close itself.

Currently, nothing is being done with the picked data. But it will be fed
into a calibration function soon.

For powder overlays, the detector association may not be correct if the
user did not click on the right detector. To make things simpler, we should
just automatically determine which detector each point is on and associate
them in that way.

![calibration_runner](https://user-images.githubusercontent.com/9558430/94182277-c13bc980-fe6e-11ea-9371-1b68e6806bdd.gif)

Fixes: #524