### PR TITLE
Give the zoom canvas an expanding size policy

### DIFF
--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -55,7 +55,7 @@ class LinePickerDialog(QObject):
         self.zoom_canvas = ZoomCanvas(canvas)
         self.zoom_canvas.tth_tol = self.ui.zoom_tth_width.value()
         self.zoom_canvas.eta_tol = self.ui.zoom_eta_width.value()
-        self.ui.layout().insertWidget(1, self.zoom_canvas)
+        self.ui.zoom_canvas_layout.addWidget(self.zoom_canvas)
 
         prop_cycle = plt.rcParams['axes.prop_cycle']
         self.color_cycler = cycle(prop_cycle.by_key()['color'])

--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -13,7 +13,7 @@
   <layout class="QVBoxLayout" name="verticalLayout_2">
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="zoom_eta_width_label">
        <property name="text">
         <string>Zoom η Width:</string>
@@ -34,39 +34,34 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="6" column="1">
+      <widget class="QPushButton" name="back_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the most recently picked point&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Back</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
       <widget class="QLabel" name="zoom_tth_width_label">
        <property name="text">
         <string>Zoom 2θ Width:</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="zoom_tth_width">
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
-       <property name="minimum">
-        <double>0.001000000000000</double>
-       </property>
-       <property name="maximum">
-        <double>1000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.200000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.500000000000000</double>
+     <item row="2" column="0" colspan="2">
+      <widget class="QLabel" name="finish_label">
+       <property name="text">
+        <string>Click &quot;Ok&quot; to finish.</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QDoubleSpinBox" name="zoom_eta_width">
        <property name="keyboardTracking">
         <bool>false</bool>
@@ -91,25 +86,33 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0" colspan="2">
-      <widget class="QLabel" name="finish_label">
-       <property name="text">
-        <string>Click &quot;Ok&quot; to finish.</string>
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="zoom_tth_width">
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="suffix">
+        <string>°</string>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="minimum">
+        <double>0.001000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>1000.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.200000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.500000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QPushButton" name="back_button">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Remove the most recently picked point&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Back</string>
-       </property>
-      </widget>
+     <item row="3" column="0" colspan="2">
+      <layout class="QVBoxLayout" name="zoom_canvas_layout"/>
      </item>
     </layout>
    </item>

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -1,3 +1,5 @@
+from PySide2.QtWidgets import QSizePolicy
+
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 
 from matplotlib.figure import Figure
@@ -9,7 +11,9 @@ class ZoomCanvas(FigureCanvas):
 
     def __init__(self, main_canvas, draw_crosshairs=True):
         self.figure = Figure()
-        super(FigureCanvas, self).__init__(self.figure)
+        super().__init__(self.figure)
+
+        self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
         self.main_canvas = main_canvas
         self.pv = main_canvas.iviewer.pv


### PR DESCRIPTION
By default, get the zoom canvas to expand the most that it can.

This makes resizing the line picker dialog actually useful.