### PR TITLE
Display raw view cursor info in status bar

### DIFF
--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -245,7 +245,7 @@ class ImageTabWidget(QTabWidget):
         mode = self.image_canvases[0].mode
 
         if mode is None:
-            mode = 'images'
+            mode = ViewType.raw
 
         info = {
             'x': event.x,
@@ -272,14 +272,20 @@ class ImageTabWidget(QTabWidget):
 
         # intensity being None implies here that the mouse is on top of the
         # azimuthal integration plot in the polar view.
-        if (mode in [ViewType.cartesian, ViewType.polar] and
-                intensity is not None):
+        if intensity is not None:
 
             iviewer = self.image_canvases[0].iviewer
 
-            if mode == ViewType.cartesian:
-                xy_data = iviewer.dpanel.pixelToCart(np.vstack([i, j]).T)
-                ang_data, gvec = iviewer.dpanel.cart_to_angles(xy_data)
+            if mode in (ViewType.cartesian, ViewType.raw):
+                if mode == ViewType.cartesian:
+                    dpanel = iviewer.dpanel
+                else:
+                    # The title is the name of the detector
+                    key = event.inaxes.get_title()
+                    dpanel = iviewer.instr.detectors[key]
+
+                xy_data = dpanel.pixelToCart(np.vstack([i, j]).T)
+                ang_data, gvec = dpanel.cart_to_angles(xy_data)
                 tth = ang_data[:, 0][0]
                 eta = ang_data[:, 1][0]
             else:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -885,12 +885,10 @@ class MainWindow(QObject):
         intensity = info['intensity']
         if intensity is not None:
             labels.append('value = {:8.3f}'.format(info['intensity']))
-
-            if info['mode'] in [ViewType.cartesian, ViewType.polar]:
-                labels.append('tth = {:8.3f}'.format(info['tth']))
-                labels.append('eta = {:8.3f}'.format(info['eta']))
-                labels.append('dsp = {:8.3f}'.format(info['dsp']))
-                labels.append('hkl = ' + info['hkl'])
+            labels.append('tth = {:8.3f}'.format(info['tth']))
+            labels.append('eta = {:8.3f}'.format(info['eta']))
+            labels.append('dsp = {:8.3f}'.format(info['dsp']))
+            labels.append('hkl = ' + info['hkl'])
 
         msg = delimiter.join(labels)
         self.ui.status_bar.showMessage(msg)


### PR DESCRIPTION
Previously, only the polar and cartesian views would display the extra
information of tth, eta, dsp, and hkl.

Now, the raw view displays this information as well, in the untabbed
mode, tabbed mode, and zoomed in as well.

https://user-images.githubusercontent.com/9558430/106696617-b6264200-65a2-11eb-9b0b-37571de91e9f.mp4

Fixes: hexrd/hexrd#168