### PR TITLE
Support converting masks between raw and polar views

### DIFF
--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -40,19 +40,19 @@ def _create_threshold_mask(img, comparison, value):
 
 def convert_polar_to_raw(line):
     line_data = []
-    for l in line:
-        for key, panel in create_hedm_instrument().detectors.items():
-            cart = panel.angles_to_cart(np.radians(l))
-            raw = panel.cartToPixel(cart)
-            line_data.append((key, raw))
+    for key, panel in create_hedm_instrument().detectors.items():
+        cart = panel.angles_to_cart(np.radians(line))
+        raw = panel.cartToPixel(cart)
+        line_data.append((key, raw))
     return line_data
 
 
 def create_raw_mask(name, line_data):
-    det, data = line_data
-    img = HexrdConfig().image(det, 0)
-    rr, cc = polygon(data[:, 1], data[:, 0], shape=img.shape)
-    if len(rr) >= 1:
-        mask = np.ones(img.shape, dtype=bool)
-        mask[rr, cc] = False
-        HexrdConfig().raw_masks[name] = (det, mask)
+    for l in line_data:
+        det, data = l
+        img = HexrdConfig().image(det, 0)
+        rr, cc = polygon(data[:, 1], data[:, 0], shape=img.shape)
+        if len(rr) >= 1:
+            mask = np.ones(img.shape, dtype=bool)
+            mask[rr, cc] = False
+            HexrdConfig().raw_masks[name] = (det, mask)

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -48,8 +48,8 @@ def convert_polar_to_raw(line):
 
 
 def create_raw_mask(name, line_data):
-    for l in line_data:
-        det, data = l
+    for line in line_data:
+        det, data = line
         img = HexrdConfig().image(det, 0)
         rr, cc = polygon(data[:, 1], data[:, 0], shape=img.shape)
         if len(rr) >= 1:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -817,8 +817,9 @@ class MainWindow(QObject):
             # Rebuild polar masks
             HexrdConfig().polar_masks.clear()
             for name, line_data in HexrdConfig().polar_masks_line_data.items():
-                create_polar_mask(line_data, name)
-            for name, (det, data) in HexrdConfig().raw_masks_line_data.items():
+                create_polar_mask([line_data], name)
+            for name, value in HexrdConfig().raw_masks_line_data.items():
+                det, data = value[0]
                 line_data = convert_raw_to_polar(det, data)
                 create_polar_mask(line_data, name)
             self.ui.image_tab_widget.show_polar()
@@ -829,8 +830,7 @@ class MainWindow(QObject):
                 create_raw_mask(name, line_data)
             for name, data in HexrdConfig().polar_masks_line_data.items():
                 line_data = convert_polar_to_raw(data)
-                for line in line_data:
-                    create_raw_mask(name, line)
+                create_raw_mask(name, line_data)
             self.ui.image_tab_widget.load_images()
 
         # Only ask if have haven't asked before

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -176,22 +176,22 @@ class MaskRegionsDialog(QObject):
         if self.image_mode == ViewType.raw:
             self.raw_masks_line_data.append((self.det, data_coords))
         elif self.image_mode == ViewType.polar:
-            self.polar_masks_line_data.append([data_coords])
+            self.polar_masks_line_data.append(data_coords)
 
     def create_masks(self):
         for data in self.raw_masks_line_data:
             name = create_unique_name(
                 HexrdConfig().raw_masks_line_data, 'raw_mask_0')
-            HexrdConfig().raw_masks_line_data[name] = data
-            create_raw_mask(name, data)
+            HexrdConfig().raw_masks_line_data[name] = [data]
+            create_raw_mask(name, [data])
             HexrdConfig().visible_masks.append(name)
             HexrdConfig().raw_masks_changed.emit()
 
         for data_coords in self.polar_masks_line_data:
             name = create_unique_name(
                 HexrdConfig().polar_masks_line_data, 'polar_mask_0')
-            HexrdConfig().polar_masks_line_data[name] = [data_coords]
-            create_polar_mask(data_coords, name)
+            HexrdConfig().polar_masks_line_data[name] = data_coords
+            create_polar_mask([data_coords], name)
             HexrdConfig().visible_masks.append(name)
             HexrdConfig().polar_masks_changed.emit()
 


### PR DESCRIPTION
Fixes #585

Masks created in raw view will be applied to polar and vice versa. At this point if masks created in polar view include points outside of a panel there will be errors - see [this comment](https://github.com/HEXRD/hexrdgui/issues/556#issuecomment-698049270) for discussion around this problem.