### PR TITLE
Allow fit grains to be ran directly

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -1,5 +1,5 @@
 from PySide2.QtCore import (
-    QItemSelectionModel, QObject, QSignalBlocker, Qt, Signal, Slot)
+    QItemSelectionModel, QObject, QSignalBlocker, Qt, Signal)
 from PySide2.QtWidgets import QDialogButtonBox, QHeaderView
 
 from hexrd.ui import enter_key_filter
@@ -71,13 +71,11 @@ class FitGrainsOptionsDialog(QObject):
     def show(self):
         self.ui.show()
 
-    @Slot()
     def on_accepted(self):
         # Save the selected options on the config
         self.update_config()
         self.accepted.emit()
 
-    @Slot()
     def on_tolerances_add_row(self):
         new_row_num = self.tolerances_model.rowCount()
         self.tolerances_model.add_row()
@@ -91,28 +89,24 @@ class FitGrainsOptionsDialog(QObject):
         # Have to repaint - is that because we are in a modal dialog?
         self.ui.tolerances_view.repaint(self.ui.tolerances_view.rect())
 
-    @Slot()
     def on_tolerances_delete_row(self):
         rows = self._get_selected_rows()
         self.tolerances_model.delete_rows(rows)
         self.ui.tolerances_view.selectionModel().clear()
         self.ui.tolerances_view.repaint(self.ui.tolerances_view.rect())
 
-    @Slot()
     def on_tolerances_move_down(self):
         rows = self._get_selected_rows()
         self.tolerances_model.move_rows(rows, 1)
         self.ui.tolerances_view.selectionModel().clear()
         self.ui.tolerances_view.repaint(self.ui.tolerances_view.rect())
 
-    @Slot()
     def on_tolerances_move_up(self):
         rows = self._get_selected_rows()
         self.tolerances_model.move_rows(rows, -1)
         self.ui.tolerances_view.selectionModel().clear()
         self.ui.tolerances_view.repaint(self.ui.tolerances_view.rect())
 
-    @Slot()
     def on_tolerances_select(self):
         """Sets button enable states based on current selection"""
         delete_enable = False
@@ -139,7 +133,6 @@ class FitGrainsOptionsDialog(QObject):
         self.ui.move_up.setEnabled(up_enable)
         self.ui.move_down.setEnabled(down_enable)
 
-    @Slot(bool)
     def on_tth_max_toggled(self, checked):
         enabled = checked
         self.ui.tth_max_instrument.setEnabled(enabled)
@@ -147,7 +140,6 @@ class FitGrainsOptionsDialog(QObject):
         specify = self.ui.tth_max_specify.isChecked()
         self.ui.tth_max_value.setEnabled(enabled and specify)
 
-    @Slot(bool)
     def on_tth_specify_toggled(self, checked):
         self.ui.tth_max_value.setEnabled(checked)
 

