### PR TITLE
Add apply/reset buttons to MaterialStructureEditor

### DIFF
--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -66,10 +66,13 @@ class MaterialStructureEditor(QObject):
         self.ui.table.selectionModel().selectionChanged.connect(
             self.selection_changed)
 
+        self.ui.apply.pressed.connect(self.update_material)
+        self.ui.reset.pressed.connect(self.update_gui)
+
     def site_modified(self):
         site = copy.deepcopy(self.material_site_editor.site)
         self.sites[self.selected_row] = site
-        self.update_material()
+        self.material_edited()
 
     def ensure_scalar_U(self):
         # When we allow editing a tensor U, we can remove this function.
@@ -83,7 +86,7 @@ class MaterialStructureEditor(QObject):
         if tensor_encountered:
             name = self.material.name
             print(f'Warning: converting U tensors in {name} to scalars')
-            self.update_material()
+            self.material_edited()
 
     def name_changed(self, row, column):
         new_name = self.ui.table.item(row, column).text()
@@ -102,6 +105,7 @@ class MaterialStructureEditor(QObject):
     def update_gui(self):
         self.generate_sites()
         self.update_table()
+        self.modified = False
 
     def update_enable_states(self):
         enable_remove = self.num_rows > 1 and self.selected_row is not None
@@ -191,7 +195,7 @@ class MaterialStructureEditor(QObject):
         # Select the newly added row
         self.select_row(len(self.sites) - 1)
 
-        self.update_material()
+        self.material_edited()
 
     def remove_site(self):
         selected_row = self.selected_row
@@ -205,7 +209,7 @@ class MaterialStructureEditor(QObject):
             # Select the last row
             self.select_row(len(self.sites) - 1)
 
-        self.update_material()
+        self.material_edited()
 
     def create_table_widget(self, v):
         w = QTableWidgetItem(v)
@@ -280,6 +284,8 @@ class MaterialStructureEditor(QObject):
 
         self.material_modified.emit()
 
+        self.modified = False
+
     def generate_sites(self):
         """The sites have a structure like the following:
         {
@@ -349,6 +355,19 @@ class MaterialStructureEditor(QObject):
         # FIXME: allow editing a tensor U as well.
         # We can remove this function when that is done.
         self.ensure_scalar_U()
+
+    def material_edited(self):
+        self.modified = True
+
+    @property
+    def modified(self):
+        return self._modified
+
+    @modified.setter
+    def modified(self, b):
+        self._modified = b
+        self.ui.apply.setEnabled(b)
+        self.ui.reset.setEnabled(b)
 
 
 class Delegate(QStyledItemDelegate):

--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -259,28 +259,9 @@ class MaterialStructureEditor(QObject):
                 U_array.append(atom['U'])
 
         mat = self.material
-        mat._atominfo = np.array(info_array)
-        mat._atomtype = np.array(type_array)
-        mat._U = np.array(U_array)
-
-        old_unitcell = mat.unitcell
-
-        # Re-create the unit cell from scratch. This is easier to do
-        # right now than setting the variables and figuring out which
-        # properties need to be updated and in what order...
-        mat._unitcell = unitcell(mat._lparms, mat.sgnum, mat._atomtype,
-                                 mat._atominfo, mat._U, mat._dmin.getVal('nm'),
-                                 mat._beamEnergy.value, mat._sgsetting)
-
-        # Set the stiffness back on it if it existed
-        if hasattr(old_unitcell, 'stiffness'):
-            mat.unitcell.stiffness = old_unitcell.stiffness
-
-        # Compute the density
-        mat.unitcell.CalcDensity()
-
-        # Update the structure factor of the PData
-        mat.update_structure_factor()
+        mat.atominfo = np.array(info_array)
+        mat.atomtype = np.array(type_array)
+        mat.U = np.array(U_array)
 
         self.material_modified.emit()
 

--- a/hexrd/ui/resources/ui/material_structure_editor.ui
+++ b/hexrd/ui/resources/ui/material_structure_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>502</height>
+    <height>597</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -29,40 +29,6 @@
      <property name="text">
       <string>+</string>
      </property>
-    </widget>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QTabWidget" name="site_editor_tab_widget">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="site_editor_tab">
-      <attribute name="title">
-       <string>Site Editor</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout_3">
-       <item>
-        <layout class="QVBoxLayout" name="material_site_editor_layout"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="empty_tab">
-      <attribute name="title">
-       <string>Empty</string>
-      </attribute>
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>No Site Selected</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
     </widget>
    </item>
    <item row="2" column="1">
@@ -102,6 +68,60 @@
      </column>
     </widget>
    </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QTabWidget" name="site_editor_tab_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="site_editor_tab">
+      <attribute name="title">
+       <string>Site Editor</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <layout class="QVBoxLayout" name="material_site_editor_layout"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="empty_tab">
+      <attribute name="title">
+       <string>Empty</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>No Site Selected</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QPushButton" name="apply">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Apply</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="reset">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -109,6 +129,8 @@
   <tabstop>add_site</tabstop>
   <tabstop>remove_site</tabstop>
   <tabstop>site_editor_tab_widget</tabstop>
+  <tabstop>apply</tabstop>
+  <tabstop>reset</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
When the material is modified, the updates no longer get pushed to
hexrd immediately. Instead, the apply/reset buttons become enabled,
and the user can either click "reset" to reset the settings to what
hexrd has, or "apply" to push the changes to hexrd.


https://user-images.githubusercontent.com/9558430/111512624-ef171200-871d-11eb-9e61-97d4da3f34e3.mp4

Addresses one of the items in #779