### PR TITLE
Only use 'image-files' for raw images

### DIFF
--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -48,13 +48,13 @@ class ImageFileManager(metaclass=Singleton):
             ims = imageseries.open(None, 'array', data=data)
             HexrdConfig().imageseries_dict[det] = ims
 
-    def load_images(self, detectors, file_names):
+    def load_images(self, detectors, file_names, options=None):
         HexrdConfig().imageseries_dict.clear()
         for name, f in zip(detectors, file_names):
             try:
                 if isinstance(f, list):
                     f = f[0]
-                ims = self.open_file(f)
+                ims = self.open_file(f, options)
                 HexrdConfig().imageseries_dict[name] = ims
             except (Exception, IOError) as error:
                 msg = ('ERROR - Could not read file: \n' + str(error))
@@ -76,7 +76,7 @@ class ImageFileManager(metaclass=Singleton):
                 QMessageBox.warning(None, 'HEXRD', msg)
                 return
 
-    def open_file(self, f):
+    def open_file(self, f, options=None):
         # f could be either a file or numpy array
         ext = os.path.splitext(f)[1] if isinstance(f, str) else None
         if ext is None:
@@ -109,7 +109,7 @@ class ImageFileManager(metaclass=Singleton):
             }
             input_dict['image-files']['directory'] = os.path.dirname(f)
             input_dict['image-files']['files'] = os.path.basename(f)
-            input_dict['options'] = {}
+            input_dict['options'] = {} if options is None else options
             input_dict['meta'] = {}
             temp = tempfile.NamedTemporaryFile(delete=False)
             try:

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -175,19 +175,20 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             self.parent_dir = HexrdConfig().images_dir
             det_names = HexrdConfig().detector_names
 
-            if len(self.files[0]) > 1 or self.data is not None:
+            options = {
+                'empty-frames': self.data.get('empty_frames', 0),
+                'max-file-frames': self.data.get('max_file_frames', 0),
+                'max-total-frames': self.data.get(
+                    'max_total_frames', 0),
+            }
+
+            if len(self.files[0]) > 1:
                 for i, det in enumerate(det_names):
                     dirs = os.path.dirname(self.files[i][0])
-                    options = {
-                        'empty-frames': self.data.get('empty_frames', 0),
-                        'max-file-frames': self.data.get('max_file_frames', 0),
-                        'max-total-frames': self.data.get(
-                            'max_total_frames', 0),
-                    }
                     ims = ImageFileManager().open_directory(dirs, self.files[i], options)
                     HexrdConfig().imageseries_dict[det] = ims
             else:
-                ImageFileManager().load_images(det_names, self.files)
+                ImageFileManager().load_images(det_names, self.files, options)
         elif self.unaggregated_images is not None:
             HexrdConfig().imageseries_dict = copy.copy(self.unaggregated_images)
             self.reset_unagg_imgs()


### PR DESCRIPTION
This fixes a bug introduced in [this commit](https://github.com/HEXRD/hexrdgui/commit/7416b6aafd1b27782847217dcc2aa34e38e04a36).

The original approach was flawed, but was intended to handle the case where a single raw image is loaded with empty frames. This change uses the correct load path for each file type and instead offers the option of passing in a dict of options that may need to be set on (a) raw image(s). If the options are there they are added to the yaml file and used in creating the imageseries.