--- a/hexrd/ui/indexing/fit_grains_select_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_select_dialog.py
@@ -1,0 +1,147 @@
+import os
+
+import numpy as np
+
+from PySide2.QtCore import QObject, QSignalBlocker, Signal
+from PySide2.QtWidgets import QFileDialog, QMessageBox
+
+from hexrd.ui import enter_key_filter
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.indexing.utils import generate_grains_table
+
+
+class FitGrainsSelectDialog(QObject):
+
+    accepted = Signal()
+    rejected = Signal()
+
+    def __init__(self, indexing_runner=None, parent=None):
+        super().__init__(parent)
+
+        self.indexing_runner = indexing_runner
+        self.grains_table = None
+
+        loader = UiLoader()
+        self.ui = loader.load_file('fit_grains_select_dialog.ui', parent)
+        self.ui.setWindowTitle('Select Grains to Fit')
+        self.ui.installEventFilter(enter_key_filter)
+
+        # Hide the tab bar. It gets selected by changes to the combo box.
+        self.ui.tab_widget.tabBar().hide()
+
+        self.update_valid_methods()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.select_estimate_file_button.pressed.connect(
+            self.select_estimate_file)
+        self.ui.select_orientations_file_button.pressed.connect(
+            self.select_orientations_file)
+        self.ui.method.currentIndexChanged.connect(self.update_method_tab)
+        self.ui.accepted.connect(self.on_accepted)
+        self.ui.rejected.connect(self.on_rejected)
+
+    def show(self):
+        self.ui.show()
+
+    def on_accepted(self):
+        # Validate
+        if self.method in self.file_methods and not self.file_name:
+            msg = 'Please select a file'
+            QMessageBox.critical(self.ui, 'HEXRD', msg)
+            self.show()
+            return
+
+        self.set_grains_table()
+        self.accepted.emit()
+
+    def set_grains_table(self):
+        if self.method == 'indexing':
+            # Get the grains table off the indexing runner
+            self.grains_table = self.indexing_runner.grains_table
+        elif self.method == 'estimate':
+            # It is a grains.out file
+            self.grains_table = np.loadtxt(self.file_name)
+        elif self.method == 'orientations':
+            # It is an accepted_orientations*.dat file
+            qbar = np.loadtxt(self.file_name, ndmin=2).T
+            self.grains_table = generate_grains_table(qbar)
+        else:
+            raise Exception(f'Unknown method: {self.method}')
+
+    def on_rejected(self):
+        self.rejected.emit()
+
+    def select_estimate_file(self):
+        self.select_file('Load grains.out file', 'grains.out files (*.out)')
+
+    def select_orientations_file(self):
+        self.select_file('Load orientations file',
+                         'Accepted orientations files (*.dat)')
+
+    def select_file(self, title, filters):
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            self.ui, title, HexrdConfig().working_dir, filters)
+
+        if selected_file:
+            HexrdConfig().working_dir = os.path.dirname(selected_file)
+            self.file_name = selected_file
+
+    @property
+    def file_methods(self):
+        # Methods that use a file name...
+        return ('estimate', 'orientations')
+
+    @property
+    def all_methods(self):
+        return ('indexing',) + self.file_methods
+
+    @property
+    def file_name(self):
+        self.assert_file_method()
+        widget = getattr(self.ui, f'{self.method}_file_name')
+        return widget.text()
+
+    @file_name.setter
+    def file_name(self, v):
+        self.assert_file_method()
+        widget = getattr(self.ui, f'{self.method}_file_name')
+        widget.setText(v)
+
+    def assert_file_method(self):
+        if self.method not in self.file_methods:
+            raise Exception(f'{self.method} is not a file method')
+
+    @property
+    def method(self):
+        return self.ui.method.currentText().lower()
+
+    @method.setter
+    def method(self, v):
+        v = v.capitalize()
+        ind = self.ui.method.findText(v)
+        if ind == -1:
+            raise Exception(f'Invalid method name: {v}')
+
+        self.ui.method.setCurrentIndex(ind)
+
+    def update_method_tab(self):
+        # Take advantage of the naming scheme...
+        method_tab = getattr(self.ui, f'{self.method}_tab')
+        self.ui.tab_widget.setCurrentWidget(method_tab)
+
+    def update_valid_methods(self):
+        valid_methods = list(self.all_methods)
+
+        if getattr(self.indexing_runner, 'grains_table', None) is None:
+            valid_methods.remove('indexing')
+
+        widget = self.ui.method
+        blocker = QSignalBlocker(widget)  # noqa: F841
+        widget.clear()
+        widget.addItems([x.capitalize() for x in valid_methods])
+
+        # In case the current widget changed...
+        self.update_method_tab()

--- a/hexrd/ui/indexing/utils.py
+++ b/hexrd/ui/indexing/utils.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+from hexrd import constants
+from hexrd import instrument
+from hexrd.transforms import xfcapi
+
+
+def generate_grains_table(qbar):
+    num_grains = qbar.shape[1]
+    grains_table = np.empty((num_grains, 21))
+    gw = instrument.GrainDataWriter(array=grains_table)
+    for i, q in enumerate(qbar.T):
+        phi = 2 * np.arccos(q[0])
+        n = xfcapi.unitRowVector(q[1:])
+        grain_params = np.hstack(
+            [phi * n, constants.zeros_3, constants.identity_6x1]
+        )
+        gw.dump_grain(i, 1, 0, grain_params)
+    gw.close()
+    return grains_table

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -17,7 +17,7 @@ from hexrd.ui.color_map_editor import ColorMapEditor
 from hexrd.ui.progress_dialog import ProgressDialog
 from hexrd.ui.cal_tree_view import CalTreeView
 from hexrd.ui.hand_drawn_mask_dialog import HandDrawnMaskDialog
-from hexrd.ui.indexing.run import IndexingRunner
+from hexrd.ui.indexing.run import FitGrainsRunner, IndexingRunner
 from hexrd.ui.indexing.fit_grains_results_dialog import FitGrainsResultsDialog
 from hexrd.ui.calibration.calibration_runner import CalibrationRunner
 from hexrd.ui.calibration.powder_calibration import run_powder_calibration
@@ -189,9 +189,11 @@ class MainWindow(QObject):
             self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_run_indexing.triggered.connect(
             self.on_action_run_indexing_triggered)
+        self.ui.action_run_fit_grains.triggered.connect(
+            self.on_action_run_fit_grains_triggered)
         self.ui.action_run_wppf.triggered.connect(self.run_wppf)
         self.new_images_loaded.connect(self.update_color_map_bounds)
-        self.new_images_loaded.connect(self.update_indexing_menu)
+        self.new_images_loaded.connect(self.update_hedm_enable_states)
         self.new_images_loaded.connect(self.color_map_editor.reset_range)
         self.new_images_loaded.connect(self.image_mode_widget.reset_masking)
         self.ui.image_tab_widget.update_needed.connect(self.update_all)
@@ -590,6 +592,15 @@ class MainWindow(QObject):
         self._indexing_runner = IndexingRunner(self.ui)
         self._indexing_runner.run()
 
