### PR TITLE
Update overlays in raw view mode on detector edit

### DIFF
--- a/hexrd/ui/calibration/raw_iviewer.py
+++ b/hexrd/ui/calibration/raw_iviewer.py
@@ -1,5 +1,6 @@
 from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
+from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlays import update_overlay_data
 
 
@@ -15,3 +16,13 @@ class InstrumentViewer:
 
     def update_overlay_data(self):
         update_overlay_data(self.instr, self.type)
+
+    def update_detector(self, det):
+        # First, convert to the "None" angle convention
+        iconfig = HexrdConfig().instrument_config_none_euler_convention
+
+        t_conf = iconfig['detectors'][det]['transform']
+        self.instr.detectors[det].tvec = t_conf['translation']
+        self.instr.detectors[det].tilt = t_conf['tilt']
+
+        # Since these are just individual images, no further updates are needed

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -688,10 +688,16 @@ class ImageCanvas(FigureCanvas):
         self.wppf_plot = axis.scatter(*wppf_data, **style)
 
     def on_detector_transform_modified(self, det):
-        if self.mode not in [ViewType.cartesian, ViewType.polar]:
+        if self.mode is None:
             return
 
         self.iviewer.update_detector(det)
+        if self.mode == ViewType.raw:
+            # Only overlays need to be updated
+            HexrdConfig().flag_overlay_updates_for_all_materials()
+            self.update_overlays()
+            return
+
         self.axes_images[0].set_data(self.iviewer.img)
 
         # This will only run if we are in polar mode


### PR DESCRIPTION
When the detector transforms get modified, update the overlays
in the raw view.

This is a little slow to use in the slider view, because it is
currently re-generating overlays for all of the raw images (not just
the one that got changed). But maybe we can fix that in the future...

Fixes: #592