### PR TITLE
Use default Material() when a material is added

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -119,6 +119,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when the threshold mask status changes via mask manager"""
     mgr_threshold_mask_changed = Signal(bool)
 
+    """Emitted when the active material is changed to a different material"""
+    active_material_changed = Signal()
+
     """Emitted when the materials panel should update"""
     active_material_modified = Signal()
 
@@ -483,8 +486,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         material = Material(name, f, kev=beam_energy)
         self.add_material(name, material)
 
-        # Make it the active material
-        self.active_material = name
+        return name
 
     def set_live_update(self, status):
         self.live_update = status
@@ -903,7 +905,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
             if self.active_material_name == old_name:
                 # Change the active material before removing the old one
-                self.active_material = new_name
+                # Set the dict directly to bypass the updates that occur
+                # if we did self.active_material = new_name
+                self.config['materials']['active_material'] = new_name
 
             self.remove_material(old_name)
 
@@ -955,6 +959,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
 
         self.config['materials']['active_material'] = name
         self.update_active_material_energy()
+        self.active_material_changed.emit()
 
     active_material = property(_active_material, _set_active_material)
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -125,6 +125,12 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when the materials panel should update"""
     active_material_modified = Signal()
 
+    """Emitted when a material is renamed"""
+    material_renamed = Signal()
+
+    """Emitted when a material is removed"""
+    material_removed = Signal()
+
     """Emitted when a new raw mask has been created"""
     raw_masks_changed = Signal()
 
@@ -909,7 +915,11 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 # if we did self.active_material = new_name
                 self.config['materials']['active_material'] = new_name
 
-            self.remove_material(old_name)
+            # Avoid calling self.remove_material() to avoid pruning
+            # overlays and such.
+            del self.config['materials']['materials'][old_name]
+
+            self.material_renamed.emit()
 
     def modify_material(self, name, material):
         if name not in self.materials:
@@ -930,6 +940,8 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 self.active_material = list(self.materials.keys())[0]
             else:
                 self.active_material = None
+
+        self.material_removed.emit()
 
     def _materials(self):
         return self.config['materials'].get('materials', {})

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -491,8 +491,6 @@ class MainWindow(QObject):
         if selected_file:
             HexrdConfig().working_dir = os.path.dirname(selected_file)
             HexrdConfig().load_materials(selected_file)
-            self.materials_panel.update_gui_from_config()
-            self.materials_panel.update_structure_tab()
 
     def on_action_save_imageseries_triggered(self):
         if not HexrdConfig().has_images():

--- a/hexrd/ui/material_editor_widget.py
+++ b/hexrd/ui/material_editor_widget.py
@@ -14,7 +14,7 @@ class MaterialEditorWidget(QObject):
     material_modified = Signal()
 
     def __init__(self, material, parent=None):
-        super(MaterialEditorWidget, self).__init__(parent)
+        super().__init__(parent)
 
         loader = UiLoader()
         self.ui = loader.load_file('material_editor_widget.ui', parent)

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -271,7 +271,9 @@ class MaterialsPanel(QObject):
         HexrdConfig().remove_material(name)
 
     def modify_material_name(self):
-        new_name = self.ui.materials_combo.currentText()
+        combo = self.ui.materials_combo
+
+        new_name = combo.currentText()
         names = HexrdConfig().materials.keys()
 
         if new_name in names:
@@ -280,6 +282,9 @@ class MaterialsPanel(QObject):
 
         old_name = HexrdConfig().active_material_name
         HexrdConfig().rename_material(old_name, new_name)
+
+        # Update the text of the combo box item in the list
+        combo.setItemText(combo.currentIndex(), new_name)
 
     def show_materials_table(self):
         self.materials_table.show()

--- a/hexrd/ui/materials_table.py
+++ b/hexrd/ui/materials_table.py
@@ -32,6 +32,8 @@ class MaterialsTable:
         self.ui.table.selectionModel().selectionChanged.connect(
             self.update_selections)
 
+        HexrdConfig().material_renamed.connect(self.update_material_name)
+
     def show(self):
         if not hasattr(self, 'already_shown'):
             self.already_shown = True

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -41,6 +41,8 @@ class OverlayManager:
         self.ui.remove_button.pressed.connect(self.remove)
         self.ui.edit_style_button.pressed.connect(self.edit_style)
         HexrdConfig().calibration_complete.connect(self.update_overlay_editor)
+        HexrdConfig().material_renamed.connect(self.update_table)
+        HexrdConfig().material_removed.connect(self.update_table)
 
     def show(self):
         self.update_table()


### PR DESCRIPTION
Previously, we would perform a deep copy of the active material
to create a new material when a material was added.

Instead, just create a default `Material()` object and use that.

This PR also cleans up some of the updating in the materials panel to
make it easier and more intuitive to keep the panel up to date with
changes.

It also fixes renaming updates in the overlay manager as well as in
the materials table.

Fixes: #767