### PR TITLE
Update materials table when structure edited

### DIFF
--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -191,6 +191,7 @@ class MaterialsPanel(QObject):
         self.update_properties_tab()
 
     def material_structure_edited(self):
+        self.update_table()
         self.update_properties_tab()
 
     def update_structure_tab(self):


### PR DESCRIPTION
Previously, the materials table did not need to be updated when
the structure was edited. But now, since the structure factor is
included, it does. Update the materials table when the structure is
edited.

Fixes the first part of #821