### PR TITLE
Remove need to install numpy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ git clone https://github.com/HEXRD/hexrdgui.git
 ## pip
 
 ```bash
-pip install numpy
 # For now we need to explicitly install hexrd, until we push it to PyPI
 pip install -e hexrd
 pip install -e hexrdgui


### PR DESCRIPTION
Now that HEXRD has a pyproject.toml we shouldn't need to do this.