### PR TITLE
Add stiffness tensor editor and strain to stress conversion

### DIFF
--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -381,6 +381,11 @@ if __name__ == '__main__':
     # print(data)
 
     dialog = FitGrainsResultsDialog(data)
+
+    # For the sample, don't make it a Qt tool
+    flags = dialog.ui.windowFlags()
+    dialog.ui.setWindowFlags(flags & ~Qt.Tool)
+
     dialog.ui.resize(1200, 800)
     dialog.finished.connect(app.quit)
     dialog.show()

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -235,8 +235,11 @@ class IndexingRunner(QObject):
             gw.dump_grain(*result)
         gw.close()
 
+        # Use the material to compute stress from strain
+        material = HexrdConfig().active_material
+
         # Display results dialog
-        dialog = FitGrainsResultsDialog(grains_table, self.parent)
+        dialog = FitGrainsResultsDialog(grains_table, material, self.parent)
         dialog.ui.resize(1200, 800)
         self.fit_grains_results_dialog = dialog
         dialog.show()

--- a/hexrd/ui/material_properties_editor.py
+++ b/hexrd/ui/material_properties_editor.py
@@ -1,0 +1,66 @@
+import copy
+import numpy as np
+
+from hexrd.unitcell import _StiffnessDict
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.matrix_editor import MatrixEditor
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import compose
+
+
+class MaterialPropertiesEditor:
+
+    stiffness_tensor_shape = (6, 6)
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('material_properties_editor.ui', parent)
+
+        self.null_tensor = np.zeros(self.stiffness_tensor_shape)
+        self.stiffness_tensor_editor = MatrixEditor(self.null_tensor, self.ui)
+        self.ui.stiffness_tensor_editor_layout.addWidget(
+            self.stiffness_tensor_editor)
+
+        self.setup_connections()
+
+        self.update_gui()
+
+    def setup_connections(self):
+        self.stiffness_tensor_editor.data_modified.connect(
+            self.stiffness_tensor_edited)
+
+    @property
+    def material(self):
+        return HexrdConfig().active_material
+
+    def update_gui(self):
+        material = self.material
+        if hasattr(material.unitcell, 'stiffness'):
+            data = copy.deepcopy(material.unitcell.stiffness)
+        else:
+            # Just use zeros...
+            data = np.zeros(self.stiffness_tensor_shape)
+
+        enabled, constraints = _StiffnessDict[material.unitcell._laueGroup]
+
+        constraints_func = compose(apply_symmetric_constraint, constraints)
+
+        editor = self.stiffness_tensor_editor
+        editor.enabled_elements = enabled
+        editor.apply_constraints_func = constraints_func
+        editor.data = data
+
+    def stiffness_tensor_edited(self):
+        material = self.material
+        material.unitcell.stiffness = copy.deepcopy(
+            self.stiffness_tensor_editor.data)
+
+
+def apply_symmetric_constraint(x):
+    # Copy values from upper triangle to lower triangle.
+    # Only works for square matrices.
+    for i in range(x.shape[0]):
+        for j in range(i):
+            x[i, j] = x[j, i]
+    return x

--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -239,12 +239,18 @@ class MaterialStructureEditor:
         mat._atomtype = np.array(type_array)
         mat._U = np.array(U_array)
 
+        old_unitcell = mat.unitcell
+
         # Re-create the unit cell from scratch. This is easier to do
         # right now than setting the variables and figuring out which
         # properties need to be updated and in what order...
         mat.unitcell = unitcell(mat._lparms, mat.sgnum, mat._atomtype,
                                 mat._atominfo, mat._U, mat._dmin.getVal('nm'),
                                 mat._beamEnergy.value, mat._sgsetting)
+
+        # Set the stiffness back on it if it existed
+        if hasattr(old_unitcell, 'stiffness'):
+            mat.unitcell.stiffness = old_unitcell.stiffness
 
         # Update the structure factor of the PData
         mat.update_structure_factor()

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -9,6 +9,7 @@ from PySide2.QtWidgets import QComboBox, QFileDialog, QMenu, QMessageBox
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.materials_table import MaterialsTable
 from hexrd.ui.material_editor_widget import MaterialEditorWidget
+from hexrd.ui.material_properties_editor import MaterialPropertiesEditor
 from hexrd.ui.material_structure_editor import MaterialStructureEditor
 from hexrd.ui.overlay_manager import OverlayManager
 from hexrd.ui.ui_loader import UiLoader
@@ -32,6 +33,10 @@ class MaterialsPanel(QObject):
         self.material_structure_editor = MaterialStructureEditor(self.ui)
         self.ui.material_structure_editor_layout.addWidget(
             self.material_structure_editor.ui)
+
+        self.material_properties_editor = MaterialPropertiesEditor(self.ui)
+        self.ui.material_properties_editor_layout.addWidget(
+            self.material_properties_editor.ui)
 
         # Turn off autocomplete for the QComboBox
         self.ui.materials_combo.setCompleter(None)
