### PR TITLE
Looks like the conda-build issue is resolved in 3.21.4

### DIFF
--- a/packaging/environment.yml
+++ b/packaging/environment.yml
@@ -6,6 +6,6 @@ dependencies:
   - coloredlogs
   - conda
   - cmake
-  - conda-build=3.21.1
+  - conda-build
   - conda-pack
   - click


### PR DESCRIPTION
So move back to latest. See https://github.com/conda/conda-build/issues/4182 for more details.