### PR TITLE
Add hkl_seeds to default indexing config

### DIFF
--- a/hexrd/ui/resources/indexing/default_indexing_config.yml
+++ b/hexrd/ui/resources/indexing/default_indexing_config.yml
@@ -31,8 +31,7 @@ find_orientations:
   #
   # otherwise defaults to seeded search:
   seed_search: # this section is ignored if use_quaternion_grid is defined
-    # *** This is automatically set from the eta omega maps
-    # hkl_seeds: [0,1,2] # hkls ids to use, must be defined for seeded search
+    hkl_seeds: [0, 1, 2] # hkls ids to use, must be defined for seeded search
     fiber_step: 0.5 # degrees, defaults to ome tolerance
     # Method selection:
     #   Now 3 choices: label (the original), 'blob_dog', and 'blob_log'


### PR DESCRIPTION
For a first-time user, this will add the hkl_seeds to their indexing
config dictionary, which will prevent a key error in
`OmeMapsViewerDialog.setup_hkls_table()`.

For users of previous versions, this will also automatically add
the hkl_seeds to their indexing config dictionary (if it is missing),
which will also prevent the same key error.