@@ -69,9 +74,7 @@ class MaterialsPanel(QObject):
             self.modify_material_name)
 
         self.material_editor_widget.material_modified.connect(
-            self.update_table)
-        self.material_editor_widget.material_modified.connect(
-            self.update_refinement_options)
+            self.material_modified)
 
         self.ui.show_materials_table.pressed.connect(self.show_materials_table)
         self.ui.show_overlay_manager.pressed.connect(self.show_overlay_manager)
@@ -172,8 +175,16 @@ class MaterialsPanel(QObject):
         self.update_table()
         self.update_enable_states()
 
+    def material_modified(self):
+        self.update_table()
+        self.update_refinement_options()
+        self.update_properties_tab()
+
     def update_structure_tab(self):
         self.material_structure_editor.update_gui()
+
+    def update_properties_tab(self):
+        self.material_properties_editor.update_gui()
 
     def update_material_limits(self):
         max_tth = HexrdConfig().active_material_tth_max
@@ -203,6 +214,7 @@ class MaterialsPanel(QObject):
         HexrdConfig().active_material = self.current_material()
         self.material_editor_widget.material = HexrdConfig().active_material
         self.update_structure_tab()
+        self.update_properties_tab()
 
     def current_material(self):
         return self.ui.materials_combo.currentText()
@@ -235,6 +247,7 @@ class MaterialsPanel(QObject):
             HexrdConfig().import_material(selected_file)
             self.update_gui_from_config()
             self.update_structure_tab()
+            self.update_properties_tab()
 
     def remove_current_material(self):
         # Don't allow the user to remove all of the materials
@@ -248,6 +261,7 @@ class MaterialsPanel(QObject):
         self.material_editor_widget.material = HexrdConfig().active_material
         self.update_gui_from_config()
         self.update_structure_tab()
+        self.update_properties_tab()
 
     def modify_material_name(self):
         new_name = self.ui.materials_combo.currentText()

--- a/hexrd/ui/matrix_editor.py
+++ b/hexrd/ui/matrix_editor.py
@@ -1,0 +1,174 @@
+import numpy as np
+
+from PySide2.QtCore import QSignalBlocker, Signal
+from PySide2.QtWidgets import QGridLayout, QWidget
+
+from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
+
+
+class MatrixEditor(QWidget):
+
+    data_modified = Signal()
+
+    def __init__(self, data, parent=None):
+        super().__init__(parent)
+
+        self._data = data
+
+        # If this is not None, then only the elements present in the
+        # list (as (i, j) items) will be enabled.
+        self._enabled_elements = None
+
+        # If this is set, it will be called every time the data updates
+        # to apply equality constraints.
+        self._apply_constraints_func = None
+
+        self.setLayout(QGridLayout())
+        self.add_spin_boxes()
+        self.update_gui()
+
+    def add_spin_boxes(self):
+        layout = self.layout()
+        for i in range(self.rows):
+            for j in range(self.cols):
+                sb = self.create_spin_box()
+                layout.addWidget(sb, i, j)
+
+    def create_spin_box(self):
+        sb = ScientificDoubleSpinBox()
+        sb.setKeyboardTracking(False)
+        sb.valueChanged.connect(self.element_modified)
+        return sb
+
+    def element_modified(self):
+        self.update_data()
+
+    @property
+    def data(self):
+        return self._data
+
+    @data.setter
+    def data(self, v):
+        if not np.array_equal(self._data, v):
+            if self._data.shape != v.shape:
+                msg = (f'Shape {v.shape} does not match original shape '
+                       f'{self._data.shape}')
+                raise AttributeError(msg)
+
+            self._data = v
+            self.apply_constraints()
+            self.update_gui()
+
+    @property
+    def rows(self):
+        return self.data.shape[0]
+
+    @property
+    def cols(self):
+        return self.data.shape[1]
+
+    def update_data(self):
+        self.data[:] = self.gui_data
+        self.apply_constraints()
+        self.data_modified.emit()
+
+    def update_gui(self):
+        self.gui_data = self.data
+
+    @property
+    def gui_data(self):
+        row_range = range(self.rows)
+        col_range = range(self.cols)
+        return [[self.gui_value(i, j) for j in col_range] for i in row_range]
+
+    @gui_data.setter
+    def gui_data(self, v):
+        blockers = [QSignalBlocker(w) for w in self.all_widgets]  # noqa: F841
+        for i in range(self.rows):
+            for j in range(self.cols):
+                self.set_gui_value(i, j, v[i][j])
+
+    @property
+    def all_widgets(self):
+        row_range = range(self.rows)
+        col_range = range(self.cols)
+        return [self.widget(i, j) for j in col_range for i in row_range]
+
+    def widget(self, row, col):
+        return self.layout().itemAtPosition(row, col).widget()
+
+    def gui_value(self, row, col):
+        return self.widget(row, col).value()
+
+    def set_gui_value(self, row, col, val):
+        self.widget(row, col).setValue(val)
+
+    def update_enable_states(self):
+        enable_all = self.enabled_elements is None
+        for i in range(self.rows):
+            for j in range(self.cols):
+                enable = enable_all or (i, j) in self.enabled_elements
+                self.widget(i, j).setEnabled(enable)
+
+    @property
+    def enabled_elements(self):
+        return self._enabled_elements
+
+    @enabled_elements.setter
+    def enabled_elements(self, v):
+        if self._enabled_elements != v:
+            self._enabled_elements = v
+            self.update_enable_states()
+
+    @property
+    def apply_constraints_func(self):
+        return self._apply_constraints_func
+
+    @apply_constraints_func.setter
+    def apply_constraints_func(self, v):
+        if self._apply_constraints_func != v:
+            self._apply_constraints_func = v
+            self.apply_constraints()
+
+    def apply_constraints(self):
+        func = self.apply_constraints_func
+        if func is None:
+            return
+
+        func(self.data)
+        self.update_gui()
+
+
+if __name__ == '__main__':
+    import sys
+
+    from PySide2.QtWidgets import QApplication, QDialog, QVBoxLayout
+
+    if len(sys.argv) < 2:
+        sys.exit('Usage: <script> <matrix_size>')
+
+    rows, cols = [int(x) for x in sys.argv[1].split('x')]
+    data = np.ones((rows, cols))
+
+    app = QApplication(sys.argv)
+    dialog = QDialog()
+    layout = QVBoxLayout()
+
+    dialog.setLayout(layout)
+    editor = MatrixEditor(data)
+    layout.addWidget(editor)
+
+    # def constraints(x):
+    #     x[2][2] = x[1][1]
+
+    # editor.enabled_elements = [(1, 1), (3, 4)]
+    # editor.apply_constraints_func = constraints
+
+    def on_data_modified():
+        print(f'Data modified: {editor.data}')
+
+    editor.data_modified.connect(on_data_modified)
+    dialog.finished.connect(app.quit)
+    dialog.show()
+
+    app.exec_()

