### PR TITLE
Use scientific spin boxes in form view

### DIFF
--- a/hexrd/ui/resources/ui/calibration_config_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_config_widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>506</width>
+    <width>560</width>
     <height>595</height>
    </rect>
   </property>
@@ -69,7 +69,7 @@
           <number>0</number>
          </property>
          <item>
-          <widget class="QDoubleSpinBox" name="cal_energy_wavelength">
+          <widget class="ScientificDoubleSpinBox" name="cal_energy_wavelength">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -80,7 +80,7 @@
             <string> Å</string>
            </property>
            <property name="decimals">
-            <number>6</number>
+            <number>8</number>
            </property>
            <property name="minimum">
             <double>0.000001000000000</double>
@@ -97,7 +97,7 @@
           </widget>
          </item>
          <item>
-          <widget class="QDoubleSpinBox" name="cal_energy">
+          <widget class="ScientificDoubleSpinBox" name="cal_energy">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -108,10 +108,10 @@
             <string> keV</string>
            </property>
            <property name="decimals">
-            <number>4</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>0.100000000000000</double>
+            <double>0.000001000000000</double>
            </property>
            <property name="maximum">
             <double>1000000.000000000000000</double>
@@ -149,7 +149,7 @@
           <number>0</number>
          </property>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="cal_vector_azimuth">
+          <widget class="ScientificDoubleSpinBox" name="cal_vector_azimuth">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -163,7 +163,7 @@
             <string>°</string>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="maximum">
             <double>360.000000000000000</double>
@@ -177,7 +177,7 @@
           </widget>
          </item>
          <item row="2" column="1">
-          <widget class="QDoubleSpinBox" name="cal_vector_polar">
+          <widget class="ScientificDoubleSpinBox" name="cal_vector_polar">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -191,7 +191,7 @@
             <string>°</string>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="maximum">
             <double>360.000000000000000</double>
@@ -252,7 +252,7 @@
        <number>0</number>
       </property>
       <item row="4" column="1" colspan="2">
-       <widget class="QDoubleSpinBox" name="cal_det_saturation">
+       <widget class="ScientificDoubleSpinBox" name="cal_det_saturation">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -260,10 +260,10 @@
          <bool>false</bool>
         </property>
         <property name="decimals">
-         <number>1</number>
+         <number>8</number>
         </property>
         <property name="maximum">
-         <double>100000.000000000000000</double>
+         <double>10000000.000000000000000</double>
         </property>
         <property name="value">
          <double>14000.000000000000000</double>
@@ -299,7 +299,7 @@
           <number>0</number>
          </property>
          <item row="0" column="2">
-          <widget class="QDoubleSpinBox" name="cal_det_translation_1">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_1">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -310,13 +310,13 @@
             <string/>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -334,7 +334,7 @@
           </widget>
          </item>
          <item row="0" column="3">
-          <widget class="QDoubleSpinBox" name="cal_det_translation_2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_2">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -345,13 +345,13 @@
             <string/>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -359,7 +359,7 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="cal_det_translation_0">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_0">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -370,13 +370,13 @@
             <string/>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -394,7 +394,7 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="cal_det_tilt_0">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_0">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -405,13 +405,13 @@
             <string>°</string>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -419,7 +419,7 @@
           </widget>
          </item>
          <item row="1" column="2">
-          <widget class="QDoubleSpinBox" name="cal_det_tilt_1">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_1">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -430,13 +430,13 @@
             <string>°</string>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -444,7 +444,7 @@
           </widget>
          </item>
          <item row="1" column="3">
-          <widget class="QDoubleSpinBox" name="cal_det_tilt_2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_2">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -455,13 +455,13 @@
             <string>°</string>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -552,13 +552,13 @@
             <string/>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -580,13 +580,13 @@
             <string/>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -608,13 +608,13 @@
             <string/>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -633,13 +633,13 @@
             <bool>false</bool>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -658,13 +658,13 @@
             <bool>false</bool>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -683,13 +683,13 @@
             <bool>false</bool>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>-10000.000000000000000</double>
+            <double>-100000.000000000000000</double>
            </property>
            <property name="maximum">
-            <double>10000.000000000000000</double>
+            <double>100000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -741,7 +741,7 @@
           <number>0</number>
          </property>
          <item row="2" column="2">
-          <widget class="QDoubleSpinBox" name="cal_det_size_0">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_size_0">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -749,13 +749,13 @@
             <bool>false</bool>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>0.100000000000000</double>
+            <double>0.000001000000000</double>
            </property>
            <property name="maximum">
-            <double>100.000000000000000</double>
+            <double>1000000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -786,7 +786,7 @@
           </widget>
          </item>
          <item row="2" column="3">
-          <widget class="QDoubleSpinBox" name="cal_det_size_1">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_size_1">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -794,13 +794,13 @@
             <bool>false</bool>
            </property>
            <property name="decimals">
-            <number>5</number>
+            <number>8</number>
            </property>
            <property name="minimum">
