### PR TITLE
Add y integration and extended cursor to zoom canvas

### DIFF
--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -39,8 +39,10 @@ class ZoomCanvas(FigureCanvas):
         self.setup_connections()
 
     def setup_connections(self):
-        self.mne_id = self.main_canvas.mpl_connect('motion_notify_event',
-                                                   self.mouse_moved)
+        self.mc_mne_id = self.main_canvas.mpl_connect(
+            'motion_notify_event', self.main_canvas_mouse_moved)
+        self.mne_id = self.mpl_connect('motion_notify_event',
+                                       self.mouse_moved)
         self.bp_id = self.mpl_connect('button_press_event',
                                       self.button_pressed)
 
@@ -52,9 +54,17 @@ class ZoomCanvas(FigureCanvas):
         self.remove_overlay_lines()
 
     def disconnect(self):
+        if self.mc_mne_id is not None:
+            self.main_canvas.mpl_disconnect(self.mc_mne_id)
+            self.mc_mne_id = None
+
         if self.mne_id is not None:
-            self.main_canvas.mpl_disconnect(self.mne_id)
+            self.mpl_disconnect(self.mne_id)
             self.mne_id = None
+
+        if self.bp_id is not None:
+            self.mpl_disconnect(self.bp_id)
+            self.bp_id = None
 
     def remove_overlay_lines(self):
         if self.box_overlay_line is not None:
@@ -78,6 +88,11 @@ class ZoomCanvas(FigureCanvas):
         self.point_picked.emit(event)
 
     def mouse_moved(self, event):
+        # Clear the crosshairs when the mouse is moving over the canvas
+        self.clear_crosshairs()
+        self.draw()
+
+    def main_canvas_mouse_moved(self, event):
         if event.inaxes is None:
             # Do nothing...
             return

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -24,6 +24,7 @@ class ZoomCanvas(FigureCanvas):
 
         self.draw_crosshairs = draw_crosshairs
 
+        self.axes = None
         self.axes_images = None
         self.frozen = False
 
@@ -31,6 +32,7 @@ class ZoomCanvas(FigureCanvas):
         ax = self.main_canvas.axis
         self.box_overlay_line = ax.plot([], [], 'm-')[0]
         self.crosshairs = None
+        self.vhlines = None
 
         # user-specified ROI in degrees (from interactors)
         self.tth_tol = 0.5
@@ -90,7 +92,19 @@ class ZoomCanvas(FigureCanvas):
     def mouse_moved(self, event):
         # Clear the crosshairs when the mouse is moving over the canvas
         self.clear_crosshairs()
+        self.update_vhlines(event)
         self.draw()
+
+    def update_vhlines(self, event):
+        # These are vertical and horizontal lines on the integral axes
+        if any(not x for x in [self.vhlines, self.axes]):
+            return
+
+        _, a2, a3 = self.axes
+        vline, hline = self.vhlines
+
+        vline.set_data([event.xdata] * 2, a2.get_ylim())
+        hline.set_data(a3.get_xlim(), [event.ydata] * 2)
 
     def main_canvas_mouse_moved(self, event):
         if event.inaxes is None:
@@ -195,6 +209,11 @@ class ZoomCanvas(FigureCanvas):
             self.axes = [a1, a2, a3]
             self.axes_images = [im1, im2, im3]
             self.grid = grid
+
+            # These are vertical and horizontal lines on the integral axes
+            vline, = a2.plot([], [], color='red', linewidth=1)
+            hline, = a3.plot([], [], color='red', linewidth=1)
+            self.vhlines = [vline, hline]
         else:
             # Make sure we update the color map and norm each time
             self.axes_images[0].set_cmap(self.main_canvas.cmap)

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -4,6 +4,7 @@ from PySide2.QtWidgets import QSizePolicy
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 
 from matplotlib.figure import Figure
+from matplotlib.widgets import Cursor
 
 import numpy as np
 
@@ -160,6 +161,7 @@ class ZoomCanvas(FigureCanvas):
                             interpolation='none')
             a1.axis('auto')
             a1.label_outer()
+            self.cursor = Cursor(a1, useblit=True, color='red', linewidth=1)
             im2, = a2.plot(a2_data[0], a2_data[1])
             self.figure.suptitle(r"ROI zoom")
             a2.set_xlabel(r"$2\theta$ [deg]")


### PR DESCRIPTION
This adds a y integration plot to the zoom canvas on the right side of it, to assist with picking Laue spots. It also adds a cursor when the mouse is over the canvas, and the cursor is extended to the two integration axes.

The crosshairs are also removed when the mouse is over the zoom canvas.

![new_zoom_features](https://user-images.githubusercontent.com/9558430/94699973-f16ce780-0308-11eb-85f6-4de3b7490118.gif)
