### PR TITLE
Overlay fixes

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -640,6 +640,12 @@ class ImageCanvas(FigureCanvas):
         # This will call self.draw()
         self.draw_detector_borders()
 
+        # In polar mode, the overlays are clipped to the detectors, so
+        # they must be re-drawn as well
+        if self.mode == ViewType.polar:
+            HexrdConfig().flag_overlay_updates_for_all_materials()
+            self.update_overlays()
+
     def export_polar_plot(self, filename):
         if self.mode != ViewType.polar:
             raise Exception('Not in polar mode. Cannot export polar plot')

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -491,12 +491,12 @@ class ImageCanvas(FigureCanvas):
         # if HexrdConfig().polar_show_azimuthal_integral
         if True:
             # The top image will have 2x the height of the bottom image
-            grid = plt.GridSpec(3, 1)
+            grid = plt.GridSpec(4, 1)
 
             # It is important to persist the plot so that we don't reset the
             # scale.
             if len(self.axes_images) == 0:
-                self.axis = self.figure.add_subplot(grid[:2, 0])
+                self.axis = self.figure.add_subplot(grid[:3, 0])
                 self.axes_images.append(self.axis.imshow(img, extent=extent,
                                                          cmap=self.cmap,
                                                          norm=self.norm,
@@ -517,7 +517,7 @@ class ImageCanvas(FigureCanvas):
             tth = np.degrees(angular_grid[1][0])
 
             if self.azimuthal_integral_axis is None:
-                axis = self.figure.add_subplot(grid[2, 0], sharex=self.axis)
+                axis = self.figure.add_subplot(grid[3, 0], sharex=self.axis)
                 data = (tth, np.sum(img, axis=0))
                 self.azimuthal_line_artist, = axis.plot(*data)
                 HexrdConfig().last_azimuthal_integral_data = data

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -144,7 +144,7 @@ class LaueSpotOverlay:
             # convert to angles in LAB ref
             angles_corr, _ = xfcapi.detectorXYToGvec(
                 xy_data, panel.rmat, self.sample_rmat,
-                panel.tvec, constants.zeros_3, constants.zeros_3,
+                panel.tvec, self.instrument.tvec, constants.zeros_3,
                 beamVec=self.instrument.beam_vector,
                 etaVec=self.instrument.eta_vector
             )

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -119,10 +119,6 @@ class PowderLineOverlay:
 
             # !!! must apply offset
             xys_full = panel.angles_to_cart(ang_crds, tvec_c=self.tvec)
-
-            # !!! distortion
-            if panel.distortion is not None:
-                xys_full = panel.distortion.apply_inverse(xys_full)
                 
             # clip to detector panel
             xys, on_panel = panel.clip_to_panel(
@@ -132,8 +128,9 @@ class PowderLineOverlay:
             if display_mode == ViewType.polar:
                 if panel.distortion is not None:
                     xys = panel.distortion.apply(xys)
-                ang_crds, _ = panel.cart_to_angles(xys)
+                ang_crds, _ = panel.cart_to_angles(xys, self.instrument.tvec)
 
+                '''
                 # !!! apply offset correction
                 ang_crds = _convert_angles(
                     ang_crds, panel,
@@ -141,6 +138,7 @@ class PowderLineOverlay:
                     beam_vector=self.instrument.beam_vector,
                     eta_vector=self.instrument.eta_vector
                 )
+                '''
 
                 # Swap columns, convert to degrees
                 ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])
@@ -160,6 +158,10 @@ class PowderLineOverlay:
             elif display_mode in [ViewType.raw, ViewType.cartesian]:
 
                 if display_mode == ViewType.raw:
+                    # !!! distortion
+                    if panel.distortion is not None:
+                        xys_full = panel.distortion.apply_inverse(xys_full)
+
                     # Convert to pixel coordinates
                     # ??? keep in pixels?
                     xys = panel.cartToPixel(xys)

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -124,19 +124,8 @@ class PowderLineOverlay:
             )
 
             if display_mode == ViewType.polar:
-                if panel.distortion is not None:
-                    xys = panel.distortion.apply(xys)
-                ang_crds, _ = panel.cart_to_angles(xys, self.instrument.tvec)
-
-                '''
                 # !!! apply offset correction
-                ang_crds = _convert_angles(
-                    ang_crds, panel,
-                    identity_3x3, self.tvec,
-                    beam_vector=self.instrument.beam_vector,
-                    eta_vector=self.instrument.eta_vector
-                )
-                '''
+                ang_crds, _ = panel.cart_to_angles(xys, self.instrument.tvec)
 
                 # Swap columns, convert to degrees
                 ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -114,8 +114,26 @@ class PowderLineOverlay:
     def generate_ring_points(self, tths, etas, panel, display_mode):
         ring_pts = []
         for tth in tths:
+            # construct ideal angular coords
             ang_crds = np.vstack([np.tile(tth, len(etas)), etas]).T
