### PR TITLE
Add two click option to line picker dialog

### DIFF
--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -114,6 +114,16 @@
      <item row="3" column="0" colspan="2">
       <layout class="QVBoxLayout" name="zoom_canvas_layout"/>
      </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="two_click_mode">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If enabled, upon the first click on the main canvas, the zoom will be frozen, and then the user will click on the zoom canvas for the point to be added.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Two click mode</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -128,6 +138,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>zoom_tth_width</tabstop>
+  <tabstop>zoom_eta_width</tabstop>
+  <tabstop>two_click_mode</tabstop>
+  <tabstop>back_button</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -118,7 +118,7 @@ class ZoomCanvas(FigureCanvas):
         i_row = pv.eta_to_pixel(np.radians(roi_deg[:, 1]))
         j_col = pv.tth_to_pixel(np.radians(roi_deg[:, 0]))
 
-        # Convert to intgers
+        # Convert to integers
         i_row = np.round(i_row).astype(int)
         j_col = np.round(j_col).astype(int)
 


### PR DESCRIPTION
If enabled, the two click option will have the user first click on
the main canvas, at which point the zoom canvas will be frozen. The
user must then click on the zoom canvas to add the point.

It allows for finer point picking.

![two_pick_mode](https://user-images.githubusercontent.com/9558430/94612070-95ef1b00-0270-11eb-8401-42149c794e4e.gif)

Fixes: #242
Fixes: #485