+    def on_action_run_fit_grains_triggered(self):
+        kwargs = {
+            'grains_table': None,
+            'indexing_runner': getattr(self, '_indexing_runner', None),
+            'parent': self.ui,
+        }
+        runner = self._grain_fitting_runner = FitGrainsRunner(**kwargs)
+        runner.run()
+
     def run_wppf(self):
         self._wppf_runner = WppfRunner(self.ui)
         try:
@@ -892,16 +903,26 @@ class MainWindow(QObject):
     def on_action_switch_workflow_triggered(self):
         self.workflow_selection_dialog.show()
 
+    def update_hedm_enable_states(self):
+        actions = (self.ui.action_run_indexing, self.ui.action_run_fit_grains)
+        for action in actions:
+            action.setEnabled(False)
 
-    def update_indexing_menu(self):
-        enabled = False
         image_series_dict = ImageLoadManager().unaggregated_images
-        image_series_dict = HexrdConfig().imageseries_dict if image_series_dict is None else image_series_dict
-        if image_series_dict:
-            # Check length of first series
-            series = next(iter(image_series_dict.values()))
-            enabled = len(series) > 1
-        self.ui.action_run_indexing.setEnabled(enabled)
+        if image_series_dict is None:
+            image_series_dict = HexrdConfig().imageseries_dict
+
+        if not image_series_dict:
+            return
+
+        # Check length of first series
+        series = next(iter(image_series_dict.values()))
+        if not len(series) > 1:
+            return
+
+        # If we made it here, they should be enabled.
+        for action in actions:
+            action.setEnabled(True)
 
     def on_action_open_mask_manager_triggered(self):
         self.mask_manager_dialog.show()

--- a/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
@@ -160,6 +160,9 @@
    </item>
    <item>
     <widget class="QTableView" name="tolerances_view">
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
      <attribute name="horizontalHeaderMinimumSectionSize">
       <number>26</number>
      </attribute>

--- a/hexrd/ui/resources/ui/fit_grains_select_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_select_dialog.ui
@@ -1,0 +1,173 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>fit_grains_select_dialog</class>
+ <widget class="QDialog" name="fit_grains_select_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>635</width>
+    <height>241</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="1">
+    <widget class="QComboBox" name="method">
+     <item>
+      <property name="text">
+       <string>Indexing</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Estimate</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Orientations</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="indexing_tab">
+      <attribute name="title">
+       <string>Indexing</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QLabel" name="indexing_label">
+         <property name="text">
+          <string>Use grains from most recent indexing</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="estimate_tab">
+      <attribute name="title">
+       <string>Estimate</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="1" column="0">
+        <widget class="QLineEdit" name="estimate_file_name"/>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="select_estimate_file_button">
+         <property name="text">
+          <string>Select File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="estimate_label">
+         <property name="text">
+          <string>Load grains.out file</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="orientations_tab">
+      <attribute name="title">
+       <string>Orientations</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="1" column="0">
+        <widget class="QLineEdit" name="orientations_file_name"/>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="select_orientations_file_button">
+         <property name="text">
+          <string>Select File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="orientations_label">
+         <property name="text">
+          <string>Load accepted_orientations.dat file</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Method:</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>method</tabstop>
+  <tabstop>tab_widget</tabstop>
+  <tabstop>estimate_file_name</tabstop>
+  <tabstop>select_estimate_file_button</tabstop>
+  <tabstop>orientations_file_name</tabstop>
+  <tabstop>select_orientations_file_button</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>fit_grains_select_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>fit_grains_select_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -128,8 +128,10 @@
     </property>
     <addaction name="action_run_powder_calibration"/>
     <addaction name="action_run_calibration"/>
-    <addaction name="action_run_indexing"/>
     <addaction name="action_run_wppf"/>
+    <addaction name="separator"/>
+    <addaction name="action_run_indexing"/>
+    <addaction name="action_run_fit_grains"/>
    </widget>
    <addaction name="menu_file"/>
    <addaction name="menu_edit"/>
@@ -547,6 +549,14 @@
   <action name="action_view_fit_grains_config">
    <property name="text">
     <string>Fit Grains Config</string>
+   </property>
+  </action>
+  <action name="action_run_fit_grains">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Fit Grains</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This allows bypassing the indexing and running fit grains directly.

When the user runs fit grains directly, they must provide the grains
table in one of three ways. A select dialog will appear where the user
can choose from:

1. Indexing: use the grains table from the most recent indexing run
             (Only available if indexing has been performed)
2. Estimate: use the grains table from a grains.out file
3. Orientation: generate a grains table from an accepted_orientations.dat file

Once the user has selected one of these, the grain fit options dialog
will appear, and the user can select the grain fitting options. Afterwards,
grain fitting is ran and the results are viewed.

Internally, this re-organized the indexing runner into separate IndexingRunner
and FitGrainsRunner classes, so that the FitGrainsRunner can be used both
at the end of indexing, and also directly through the main window.

Some other cleanup has been performed, including making the tolerances
editable in the fit grains options dialog.

![fit_grains_directly](https://user-images.githubusercontent.com/9558430/103941697-da524880-50f4-11eb-8079-46341ac37e86.gif)

Fixes: #652