### PR TITLE
Add cylindrical reference display to fit grains

### DIFF
--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -25,6 +25,12 @@ from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
 
 
+COORDS_SLICE = slice(6, 9)
+ELASTIC_SLICE = slice(15, 21)
+ELASTIC_OFF_DIAGONAL_SLICE = slice(18, 21)
+EQUIVALENT_IND = 21
+HYDROSTATIC_IND = 22
+
 # Sortable columns are grain id, completeness, chi^2, and t_vec_c
 SORTABLE_COLUMNS = [
     *range(0, 3),
@@ -72,7 +78,7 @@ class FitGrainsResultsDialog(QObject):
         eqv_strain = np.zeros(self.num_grains)
         hydrostatic_strain = np.zeros(self.num_grains)
         for i, grain in enumerate(self.data):
-            epsilon = vecMVToSymm(grain[15:21], scale=False)
+            epsilon = vecMVToSymm(grain[ELASTIC_SLICE], scale=False)
             deviator = epsilon - (1/3) * np.trace(epsilon) * np.identity(3)
             eqv_strain[i] = 2 * np.sqrt(np.sum(deviator**2)) / 3
             hydrostatic_strain[i] = 1 / 3 * np.trace(epsilon)
@@ -104,22 +110,44 @@ class FitGrainsResultsDialog(QObject):
         tensor_type = self.tensor_type
         data = copy.deepcopy(self.data)
 
+        if self.cylindrical_reference:
+            for grain in data:
+                x, y, z = grain[COORDS_SLICE]
+                rho = np.sqrt(x**2 + z**2)
+                phi = np.arctan2(z, x)
+                grain[COORDS_SLICE] = (rho, phi, y)
+
         if tensor_type == 'stress':
             for grain in data:
                 # Convert strain to stress
                 # Multiply last three numbers by factor of 2
-                grain[18:21] *= 2
-                grain[15:21] = np.dot(self.compliance, grain[15:21])
+                grain[ELASTIC_OFF_DIAGONAL_SLICE] *= 2
+                grain[ELASTIC_SLICE] = np.dot(self.compliance,
+                                              grain[ELASTIC_SLICE])
 
                 # Compute the equivalent stress
-                sigma = vecMVToSymm(grain[15:21], scale=False)
+                sigma = vecMVToSymm(grain[ELASTIC_SLICE], scale=False)
                 deviator = sigma - (1/3) * np.trace(sigma) * np.identity(3)
-                grain[21] = 3 * np.sqrt(np.sum(deviator**2)) / 2
+                grain[EQUIVALENT_IND] = 3 * np.sqrt(np.sum(deviator**2)) / 2
 
                 # Compute the hydrostatic stress
-                grain[22] = 1 / 3 * np.trace(sigma)
+                grain[HYDROSTATIC_IND] = 1 / 3 * np.trace(sigma)
 
         return data
+
+    @property
+    def axes_labels(self):
+        if self.cylindrical_reference:
+            return ('ρ', 'φ', 'Y')
+        return ('X', 'Y', 'Z')
+
+    @property
+    def cylindrical_reference(self):
+        return self.ui.cylindrical_reference.isChecked()
+
+    @cylindrical_reference.setter
+    def cylindrical_reference(self, v):
+        self.ui.cylindricalreference.setChecked(v)
 
     @property
     def stiffness(self):
@@ -155,10 +183,11 @@ class FitGrainsResultsDialog(QObject):
         self.update_plot()
 
     def update_plot(self):
+        data = self.converted_data
         column = self.ui.plot_color_option.currentData()
-        colors = self.converted_data[:, column]
+        colors = data[:, column]
 
-        coords = self.data[:, 6:9]
+        coords = data[:, COORDS_SLICE]
         sz = self.ui.glyph_size_slider.value()
 
         # I could not find a way to update scatter plot marker colors and
@@ -198,7 +227,7 @@ class FitGrainsResultsDialog(QObject):
         if not selected_file:
             return
 
-        stresses = self.converted_data[:, 15:21]
+        stresses = self.converted_data[:, ELASTIC_SLICE]
         HexrdConfig().working_dir = str(Path(selected_file).parent)
         ext = Path(selected_file).suffix
         if ext != '.npz':
@@ -235,6 +264,10 @@ class FitGrainsResultsDialog(QObject):
         self.ax.set_proj_type(self.projection)
         self.draw()
 
+    def cylindrical_reference_toggled(self):
+        self.update_axes_labels()
+        self.update_plot()
+
     def setup_connections(self):
         self.ui.export_button.clicked.connect(self.on_export_button_pressed)
         self.ui.export_stresses.clicked.connect(
@@ -248,6 +281,8 @@ class FitGrainsResultsDialog(QObject):
         self.ui.color_maps.currentIndexChanged.connect(self.update_cmap)
         self.ui.glyph_size_slider.valueChanged.connect(self.update_plot)
         self.ui.reset_glyph_size.clicked.connect(self.reset_glyph_size)
+        self.ui.cylindrical_reference.toggled.connect(
+            self.cylindrical_reference_toggled)
 
         for name in ('x', 'y', 'z'):
             action = getattr(self, f'set_view_{name}')
@@ -270,14 +305,14 @@ class FitGrainsResultsDialog(QObject):
 
         fig = canvas.figure
         ax = fig.add_subplot(111, projection='3d', proj_type=self.projection)
-        ax.set_xlabel('X')
-        ax.set_ylabel('Y')
-        ax.set_zlabel('Z')
+
         self.ui.canvas_layout.addWidget(canvas)
 
         self.fig = fig
         self.ax = ax
         self.canvas = canvas
+
+        self.update_axes_labels()
 
     def setup_toolbar(self):
         # These don't work for 3D plots
@@ -362,6 +397,13 @@ class FitGrainsResultsDialog(QObject):
 
         self.draw()
 
+    def update_axes_labels(self):
+        axes = ('x', 'y', 'z')
+        labels = self.axes_labels
+        for axis, label in zip(axes, labels):
+            func = getattr(self.ax, f'set_{axis}label')
+            func(label)
+
     def update_selectors(self):
         tensor_type = self.tensor_type.capitalize()
 
@@ -369,8 +411,8 @@ class FitGrainsResultsDialog(QObject):
         items = [
             ('Completeness', 1),
             ('Goodness of Fit', 2),
-            (f'Equivalent {tensor_type}', 21),
-            (f'Hydrostatic {tensor_type}', 22),
+            (f'Equivalent {tensor_type}', EQUIVALENT_IND),
+            (f'Hydrostatic {tensor_type}', HYDROSTATIC_IND),
             (f'XX {tensor_type}', 15),
             (f'YY {tensor_type}', 16),
             (f'ZZ {tensor_type}', 17),
@@ -393,7 +435,7 @@ class FitGrainsResultsDialog(QObject):
             self.ui.plot_color_option.setCurrentIndex(prev_ind)
         else:
             self._first_selector_update = True
-            index = self.ui.plot_color_option.findData(21)
+            index = self.ui.plot_color_option.findData(EQUIVALENT_IND)
             self.ui.plot_color_option.setCurrentIndex(index)
 
     def setup_tableview(self):

--- a/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
@@ -517,6 +517,16 @@
                </property>
               </widget>
              </item>
+             <item row="3" column="1">
+              <widget class="QCheckBox" name="cylindrical_reference">
+               <property name="toolTip">
+                <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For the 3D coordinates, use a cylindrical reference frame (ρ, φ, Y) instead of cartesian coordinates.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="text">
+                <string>Cylindrical  Reference</string>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
           </item>
@@ -561,6 +571,7 @@
   <tabstop>hide_axes</tabstop>
   <tabstop>set_view_direction</tabstop>
   <tabstop>depth_shading</tabstop>
+  <tabstop>cylindrical_reference</tabstop>
   <tabstop>convert_strain_to_stress</tabstop>
   <tabstop>export_stresses</tabstop>
   <tabstop>glyph_size_slider</tabstop>


### PR DESCRIPTION
This allows the user to choose a cylindrical reference frame instead
of the standard cartesian reference for the 3D plot.

In the cylindrical reference frame, the coordinates are (ρ, φ, Y),
where ρ = np.sqrt(x*x + z*z), and φ = np.arctan2(z, x).

![cylind](https://user-images.githubusercontent.com/9558430/104020377-b8070c00-5182-11eb-83f5-da38c48af396.gif)

Fixes: #678