### PR TITLE
Fix fit grains plot coordinates

### DIFF
--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -187,7 +187,7 @@ class FitGrainsResultsDialog(QObject):
         column = self.ui.plot_color_option.currentData()
         colors = data[:, column]
 
-        coords = data[:, COORDS_SLICE]
+        coords = data[:, COORDS_SLICE].T
         sz = self.ui.glyph_size_slider.value()
 
         # I could not find a way to update scatter plot marker colors and


### PR DESCRIPTION
It was plotting:
```python
(grain1[0], grain2[0], grain3[0])
(grain1[1], grain2[1], grain3[1])
(grain1[2], grain2[2], grain3[2])
```

When it should have been plotting:
```python
(grain1[0], grain1[1], grain1[2])
(grain2[0], grain2[1], grain2[2])
(grain3[0], grain3[1], grain3[2])
```

This bug was introduced in 87545810f98dce86678aa83c268f76a3bbb6bec8

The transpose fixes it. You can see the change with the data below:

![Screenshot from 2021-01-08 11-31-05](https://user-images.githubusercontent.com/9558430/104046461-c0247300-51a5-11eb-9b55-d65814f139fd.png)

Before
=====
![bad](https://user-images.githubusercontent.com/9558430/104046483-ca467180-51a5-11eb-874c-a0b8f533e0e5.png)

After
====
![good](https://user-images.githubusercontent.com/9558430/104046506-cfa3bc00-51a5-11eb-9c62-3d22f13ed179.png)
