### PR TITLE
Highlight grain row when point is picked

### DIFF
--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -231,6 +231,7 @@ class FitGrainsResultsDialog(QObject):
             'cmap': self.cmap,
             's': sz,
             'depthshade': self.depth_shading,
+            'picker': True,
         }
         self.scatter_artist = self.ax.scatter3D(*coords, **kwargs)
         self.update_color_settings()
@@ -340,6 +341,8 @@ class FitGrainsResultsDialog(QObject):
         # Get the canvas to take up the majority of the screen most of the time
         canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
+        canvas.mpl_connect('pick_event', self.point_picked)
+
         fig = canvas.figure
         ax = fig.add_subplot(111, projection='3d', proj_type=self.projection)
 
@@ -355,6 +358,25 @@ class FitGrainsResultsDialog(QObject):
         self.canvas = canvas
 
         self.update_axes_labels()
+
+    def point_picked(self, event):
+        self.select_grain_in_table(event.ind[0])
+
+    def select_grain_in_table(self, grain_id):
+        table_model = self.ui.table_view.model()
+        for i in range(self.data_model.rowCount()):
+            if grain_id == table_model.index(i, 0).data():
+                return self.select_row(i)
+
+        raise Exception(f'Failed to find grain_id {grain_id} in table')
+
+    def select_row(self, i):
+        if i is None or i >= self.data_model.rowCount():
+            # Out of range. Don't do anything.
+            return
+
+        # Select the row
+        self.ui.table_view.selectRow(i)
 
     def setup_toolbar(self):
         # These don't work for 3D plots

--- a/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
@@ -47,6 +47,9 @@
       <property name="alternatingRowColors">
        <bool>true</bool>
       </property>
+      <property name="selectionBehavior">
+       <enum>QAbstractItemView::SelectRows</enum>
+      </property>
      </widget>
      <widget class="QWidget" name="plot_widget" native="true">
       <layout class="QHBoxLayout" name="horizontalLayout">


### PR DESCRIPTION
This almost works. A row is highlighted when a point is picked,
and this is based upon the `event.ind` that gets passed to the
event callback when a point is picked. In theory, this index
should match up with the index of the data that was used to
generate the point (see [here](https://matplotlib.org/3.3.3/gallery/event_handling/pick_event_demo.html) for an example). However,
in our case, the index does not seem to match the data. I'm
not sure why. It could be a bug on matplotlib's side.

Anyways, if we can fix that, this will be mostly ready to go.
The one other thing we should check is what happens if multiple
points are selected when the user clicks (which one gets chosen?).

Fixes: #679
Fixes: #680