### PR TITLE
Always update polar view when beam vector changes

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -186,8 +186,6 @@ class MainWindow(QObject):
             self.new_mouse_position)
         self.ui.image_tab_widget.clear_mouse_position.connect(
             self.ui.status_bar.clearMessage)
-        self.calibration_slider_widget.update_if_mode_matches.connect(
-            self.update_if_mode_matches)
         self.load_widget.images_loaded.connect(self.images_loaded)
         self.import_data_widget.new_config_loaded.connect(
             self.update_config_gui)


### PR DESCRIPTION
The polar view was only being updated for changes to the beam vector
in the slider widget, but not for changes to the beam vector in the
form view or tree view.

It now updates for all three views. There is also a timer attached to
it so that if the slider view is being used, it doesn't trigger too
many updates.

Fixes: #607