### PR TITLE
Only remove last Laue spot when back pressed

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -420,4 +420,5 @@ class CalibrationRunner:
             self.current_data_list.pop(-1)
         elif self.active_overlay_type == OverlayType.laue:
             self.decrement_overlay_data_index()
-            self.current_data_list.clear()
+            if self.current_data_list:
+                self.current_data_list.pop(-1)


### PR DESCRIPTION
This was previously removing all Laue spots in the current detector
when the back button was pressed. Only remove the last Laue spot.