### PR TITLE
Avoid trying to format MaskedArray instances

### DIFF
--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -263,7 +263,7 @@ class ImageTabWidget(QTabWidget):
             # Image was created with imshow()
             artist = event.inaxes.get_images()[0]
             i, j = utils.coords2index(artist, info['x_data'], info['y_data'])
-            intensity = artist.get_array()[i, j]
+            intensity = artist.get_array().data[i, j]
         else:
             # This is probably just a plot. Do not calculate intensity.
             intensity = None

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -878,17 +878,22 @@ class MainWindow(QObject):
 
     def new_mouse_position(self, info):
         labels = []
-        labels.append('x = {:8.3f}'.format(info['x_data']))
-        labels.append('y = {:8.3f}'.format(info['y_data']))
+        labels.append(f'x = {info["x_data"]:8.3f}')
+        labels.append(f'y = {info["y_data"]:8.3f}')
         delimiter = ',  '
 
         intensity = info['intensity']
         if intensity is not None:
-            labels.append('value = {:8.3f}'.format(info['intensity']))
-            labels.append('tth = {:8.3f}'.format(info['tth']))
-            labels.append('eta = {:8.3f}'.format(info['eta']))
-            labels.append('dsp = {:8.3f}'.format(info['dsp']))
-            labels.append('hkl = ' + info['hkl'])
+            if isinstance(intensity, np.ma.MaskedArray):
+                masked_label = '--'
+                labels.append(f'value = {masked_label:>8}')
+            else:
+                labels.append(f'value = {info["intensity"]:8.3f}')
+
+            labels.append(f'tth = {info["tth"]:8.3f}')
+            labels.append(f'eta = {info["eta"]:8.3f}')
+            labels.append(f'dsp = {info["dsp"]:8.3f}')
+            labels.append(f'hkl = {info["hkl"]}')
 
         msg = delimiter.join(labels)
         self.ui.status_bar.showMessage(msg)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -884,12 +884,7 @@ class MainWindow(QObject):
 
         intensity = info['intensity']
         if intensity is not None:
-            if isinstance(intensity, np.ma.MaskedArray):
-                masked_label = '--'
-                labels.append(f'value = {masked_label:>8}')
-            else:
-                labels.append(f'value = {info["intensity"]:8.3f}')
-
+            labels.append(f'value = {info["intensity"]:8.3f}')
             labels.append(f'tth = {info["tth"]:8.3f}')
             labels.append(f'eta = {info["eta"]:8.3f}')
             labels.append(f'dsp = {info["dsp"]:8.3f}')


### PR DESCRIPTION
Matplotlib is creating a MaskedArray from the data, where nans and infs
are masked. We tried to format the intensity with a float formatting string, and
this was producing a warning on Linux and an error on Windows.

Check to see if the intensity is an instance of np.ma.MaskedArray
(as a side note: np.ma.core.MaskedConstant inherits from np.ma.MaskedArray,
so this check also works for np.ma.core.MaskedConstant). If it is,
then show another label and don't try to format it.

Fixes: #641 
Fixes: #752