### PR TITLE
Prevent unnecessary re-rendering of the window

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -37,6 +37,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
     update_needed = Signal()
     new_images_loaded = Signal()
     images_transformed = Signal()
+    live_update_status = Signal(bool)
 
     def __init__(self):
         super(ImageLoadManager, self).__init__(None)
@@ -139,6 +140,9 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         self.begin_processing()
 
     def begin_processing(self, postprocess=False):
+        self.update_status = HexrdConfig().live_update
+        self.live_update_status.emit(False)
+
         # Create threads and loading dialog
         thread_pool = QThreadPool(self.parent)
         progress_dialog = ProgressDialog(self.parent)
@@ -198,8 +202,10 @@ class ImageLoadManager(QObject, metaclass=Singleton):
 
     def finish_processing_ims(self):
         # Display processed images on completion
-        self.update_needed.emit()
         self.new_images_loaded.emit()
+        self.live_update_status.emit(self.update_status)
+        if not self.update_status:
+            self.update_needed.emit()
         if self.transformed_images:
             HexrdConfig().instrument_config_loaded.emit()
             HexrdConfig().deep_rerender_needed.emit()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -506,4 +506,3 @@ class LoadPanel(QObject):
             data['yml_files'] = self.yml_files
         HexrdConfig().load_panel_state.update(copy.copy(self.state))
         ImageLoadManager().read_data(self.files, data, self.parent())
-        self.images_loaded.emit()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -222,6 +222,7 @@ class MainWindow(QObject):
         ImageLoadManager().update_needed.connect(self.update_all)
         ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)
         ImageLoadManager().images_transformed.connect(self.update_config_gui)
+        ImageLoadManager().live_update_status.connect(self.live_update)
 
         self.ui.action_switch_workflow.triggered.connect(
             self.on_action_switch_workflow_triggered)


### PR DESCRIPTION
Repeated calls to the `update_all` function was causing the canvas to be redrawn multiple times during the process of loading images. Prevent these unnecessary calls by temporarily turning off live updates until the image processing has completed.