### PR TITLE
Various structure tab fixes

### DIFF
--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -241,7 +241,6 @@ class MaterialStructureEditor:
         """The sites have a structure like the following:
         {
             'name': 'NaBr1',
-            'total_occupancy': 1.0,
             'fractional_coords': [0.25, 0.25, 0.25],
             'atoms': [
                 {
@@ -294,7 +293,6 @@ class MaterialStructureEditor:
 
             # Combine the symbols for a basic name
             site['name'] = self.next_name(''.join(symbols))
-            site['total_occupancy'] = sum(info_array[i][3] for i in indices)
             site['fractional_coords'] = coords
             site['atoms'] = []
 

--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -16,6 +16,24 @@ from hexrd.ui.material_site_editor import MaterialSiteEditor
 from hexrd.ui.ui_loader import UiLoader
 
 
+DEFAULT_SITE = {
+    'name': 'CeO',
+    'fractional_coords': [0, 0, 0],
+    'atoms': [
+        {
+            'symbol': 'O',
+            'occupancy': 0.5,
+            'U': 1e-6
+        },
+        {
+            'symbol': 'Ce',
+            'occupancy': 0.5,
+            'U': 1e-6
+        }
+    ],
+}
+
+
 class MaterialStructureEditor:
 
     def __init__(self, parent=None):
@@ -147,13 +165,7 @@ class MaterialStructureEditor:
         return new
 
     def add_site(self):
-        # Copy if the active site if there is one. Otherwise, copy the
-        # last row.
-        site = self.active_site
-        if site is None:
-            site = self.sites[-1]
-
-        self.sites.append(self.new_site(site))
+        self.sites.append(self.new_site(DEFAULT_SITE))
         self.update_table()
 
         # Select the newly added row

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -243,6 +243,7 @@ class MaterialsPanel(QObject):
         HexrdConfig().remove_material(name)
         self.material_editor_widget.material = HexrdConfig().active_material
         self.update_gui_from_config()
+        self.update_structure_tab()
 
     def modify_material_name(self):
         new_name = self.ui.materials_combo.currentText()

--- a/hexrd/ui/resources/ui/material_site_editor.ui
+++ b/hexrd/ui/resources/ui/material_site_editor.ui
@@ -30,23 +30,16 @@
       <string>Site Atom Types</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="1" column="1" colspan="2">
-       <widget class="QPushButton" name="select_atom_types">
-        <property name="text">
-         <string>Select Atom Types</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="1" colspan="2">
        <widget class="QTableWidget" name="table">
         <property name="editTriggers">
          <set>QAbstractItemView::NoEditTriggers</set>
         </property>
         <property name="selectionMode">
-         <enum>QAbstractItemView::NoSelection</enum>
+         <enum>QAbstractItemView::SingleSelection</enum>
         </property>
         <property name="selectionBehavior">
-         <enum>QAbstractItemView::SelectItems</enum>
+         <enum>QAbstractItemView::SelectRows</enum>
         </property>
         <attribute name="horizontalHeaderDefaultSectionSize">
          <number>120</number>
@@ -69,6 +62,23 @@
           <string>U</string>
          </property>
         </column>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="remove_atom_type">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>-</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QPushButton" name="select_atom_types">
+        <property name="text">
+         <string>Select Atom Types</string>
+        </property>
        </widget>
       </item>
      </layout>
@@ -198,6 +208,7 @@
   <tabstop>thermal_factor_type</tabstop>
   <tabstop>table</tabstop>
   <tabstop>select_atom_types</tabstop>
+  <tabstop>remove_atom_type</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/material_site_editor.ui
+++ b/hexrd/ui/resources/ui/material_site_editor.ui
@@ -92,6 +92,9 @@
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="1" colspan="3">
        <widget class="QDoubleSpinBox" name="total_occupancy">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>


### PR DESCRIPTION
This fixes 2 and 3 in #582 

It also fixes several of the general issues mentioned in #545 

Some of the changes:
1. Update structure tab on material deletion
2. Add remove button for atom types
3. Make total occupancy computed instead of editable, and set a max of 1
4. For newly added sites, use a default site instead of copying the previously selected site. The default site is CeO.

Fixes: #582 