### PR TITLE
Add extra WPPF params and update materials from output

### DIFF
--- a/hexrd/ui/calibration/wppf_options_dialog.py
+++ b/hexrd/ui/calibration/wppf_options_dialog.py
@@ -1,7 +1,9 @@
+import copy
 import importlib.resources
 import os
 from pathlib import Path
 
+import numpy as np
 import yaml
 
 from PySide2.QtCore import Qt, QObject, QSignalBlocker, Signal
@@ -9,6 +11,9 @@ from PySide2.QtWidgets import (
     QCheckBox, QFileDialog, QHBoxLayout, QMessageBox, QSizePolicy,
     QTableWidgetItem, QWidget
 )
+
+from hexrd.material import _angstroms
+from hexrd.WPPF import LeBail, Rietveld, Parameters
 
 from hexrd.ui import enter_key_filter
 
@@ -44,6 +49,7 @@ class WppfOptionsDialog(QObject):
 
         self.load_initial_params()
         self.load_settings()
+        self.update_extra_params()
 
         self.value_spinboxes = []
         self.minimum_spinboxes = []
@@ -60,6 +66,8 @@ class WppfOptionsDialog(QObject):
             self.update_visible_background_parameters)
         self.ui.select_experiment_file_button.pressed.connect(
             self.select_experiment_file)
+        self.ui.reset_table_to_defaults.pressed.connect(
+            self.reset_table_to_defaults)
 
         self.ui.accepted.connect(self.accept)
         self.ui.rejected.connect(self.reject)
@@ -87,7 +95,37 @@ class WppfOptionsDialog(QObject):
     def load_initial_params(self):
         text = importlib.resources.read_text(calibration_resources,
                                              'wppf_params.yml')
-        self.params = yaml.load(text, Loader=yaml.FullLoader)
+        self.default_params = yaml.load(text, Loader=yaml.FullLoader)
+        self.params = copy.deepcopy(self.default_params)
+
+    def update_extra_params(self):
+        # First, make a copy of the old params object. We will remove all
+        # extra params currently in place.
+        old_params = copy.deepcopy(self.params)
+        for key in list(self.params.keys()):
+            if key not in self.default_params:
+                del self.params[key]
+
+        # Next, create the WPPF object and allow it to add whatever params
+        # it wants to. Then we will add them to the new params.
+        wppf_object = self.create_wppf_object(add_params=True)
+        for key, obj in wppf_object.params.param_dict.items():
+            if key in self.params:
+                # Already present. Continue
+                continue
+
+            if key in old_params:
+                # Copy over the previous info for the key
+                self.params[key] = old_params[key]
+                continue
+
+            # Otherwise, copy it straight from the WPPF object.
+            self.params[key] = [
+                obj.value,
+                obj.lb,
+                obj.ub,
+                obj.vary
+            ]
 
     def show(self):
         self.ui.show()
@@ -120,6 +158,8 @@ class WppfOptionsDialog(QObject):
         dialog = SelectItemsDialog(items, self.ui)
         if dialog.exec_():
             self.selected_materials = dialog.selected_items
+            self.update_extra_params()
+            self.update_table()
 
     def update_visible_background_parameters(self):
         is_chebyshev = self.background_method == 'chebyshev'
@@ -225,6 +265,11 @@ class WppfOptionsDialog(QObject):
             HexrdConfig().working_dir = str(path.parent)
             self.ui.experiment_file.setText(selected_file)
 
+    def reset_table_to_defaults(self):
+        self.params = copy.deepcopy(self.default_params)
+        self.update_extra_params()
+        self.update_table()
+
     def create_label(self, v):
         w = QTableWidgetItem(v)
         w.setTextAlignment(Qt.AlignCenter)
@@ -322,6 +367,58 @@ class WppfOptionsDialog(QObject):
             'table'
         ]
         return [getattr(self.ui, x) for x in names]
+
+    def create_wppf_params_object(self):
+        params = Parameters()
+        for name, val in self.params.items():
+            kwargs = {
+                'name': name,
+                'value': float(val[0]),
+                'lb': float(val[1]),
+                'ub': float(val[2]),
+                'vary': bool(val[3])
+            }
+            params.add(**kwargs)
+        return params
+
+    def create_wppf_object(self, add_params=False):
+        # If add_params is True, it allows WPPF to add more parameters
+        # This is mostly for material lattice parameters
+
+        method = self.wppf_method
+        if method == 'LeBail':
+            class_type = LeBail
+        elif method == 'Rietveld':
+            class_type = Rietveld
+        else:
+            raise Exception(f'Unknown method: {method}')
+
+        if add_params:
+            params = self.params
+        else:
+            params = self.create_wppf_params_object()
+
+        wavelength = {
+            'synchrotron': _angstroms(HexrdConfig().beam_wavelength)
+        }
+
+        if self.use_experiment_file:
+            expt_spectrum = np.loadtxt(self.experiment_file)
+        else:
+            expt_spectrum = HexrdConfig().last_azimuthal_integral_data
+            # Re-format it to match the expected input format
+            expt_spectrum = np.array(list(zip(*expt_spectrum)))
+
+        phases = [HexrdConfig().material(x) for x in self.selected_materials]
+        kwargs = {
+            'expt_spectrum': expt_spectrum,
+            'params': params,
+            'phases': phases,
+            'wavelength': wavelength,
+            'bkgmethod': self.background_method_dict
+        }
+
+        return class_type(**kwargs)
 
 
 if __name__ == '__main__':

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -90,6 +90,8 @@ class MaterialsPanel(QObject):
 
         HexrdConfig().active_material_modified.connect(
             self.update_gui_from_config)
