### PR TITLE
Fix a few workflow selection issues

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -218,13 +218,14 @@ class HexrdConfig(QObject, metaclass=Singleton):
         # Clear the overlay data and save the overlays as well
         HexrdConfig().clear_overlay_data()
         settings.setValue('overlays', self.overlays)
+        settings.setValue('workflow', self.workflow)
 
-    def save_workflow(self):
-        settings = QSettings()
-        old_workflow = settings.value('workflow', None)
-        if old_workflow != self.workflow:
-            settings.setValue('workflow', self.workflow)
-            self.workflow_changed.emit()
+    def set_workflow(self, workflow):
+        if workflow == self.workflow:
+            return
+
+        self.workflow = workflow
+        self.workflow_changed.emit()
 
     def load_settings(self):
         settings = QSettings()

--- a/hexrd/ui/workflow_selection_dialog.py
+++ b/hexrd/ui/workflow_selection_dialog.py
@@ -25,11 +25,15 @@ class WorkflowSelectionDialog:
         self.ui.workflowComboBox.setCurrentText(HexrdConfig().workflow)
 
     def accepted(self):
-        HexrdConfig().workflow = self.ui.workflowComboBox.currentText()
-        HexrdConfig().save_workflow()
+        HexrdConfig().set_workflow(self.ui.workflowComboBox.currentText())
 
     def rejected(self):
-        pass
+        # If the user cancels this by accident the first time they start the
+        # program, they will be running without a workflow!
+        # Avoid this by ensuring a workflow gets set.
+        if HexrdConfig().workflow is None:
+            HexrdConfig().set_workflow(self.ui.workflowComboBox.currentText())
 
     def show(self):
+        self.update_gui_from_config()
         self.ui.show()


### PR DESCRIPTION
Here are the issues fixed:

1. If hexrdgui was started with "--ignore-settings", and the workflow
   was selected that matched the workflow in the settings, then there
   would be no workflow widgets! This fixes the issue by getting it
   to load/save to QSettings with the rest of the settings, rather
   than saving/loading QSettings on its own.
2. If the user started the program for the first time and accidentally
   clicked "Cancel", they would be running a program without workflow widgets.
   This ensures that even if they accidentally cancel the dialog, a valid
   workflow will get set.
3. If the user changed workflows and hit "Cancel", then brought the dialog
   back up, the workflow would match what was previously selected rather
   than the current workflow. This could be confusing, since they may think
   the previously selected workflow was their current workflow.

@joelvbernier This fixes some of the issues we were seeing.