-            <double>0.100000000000000</double>
+            <double>0.000001000000000</double>
            </property>
            <property name="maximum">
-            <double>100.000000000000000</double>
+            <double>1000000.000000000000000</double>
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
@@ -913,7 +913,7 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="cal_osc_translation_0">
+       <widget class="ScientificDoubleSpinBox" name="cal_osc_translation_0">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -924,7 +924,7 @@
          <string/>
         </property>
         <property name="decimals">
-         <number>5</number>
+         <number>8</number>
         </property>
         <property name="minimum">
          <double>-100000.000000000000000</double>
@@ -938,7 +938,7 @@
        </widget>
       </item>
       <item row="1" column="3">
-       <widget class="QDoubleSpinBox" name="cal_osc_translation_2">
+       <widget class="ScientificDoubleSpinBox" name="cal_osc_translation_2">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -949,7 +949,7 @@
          <string/>
         </property>
         <property name="decimals">
-         <number>5</number>
+         <number>8</number>
         </property>
         <property name="minimum">
          <double>-100000.000000000000000</double>
@@ -963,7 +963,7 @@
        </widget>
       </item>
       <item row="1" column="2">
-       <widget class="QDoubleSpinBox" name="cal_osc_translation_1">
+       <widget class="ScientificDoubleSpinBox" name="cal_osc_translation_1">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -974,7 +974,7 @@
          <string/>
         </property>
         <property name="decimals">
-         <number>5</number>
+         <number>8</number>
         </property>
         <property name="minimum">
          <double>-100000.000000000000000</double>
@@ -988,7 +988,7 @@
        </widget>
       </item>
       <item row="0" column="1" colspan="3">
-       <widget class="QDoubleSpinBox" name="cal_osc_chi">
+       <widget class="ScientificDoubleSpinBox" name="cal_osc_chi">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
@@ -999,7 +999,7 @@
          <string>°</string>
         </property>
         <property name="decimals">
-         <number>5</number>
+         <number>8</number>
         </property>
         <property name="minimum">
          <double>-100000.000000000000000</double>

--- a/hexrd/ui/scientificspinbox.py
+++ b/hexrd/ui/scientificspinbox.py
@@ -1,3 +1,4 @@
+from functools import wraps
 import re
 import math
 
@@ -41,6 +42,20 @@ class FloatValidator(QValidator):
         return match.group(1) + 'inf' if match else ''
 
 
+def clean_text(func):
+    """Clean text for ScientificDoubleSpinBox functions
+
+    This removes the prefix, suffix, and leading/trailing white space.
+    """
+    @wraps(func)
+    def wrapped(self, text, *args, **kwargs):
+        text = remove_prefix(text, self.prefix())
+        text = remove_suffix(text, self.suffix())
+        text = text.strip()
+        return func(self, text, *args, **kwargs)
+    return wrapped
+
+
 class ScientificDoubleSpinBox(QDoubleSpinBox):
 
     @staticmethod
@@ -48,7 +63,7 @@ class ScientificDoubleSpinBox(QDoubleSpinBox):
         """Modified form of the 'g' format specifier."""
 
         string = '{:.10g}'.format(value).replace('e+', 'e')
-        string = re.sub('e(-?)0*(\d+)', r'e\1\2', string)
+        string = re.sub(r'e(-?)0*(\d+)', r'e\1\2', string)
 
         return string
 
@@ -59,12 +74,15 @@ class ScientificDoubleSpinBox(QDoubleSpinBox):
         self.validator = FloatValidator()
         self.setDecimals(1000)
 
+    @clean_text
     def validate(self, text, position):
         return self.validator.validate(text, position)
 
+    @clean_text
     def fixup(self, text):
         return self.validator.fixup(text)
 
+    @clean_text
     def valueFromText(self, text):
         return float(self.fixup(text))
 
@@ -76,10 +94,24 @@ class ScientificDoubleSpinBox(QDoubleSpinBox):
         groups = FLOAT_REGEX.search(text).groups()
         decimal = float(groups[1])
         decimal += steps
-        new_string = '{:.10g}'.format(decimal) + (groups[3] if groups[3] else '')
+        new_string = f'{decimal:.10g}' + (groups[3] if groups[3] else '')
 
         # Set the value so that signals get emitted properly
         self.setValue(self.valueFromText(new_string))
 
         # Select the text just like a regular spin box would...
         self.selectAll()
+
+
+def remove_prefix(text, prefix):
+    # This can be replaced with str.removeprefix() in python >=3.9
+    if prefix and text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
+
+def remove_suffix(text, suffix):
+    # This can be replaced with str.removesuffix() in python >=3.9
+    if suffix and text.endswith(suffix):
+        return text[:-len(suffix)]
+    return text


### PR DESCRIPTION
This PR fixes the scientific spin box so that it ignores the prefix/suffix (if they are present), and it also changes all of the widgets in the form view to use the scientific spin box. This increases the precision for displaying and entering parameters.

This also fixes #716, which was being caused by the spinboxes now allowing values below 0.1.

Fixes: #716