--- a/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
@@ -228,7 +228,7 @@
                </property>
               </widget>
              </item>
-             <item row="4" column="0" colspan="2">
+             <item row="5" column="0" colspan="2">
               <widget class="QGroupBox" name="ranges_group">
                <property name="title">
                 <string>Ranges</string>
@@ -427,6 +427,19 @@
                </layout>
               </widget>
              </item>
+             <item row="4" column="0" colspan="2">
+              <widget class="QCheckBox" name="convert_strain_to_stress">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Convert strain to stress. Requires a material where the elastic stiffness tensor is defined (see the properties tab in the materials panel).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Convert Strain to Stress</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
@@ -469,6 +482,14 @@
   <tabstop>plot_color_option</tabstop>
   <tabstop>hide_axes</tabstop>
   <tabstop>set_view_direction</tabstop>
+  <tabstop>convert_strain_to_stress</tabstop>
+  <tabstop>range_x_0</tabstop>
+  <tabstop>range_x_1</tabstop>
+  <tabstop>range_y_0</tabstop>
+  <tabstop>range_y_1</tabstop>
+  <tabstop>range_z_0</tabstop>
+  <tabstop>range_z_1</tabstop>
+  <tabstop>reset_ranges</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/hexrd/ui/resources/ui/material_properties_editor.ui
+++ b/hexrd/ui/resources/ui/material_properties_editor.ui
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>material_properties_editor</class>
+ <widget class="QWidget" name="material_properties_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>502</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="stiffness_tensor_group">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The elastic stiffness tensor in Voigt notation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="title">
+      <string>Stiffness Tensor</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="1" column="0">
+       <layout class="QVBoxLayout" name="stiffness_tensor_editor_layout"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <spacer name="vertical_spacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -180,6 +180,16 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="properties_tab">
+        <attribute name="title">
+         <string>Properties</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="0" column="0">
+          <layout class="QVBoxLayout" name="material_properties_editor_layout"/>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
      <item row="1" column="1">

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -1,6 +1,7 @@
 # Some general utilities that are used in multiple places
 
 from enum import IntEnum
+from functools import reduce
 import math
 import numpy as np
 
@@ -226,3 +227,9 @@ def wrap_with_callbacks(func):
         return ret
 
     return wrapper
+
+
+def compose(*functions):
+    # Combine a series of functions together.
+    # Note that the functions are called from right to left.
+    return reduce(lambda f, g: lambda x: f(g(x)), functions, lambda x: x)


### PR DESCRIPTION
This adds a stiffness tensor editor to the materials panel under a new tab called "Properties". It also adds the ability in the fit grains dialog to convert from strain to stress, if the stiffness tensor is defined.

![Screenshot from 2020-11-10 08-14-35](https://user-images.githubusercontent.com/9558430/98685423-f7ed7680-232c-11eb-90aa-64abce7240bb.png)

![Screenshot from 2020-11-10 08-15-31](https://user-images.githubusercontent.com/9558430/98685436-fd4ac100-232c-11eb-9b0d-3ef35ffe0f1c.png)

We should verify the math is all correct.

Fixes: #653 
Fixes: #458 