+        HexrdConfig().active_material_modified.connect(
+            self.material_editor_widget.update_gui_from_material)
 
     def update_enable_states(self):
         limit_active = self.ui.limit_active.isChecked()

--- a/hexrd/ui/resources/ui/wppf_options_dialog.ui
+++ b/hexrd/ui/resources/ui/wppf_options_dialog.ui
@@ -11,13 +11,61 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="8" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="5" column="0">
+    <widget class="QCheckBox" name="use_experiment_file">
+     <property name="text">
+      <string>Use Experiment File</string>
      </property>
-     <property name="centerButtons">
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="background_method_label">
+     <property name="text">
+      <string>Background Method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <widget class="QPushButton" name="select_materials_button">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Select Materials</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <layout class="QGridLayout" name="background_method_parameters_layout">
+     <item row="1" column="0">
+      <widget class="QLabel" name="chebyshev_polynomial_degree_label">
+       <property name="text">
+        <string>Chebyshev Polynomial Degree:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QSpinBox" name="chebyshev_polynomial_degree">
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <number>100000000</number>
+       </property>
+       <property name="value">
+        <number>6</number>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="1">
+    <widget class="QLineEdit" name="experiment_file">
+     <property name="enabled">
       <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
      </property>
     </widget>
    </item>
@@ -49,50 +97,6 @@
      </item>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSpinBox" name="refinement_steps">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10000000</number>
-     </property>
-     <property name="value">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="refinement_steps_label">
-     <property name="text">
-      <string>Refinement Steps:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="3">
-    <layout class="QGridLayout" name="background_method_parameters_layout">
-     <item row="1" column="0">
-      <widget class="QLabel" name="chebyshev_polynomial_degree_label">
-       <property name="text">
-        <string>Chebyshev Polynomial Degree:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QSpinBox" name="chebyshev_polynomial_degree">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>100000000</number>
-       </property>
-       <property name="value">
-        <number>6</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
    <item row="5" column="2">
     <widget class="QPushButton" name="select_experiment_file_button">
      <property name="enabled">
@@ -100,37 +104,6 @@
      </property>
      <property name="text">
       <string>Select File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QCheckBox" name="use_experiment_file">
-     <property name="text">
-      <string>Use Experiment File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="wppf_method_label">
-     <property name="text">
-      <string>WPPF Method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QLineEdit" name="experiment_file">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="background_method_label">
-     <property name="text">
-      <string>Background Method:</string>
      </property>
     </widget>
    </item>
@@ -169,13 +142,47 @@
      </column>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QPushButton" name="select_materials_button">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+   <item row="9" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="refinement_steps">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000000</number>
+     </property>
+     <property name="value">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="wppf_method_label">
      <property name="text">
-      <string>Select Materials</string>
+      <string>WPPF Method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="refinement_steps_label">
+     <property name="text">
+      <string>Refinement Steps:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="3">
+    <widget class="QPushButton" name="reset_table_to_defaults">
+     <property name="text">
+      <string>Reset Table to Defaults</string>
      </property>
     </widget>
    </item>
@@ -191,6 +198,7 @@
   <tabstop>experiment_file</tabstop>
   <tabstop>select_experiment_file_button</tabstop>
   <tabstop>table</tabstop>
+  <tabstop>reset_table_to_defaults</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -201,8 +209,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>217</x>
-     <y>205</y>
+     <x>226</x>
+     <y>383</y>
     </hint>
     <hint type="destinationlabel">
      <x>217</x>
@@ -217,8 +225,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>217</x>
-     <y>205</y>
+     <x>226</x>
+     <y>383</y>
     </hint>
     <hint type="destinationlabel">
      <x>217</x>
@@ -233,12 +241,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>89</x>
-     <y>149</y>
+     <x>98</x>
+     <y>191</y>
     </hint>
     <hint type="destinationlabel">
-     <x>357</x>
-     <y>149</y>
+     <x>533</x>
+     <y>192</y>
     </hint>
    </hints>
   </connection>
@@ -249,12 +257,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>89</x>
-     <y>149</y>
+     <x>98</x>
+     <y>191</y>
     </hint>
     <hint type="destinationlabel">
-     <x>585</x>
-     <y>149</y>
+     <x>625</x>
+     <y>192</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
This adds the extra refinement options for the materials' lattice parameters to the WPPF options table,
and it also updates the material objects in hexrdgui from the output of WPPF.

![wppf_extra_params](https://user-images.githubusercontent.com/9558430/94471792-be571680-0197-11eb-8fa1-621522686711.gif)

Fixes: #588