### PR TITLE
typo in distortion application

### DIFF
--- a/hexrd/ui/overlays/powder_diffraction.py
+++ b/hexrd/ui/overlays/powder_diffraction.py
@@ -185,7 +185,7 @@ class PowderLineOverlay:
                 if display_mode == ViewType.raw:
                     # !!! distortion
                     if panel.distortion is not None:
-                        xys_full = panel.distortion.apply_inverse(xys_full)
+                        xys = panel.distortion.apply_inverse(xys)
 
                     # Convert to pixel coordinates
                     # ??? keep in pixels?


### PR DESCRIPTION
I noticed for a user's GE detector example that the overlays in the raw and cartesian mode were way off after calibration, while the polar view showed great alignment.  I found a simple typo where the distortion function was being applied to the wrong variable in the powder diffraction overlays.  Unfortunately, the Cartesian view mode will require a more in-depth fix.