### PR TITLE
Update spots with chosen method in ome maps viewer

### DIFF
--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -5,11 +5,14 @@ import matplotlib
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 import numpy as np
-from scipy import ndimage
 import yaml
 
 from PySide2.QtCore import Signal, QObject, QSignalBlocker, Qt
-from PySide2.QtWidgets import QComboBox, QFileDialog, QSizePolicy
+from PySide2.QtWidgets import (
+    QComboBox, QDoubleSpinBox, QFileDialog, QSizePolicy, QSpinBox
+)
+
+from hexrd.findorientations import label_spots
 
 from hexrd.ui import enter_key_filter, resource_loader
 
@@ -38,6 +41,7 @@ class OmeMapsViewerDialog(QObject):
         self.cmap = hexrd.ui.constants.DEFAULT_CMAP
         self.norm = None
         self.spots = None
+        self.reset_internal_config()
 
         self.setup_widget_paths()
 
@@ -61,11 +65,28 @@ class OmeMapsViewerDialog(QObject):
         self.ui.rejected.connect(self.on_rejected)
 
         self.ui.method.currentIndexChanged.connect(self.update_method_tab)
+        self.ui.method.currentIndexChanged.connect(self.update_config)
         self.color_map_editor.ui.minimum.valueChanged.connect(
-            self.update_spots)
+            self.update_config)
 
         # A plot reset is needed for log scale to handle the NaN values
         self.color_map_editor.ui.log_scale.toggled.connect(self.reset_plot)
+
+        def changed_signal(w):
+            if isinstance(w, QComboBox):
+                return w.currentIndexChanged
+            elif isinstance(w, (QDoubleSpinBox, QSpinBox)):
+                return w.valueChanged
+            else:
+                raise Exception(f'Unhandled widget type: {type(w)}')
+
+        for w in self.yaml_widgets:
+            changed_signal(w).connect(self.update_config)
+
+        for w in self.method_parameter_widgets:
+            changed_signal(w).connect(self.update_spots)
+
+        self.ui.method.currentIndexChanged.connect(self.update_spots)
 
     def setup_combo_box_item_data(self):
         # Set the item data for the combo boxes to be the names we want
@@ -86,13 +107,18 @@ class OmeMapsViewerDialog(QObject):
         for i, data in enumerate(item_data):
             self.ui.clustering_algorithm.setItemData(i, data)
 
+    def reset_internal_config(self):
+        self.config = copy.deepcopy(HexrdConfig().indexing_config)
+
     def show(self):
         self.reset_plot()
         self.ui.show()
 
     def on_accepted(self):
         # Any validation may be performed here first
+        # Update the config one last time before saving...
         self.update_config()
+        self.save_config()
         self.accepted.emit()
 
     def on_rejected(self):
@@ -117,6 +143,13 @@ class OmeMapsViewerDialog(QObject):
         initial_path = []
         recursive_get_paths(self.gui_config_maps, initial_path)
         self.widget_paths = paths
+
+    @property
+    def method_parameter_widgets(self):
+        maps = self.gui_config_maps
+        methods = maps['find_orientations']['seed_search']['method']
+        names = [v for d in methods.values() for v in d.values()]
+        return [getattr(self.ui, x) for x in names]
 
     @property
     def method_name(self):
@@ -224,8 +257,16 @@ class OmeMapsViewerDialog(QObject):
             return
 
         self.create_spots()
-        self._spot_lines = self.ax.scatter(self.spots[:, 1], self.spots[:, 0],
-                                           18, 'm', '+')
+        if self.spots.size:
+            kwargs = {
+                'x': self.spots[:, 1],
+                'y': self.spots[:, 0],
+                's': 18,
+                'c': 'm',
+                'marker': '+',
+            }
+            self._spot_lines = self.ax.scatter(**kwargs)
+
         self.draw()
 
     def reset_plot(self):
@@ -284,22 +325,22 @@ class OmeMapsViewerDialog(QObject):
         # Get rid of nans to make our work easier
         data[np.isnan(data)] = 0
 
-        structure = np.ones((3, 3))
-        labels, numSpots = ndimage.label(data > self.threshold, structure)
+        method_name = self.method_name
+        method_dict = self.config['find_orientations']['seed_search']['method']
+        method_kwargs = method_dict[method_name]
 
-        index = np.arange(np.amax(labels)) + 1
-        spots = ndimage.measurements.center_of_mass(data, labels, index)
-        spots = np.array(spots)
+        _, spots = label_spots(data, method_name, method_kwargs)
 