+
+            # !!! must apply offset
+            xys_full = panel.angles_to_cart(ang_crds, tvec_c=self.tvec)
+
+            # !!! distortion
+            if panel.distortion is not None:
+                xys_full = panel.distortion.apply_inverse(xys_full)
+                
+            # clip to detector panel
+            xys, on_panel = panel.clip_to_panel(
+                xys_full, buffer_edges=False
+            )
+            
             if display_mode == ViewType.polar:
+                if panel.distortion is not None:
+                    xys = panel.distortion.apply(xys)
+                ang_crds, _ = panel.cart_to_angles(xys)
+
                 # !!! apply offset correction
                 ang_crds = _convert_angles(
                     ang_crds, panel,
@@ -123,6 +141,7 @@ class PowderLineOverlay:
                     beam_vector=self.instrument.beam_vector,
                     eta_vector=self.instrument.eta_vector
                 )
+
                 # Swap columns, convert to degrees
                 ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])
 
@@ -137,18 +156,8 @@ class PowderLineOverlay:
 
                 # append to list with nan padding
                 ring_pts.append(np.vstack([ang_crds, nans_row]))
+
             elif display_mode in [ViewType.raw, ViewType.cartesian]:
-                # !!! must apply offset
-                xys_full = panel.angles_to_cart(ang_crds, tvec_c=self.tvec)
-
-                # !!! distortion
-                if panel.distortion is not None:
-                    xys_full = panel.distortion.apply_inverse(xys_full)
-
-                # clip to detector panel
-                xys, on_panel = panel.clip_to_panel(
-                    xys_full, buffer_edges=False
-                )
 
                 if display_mode == ViewType.raw:
                     # Convert to pixel coordinates

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from hexrd import constants
+
 from hexrd.transforms import xfcapi
 
 from hexrd.ui.constants import ViewType
@@ -110,6 +112,7 @@ class PowderLineOverlay:
         return point_groups
 
     def generate_ring_points(self, tths, etas, panel, display_mode):
+        delta_eta_nom = np.degrees(np.median(np.diff(etas)))
         ring_pts = []
         for tth in tths:
             # construct ideal angular coords
@@ -117,6 +120,10 @@ class PowderLineOverlay:
 
             # !!! must apply offset
             xys_full = panel.angles_to_cart(ang_crds, tvec_c=self.tvec)
+
+            # skip if ring not on panel
+            if len(xys_full) == 0:
+                continue
 
             # clip to detector panel
             xys, on_panel = panel.clip_to_panel(
@@ -126,6 +133,9 @@ class PowderLineOverlay:
             if display_mode == ViewType.polar:
                 # !!! apply offset correction
                 ang_crds, _ = panel.cart_to_angles(xys, self.instrument.tvec)
+
+                if len(ang_crds) == 0:
+                    continue
 
                 # Swap columns, convert to degrees
                 ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])
@@ -138,6 +148,26 @@ class PowderLineOverlay:
                 # sort points for monotonic eta
                 eidx = np.argsort(ang_crds[:, 0])
                 ang_crds = ang_crds[eidx, :]
+
+                # branch cut
+                delta_eta_est = np.median(np.diff(ang_crds[:, 0]))
+                cut_on_panel = bool(
+                    xfcapi.angularDifference(
+                        np.min(ang_crds[:, 0]),
+                        np.max(ang_crds[:, 0]),
+                        units='degrees'
+                    ) < 2*delta_eta_est
+                )
+                if cut_on_panel and len(ang_crds) > 2:
+                    split_idx = np.argmax(
+                        np.abs(np.diff(ang_crds[:, 0]) - delta_eta_est)
+                    ) + 1
+
+                    ang_crds = np.vstack(
+                        [ang_crds[:split_idx, :],
+                         nans_row,
+                         ang_crds[split_idx:, :]]
+                    )
 
                 # append to list with nan padding
                 ring_pts.append(np.vstack([ang_crds, nans_row]))

--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -1,8 +1,6 @@
 import numpy as np
 
-from hexrd.constants import identity_3x3
 from hexrd.transforms import xfcapi
-from hexrd.xrdutil import _convert_angles
 
 from hexrd.ui.constants import ViewType
 
@@ -119,12 +117,12 @@ class PowderLineOverlay:
 
             # !!! must apply offset
             xys_full = panel.angles_to_cart(ang_crds, tvec_c=self.tvec)
-                
+
             # clip to detector panel
             xys, on_panel = panel.clip_to_panel(
                 xys_full, buffer_edges=False
             )
-            
+
             if display_mode == ViewType.polar:
                 if panel.distortion is not None:
                     xys = panel.distortion.apply(xys)


### PR DESCRIPTION
Fixed the powder overlays (no issue, just email thread).  Attached are the new simulation images with a BCC (sgnum 229, lparam 2.51Å) powder phase added at a 0.1625mm z-offset.  @saransh13 -- images here if you want them.
![Screenshot from 2020-09-24 16-40-45](https://user-images.githubusercontent.com/1154130/94210980-171b6c00-fe85-11ea-9a04-58124167f4a4.png)

[Tardis_BCC_and_LiF_sim.zip](https://github.com/HEXRD/hexrdgui/files/5279772/Tardis_BCC_and_LiF_sim.zip)
