### PR TITLE
Load panel bugs

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -145,12 +145,12 @@ class LoadPanel(QObject):
         self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
 
     def config_changed(self):
-        self.setup_processing_options()
-        self.detectors_changed()
-        self.ui.file_options.setRowCount(0)
-        self.reset_data()
-        self.enable_read()
-        self.setup_gui()
+        if HexrdConfig().detector_names != self.dets:
+            self.detectors_changed()
+            self.ui.file_options.setRowCount(0)
+            self.reset_data()
+            self.enable_read()
+            self.setup_gui()
 
     def switch_detector(self):
         self.idx = self.ui.detector.currentIndex()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -36,7 +36,7 @@ class LoadPanel(QObject):
         self.ui = loader.load_file('load_panel.ui', parent)
 
         self.ims = HexrdConfig().imageseries_dict
-        self.parent_dir = HexrdConfig().images_dir if HexrdConfig().images_dir else ''
+        self.parent_dir = HexrdConfig().images_dir
 
         self.files = []
         self.omega_min = []
@@ -65,7 +65,10 @@ class LoadPanel(QObject):
         if not self.parent_dir:
             self.ui.img_directory.setText('No directory set')
         else:
-            self.ui.img_directory.setText(self.parent_dir)
+            directory = self.parent_dir
+            if os.path.isfile(directory):
+                directory = os.path.basename(directory)
+            self.ui.img_directory.setText(directory)
 
         self.detectors_changed()
         self.ui.file_options.resizeColumnsToContents()
@@ -135,7 +138,7 @@ class LoadPanel(QObject):
             [fname for fnames in self.files for fname in fnames])
         HexrdConfig().set_images_dir(new_dir)
         self.parent_dir = new_dir
-        self.ui.img_directory.setText(self.parent_dir)
+        self.ui.img_directory.setText(os.path.dirname(self.parent_dir))
 
     def config_changed(self):
         self.setup_processing_options()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -78,7 +78,8 @@ class LoadPanel(QObject):
     def setup_connections(self):
         HexrdConfig().detectors_changed.connect(self.detectors_changed)
         HexrdConfig().instrument_config_loaded.connect(self.config_changed)
-        HexrdConfig().load_panel_state_reset.connect(self.setup_processing_options)
+        HexrdConfig().load_panel_state_reset.connect(
+            self.setup_processing_options)
 
         self.ui.image_folder.clicked.connect(self.select_folder)
         self.ui.image_files.clicked.connect(self.select_images)
@@ -101,8 +102,10 @@ class LoadPanel(QObject):
         self.state = HexrdConfig().load_panel_state
         num_dets = len(HexrdConfig().detector_names)
         self.state.setdefault('agg', UI_AGG_INDEX_NONE)
-        self.state.setdefault('trans', [UI_TRANS_INDEX_NONE for x in range(num_dets)])
-        self.state.setdefault('dark', [UI_DARK_INDEX_NONE for x in range(num_dets)])
+        self.state.setdefault(
+            'trans', [UI_TRANS_INDEX_NONE for x in range(num_dets)])
+        self.state.setdefault(
+            'dark', [UI_DARK_INDEX_NONE for x in range(num_dets)])
         self.state.setdefault('dark_files', [None for x in range(num_dets)])
 
     # Handle GUI changes


### PR DESCRIPTION
Fixes some bugs I found in the load panel:

- The directory label should only display the parent directory. It was being updated to display a full file path on occasion; fix this.
- Connect the clear load panel state signal to the load panel so that the current selections are updated accordingly (this happens if a new instrument config is loaded)
- Do not reset the table unless a new instrument config is loaded (the table was previously being cleared every time a transform was applied and the images were loaded)