### PR TITLE
Add options to filter eta omega maps

### DIFF
--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -15,7 +15,7 @@ from PySide2.QtWidgets import (
 
 from hexrd.constants import sigma_to_fwhm
 from hexrd.findorientations import (
-    filter_maps_if_requested, filter_stdev_DFLT, label_spots
+    clean_map, filter_maps_if_requested, filter_stdev_DFLT, label_spots
 )
 
 from hexrd.ui import enter_key_filter, resource_loader
@@ -329,7 +329,12 @@ class OmeMapsViewerDialog(QObject):
         if hasattr(self, '_data') and d == self._data:
             return
 
-        self.raw_data = d
+        # Make a deep copy, and clean the data. Hexrd will do this
+        # cleaning on the original data on its own in
+        # generate_orientation_fibers().
+        self.raw_data = copy.deepcopy(d)
+        for map in self.raw_data.dataStore:
+            clean_map(map)
 
         # This data will have filters applied to it
         # We will make a shallow copy, and deep copy the data store

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -5,8 +5,8 @@ from PySide2.QtWidgets import QMessageBox
 
 from hexrd import indexer, instrument
 from hexrd.findorientations import (
-    clean_map, create_clustering_parameters, generate_eta_ome_maps,
-    generate_orientation_fibers, run_cluster
+    create_clustering_parameters, filter_maps_if_requested,
+    generate_eta_ome_maps, generate_orientation_fibers, run_cluster
 )
 from hexrd.fitgrains import fit_grains
 from hexrd.xrdutil import EtaOmeMaps
@@ -99,10 +99,6 @@ class IndexingRunner(Runner):
         self.ome_maps = generate_eta_ome_maps(config, save=False)
 
     def ome_maps_loaded(self):
-        # Perform cleaning on the maps
-        for map in self.ome_maps.dataStore:
-            clean_map(map)
-
         self.view_ome_maps()
 
     def view_ome_maps(self):
@@ -121,6 +117,10 @@ class IndexingRunner(Runner):
 
         # Create a full indexing config
         config = create_indexing_config()
+
+        # Hexrd normally applies filtering immediately after eta omega
+        # maps are loaded. We will perform the user-selected filtering now.
+        filter_maps_if_requested(self.ome_maps, config)
 
         # Setup to run indexing in background
         self.progress_dialog.setWindowTitle('Find Orientations')

--- a/hexrd/ui/resources/indexing/default_indexing_config.yml
+++ b/hexrd/ui/resources/indexing/default_indexing_config.yml
@@ -17,6 +17,8 @@ find_orientations:
     threshold: 250
     bin_frames: 1 # defaults to 1
 
+    filter_maps: False
+
     # "all", or a list of hkl orders used to find orientations
     # defaults to all orders listed in the material definition
     # *** These are set automatically by hexrdgui based on the materials table

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -7,21 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>728</height>
+    <height>868</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" rowspan="3">
+   <item row="4" column="1">
     <widget class="QGroupBox" name="seed_search_group_box">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -39,48 +29,7 @@
       <string>Seed Search</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_6">
-      <item row="2" column="0" colspan="2">
-       <widget class="QGroupBox" name="omega_group_box">
-        <property name="title">
-         <string>Omega</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_7">
-         <item row="0" column="0">
-          <widget class="QLabel" name="tolerance_label">
-           <property name="text">
-            <string>Tolerance:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="ScientificDoubleSpinBox" name="omega_tolerance">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>0.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>360.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="ScientificDoubleSpinBox" name="fiber_step">
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -105,7 +54,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0" colspan="2">
+      <item row="1" column="0" colspan="2">
        <widget class="QGroupBox" name="method_group_box">
         <property name="title">
          <string>Method</string>
@@ -507,7 +456,14 @@
         </layout>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
+      <item row="2" column="0">
+       <widget class="QLabel" name="fiber_step_label">
+        <property name="text">
+         <string>Fiber Step:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
        <widget class="QGroupBox" name="eta_group_box">
         <property name="title">
          <string>Eta</string>
@@ -574,14 +530,48 @@
         </layout>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="fiber_step_label">
-        <property name="text">
-         <string>Fiber Step:</string>
+      <item row="3" column="0" colspan="2">
+       <widget class="QGroupBox" name="omega_group_box">
+        <property name="title">
+         <string>Omega</string>
         </property>
+        <layout class="QGridLayout" name="gridLayout_7">
+         <item row="0" column="0">
+          <widget class="QLabel" name="tolerance_label">
+           <property name="text">
+            <string>Tolerance:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="ScientificDoubleSpinBox" name="omega_tolerance">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>0.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>360.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>1.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QGroupBox" name="clustering_group_box">
         <property name="title">
          <string>Clustering</string>
@@ -670,9 +660,6 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="2">
-    <layout class="QVBoxLayout" name="canvas_layout"/>
-   </item>
    <item row="0" column="2" rowspan="2">
     <layout class="QGridLayout" name="grid_layout">
      <item row="2" column="2">
@@ -738,6 +725,83 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="1" rowspan="2">
+    <widget class="QGroupBox" name="filtering_group">
+     <property name="title">
+      <string>Filtering</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_10">
+      <item row="2" column="0">
+       <widget class="QLabel" name="filtering_fwhm_label">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>FWHM:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="filtering_apply_gaussian_laplace">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply Laplace filter using Gaussian second derivatives&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Apply Gaussian Laplace?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QCheckBox" name="apply_filtering">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply filtering to the eta omega maps?&lt;/p&gt;&lt;p&gt;Subtracts a row-wise median, and optionally performs a Laplace filter using Gaussian second derivatives&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Apply filtering?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ScientificDoubleSpinBox" name="filtering_fwhm">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-100000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2" rowspan="3">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -748,6 +812,9 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>apply_filtering</tabstop>
+  <tabstop>filtering_apply_gaussian_laplace</tabstop>
+  <tabstop>filtering_fwhm</tabstop>
   <tabstop>method</tabstop>
   <tabstop>tab_widget</tabstop>
   <tabstop>filter_radius</tabstop>

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -255,3 +255,8 @@ def exclusions_off(plane_data):
         yield
     finally:
         plane_data.exclusions = prev
+
+
+def has_nan(x):
+    # Utility function to check if there are any NaNs in x
+    return np.isnan(np.min(x))


### PR DESCRIPTION
This provides options to either apply a default filtering,
or apply a Laplace filter based upon Gaussian second derivatives,
for which a full width at half max (FWHM) can be specified.

Modifications to the filtering options result in immediate updates to
the plot.

![example](https://user-images.githubusercontent.com/9558430/109993872-5a9ac180-7cd2-11eb-94ac-d564052443be.gif)

This also performs filtering and map cleaning at the right times. It's a little
hard to keep track of, though, so there may be some improvements here and in hexrd for maintenance.

Depends on: hexrd/hexrd#193