-        # Rescale the points to match the extents
-        old_extent = self.original_extent
-        old_x_range = (old_extent[0], old_extent[1])
-        old_y_range = (old_extent[3], old_extent[2])
-        new_x_range = (self.extent[0], self.extent[1])
-        new_y_range = (self.extent[3], self.extent[2])
+        if spots.size:
+            # Rescale the points to match the extents
+            old_extent = self.original_extent
+            old_x_range = (old_extent[0], old_extent[1])
+            old_y_range = (old_extent[3], old_extent[2])
+            new_x_range = (self.extent[0], self.extent[1])
+            new_y_range = (self.extent[3], self.extent[2])
 
-        spots[:, 1] = np.interp(spots[:, 1], old_x_range, new_x_range)
-        spots[:, 0] = np.interp(spots[:, 0], old_y_range, new_y_range)
+            spots[:, 1] = np.interp(spots[:, 1], old_x_range, new_x_range)
+            spots[:, 0] = np.interp(spots[:, 0], old_y_range, new_y_range)
 
         self.spots = spots
 
@@ -351,7 +392,7 @@ class OmeMapsViewerDialog(QObject):
             # Assume it is a spin box of some kind
             return w.setValue
 
-        config = HexrdConfig().indexing_config
+        config = self.config
 
         def set_val(w, path):
             cur = config
@@ -377,7 +418,7 @@ class OmeMapsViewerDialog(QObject):
 
     def update_config(self):
         # Update all of the config with their settings from the widgets
-        config = HexrdConfig().indexing_config
+        config = self.config
 
         # Clear the method so it can be set to a different one
         method = config['find_orientations']['seed_search']['method']
@@ -413,3 +454,6 @@ class OmeMapsViewerDialog(QObject):
 
         # Also set the threshold to the minimum color map value...
         config['find_orientations']['threshold'] = self.threshold
+
+    def save_config(self):
+        HexrdConfig().config['indexing'] = copy.deepcopy(self.config)

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>725</height>
+    <height>728</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -56,9 +56,15 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="omega_tolerance">
+          <widget class="ScientificDoubleSpinBox" name="omega_tolerance">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="suffix">
             <string>°</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
            </property>
            <property name="minimum">
             <double>0.000000000000000</double>
@@ -78,9 +84,15 @@
        </widget>
       </item>
       <item row="1" column="1">
-       <widget class="QDoubleSpinBox" name="fiber_step">
+       <widget class="ScientificDoubleSpinBox" name="fiber_step">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
         <property name="suffix">
          <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
         </property>
         <property name="minimum">
          <double>0.000000000000000</double>
@@ -114,33 +126,13 @@
             </size>
            </property>
            <property name="currentIndex">
-            <number>2</number>
+            <number>0</number>
            </property>
            <widget class="QWidget" name="label_tab">
             <attribute name="title">
              <string>Label</string>
             </attribute>
             <layout class="QGridLayout" name="gridLayout_2">
-             <item row="1" column="1">
-              <widget class="QSpinBox" name="label_threshold">
-               <property name="maximum">
-                <number>1000</number>
-               </property>
-               <property name="value">
-                <number>1</number>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QSpinBox" name="filter_radius">
-               <property name="maximum">
-                <number>1000</number>
-               </property>
-               <property name="value">
-                <number>1</number>
-               </property>
-              </widget>
-             </item>
              <item row="1" column="0">
               <widget class="QLabel" name="label_threshold_label">
                <property name="text">
@@ -168,6 +160,38 @@
                </property>
               </spacer>
              </item>
+             <item row="0" column="1">
+              <widget class="ScientificDoubleSpinBox" name="filter_radius">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="maximum">
+                <double>10000000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="ScientificDoubleSpinBox" name="label_threshold">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="maximum">
+                <double>1000000.000000000000000</double>
+               </property>
+               <property name="value">
+                <double>1.000000000000000</double>
+               </property>
+              </widget>
+             </item>
             </layout>
            </widget>
            <widget class="QWidget" name="blob_dog_tab">
@@ -176,9 +200,18 @@
             </attribute>
             <layout class="QGridLayout" name="gridLayout_3">
              <item row="0" column="1">
