### PR TITLE
Keep zoom canvas cmap and norm up to date

### DIFF
--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -170,6 +170,10 @@ class ZoomCanvas(FigureCanvas):
             self.axes_images = [im1, im2]
             self.grid = grid
         else:
+            # Make sure we update the color map and norm each time
+            self.axes_images[0].set_cmap(self.main_canvas.cmap)
+            self.axes_images[0].set_norm(self.main_canvas.norm)
+
             self.axes[0].set_xlim(*xlims)
             self.axes[0].set_ylim(*ylims)
             self.axes_images[1].set_data(a2_data)


### PR DESCRIPTION
Keep the zoom canvas cmap and norm in sync with the main
canvas cmap and norm, so that if the user modifies the main
canvas cmap and norm, the zoom canvas gets updated also.

Hopefully, this won't slow down the performance much...