### PR TITLE
Apply 2D panel buffer as a mask to the polar view

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -200,6 +200,12 @@ class PolarView:
         panel = self.detectors[det]
         img = self.images_dict[det]
 
+        if isinstance(panel.panel_buffer, np.ndarray):
+            if img.shape == panel.panel_buffer.shape:
+                # Assume it's a mask array
+                img = np.ma.masked_array(img, mask=panel.panel_buffer,
+                                         fill_value=0)
+
         gvec_angs = np.vstack([
                 angpts[1].flatten(),
                 angpts[0].flatten(),


### PR DESCRIPTION
This checks if the panel buffer is a 2D numpy array, and if it is,
it will apply it as a mask to the polar view.

This seems to correctly generate NaNs in the output. However, the
image doesn't look so good. Maybe the mask is messing up the math
somewhere...

![bad_image](https://user-images.githubusercontent.com/9558430/110868397-21dc8880-828e-11eb-98fd-a6dcf106759a.png)

Fixes: #805