### PR TITLE
Save with a tight bbox by default in matplotlib

### DIFF
--- a/hexrd/ui/navigation_toolbar.py
+++ b/hexrd/ui/navigation_toolbar.py
@@ -1,3 +1,4 @@
+from matplotlib import rc_context
 from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
 
 from hexrd.ui.utils import wrap_with_callbacks
@@ -8,11 +9,13 @@ class NavigationToolbar(NavigationToolbar2QT):
     default_button_blacklist = ['Subplots', 'Customize']
 
     def __init__(self, canvas, parent, coordinates=True,
-                 button_blacklist=None):
+                 button_blacklist=None, tight_savefig=True):
         # This adds the option to blacklist some of the buttons for the
         # toolbar. Options are currently: Home, Back, Forward, Pan, Zoom,
         # Subplots, Save.
         # Blacklisting the None object removes separators.
+        # tight_savefig causes the figure to use the "tight" bbox when it is
+        # saved.
         if button_blacklist is None:
             button_blacklist = self.default_button_blacklist
         elif not isinstance(button_blacklist, (list, tuple)):
@@ -30,6 +33,8 @@ class NavigationToolbar(NavigationToolbar2QT):
         # the program to use them.
         NavigationToolbar2QT.toolitems = old_toolitems
 
+        self.tight_savefig = tight_savefig
+
     @wrap_with_callbacks
     def home(self, *args):
         super().home(*args)
@@ -41,3 +46,11 @@ class NavigationToolbar(NavigationToolbar2QT):
     @wrap_with_callbacks
     def forward(self, *args):
         super().back(*args)
+
+    def save_figure(self, *args, **kwargs):
+        context = {}
+        if self.tight_savefig:
+            context['savefig.bbox'] = 'tight'
+
+        with rc_context(context):
+            return super().save_figure(*args, **kwargs)


### PR DESCRIPTION
To our custom navigation toolbar, add an argument to the initializer
that indicates whether figures should be saved with a tight bbox
(defaults to `True`).

This will override the rcParams at the time of saving, but they are
restored afterward.

Here are some examples:

Not tight
=======
![not_tight](https://user-images.githubusercontent.com/9558430/103953768-5bffa180-5108-11eb-9743-5f71df40604e.png)

Tight
=====
![tight](https://user-images.githubusercontent.com/9558430/103953787-61f58280-5108-11eb-87af-154ff567c82e.png)

Fixes: #681