### PR TITLE
Add elastic compliance as an editing option

### DIFF
--- a/hexrd/ui/material_properties_editor.py
+++ b/hexrd/ui/material_properties_editor.py
@@ -1,5 +1,6 @@
 import copy
 import numpy as np
+from numpy.linalg import LinAlgError, inv
 
 from PySide2.QtCore import QSignalBlocker
 
@@ -13,47 +14,84 @@ from hexrd.ui.utils import compose
 
 class MaterialPropertiesEditor:
 
-    stiffness_tensor_shape = (6, 6)
+    elastic_tensor_shape = (6, 6)
 
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('material_properties_editor.ui', parent)
 
-        self.null_tensor = np.zeros(self.stiffness_tensor_shape)
-        self.stiffness_tensor_editor = MatrixEditor(self.null_tensor, self.ui)
-        self.ui.stiffness_tensor_editor_layout.addWidget(
-            self.stiffness_tensor_editor)
+        self.null_tensor = np.zeros(self.elastic_tensor_shape)
+        self.elastic_tensor_editor = MatrixEditor(self.null_tensor, self.ui)
+        self.ui.elastic_tensor_editor_layout.addWidget(
+            self.elastic_tensor_editor)
 
         self.setup_connections()
+
+        self.elastic_tensor_type_changed()
 
         self.update_gui()
 
     def setup_connections(self):
-        self.stiffness_tensor_editor.data_modified.connect(
-            self.stiffness_tensor_edited)
+        self.ui.elastic_tensor_type.currentIndexChanged.connect(
+            self.elastic_tensor_type_changed)
+        self.elastic_tensor_editor.data_modified.connect(
+            self.elastic_tensor_edited)
         self.ui.density.valueChanged.connect(self.density_edited)
 
     @property
     def material(self):
         return HexrdConfig().active_material
 
+    @property
+    def elastic_tensor_type(self):
+        type_map = {
+            'Stiffness': 'stiffness',
+            'Compliance': 'compliance',
+        }
+        return type_map[self.ui.elastic_tensor_type.currentText()]
+
+    @property
+    def elastic_tensor(self):
+        return getattr(self.material.unitcell, self.elastic_tensor_type, None)
+
+    @elastic_tensor.setter
+    def elastic_tensor(self, v):
+        return setattr(self.material.unitcell, self.elastic_tensor_type, v)
+
+    def elastic_tensor_type_changed(self):
+        self.update_elastic_tensor_gui()
+        self.update_elastic_tensor_tooltip()
+
+    def update_elastic_tensor_tooltip(self):
+        units_map = {
+            'stiffness': 'GPa',
+            'compliance': 'TPa⁻¹',
+        }
+
+        tensor_type = self.elastic_tensor_type
+        units = units_map[tensor_type]
+        tooltip = (f'The elastic {tensor_type} tensor in Voigt notation. '
+                   f'({units})')
+
+        self.ui.elastic_tensor_group.setToolTip(tooltip)
+
     def update_gui(self):
-        self.update_stiffness_tensor_gui()
+        self.update_elastic_tensor_gui()
         self.update_misc_gui()
 
-    def update_stiffness_tensor_gui(self):
-        material = self.material
-        if hasattr(material.unitcell, 'stiffness'):
-            data = copy.deepcopy(material.unitcell.stiffness)
+    def update_elastic_tensor_gui(self):
+        if (elastic_tensor := self.elastic_tensor) is not None:
+            data = copy.deepcopy(elastic_tensor)
         else:
             # Just use zeros...
-            data = np.zeros(self.stiffness_tensor_shape)
+            data = np.zeros(self.elastic_tensor_shape)
 
+        material = self.material
         enabled, constraints = _StiffnessDict[material.unitcell._laueGroup]
 
         constraints_func = compose(apply_symmetric_constraint, constraints)
 
-        editor = self.stiffness_tensor_editor
+        editor = self.elastic_tensor_editor
         editor.enabled_elements = enabled
         editor.apply_constraints_func = constraints_func
         editor.data = data
