### PR TITLE
Add option to load BBXRD instrument

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -41,7 +41,7 @@ class ImportDataPanel(QObject):
         self.setup_connections()
 
     def setup_connections(self):
-        self.ui.instruments.currentIndexChanged.connect(
+        self.ui.instruments.currentTextChanged.connect(
             self.instrument_selected)
         self.ui.detectors.currentIndexChanged.connect(self.detector_selected)
         self.ui.load.clicked.connect(self.load_images)
@@ -82,10 +82,9 @@ class ImportDataPanel(QObject):
         for det, vals in defaults['detectors'].items():
             self.detector_defaults[det] = vals['transform']
 
-    def instrument_selected(self, idx):
+    def instrument_selected(self, instrument):
         self.detector_defaults.clear()
-        instruments = {1: 'TARDIS', 2: 'PXRDIP'}
-        self.instrument = instruments.get(idx, None)
+        self.instrument = instrument
 
         if self.instrument is None:
             self.ui.detectors.setCurrentIndex(0)

--- a/hexrd/ui/resources/ui/import_data_panel.ui
+++ b/hexrd/ui/resources/ui/import_data_panel.ui
@@ -68,6 +68,11 @@
             <string>PXRDIP</string>
            </property>
           </item>
+          <item>
+           <property name="text">
+            <string>BBXRD</string>
+           </property>
+          </item>
          </widget>
         </item>
        </layout>


### PR DESCRIPTION
Addresses #814 

@joelvbernier We'll need a default config file and sample hdf4 file with the raw images to test this properly, but a quick test using the BBXRD boundaries on the PXRDIP images shows that the boundaries look correct at least so this should pretty much work as-is for the instrument (with these few changes to actually add it as an option).