### PR TITLE
Update install to get fabio for HEXRD channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ pip install -e hexrdgui
 # If it is not, run the following command:
 conda install -c anaconda python=3.8
 # Install deps using conda package
-conda install -c HEXRD -c cjh1 -c anaconda -c conda-forge hexrdgui
+conda install -c HEXRD -c anaconda -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 pip install --no-deps -U -e hexrd
 CONDA_BUILD=1 pip install --no-deps -U -e hexrdgui
@@ -37,7 +37,7 @@ CONDA_BUILD=1 pip install --no-deps -U -e hexrdgui
 # See the following issue for more details: https://github.com/HEXRD/hexrdgui/issues/505
 conda install -c HEXRD python=3.8.4
 # Install deps using conda package
-conda install -c HEXRD -c cjh1 -c anaconda -c conda-forge hexrdgui
+conda install -c HEXRD -c anaconda -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 pip install --no-deps -U -e hexrd
 CONDA_BUILD=1 pip install --no-deps -U -e hexrdgui
@@ -49,7 +49,7 @@ CONDA_BUILD=1 pip install --no-deps -U -e hexrdgui
 # If it is not, run the following command:
 conda install -c anaconda python=3.8
 # Install deps using conda package
-conda install -c HEXRD -c cjh1 -c anaconda -c conda-forge hexrdgui
+conda install -c HEXRD -c anaconda -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 pip install --no-deps -U -e hexrd
 set CONDA_BUILD=1
@@ -66,14 +66,14 @@ and stderr is not appearing in the console you can run the python module directl
 ### Install the latest release
 
 ```bash
-conda install -c hexrd -c cjh1 -c anaconda -c conda-forge hexrdgui
+conda install -c hexrd -c anaconda -c conda-forge hexrdgui
 ```
 
 ## conda (prerelease)
 ### Install the latest changes on master. This release may be unstable.
 
 ```bash
-conda install -c hexrd/label/hexrd-prerelease -c hexrd/label/hexrdgui-prerelease -c cjh1 -c anaconda -c conda-forge hexrdgui
+conda install -c hexrd/label/hexrd-prerelease -c hexrd/label/hexrdgui-prerelease -c HEXRD -c anaconda -c conda-forge hexrdgui
 ```
 
 ## Binary packages


### PR DESCRIPTION
@joelvbernier This updates the instructions to use a update version of fabio with the TIFF fix.