-              <widget class="QDoubleSpinBox" name="bd_min_sigma">
+              <widget class="ScientificDoubleSpinBox" name="bd_min_sigma">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -203,9 +236,18 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QDoubleSpinBox" name="bd_max_sigma">
+              <widget class="ScientificDoubleSpinBox" name="bd_max_sigma">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -223,9 +265,18 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="bd_sigma_ratio">
+              <widget class="ScientificDoubleSpinBox" name="bd_sigma_ratio">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -243,12 +294,18 @@
               </widget>
              </item>
              <item row="3" column="1">
-              <widget class="QDoubleSpinBox" name="bd_threshold">
+              <widget class="ScientificDoubleSpinBox" name="bd_threshold">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
                <property name="decimals">
-                <number>3</number>
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
                </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -266,9 +323,18 @@
               </widget>
              </item>
              <item row="4" column="1">
-              <widget class="QDoubleSpinBox" name="bd_overlap">
+              <widget class="ScientificDoubleSpinBox" name="bd_overlap">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="value">
                 <double>0.100000000000000</double>
@@ -297,9 +363,18 @@
               </widget>
              </item>
              <item row="2" column="1">
-              <widget class="QDoubleSpinBox" name="bl_max_sigma">
+              <widget class="ScientificDoubleSpinBox" name="bl_max_sigma">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -331,9 +406,18 @@
               </widget>
              </item>
              <item row="1" column="1">
-              <widget class="QDoubleSpinBox" name="bl_min_sigma">
+              <widget class="ScientificDoubleSpinBox" name="bl_min_sigma">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.100000000000000</double>
@@ -345,6 +429,9 @@
              </item>
              <item row="3" column="1">
               <widget class="QSpinBox" name="bl_num_sigma">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
                <property name="minimum">
                 <number>1</number>
                </property>
@@ -357,12 +444,18 @@
               </widget>
              </item>
              <item row="4" column="1">
-              <widget class="QDoubleSpinBox" name="bl_threshold">
+              <widget class="ScientificDoubleSpinBox" name="bl_threshold">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
                <property name="decimals">
-                <number>3</number>
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
                </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="singleStep">
                 <double>0.010000000000000</double>
@@ -373,9 +466,18 @@
               </widget>
              </item>
              <item row="5" column="1">
-              <widget class="QDoubleSpinBox" name="bl_overlap">
+              <widget class="ScientificDoubleSpinBox" name="bl_overlap">
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="minimum">
+                <double>-1000000.000000000000000</double>
+               </property>
                <property name="maximum">
-                <double>1000.000000000000000</double>
+                <double>1000000.000000000000000</double>
                </property>
                <property name="value">
                 <double>0.100000000000000</double>
@@ -422,9 +524,15 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="eta_tolerance">
+          <widget class="ScientificDoubleSpinBox" name="eta_tolerance">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="suffix">
             <string>°</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
            </property>
            <property name="minimum">
             <double>0.000000000000000</double>
@@ -448,9 +556,15 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="eta_mask">
+          <widget class="ScientificDoubleSpinBox" name="eta_mask">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="suffix">
             <string>°</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
            </property>
            <property name="minimum">
             <double>0.000000000000000</double>
@@ -498,9 +612,15 @@
           </widget>
          </item>
          <item row="0" column="1">
-          <widget class="QDoubleSpinBox" name="clustering_radius">
+          <widget class="ScientificDoubleSpinBox" name="clustering_radius">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
            <property name="maximum">
-            <double>1000.000000000000000</double>
+            <double>10000000.000000000000000</double>
            </property>
            <property name="value">
             <double>1.000000000000000</double>
@@ -532,9 +652,12 @@
           </widget>
          </item>
          <item row="1" column="1">
-          <widget class="QDoubleSpinBox" name="clustering_completeness">
+          <widget class="ScientificDoubleSpinBox" name="clustering_completeness">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
            <property name="decimals">
-            <number>3</number>
+            <number>8</number>
            </property>
            <property name="maximum">
             <double>1.000000000000000</double>
@@ -609,6 +732,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>method</tabstop>
   <tabstop>tab_widget</tabstop>


### PR DESCRIPTION
Previously, it always used logic for the "label" method when creating
the spots, and it wasn't even fully accurate for the "label" method (it
was missing some of the code logic).

Instead, we should call the "label_spots" function in hexrd so the spots
are generated the exact same way that hexrd does, to give the user an
accurate preview.

Additionally, it now generates spots based upon the method that has
been selected (label, blob dog, or blob log), and the options for each of
those methods. The spots are automatically updated with any change to
the method options or to the method itself.

Depends on: hexrd/hexrd#163
Fixes: #721