### PR TITLE
Create QLineEdit directly to avoid issue on Windows

### DIFF
--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -336,6 +336,6 @@ class EditorFactory(QItemEditorFactory):
         super().__init__(self, parent)
 
     def createEditor(self, user_type, parent):
-        editor = super().createEditor(user_type, parent)
+        editor = QLineEdit(parent)
         editor.setAlignment(Qt.AlignCenter)
         return editor


### PR DESCRIPTION
For some reason on Windows if we call super().createEditor(user_type, parent) it doesn't create a line edit, so create it directly.