### PR TITLE
Use instrinsic zxz as euler angle convention for LLNL import

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -103,9 +103,6 @@ class ImportDataPanel(QObject):
                                 enabled=True)
 
     def set_convention(self):
-        if self.instrument != 'TARDIS':
-            return
-
         new_conv = {'axes_order': 'zxz', 'extrinsic': False}
         HexrdConfig().set_euler_angle_convention(new_conv)
 


### PR DESCRIPTION
Fixes #759 

@joelvbernier It looks like the Euler angle was only being corrected in the case of TARDIS. It should now be updated to "Intrinsic ZXZ" for all instruments (this is updated any time you start using the Import Data Panel).