### PR TITLE
YAML File Loading

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -413,6 +413,7 @@ class LoadPanel(QObject):
                 self.ui.file_options.item(i, 1).setFlags(Qt.ItemIsEnabled)
 
         self.ui.file_options.resizeColumnsToContents()
+        self.ui.file_options.sortByColumn(0, Qt.AscendingOrder)
 
     def contextMenuEvent(self, event):
         # Allow user to delete selected file(s)

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -268,7 +268,10 @@ class LoadPanel(QObject):
                     self.omega_min = ['0'] * len(self.yml_files[0])
                     self.omega_max = ['0.25'] * len(self.yml_files[0])
                     self.delta = [''] * len(self.yml_files[0])
-                self.empty_frames = data['options']['empty-frames']
+                options = data.get('options', {})
+                self.empty_frames = 0
+                if isinstance(options, dict):
+                    self.empty_frames = options.get('empty-frames', 0)
         else:
             for ims in tmp_ims:
                 has_omega = 'omega' in ims.metadata


### PR DESCRIPTION
This PR fixes some things around loading images in the load panel via `YAML` file:
- The `options` keys [are optional](https://github.com/HEXRD/hexrd/wiki/ims-load-options#image-files), do not assume they will be present
- Sort the files table by file name