### PR TITLE
Yaml files

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -33,6 +33,7 @@ UI_THRESHOLD_LESS_THAN = 0
 UI_THRESHOLD_GREATER_THAN = 1
 UI_THRESHOLD_EQUAL_TO = 2
 
+YAML_EXTS = ['.yaml', '.yml']
 
 class ViewType:
     raw = 'raw'

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -354,16 +354,13 @@ class LoadPanel(QObject):
             self.yml_files.append(files)
 
     def enable_read(self):
-        if (self.ext == '.tiff'
-                or '' not in self.omega_min and '' not in self.omega_max):
+        files = self.yml_files if self.ext in YAML_EXTS else self.files
+        enabled = True
+        if len(files) and all(len(f) for f in files):
             if (self.state['dark'][self.idx] == UI_DARK_INDEX_FILE
-                    and self.dark_files[self.idx] is not None):
-                self.ui.read.setEnabled(len(self.files))
-                return
-            elif self.state['dark'][self.idx] != 4 and len(self.files):
-                self.ui.read.setEnabled(True)
-                return
-        self.ui.read.setEnabled(False)
+                    and self.dark_files[self.idx] is None):
+                enabled = False
+            self.ui.read.setEnabled(enabled)
 
     # Handle table setup and changes
 

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -1,6 +1,5 @@
 import copy
 import yaml
-import glob
 import numpy as np
 from pathlib import Path
 

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -348,8 +348,8 @@ class LoadPanel(QObject):
                     data = yaml.safe_load(yml_file)['image-files']
                 raw_images = data['files'].split()
                 for raw_image in raw_images:
-                    files.extend(glob.glob(
-                        PurePath(data['directory'], raw_image)))
+                    path = Path(self.parent_dir, data['directory'])
+                    files.extend(path.glob(raw_image))
             self.yml_files.append(files)
 
     def enable_read(self):

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -9,7 +9,7 @@ from PySide2.QtCore import QObject, Qt, QPersistentModelIndex, QDir, Signal
 from PySide2.QtWidgets import QTableWidgetItem, QFileDialog, QMenu, QMessageBox
 
 from hexrd.ui.constants import (
-    UI_DARK_INDEX_FILE, UI_DARK_INDEX_NONE, UI_AGG_INDEX_NONE)
+    UI_DARK_INDEX_FILE, UI_DARK_INDEX_NONE, UI_AGG_INDEX_NONE, YAML_EXTS)
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_file_manager import ImageFileManager
 from hexrd.ui.image_load_manager import ImageLoadManager
@@ -246,7 +246,7 @@ class LoadPanel(QObject):
 
         tmp_ims = []
         for img in selected_files:
-            if self.ext != '.yml':
+            if self.ext not in YAML_EXTS:
                 tmp_ims.append(ImageFileManager().open_file(img))
 
         self.find_images(selected_files)
@@ -254,7 +254,7 @@ class LoadPanel(QObject):
         if not self.files:
             return
 
-        if self.ext == '.yml':
+        if self.ext in YAML_EXTS:
             for yf in self.yml_files[0]:
                 ims = ImageFileManager().open_file(yf)
                 self.total_frames.append(len(ims) if len(ims) > 0 else 1)
@@ -337,7 +337,7 @@ class LoadPanel(QObject):
 
         self.dir_changed()
 
-        if self.files and self.ext == '.yml':
+        if self.files and self.ext in YAML_EXTS:
             self.get_yml_files()
 
     def get_yml_files(self):
@@ -372,7 +372,7 @@ class LoadPanel(QObject):
         if not len(self.files):
             return
 
-        if self.ext == '.yml':
+        if self.ext in YAML_EXTS:
             table_files = self.yml_files
         else:
             table_files = self.files
@@ -411,7 +411,7 @@ class LoadPanel(QObject):
             self.ui.file_options.item(i, 0).setFlags(Qt.ItemIsEnabled)
             self.ui.file_options.item(i, 2).setFlags(Qt.ItemIsEnabled)
             # If raw data offset can only be changed in YAML file
-            if self.ext == '.yml':
+            if self.ext in YAML_EXTS:
                 self.ui.file_options.item(i, 1).setFlags(Qt.ItemIsEnabled)
 
         self.ui.file_options.blockSignals(False)
@@ -502,7 +502,7 @@ class LoadPanel(QObject):
             }
         if self.ui.all_detectors.isChecked():
             data['idx'] = self.idx
-        if self.ext == '.yml':
+        if self.ext in YAML_EXTS:
             data['yml_files'] = self.yml_files
         HexrdConfig().load_panel_state.update(copy.copy(self.state))
         ImageLoadManager().read_data(self.files, data, self.parent())


### PR DESCRIPTION
This fixes some bugs revolving around loading `yaml` files through the load panel, as well as cleans up the related code.

- Check for either `.yml` or `.yaml` file extensions. Adds a constant for this purpose.
- Simplify the logic for enabling `Read Files`
- Use `pathlib` for paths rather than `os.path`
- Add the ability to handle relative directory paths in YAML files