### PR TITLE
Obtain and save more information in calibration runner

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -141,6 +141,7 @@ class CalibrationRunner:
                 'material': overlay['material'],
                 'type': overlay['type'].value,
                 'options': overlay['options'],
+                'refinements': overlay['refinements'],
                 'picks': val
             })
 

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -128,19 +128,26 @@ class CalibrationRunner:
         # Temporary
         import json
 
+        class NumpyEncoder(json.JSONEncoder):
+            def default(self, obj):
+                if isinstance(obj, np.ndarray):
+                    return obj.tolist()
+                return json.JSONEncoder.default(self, obj)
+
         pick_results = []
         for i, val in self.all_overlay_picks.items():
             overlay = self.overlays[i]
             pick_results.append({
                 'material': overlay['material'],
                 'type': overlay['type'].value,
+                'options': overlay['options'],
                 'picks': val
             })
 
         out_file = 'calibration_picks.json'
         print(f'Writing out picks to {out_file}')
         with open(out_file, 'w') as wf:
-            json.dump(pick_results, wf)
+            json.dump(pick_results, wf, cls=NumpyEncoder)
 
     def set_exclusive_overlay_visibility(self, overlay):
         self.overlay_visibilities = [overlay is x for x in self.overlays]

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -143,6 +143,12 @@ class CalibrationRunner:
                 refinements = default_overlay_refinements(overlay['type'])
             return refinements
 
+        def get_hkls(overlay):
+            return {
+                key: val.get('hkls', [])
+                for key, val in overlay['data'].items()
+            }
+
         pick_results = []
         for i, val in self.all_overlay_picks.items():
             overlay = self.overlays[i]
@@ -151,6 +157,7 @@ class CalibrationRunner:
                 'type': overlay['type'].value,
                 'options': overlay['options'],
                 'refinements': get_refinements(overlay),
+                'hkls': get_hkls(overlay),
                 'picks': val
             })
 

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -127,12 +127,21 @@ class CalibrationRunner:
     def finish(self):
         # Temporary
         import json
+        import pickle
+        from hexrd.ui.create_hedm_instrument import create_hedm_instrument
+        from hexrd.ui.overlays import default_overlay_refinements
 
         class NumpyEncoder(json.JSONEncoder):
             def default(self, obj):
                 if isinstance(obj, np.ndarray):
                     return obj.tolist()
                 return json.JSONEncoder.default(self, obj)
+
+        def get_refinements(overlay):
+            refinements = overlay.get('refinements')
+            if refinements is None:
+                refinements = default_overlay_refinements(overlay['type'])
+            return refinements
 
         pick_results = []
         for i, val in self.all_overlay_picks.items():
@@ -141,14 +150,32 @@ class CalibrationRunner:
                 'material': overlay['material'],
                 'type': overlay['type'].value,
                 'options': overlay['options'],
-                'refinements': overlay['refinements'],
+                'refinements': get_refinements(overlay),
                 'picks': val
             })
+
+            # Dump out the material
+            mat_file_name = overlay['material'] + '.pkl'
+            print(f'Writing out material to {mat_file_name}')
+            with open(mat_file_name, 'wb') as wf:
+                pickle.dump(HexrdConfig().material(overlay['material']), wf)
 
         out_file = 'calibration_picks.json'
         print(f'Writing out picks to {out_file}')
         with open(out_file, 'w') as wf:
             json.dump(pick_results, wf, cls=NumpyEncoder)
+
+        # Dump out the instrument as well
+        instr = create_hedm_instrument()
+        print(f'Writing out instrument to instrument.pkl')
+        with open('instrument.pkl', 'wb') as wf:
+            pickle.dump(instr, wf)
+
+        # Dump out refinement flags
+        flags = HexrdConfig().get_statuses_instrument_format()
+        print(f'Writing out refinement flags to refinement_flags.json')
+        with open('refinement_flags.json', 'w') as wf:
+            json.dump(flags, wf, cls=NumpyEncoder)
 
     def set_exclusive_overlay_visibility(self, overlay):
         self.overlay_visibilities = [overlay is x for x in self.overlays]

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -120,7 +120,7 @@ class LaueSpotOverlay:
             grain_params=[self.crystal_params, ])
 
         point_groups = {}
-        keys = ['spots', 'ranges']
+        keys = ['spots', 'ranges', 'hkls']
         for det_key, psim in sim_data.items():
             point_groups[det_key] = {key: [] for key in keys}
 
@@ -136,6 +136,7 @@ class LaueSpotOverlay:
             # filter (tth, eta) results
             xy_data = xy_det[0][idx, :]
             angles = angles[0][idx, :]  # these are in radians
+            point_groups[det_key]['hkls'] = hkls_in[0][:, idx].T
             angles[:, 1] = xfcapi.mapAngle(
                 angles[:, 1], np.radians(self.eta_period), units='radians'
             )


### PR DESCRIPTION
Here is the information that is being saved now after the calibration picks are complete:

1. All overlay options get written out to "calibration_picks.json" as well, under the "options" key. Overlay options include powder overlay offsets, and Laue crystal parameters, and more information too such as the laue widths, min/max energy, etc.
2. All overlay refinements get written out to "calibration_picks.json" as well, under the "refinements" key. Refinements consist of a list of (label, bool) pairs, where they should be sorted in the proper order. The powder refinements should only contain the required lattice parameters, in the right order. And, the laue should have the refineable options in the same order as the crystal parameters.
3. All materials used (including their plane data) are dumped out as "<material_name>.pkl" files, and the instrument gets dumped out as "instrument.pkl".
5. The general refinement flags are dumped as well into "refinement_flags.json".
6. The Laue hkls are saved as well in "calibration_picks.json", under the "hkls" key. It is a dict where the key is the detector, and they should be in the same order as the picks. However, the "hkls" might be a little longer than the picks if the user finished the picks early by pressing the "Ok" button.

