### PR TITLE
When exporting the polar plot, include integration

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -65,12 +65,18 @@ class InstrumentViewer:
         self.img = self.pv.img
 
     def write_image(self, filename='polar_image.npz'):
+        azimuthal_integration = HexrdConfig().last_azimuthal_integral_data
+
+        # Re-format the data so that it is in 2 columns
+        azimuthal_integration = np.array(azimuthal_integration).T
+
         # Prepare the data to write out
         data = {
             'tth_coordinates': self.angular_grid[1],
             'eta_coordinates': self.angular_grid[0],
             'intensities': self.img,
-            'extent': np.radians(self._extent)
+            'extent': np.radians(self._extent),
+            'azimuthal_integration': azimuthal_integration,
         }
 
         # Delete the file if it already exists


### PR DESCRIPTION
This exports the azimuthal integration as well when exporting
the polar plot.

The data is currently formatted to be in two columns, where the first
column is the two theta, and the second column is the intensity.

The two theta is currently in degrees, which doesn't match the
`tth_coordinates` and `eta_coordinates` units of radians. Should
we use radians for the azimuthal integration as well, @saransh?

```python
>>> data['azimuthal_integration']
array([[   9.48379266,   49.80703472],
       [  10.05258401,   58.68515111],
       [  10.62137536,   63.75402841],

       ...

       [  69.20688447,   32.74983483],
       [  69.77567582,   36.18811307],
       [  70.34446717,   43.57711938],
       [  70.91325852,  161.0254772 ],
       [  71.48204988,   54.09543593],
       [  72.05084123,   46.3929216 ]])
```

Fixes: #810