### PR TITLE
Always remove previous hexrdgui in wix

### DIFF
--- a/packaging/CPackConfig.cmake
+++ b/packaging/CPackConfig.cmake
@@ -47,6 +47,9 @@ elseif(WIN32)
 #    "@CMAKE_CURRENT_LIST_DIR@/ui_dialog.jpg"
 #    )
 
+  # Auto-generate a GUID each time so that each new install completely
+  # replaces the old install.
+  set(CPACK_WIX_PRODUCT_GUID "*")
   set(CPACK_WIX_UPGRADE_GUID "5F369ED0-05D7-4CBA-B533-D1A1B3F445C3")
   set(CPACK_WIX_TEMPLATE "${CMAKE_CURRENT_LIST_DIR}/windows/WIX.template.in")
   # We set this because it normally defaults to CMAKE_SIZEOF_VOID_P, but we aren't

--- a/packaging/windows/WIX.template.in
+++ b/packaging/windows/WIX.template.in
@@ -16,9 +16,9 @@
 
         <Media Id="1" Cabinet="media1.cab" EmbedCab="yes"/>
 
-        <MajorUpgrade
-            Schedule="afterInstallInitialize"
-            AllowDowngrades="yes"/>
+        <InstallExecuteSequence>
+            <RemoveExistingProducts After="InstallInitialize" />
+        </InstallExecuteSequence>
 
         <WixVariable Id="WixUILicenseRtf" Value="$(var.CPACK_WIX_LICENSE_RTF)"/>
         <Property Id="WIXUI_INSTALLDIR" Value="INSTALL_ROOT"/>


### PR DESCRIPTION
This is an attempt to always remove previous hexrdgui installations via
wix. The previous behavior is that old files are not removed but only
over-written with new files.