### PR TITLE
Do not mask Laue spots in raw view

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -798,8 +798,12 @@ class MainWindow(QObject):
             for name, line_data in HexrdConfig().raw_masks_line_data.items():
                 create_raw_mask(name, line_data)
             for name, data in HexrdConfig().polar_masks_line_data.items():
-                line_data = convert_polar_to_raw(data)
-                create_raw_mask(name, line_data)
+                if isinstance(data, list):
+                    # These are Laue spots
+                    continue
+                else:
+                    line_data = convert_polar_to_raw(data)
+                    create_raw_mask(name, line_data)
             self.ui.image_tab_widget.load_images()
 
         # Only ask if have haven't asked before

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -66,7 +66,8 @@ class MaskManagerDialog(QObject):
         elif mask_type == 'raw':
             if not HexrdConfig().raw_masks_line_data:
                 return
-            for name, (det, val) in HexrdConfig().raw_masks_line_data.items():
+            for name, value in HexrdConfig().raw_masks_line_data.items():
+                det, val = value[0]
                 vals = self.masks.values()
                 if any(np.array_equal(val, m) for t, m in vals):
                     continue


### PR DESCRIPTION
This provides a temporary fix for the exception described in #608, produced by switching back to raw view with Laue masks applied. Laue masks are simply not applied to the raw view.

This should be fixed in the future, but right now I don't think we'd have the time - as discussed in #595, the mask for Laue spots is completely incorrect when translated to raw right now, even when pulling from the ranges used by the overlays. This may not be a complicated fix, but it was not obvious to me what was going wrong when I tried to debug the issue yesterday.