### PR TITLE
Use a very light gray for disabled matrix elements

### DIFF
--- a/hexrd/ui/matrix_editor.py
+++ b/hexrd/ui/matrix_editor.py
@@ -65,7 +65,7 @@ class MatrixEditor(QWidget):
                 raise AttributeError(msg)
 
             self._data = v
-            self.apply_constraints()
+            self.reset_disabled_values()
             self.update_gui()
 
     @property
@@ -124,6 +124,16 @@ class MatrixEditor(QWidget):
                 style_sheet = getattr(self, f'{enabled_str}_style_sheet')
                 w.setStyleSheet(style_sheet)
 
+    def reset_disabled_values(self):
+        # Resets all disabled values to zero, then applies constraints
+        for i in range(self.rows):
+            for j in range(self.cols):
+                if not self.widget(i, j).isEnabled():
+                    self.data[i, j] = 0.0
+
+        self.apply_constraints()
+        self.update_gui()
+
     @property
     def enabled_elements(self):
         return self._enabled_elements
@@ -133,6 +143,7 @@ class MatrixEditor(QWidget):
         if self._enabled_elements != v:
             self._enabled_elements = v
             self.update_enable_states()
+            self.reset_disabled_values()
 
     @property
     def apply_constraints_func(self):
@@ -145,8 +156,7 @@ class MatrixEditor(QWidget):
             self.apply_constraints()
 
     def apply_constraints(self):
-        func = self.apply_constraints_func
-        if func is None:
+        if (func := self.apply_constraints_func) is None:
             return
 
         func(self.data)

--- a/hexrd/ui/matrix_editor.py
+++ b/hexrd/ui/matrix_editor.py
@@ -5,6 +5,9 @@ from PySide2.QtWidgets import QGridLayout, QWidget
 
 from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
 
+DEFAULT_ENABLED_STYLE_SHEET = 'background-color: white'
+DEFAULT_DISABLED_STYLE_SHEET = 'background-color: #F0F0F0'
+
 
 class MatrixEditor(QWidget):
 
@@ -22,6 +25,12 @@ class MatrixEditor(QWidget):
         # If this is set, it will be called every time the data updates
         # to apply equality constraints.
         self._apply_constraints_func = None
+
+        # The style sheet for the enabled spin boxes
+        self.enabled_style_sheet = DEFAULT_ENABLED_STYLE_SHEET
+
+        # The style sheet for the disabled spin boxes
+        self.disabled_style_sheet = DEFAULT_DISABLED_STYLE_SHEET
 
         self.setLayout(QGridLayout())
         self.add_spin_boxes()
@@ -107,8 +116,13 @@ class MatrixEditor(QWidget):
         enable_all = self.enabled_elements is None
         for i in range(self.rows):
             for j in range(self.cols):
+                w = self.widget(i, j)
                 enable = enable_all or (i, j) in self.enabled_elements
-                self.widget(i, j).setEnabled(enable)
+                w.setEnabled(enable)
+
+                enabled_str = 'enabled' if enable else 'disabled'
+                style_sheet = getattr(self, f'{enabled_str}_style_sheet')
+                w.setStyleSheet(style_sheet)
 
     @property
     def enabled_elements(self):


### PR DESCRIPTION
This allows us to read their values more easily, while still being
dark enough to be recognized as disabled.

Before:
======
![Screenshot from 2020-11-17 14-28-22](https://user-images.githubusercontent.com/9558430/99446148-3e6e4280-28e4-11eb-8a86-0d7745baa8b1.png)

After:
=====
![Screenshot from 2020-11-17 14-30-34](https://user-images.githubusercontent.com/9558430/99446166-462de700-28e4-11eb-859c-32fa47b550f9.png)

Does it look good, @saransh13 ?

Fixes: #658