### PR TITLE
Remove some instrument_config_loaded signals

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -207,7 +207,6 @@ class ImageLoadManager(QObject, metaclass=Singleton):
         if not self.update_status:
             self.update_needed.emit()
         if self.transformed_images:
-            HexrdConfig().instrument_config_loaded.emit()
             HexrdConfig().deep_rerender_needed.emit()
 
     def get_dark_aggr_op(self, ims, idx):

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -53,7 +53,6 @@ class ImportDataPanel(QObject):
         self.ui.button_box.rejected.connect(self.clear)
         self.ui.save.clicked.connect(self.save_file)
         self.ui.complete.clicked.connect(self.completed)
-        self.new_config_loaded.connect(HexrdConfig().instrument_config_loaded)
         self.ui.bb_height.valueChanged.connect(self.update_bbox_height)
         self.ui.bb_width.valueChanged.connect(self.update_bbox_width)
         self.ui.line_style.currentIndexChanged.connect(
@@ -121,7 +120,6 @@ class ImportDataPanel(QObject):
         for key, value in self.detector_defaults[det].items():
             HexrdConfig().set_instrument_config_val(
                 ['detectors', det, 'transform', key, 'value'], value)
-            self.detector_defaults[det]
         eac = {'axes_order': 'zxz', 'extrinsic': False}
         convert_tilt_convention(HexrdConfig().config['instrument'], None, eac)
         self.detector_defaults[det]['tilt'] = (

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -77,8 +77,7 @@ class LoadPanel(QObject):
         self.ui.file_options.resizeColumnsToContents()
 
     def setup_connections(self):
-        HexrdConfig().detectors_changed.connect(self.detectors_changed)
-        HexrdConfig().instrument_config_loaded.connect(self.config_changed)
+        HexrdConfig().detectors_changed.connect(self.config_changed)
         HexrdConfig().load_panel_state_reset.connect(
             self.setup_processing_options)
 


### PR DESCRIPTION
Unfortunately, instrument_config_loaded signals cause cartesian and
polar parameters to be auto generated. Auto generating the polar
parameters in particular is very time consuming, and causes the GUI to
freeze.

Thus, we should only emit "instrument_config_loaded" when an instrument
config was actually loaded by the user via "File"->"Open"->"Configuration".

This commit attempts to remove all instrument_config_loaded signals except
for that one. Some explanations will be present in the PR.