### PR TITLE
Remove make_new_pdata from hexrdgui

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -6,7 +6,7 @@ from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.line_picker_dialog import LinePickerDialog
 from hexrd.ui.overlays import default_overlay_refinements
-from hexrd.ui.utils import convert_tilt_convention, make_new_pdata
+from hexrd.ui.utils import convert_tilt_convention
 
 
 class CalibrationRunner:
@@ -231,7 +231,6 @@ class CalibrationRunner:
                 mat_name = overlay['material']
                 mat = materials[mat_name]
                 mat.latticeParameters = calibrator.params
-                make_new_pdata(mat)
                 HexrdConfig().flag_overlay_updates_for_material(mat_name)
                 if mat is HexrdConfig().active_material:
                     HexrdConfig().active_material_modified.emit()

--- a/hexrd/ui/calibration/wppf_runner.py
+++ b/hexrd/ui/calibration/wppf_runner.py
@@ -6,7 +6,6 @@ from hexrd.ui.calibration.wppf_options_dialog import WppfOptionsDialog
 from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.progress_dialog import ProgressDialog
-from hexrd.ui.utils import make_new_pdata
 
 
 class WppfRunner(QObject):
@@ -102,7 +101,6 @@ class WppfRunner(QObject):
                 lparms[i] *= 10.0
 
             mat.latticeParameters = lparms
-            make_new_pdata(mat)
             HexrdConfig().flag_overlay_updates_for_material(name)
 
             if mat is HexrdConfig().active_material:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -987,7 +987,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
             return
 
         mat.beamEnergy = energy
-        utils.make_new_pdata(mat)
         self.flag_overlay_updates_for_material(mat.name)
 
     def update_active_material_energy(self):

--- a/hexrd/ui/material_editor_widget.py
+++ b/hexrd/ui/material_editor_widget.py
@@ -5,7 +5,6 @@ from hexrd import spacegroup
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
-from hexrd.ui.utils import make_new_pdata
 
 
 class MaterialEditorWidget(QObject):
@@ -158,7 +157,6 @@ class MaterialEditorWidget(QObject):
         # already equal before setting.
         if self.material.sgnum != sgid:
             self.material.sgnum = sgid
-            make_new_pdata(self.material)
             self.material_modified.emit()
 
     def set_min_d_spacing(self):
@@ -167,7 +165,6 @@ class MaterialEditorWidget(QObject):
         val = self.ui.min_d_spacing.value()
         if self.material.dmin.getVal('angstrom') != val:
             self.material.dmin = _angstroms(val)
-            make_new_pdata(self.material)
             self.material_modified.emit()
 
     @property

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -87,21 +87,6 @@ def convert_angle_convention(angles, old_convention, new_convention):
     return np.array(rme.angles).tolist()
 
 
-def make_new_pdata(mat):
-    # This generates new PlaneData for a material
-    # This also preserves the previous exclusions of the plane data,
-    # and the previous tthWidth
-    prev_exclusions = mat.planeData.exclusions
-    prev_tThWidth = mat.planeData.tThWidth
-    prev_tThMax = mat.planeData.tThMax
-    mat._newPdata()
-    if len(mat.planeData.exclusions) == len(prev_exclusions):
-        mat.planeData.exclusions = prev_exclusions
-
-    mat.planeData.tThWidth = prev_tThWidth
-    mat.planeData.tThMax = prev_tThMax
-
-
 def coords2index(im, x, y):
     """
     This function is modified from here:


### PR DESCRIPTION
It seems that often (perhaps always), creating a new PlaneData object
from scratch is not necessary, and is a performance hit.

Try removing all cases of re-creating a PlaneData object from scratch,
and instead, we should ensure that when the relevant hexrd Material
attributes get modified, that the underlying PlaneData object will
get properly updated as well (including anything that needs to be
re-computed).

This currently seems to give a nice performance boost for modifying
the energy via the slider widget, and seeing the overlays move.

However, we're going to need to change some of the properties in
hexrd to update everything that is needed, and we should ensure
that everything in the GUI is updating as expected.