### PR TITLE
Remove structure factor bug work-around

### DIFF
--- a/hexrd/ui/materials_table.py
+++ b/hexrd/ui/materials_table.py
@@ -113,13 +113,6 @@ class MaterialsTable:
             sf = plane_data.structFact
             multiplicity = plane_data.getMultiplicity()
 
-            if len(sf) != len(hkls):
-                # The structure factor must have been generated with the wrong
-                # number of hkls. Generated it again now that the exclusions
-                # are turned off.
-                material.update_structure_factor()
-                sf = plane_data.structFact
-
         self.update_hkl_index_maps(hkls)
 
         table.clearContents()


### PR DESCRIPTION
This is no longer needed because hexrd/hexrd#194 now generates
all structure factors instead of just the ones that aren't excluded.