### PR TITLE
Fix equivalent stress computation

### DIFF
--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -98,8 +98,9 @@ class FitGrainsResultsDialog(QObject):
                 grain[15:21] = np.dot(self.compliance, grain[15:21])
 
                 # Compute the equivalent stress
-                m = vecMVToSymm(grain[15:21], scale=False)
-                grain[21] = 3 * np.sqrt(np.sum(m**2)) / 2
+                sigma = vecMVToSymm(grain[15:21], scale=False)
+                deviator = sigma - (1/3) * np.trace(sigma) * np.identity(3)
+                grain[21] = 3 * np.sqrt(np.sum(deviator**2)) / 2
 
         return data
 

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -99,7 +99,7 @@ class FitGrainsResultsDialog(QObject):
 
                 # Compute the equivalent stress
                 m = vecMVToSymm(grain[15:21], scale=False)
-                grain[21] = 2 * np.sqrt(np.sum(m**2)) / 3
+                grain[21] = 3 * np.sqrt(np.sum(m**2)) / 2
 
         return data
 


### PR DESCRIPTION
This is being done in response to https://github.com/HEXRD/hexrdgui/issues/429#issuecomment-725693239

2/3 is now 3/2. Now I just need to figure out how to make `m` the deviator of the stress...