@@ -66,10 +104,22 @@ class MaterialPropertiesEditor:
         density = getattr(material.unitcell, 'density', 0)
         self.ui.density.setValue(density)
 
-    def stiffness_tensor_edited(self):
-        material = self.material
-        material.unitcell.stiffness = copy.deepcopy(
-            self.stiffness_tensor_editor.data)
+    def update_enable_states(self):
+        matrix_valid = not self.elastic_tensor_editor.matrix_invalid
+        self.ui.elastic_tensor_type.setEnabled(matrix_valid)
+
+    def elastic_tensor_edited(self):
+        data = copy.deepcopy(self.elastic_tensor_editor.data)
+        try:
+            self.elastic_tensor = copy.deepcopy(data)
+            if self.elastic_tensor_type == 'stiffness':
+                # Make sure we can invert it
+                inv(self.elastic_tensor)
+        except LinAlgError as e:
+            self.elastic_tensor_editor.set_matrix_invalid(str(e))
+        else:
+            self.elastic_tensor_editor.set_matrix_valid()
+        self.update_enable_states()
 
     def density_edited(self):
         self.material.unitcell.density = self.ui.density.value()
@@ -79,6 +129,7 @@ class MaterialPropertiesEditor:
         return [
            self.ui.density
         ]
+
 
 def apply_symmetric_constraint(x):
     # Copy values from upper triangle to lower triangle.

--- a/hexrd/ui/resources/ui/material_properties_editor.ui
+++ b/hexrd/ui/resources/ui/material_properties_editor.ui
@@ -24,7 +24,14 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
+   <item row="0" column="0">
+    <widget class="QLabel" name="elastic_tensor_type_label">
+     <property name="text">
+      <string>Elastic Tensor type:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
     <spacer name="vertical_spacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -37,17 +44,21 @@
      </property>
     </spacer>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="density_label">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-family:'Roboto,arial,sans-serif'; font-size:14px; color:#4d5156; background-color:#ffffff;&quot;&gt;Computed from lattice parameters&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Density:</string>
-     </property>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="elastic_tensor_type">
+     <item>
+      <property name="text">
+       <string>Stiffness</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Compliance</string>
+      </property>
+     </item>
     </widget>
    </item>
-   <item row="1" column="1">
+   <item row="2" column="1">
     <widget class="ScientificDoubleSpinBox" name="density">
      <property name="enabled">
       <bool>true</bool>
@@ -78,17 +89,30 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QGroupBox" name="stiffness_tensor_group">
+   <item row="2" column="0">
+    <widget class="QLabel" name="density_label">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-family:'Roboto,arial,sans-serif'; font-size:14px; color:#4d5156; background-color:#ffffff;&quot;&gt;Computed from lattice parameters&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Density:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="elastic_tensor_group">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The elastic stiffness tensor in Voigt notation.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="title">
-      <string>Stiffness Tensor</string>
+      <string>Elastic Tensor</string>
+     </property>
+     <property name="checkable">
+      <bool>false</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="1" column="0">
-       <layout class="QVBoxLayout" name="stiffness_tensor_editor_layout"/>
+       <layout class="QVBoxLayout" name="elastic_tensor_editor_layout"/>
       </item>
      </layout>
     </widget>
@@ -102,6 +126,10 @@
    <header>scientificspinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>elastic_tensor_type</tabstop>
+  <tabstop>density</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This is the inverse of the stiffness tensor.

It has been added, along with valid/invalid matrix states, since
the elastic tensor is invalid if it is not invertible.

Units have also been added.

![example](https://user-images.githubusercontent.com/9558430/102112159-eea86b80-3dfc-11eb-94c5-84785e646582.gif)

This PR is complete, but I think the we need to examine the units in hexrd [here](https://github.com/HEXRD/hexrd/blob/ca88d475f72be177141a3ff028df90cd771ea59d/hexrd/unitcell.py#L1293-L1302) to make sure this is correct. I think the units of the stiffness and compliance tensors are currently in GPa and GPa⁻¹ (respectively), when they should be GPa and TPa⁻¹.

Fixes: #665 
Fixes: #666 

For correct compliance units in TPa⁻¹, this PR depends on hexrd/hexrd#141.