### PR TITLE
Hand mask in raw

### DIFF
--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -122,8 +122,8 @@ class HandDrawnMaskDialog(QObject):
         linebuilder.disconnect()
         self.ring_data.append(ring_data)
         self.dets.append(self.ax.get_title())
-        self.add_line()
         self.drawing = False
+        self.add_line()
 
     def button_pressed(self, event):
         if event.button == 1:

--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -68,8 +68,13 @@ class HandDrawnMaskDialog(QObject):
         self.cursor = None
 
         self.canvas.mpl_disconnect(self.bp_id)
+        self.canvas.mpl_disconnect(self.enter_id)
+        self.canvas.mpl_disconnect(self.exit_id)
+
         self.bp_id = None
-        self.canvas.draw_idle()
+        self.enter_id = None
+        self.exit_id = None
+        self.canvas.draw()
 
     def start(self):
         # list for set of rings 'picked'
@@ -117,8 +122,8 @@ class HandDrawnMaskDialog(QObject):
         linebuilder.disconnect()
         self.ring_data.append(ring_data)
         self.dets.append(self.ax.get_title())
-        self.drawing = False
         self.add_line()
+        self.drawing = False
 
     def button_pressed(self, event):
         if event.button == 1:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -594,13 +594,12 @@ class MainWindow(QObject):
             HexrdConfig().polar_masks_changed.emit()
         elif self.image_mode == ViewType.raw:
             for det, line in zip(dets, line_data):
