### PR TITLE
Scale strain values when converting to stress

### DIFF
--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -93,6 +93,8 @@ class FitGrainsResultsDialog(QObject):
         if tensor_type == 'stress':
             for grain in data:
                 # Convert strain to stress
+                # Multiply last three numbers by factor of 2
+                grain[18:21] *= 2
                 grain[15:21] = np.dot(self.compliance, grain[15:21])
 
                 # Compute the equivalent stress


### PR DESCRIPTION
Multiply the last three strain values by 3 when converting to stress.

This is being done in response to https://github.com/HEXRD/hexrdgui/issues/458#issuecomment-724358501

Hopefully, the math will all be correct now, but it would be good to double-check at some point.