### PR TITLE
Only allow unique powder params to be refinable

### DIFF
--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -77,8 +77,7 @@ class CalibrationCrystalEditor(QObject):
 
     @refinements.setter
     def refinements(self, v):
-        self.refinements_selector.items = copy.deepcopy(v)
-        self.refinements_selector.update_table()
+        self.refinements_selector.items = v
 
     def refinements_edited(self):
         self.refinements_modified.emit()

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -70,6 +70,8 @@ class MaterialsPanel(QObject):
 
         self.material_editor_widget.material_modified.connect(
             self.update_table)
+        self.material_editor_widget.material_modified.connect(
+            self.update_refinement_options)
 
         self.ui.show_materials_table.pressed.connect(self.show_materials_table)
         self.ui.show_overlay_manager.pressed.connect(self.show_overlay_manager)
@@ -272,6 +274,12 @@ class MaterialsPanel(QObject):
 
     def update_table(self):
         self.materials_table.update_table()
+
+    def update_refinement_options(self):
+        if not hasattr(self, '_overlay_manager'):
+            return
+
+        self._overlay_manager.update_refinement_options()
 
     def eventFilter(self, target, event):
         # This is almost identical to CalibrationConfigWidget.eventFilter

--- a/hexrd/ui/overlay_editor.py
+++ b/hexrd/ui/overlay_editor.py
@@ -65,3 +65,7 @@ class OverlayEditor:
             return
 
         w.update_gui()
+
+    def update_refinement_options(self):
+        # Right now, only powder refinement options can vary
+        self.powder_overlay_editor.update_refinement_options()

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -214,6 +214,9 @@ class OverlayManager:
         i = self.selected_row
         return HexrdConfig().overlays[i] if i is not None else None
 
+    def update_refinement_options(self):
+        self.overlay_editor.update_refinement_options()
+
     def add(self):
         HexrdConfig().append_overlay(self.active_material_name,
                                      OverlayType.powder)

--- a/hexrd/ui/select_items_widget.py
+++ b/hexrd/ui/select_items_widget.py
@@ -1,3 +1,5 @@
+import copy
+
 from PySide2.QtCore import QObject, Qt, Signal
 from PySide2.QtWidgets import QCheckBox, QHBoxLayout, QTableWidgetItem, QWidget
 
@@ -20,12 +22,19 @@ class SelectItemsWidget(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('select_items_widget.ui', parent)
 
+        self.checkboxes = []
+
         # The items should be a list of tuples of length two, like
         # (name, selected).
         self.items = items
 
-        self.checkboxes = []
+    @property
+    def items(self):
+        return self._items
 
+    @items.setter
+    def items(self, v):
+        self._items = copy.deepcopy(v)
         self.update_table()
 
     def create_table_widget(self, w):


### PR DESCRIPTION
It doesn't make sense to display non-unique lattice parameters
as being refinable in the powder overlay editor.

Only display unique powder parameters.

Sapphire, for example:

![image](https://user-images.githubusercontent.com/9558430/94497675-eeb5a980-01c5-11eb-911f-0bad06df1df5.png)