-                for line in line_data:
-                    name = unique_name(
-                        HexrdConfig().raw_mask_coords, 'raw_mask_0')
-                    HexrdConfig().raw_mask_coords[name] = line.copy()
-                    HexrdConfig().visible_masks.append(name)
-                    create_raw_mask(name, [(det, line)])
-                HexrdConfig().raw_masks_changed.emit()
+                name = unique_name(
+                    HexrdConfig().raw_mask_coords, 'raw_mask_0')
+                HexrdConfig().raw_mask_coords[name] = [(det, line.copy())]
+                HexrdConfig().visible_masks.append(name)
+                create_raw_mask(name, [(det, line)])
+            HexrdConfig().raw_masks_changed.emit()
         self.new_mask_added.emit(self.image_mode)
 
     def on_action_edit_apply_laue_mask_to_polar_triggered(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -559,14 +559,23 @@ class MainWindow(QObject):
         self._apply_drawn_mask_line_picker.finished.connect(
             self.run_apply_polar_mask)
 
-    def run_apply_polar_mask(self, line_data):
-        for line in line_data:
-            name = create_unique_name(
-                HexrdConfig().polar_masks_line_data, 'polar_mask_0')
-            HexrdConfig().polar_masks_line_data[name] = line.copy()
-            HexrdConfig().visible_masks.append(name)
-            create_polar_mask([line.copy()], name)
-        HexrdConfig().polar_masks_changed.emit()
+    def run_apply_polar_mask(self, dets, line_data):
+        if self.image_mode == ViewType.raw:
+            for det, line in zip(dets, line_data):
+                name = create_unique_name(
+                    HexrdConfig().raw_masks_line_data, 'raw_mask_0')
+                HexrdConfig().raw_masks_line_data[name] = [(det, line.copy())]
+                HexrdConfig().visible_masks.append(name)
+                create_raw_mask(name, [(det, line.copy())])
+            HexrdConfig().raw_masks_changed.emit()
+        elif self.image_mode == ViewType.polar:
+            for line in line_data:
+                name = create_unique_name(
+                    HexrdConfig().polar_masks_line_data, 'polar_mask_0')
+                HexrdConfig().polar_masks_line_data[name] = line.copy()
+                HexrdConfig().visible_masks.append(name)
+                create_polar_mask([line.copy()], name)
+            HexrdConfig().polar_masks_changed.emit()
         self.new_mask_added.emit(self.image_mode)
 
     def on_action_edit_apply_laue_mask_to_polar_triggered(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -170,9 +170,9 @@ class MainWindow(QObject):
             self.on_action_export_current_plot_triggered)
         self.ui.action_edit_euler_angle_convention.triggered.connect(
             self.on_action_edit_euler_angle_convention)
-        self.ui.action_edit_apply_polar_mask.triggered.connect(
-            self.on_action_edit_apply_polar_mask_triggered)
-        self.ui.action_edit_apply_polar_mask.triggered.connect(
+        self.ui.action_edit_apply_hand_drawn_mask.triggered.connect(
+            self.on_action_edit_apply_hand_drawn_mask_triggered)
+        self.ui.action_edit_apply_hand_drawn_mask.triggered.connect(
             self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_edit_apply_laue_mask_to_polar.triggered.connect(
             self.on_action_edit_apply_laue_mask_to_polar_triggered)
@@ -550,13 +550,13 @@ class MainWindow(QObject):
         self.update_all()
         self.update_config_gui()
 
-    def on_action_edit_apply_polar_mask_triggered(self):
+    def on_action_edit_apply_hand_drawn_mask_triggered(self):
         # Make the dialog
         canvas = self.ui.image_tab_widget.image_canvases[0]
-        self._apply_polar_mask_line_picker = (
+        self._apply_drawn_mask_line_picker = (
             HandDrawnMaskDialog(canvas, self.ui))
-        self._apply_polar_mask_line_picker.start()
-        self._apply_polar_mask_line_picker.finished.connect(
+        self._apply_drawn_mask_line_picker.start()
+        self._apply_drawn_mask_line_picker.finished.connect(
             self.run_apply_polar_mask)
 
     def run_apply_polar_mask(self, line_data):
@@ -645,8 +645,8 @@ class MainWindow(QObject):
         self.ui.action_export_current_plot.setEnabled(
             (is_polar or is_cartesian) and has_images)
         self.ui.action_run_calibration.setEnabled(is_polar and has_images)
-        self.ui.action_edit_apply_polar_mask.setEnabled(is_polar and
-                                                        has_images)
+        self.ui.action_edit_apply_hand_drawn_mask.setEnabled(
+            is_polar and has_images)
         self.ui.action_run_wppf.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -753,6 +753,7 @@ class MainWindow(QObject):
                     # These are Laue spots
                     continue
                 else:
+                    # This is a single mask
                     line_data = convert_polar_to_raw(data)
                     create_raw_mask(name, line_data)
             self.ui.image_tab_widget.load_images()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -21,9 +21,8 @@ from hexrd.ui.indexing.fit_grains_results_dialog import FitGrainsResultsDialog
 from hexrd.ui.calibration.calibration_runner import CalibrationRunner
 from hexrd.ui.calibration.auto.powder_runner import PowderRunner
 from hexrd.ui.calibration.wppf_runner import WppfRunner
-from hexrd.ui.create_polar_mask import (
-    create_polar_mask, create_raw_mask, rebuild_polar_masks)
-from hexrd.ui.create_raw_mask import rebuild_raw_masks
+from hexrd.ui.create_polar_mask import create_polar_mask, rebuild_polar_masks
+from hexrd.ui.create_raw_mask import create_raw_mask, rebuild_raw_masks
 from hexrd.ui.utils import unique_name
 from hexrd.ui.constants import (
     OverlayType, ViewType, WORKFLOW_HEDM, WORKFLOW_LLNL)
@@ -585,12 +584,13 @@ class MainWindow(QObject):
             HexrdConfig().raw_masks_changed.emit()
         elif self.image_mode == ViewType.polar:
             for line in line_data:
-                name = unique_name({**raw_lines, **polar_lines}, 'polar_mask_0')
+                name = unique_name(
+                    {**raw_lines, **polar_lines}, 'polar_mask_0')
                 HexrdConfig().polar_masks_line_data[name] = line.copy()
                 HexrdConfig().visible_masks.append(name)
                 create_polar_mask([line.copy()], name)
             HexrdConfig().polar_masks_changed.emit()
-        # self.new_mask_added.emit(self.image_mode)
+        self.new_mask_added.emit(self.image_mode)
 
     def on_action_edit_apply_laue_mask_to_polar_triggered(self):
         if not HexrdConfig().show_overlays:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -580,9 +580,9 @@ class MainWindow(QObject):
             HandDrawnMaskDialog(canvas, self.ui))
         self._apply_drawn_mask_line_picker.start()
         self._apply_drawn_mask_line_picker.finished.connect(
-            self.run_apply_polar_mask)
+            self.run_apply_hand_drawn_mask)
 
-    def run_apply_polar_mask(self, dets, line_data):
+    def run_apply_hand_drawn_mask(self, dets, line_data):
         if self.image_mode == ViewType.polar:
             for line in line_data:
                 name = unique_name(

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -639,6 +639,7 @@ class MainWindow(QObject):
         # This is for enable states that depend on the image mode
         is_cartesian = self.image_mode == ViewType.cartesian
         is_polar = self.image_mode == ViewType.polar
+        is_raw = self.image_mode == ViewType.raw
 
         has_images = HexrdConfig().has_images()
 
@@ -646,7 +647,7 @@ class MainWindow(QObject):
             (is_polar or is_cartesian) and has_images)
         self.ui.action_run_calibration.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_hand_drawn_mask.setEnabled(
-            is_polar and has_images)
+            (is_polar or is_raw) and has_images)
         self.ui.action_run_wppf.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
 

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -200,9 +200,9 @@ class MaskManagerDialog(QObject):
                 value = HexrdConfig().raw_masks.pop(self.old_name)
                 HexrdConfig().raw_masks[new_name] = value
 
-            if self.old_name in self.visible:
-                self.visible.append(new_name)
-                self.visible.remove(self.old_name)
+            if self.old_name in HexrdConfig().visible_masks:
+                HexrdConfig().visible_masks.append(new_name)
+                HexrdConfig().visible_masks.remove(self.old_name)
         self.old_name = None
 
     def context_menu_event(self, event):

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -110,7 +110,7 @@
      <property name="title">
       <string>Masks</string>
      </property>
-     <addaction name="action_edit_apply_polar_mask"/>
+     <addaction name="action_edit_apply_hand_drawn_mask"/>
      <addaction name="action_edit_apply_laue_mask_to_polar"/>
      <addaction name="action_edit_apply_polygon_mask"/>
      <addaction name="action_open_mask_manager"/>
@@ -496,12 +496,15 @@
     <string>Switch Workflow</string>
    </property>
   </action>
-  <action name="action_edit_apply_polar_mask">
-   <property name="enabled">
+  <action name="action_edit_apply_hand_drawn_mask">
+   <property name="checkable">
     <bool>false</bool>
    </property>
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
    <property name="text">
-    <string>Apply Polygon to Polar</string>
+    <string>Apply Hand Drawn Mask</string>
    </property>
   </action>
   <action name="action_edit_apply_laue_mask_to_polar">


### PR DESCRIPTION
This branch supports masking by hand in the raw view the same way that the polar view currently supports masking by hand. Right now masks must be completed on the current detector (either by right-clicking or selecting `Okay` from the dialog) in order to begin masking on a new detector.

Additionally, masking for Laue spots is not currently supported in the raw view, as the converted polar-to-raw coordinates do not seem to be correct (the masking does not line up with the overlays).