### PR TITLE
Normalize masked azimuthal integral data

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -239,10 +239,7 @@ class PolarView:
             self.snip1d_background = None
 
         # Apply masks if they are present
-        masks = HexrdConfig().polar_masks.items()
-        visible = HexrdConfig().visible_masks
-        visible_masks = [mask for name, mask in masks if name in visible]
-        for mask in visible_masks:
+        for mask in HexrdConfig().visible_polar_masks:
             img[~mask] = 0
 
         self.img = img

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1125,6 +1125,12 @@ class HexrdConfig(QObject, metaclass=Singleton):
         for name in self.materials:
             self.flag_overlay_updates_for_material(name)
 
+    @property
+    def visible_polar_masks(self):
+        masks = self.polar_masks.items()
+        visible = self.visible_masks
+        return [mask for name, mask in masks if name in visible]
+
     def _polar_pixel_size_tth(self):
         return self.config['image']['polar']['pixel_size_tth']
 


### PR DESCRIPTION
Adding masks causes the image to be zero in those locations. This can
produce artificial drops in the azimuthal integral axis in the polar
view. To smooth it out a little, which helps WPPF, normalize the
masked azimuthal integral data.

Before:
======
![image](https://user-images.githubusercontent.com/9558430/107708903-e6986b00-6c89-11eb-96bc-dea25fe81278.png)

After:
=====
![better](https://user-images.githubusercontent.com/9558430/107708924-edbf7900-6c89-11eb-8b90-4e770c2e668f.png)