### PR TITLE
Improve HEDM Indexing and Grain Fitting UI

### DIFF
--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -15,13 +15,19 @@ def create_indexing_config():
 
     # Make a copy to modify
     indexing_config = copy.deepcopy(HexrdConfig().indexing_config)
-    material = HexrdConfig().active_material
     omaps = indexing_config['find_orientations']['orientation_maps']
+    available_materials = list(HexrdConfig().materials.keys())
+    selected_material = omaps.get('_selected_material')
+
+    if selected_material not in available_materials:
+        raise Exception(f'Selected material {selected_material} not available')
+
+    material = HexrdConfig().material(selected_material)
     omaps['active_hkls'] = list(range(len(material.planeData.getHKLs())))
 
     # Set the active material on the config
     tmp = indexing_config.setdefault('material', {})
-    tmp['active'] = HexrdConfig().active_material_name
+    tmp['active'] = material.name
 
     # Create the root config from the indexing config dict
     config = RootConfig(indexing_config)

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -1,5 +1,7 @@
 import copy
 
+import numpy as np
+
 from hexrd.config.root import RootConfig
 from hexrd.config.material import MaterialConfig
 from hexrd.config.instrument import Instrument as InstrumentConfig
@@ -42,6 +44,9 @@ def create_indexing_config():
     mconfig = MaterialConfig(config)
     mconfig.materials = HexrdConfig().materials
     config.material = mconfig
+
+    # Set this so the config won't over-write our tThWidth
+    config.set('material:tth_width', np.degrees(material.planeData.tThWidth))
 
     # Use unaggregated images if possible
     ims_dict = ImageLoadManager().unaggregated_images

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -15,14 +15,15 @@ def create_indexing_config():
 
     # Make a copy to modify
     indexing_config = copy.deepcopy(HexrdConfig().indexing_config)
-    omaps = indexing_config['find_orientations']['orientation_maps']
     available_materials = list(HexrdConfig().materials.keys())
-    selected_material = omaps.get('_selected_material')
+    selected_material = indexing_config.get('_selected_material')
 
     if selected_material not in available_materials:
         raise Exception(f'Selected material {selected_material} not available')
 
     material = HexrdConfig().material(selected_material)
+
+    omaps = indexing_config['find_orientations']['orientation_maps']
     omaps['active_hkls'] = list(range(len(material.planeData.getHKLs())))
 
     # Set the active material on the config

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -64,7 +64,8 @@ def create_indexing_config():
 
     # Convert image series into OmegaImageSeries
     for key, ims in ims_dict.items():
-        ims_dict[key] = OmegaImageSeries(ims)
+        if not isinstance(ims, OmegaImageSeries):
+            ims_dict[key] = OmegaImageSeries(ims)
 
     config.image_series = ims_dict
 

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -306,6 +306,11 @@ class FitGrainsResultsDialog(QObject):
         fig = canvas.figure
         ax = fig.add_subplot(111, projection='3d', proj_type=self.projection)
 
+        # Set default limits to -0.5 to 0.5
+        for name in ('x', 'y', 'z'):
+            func = getattr(ax, f'set_{name}lim')
+            func(-0.5, 0.5)
+
         self.ui.canvas_layout.addWidget(canvas)
 
         self.fig = fig

--- a/hexrd/ui/indexing/fit_grains_select_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_select_dialog.py
@@ -63,7 +63,7 @@ class FitGrainsSelectDialog(QObject):
             self.grains_table = self.indexing_runner.grains_table
         elif self.method == 'estimate':
             # It is a grains.out file
-            self.grains_table = np.loadtxt(self.file_name)
+            self.grains_table = np.loadtxt(self.file_name, ndmin=2)
         elif self.method == 'orientations':
             # It is an accepted_orientations*.dat file
             qbar = np.loadtxt(self.file_name, ndmin=2).T

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -78,7 +78,17 @@ class OmeMapsSelectDialog(QObject):
 
     @property
     def threshold(self):
+        if not self.ui.apply_threshold.isChecked():
+            return None
+
         return self.ui.threshold.value()
+
+    @threshold.setter
+    def threshold(self, v):
+        apply_threshold = v is not None
+        self.ui.apply_threshold.setChecked(apply_threshold)
+        if apply_threshold:
+            self.ui.threshold.setValue(v)
 
     @property
     def bin_frames(self):
@@ -109,7 +119,7 @@ class OmeMapsSelectDialog(QObject):
         file_name = maps_config['file'] if maps_config['file'] else ''
 
         self.ui.file_name.setText(file_name)
-        self.ui.threshold.setValue(maps_config['threshold'])
+        self.threshold = maps_config['threshold']
         self.ui.bin_frames.setValue(maps_config['bin_frames'])
 
         self.update_method_tab()

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -5,6 +5,7 @@ from PySide2.QtWidgets import QFileDialog, QMessageBox
 
 from hexrd.ui import enter_key_filter
 
+from hexrd.ui.materials_table import MaterialsTable
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -33,6 +34,9 @@ class OmeMapsSelectDialog(QObject):
     def setup_connections(self):
         self.ui.select_file_button.pressed.connect(self.select_file)
         self.ui.method.currentIndexChanged.connect(self.update_method_tab)
+        self.ui.material.currentIndexChanged.connect(
+            self.selected_material_changed)
+        self.ui.choose_hkls.pressed.connect(self.choose_hkls)
         self.ui.accepted.connect(self.on_accepted)
         self.ui.rejected.connect(self.on_rejected)
 
@@ -43,6 +47,10 @@ class OmeMapsSelectDialog(QObject):
         ]
         for i, data in enumerate(item_data):
             self.ui.method.setItemData(i, data)
+
+        self.ui.material.clear()
+        self.ui.material.addItems(HexrdConfig().materials.keys())
+        self.ui.material.setCurrentText(HexrdConfig().active_material_name)
 
     def show(self):
         self.ui.show()
@@ -95,6 +103,28 @@ class OmeMapsSelectDialog(QObject):
         return self.ui.bin_frames.value()
 
     @property
+    def material_options(self):
+        w = self.ui.material
+        return [w.itemText(i) for i in range(w.count())]
+
+    def selected_material_changed(self):
+        if not hasattr(self, '_table'):
+            return
+
+        self._table.material = HexrdConfig().material(self.selected_material)
+
+    @property
+    def selected_material(self):
+        return self.ui.material.currentText()
+
+    @selected_material.setter
+    def selected_material(self, name):
+        if name is None or name not in self.material_options:
+            return
+
+        self.ui.material.setCurrentText(name)
+
+    @property
     def widgets(self):
         return [
             self.ui.file_name,
@@ -109,6 +139,7 @@ class OmeMapsSelectDialog(QObject):
         maps_config['file'] = self.file_name
         maps_config['threshold'] = self.threshold
         maps_config['bin_frames'] = self.bin_frames
+        maps_config['_selected_material'] = self.selected_material
 
     def update_gui(self):
         blockers = [QSignalBlocker(x) for x in self.widgets]  # noqa: F841
@@ -121,6 +152,7 @@ class OmeMapsSelectDialog(QObject):
         self.ui.file_name.setText(file_name)
         self.threshold = maps_config['threshold']
         self.ui.bin_frames.setValue(maps_config['bin_frames'])
+        self.selected_material = maps_config.get('_selected_material')
 
         self.update_method_tab()
 
@@ -142,3 +174,12 @@ class OmeMapsSelectDialog(QObject):
         # Take advantage of the naming scheme...
         method_tab = getattr(self.ui, self.method_name + '_tab')
         self.ui.tab_widget.setCurrentWidget(method_tab)
+
+    def choose_hkls(self):
+        kwargs = {
+            'material': HexrdConfig().material(self.selected_material),
+            'title_prefix': 'Select hkls for eta omega map generation: ',
+            'parent': self.ui,
+        }
+        self._table = MaterialsTable(**kwargs)
+        self._table.show()

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -5,8 +5,8 @@ from PySide2.QtWidgets import QFileDialog, QMessageBox
 
 from hexrd.ui import enter_key_filter
 
-from hexrd.ui.materials_table import MaterialsTable
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.materials_table import MaterialsTable
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -145,7 +145,8 @@ class OmeMapsSelectDialog(QObject):
         maps_config['file'] = self.file_name
         maps_config['threshold'] = self.threshold
         maps_config['bin_frames'] = self.bin_frames
-        maps_config['_selected_material'] = self.selected_material
+
+        indexing_config['_selected_material'] = self.selected_material
 
     def update_gui(self):
         blockers = [QSignalBlocker(x) for x in self.widgets]  # noqa: F841
@@ -158,7 +159,8 @@ class OmeMapsSelectDialog(QObject):
         self.ui.file_name.setText(file_name)
         self.threshold = maps_config['threshold']
         self.ui.bin_frames.setValue(maps_config['bin_frames'])
-        self.selected_material = maps_config.get('_selected_material')
+
+        self.selected_material = indexing_config.get('_selected_material')
 
         self.update_method_tab()
 

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -333,13 +333,14 @@ class OmeMapsViewerDialog(QObject):
         # cleaning on the original data on its own in
         # generate_orientation_fibers().
         self.raw_data = copy.deepcopy(d)
-        for map in self.raw_data.dataStore:
+        self.cleaned_data = copy.deepcopy(d)
+        for map in self.cleaned_data.dataStore:
             clean_map(map)
 
         # This data will have filters applied to it
         # We will make a shallow copy, and deep copy the data store
         # when filters are applied.
-        self._data = copy.copy(self.raw_data)
+        self._data = copy.copy(self.cleaned_data)
         self.reset_filters()
 
         self.update_extent()
@@ -480,7 +481,8 @@ class OmeMapsViewerDialog(QObject):
             if not selected_file.endswith('.npz'):
                 selected_file += '.npz'
 
-            self.data.save(selected_file)
+            # Save the raw data out...
+            self.raw_data.save(selected_file)
 
     @property
     def threshold(self):
@@ -596,7 +598,7 @@ class OmeMapsViewerDialog(QObject):
             name = '_dataStore'
         else:
             name = 'dataStore'
-        setattr(self.data, name, copy.deepcopy(self.raw_data.dataStore))
+        setattr(self.data, name, copy.deepcopy(self.cleaned_data.dataStore))
 
         # Make a fake config to pass to hexrd
         class Cfg:

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -360,6 +360,12 @@ class OmeMapsViewerDialog(QObject):
 
         self.color_map_editor.update_bounds(self.image_data)
 
+        w = self.color_map_editor.ui.minimum
+        w.setStyleSheet('background-color: yellow')
+        note = 'NOTE: this is used to set find_orientations:threshold'
+        if note not in w.toolTip():
+            w.setToolTip(f'{w.toolTip()}\n\n{note}')
+
     @property
     def display_spots(self):
         return self.ui.label_spots.isChecked()

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -102,7 +102,6 @@ class IndexingRunner(Runner):
 
     def view_ome_maps(self):
         # Now, show the Ome Map viewer
-
         dialog = OmeMapsViewerDialog(self.ome_maps, self.parent)
         dialog.accepted.connect(self.ome_maps_viewed)
         dialog.rejected.connect(self.clear)
@@ -310,7 +309,11 @@ def create_fit_grains_results_dialog(fit_grains_results, parent=None):
     gw.close()
 
     # Use the material to compute stress from strain
-    material = HexrdConfig().active_material
+    indexing_config = HexrdConfig().indexing_config
+    name = indexing_config.get('_selected_material')
+    if name not in HexrdConfig().materials:
+        name = HexrdConfig().active_material_name
+    material = HexrdConfig().material(name)
 
     # Create the dialog
     dialog = FitGrainsResultsDialog(grains_table, material, parent)

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -9,7 +9,7 @@ from hexrd.findorientations import (
     generate_eta_ome_maps, generate_orientation_fibers, run_cluster
 )
 from hexrd.fitgrains import fit_grains
-from hexrd.xrdutil import EtaOmeMaps
+from hexrd.xrdutil import EtaOmeMaps, _memo_hkls
 
 from hexrd.ui.async_worker import AsyncWorker
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -223,6 +223,7 @@ class FitGrainsRunner(Runner):
         self.fit_grains_select_dialog = None
         self.fit_grains_options_dialog = None
         self.fit_grains_results = None
+        _memo_hkls.clear()
 
     def run(self):
         # We will go through these steps:

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -26,7 +26,7 @@ class MaterialsPanel(QObject):
 
         m = HexrdConfig().active_material
         self.material_editor_widget = MaterialEditorWidget(m, self.ui)
-        self.materials_table = MaterialsTable(self.ui)
+        self.materials_table = MaterialsTable(m, parent=self.ui)
 
         self.ui.material_editor_layout.addWidget(
             self.material_editor_widget.ui)
@@ -228,6 +228,7 @@ class MaterialsPanel(QObject):
         HexrdConfig().active_material = self.current_material()
 
     def active_material_changed(self):
+        self.materials_table.material = HexrdConfig().active_material
         self.update_gui_from_config()
         self.update_structure_tab()
         self.update_properties_tab()

--- a/hexrd/ui/resources/indexing/default_indexing_config.yml
+++ b/hexrd/ui/resources/indexing/default_indexing_config.yml
@@ -14,7 +14,7 @@ find_orientations:
     # A file name must be specified. If it doesn't exist, one will be created
     file: null
 
-    threshold: 250
+    threshold: null
     bin_frames: 1 # defaults to 1
 
     filter_maps: False

--- a/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>480</height>
+    <height>561</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,7 +16,70 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="8" column="0">
+      <widget class="QRadioButton" name="tth_max_specify">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">padding-left: 20px;</string>
+       </property>
+       <property name="text">
+        <string>Specify</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QRadioButton" name="tth_max_instrument">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">padding-left: 20px;
+</string>
+       </property>
+       <property name="text">
+        <string>Instrument</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="tth_max_value">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="value">
+        <double>20.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="tth_max_enable">
+       <property name="text">
+        <string>tth max</string>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="1">
+      <widget class="QComboBox" name="material"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="npdiv_label">
+       <property name="text">
+        <string>Number of polar subdivisions</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
       <widget class="QSpinBox" name="npdiv">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -38,21 +101,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="refit_ome_label">
-       <property name="text">
-        <string>Refit ome step scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QDoubleSpinBox" name="refit_ome_step_scale">
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
+     <item row="4" column="1">
       <widget class="QDoubleSpinBox" name="refit_pixel_scale">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -65,84 +114,59 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
-      <widget class="QDoubleSpinBox" name="tth_max_value">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="value">
-        <double>20.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="refit_pixel_labe">
-       <property name="text">
-        <string>Refit pixel scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QRadioButton" name="tth_max_specify">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">padding-left: 20px;</string>
-       </property>
-       <property name="text">
-        <string>Specify</string>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroup</string>
-       </attribute>
-      </widget>
-     </item>
      <item row="5" column="0">
-      <widget class="QRadioButton" name="tth_max_instrument">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">padding-left: 20px;
-</string>
-       </property>
+      <widget class="QLabel" name="refit_ome_label">
        <property name="text">
-        <string>Instrument</string>
+        <string>Refit ome step scale</string>
        </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroup</string>
-       </attribute>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="3" column="0">
+      <widget class="QLabel" name="threshold_label">
+       <property name="text">
+        <string>Threshold</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="material_label">
+       <property name="text">
+        <string>Selected Material:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="threshold">
        <property name="value">
         <double>25.000000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QCheckBox" name="tth_max_enable">
-       <property name="text">
-        <string>tth max</string>
+     <item row="5" column="1">
+      <widget class="QDoubleSpinBox" name="refit_ome_step_scale">
+       <property name="value">
+        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="npdiv_label">
+     <item row="4" column="0">
+      <widget class="QLabel" name="refit_pixel_labe">
        <property name="text">
-        <string>Number of polar subdivisions</string>
+        <string>Refit pixel scale</string>
        </property>
       </widget>
      </item>
      <item row="1" column="0">
-      <widget class="QLabel" name="threshold_label">
+      <widget class="QLabel" name="num_hkls_selected">
        <property name="text">
-        <string>Threshold</string>
+        <string>Number of hkls selected:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPushButton" name="choose_hkls">
+       <property name="text">
+        <string>Choose HKLs</string>
        </property>
       </widget>
      </item>
@@ -271,6 +295,8 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>material</tabstop>
+  <tabstop>choose_hkls</tabstop>
   <tabstop>npdiv</tabstop>
   <tabstop>threshold</tabstop>
   <tabstop>refit_pixel_scale</tabstop>

--- a/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
@@ -62,48 +62,24 @@
        <string>Generate</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="4" column="0">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="material"/>
+       </item>
+       <item row="5" column="0">
         <widget class="QLabel" name="bin_frames_label">
          <property name="text">
           <string>Bin Frames:</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="material"/>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="material_label">
-         <property name="text">
-          <string>Material:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
+       <item row="3" column="0">
         <widget class="QCheckBox" name="apply_threshold">
          <property name="text">
           <string>Threshold data?</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QPushButton" name="choose_hkls">
-         <property name="text">
-          <string>Choose HKLs</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="1">
-        <widget class="QSpinBox" name="bin_frames">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>1000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="1">
+       <item row="3" column="1">
         <widget class="QDoubleSpinBox" name="threshold">
          <property name="enabled">
           <bool>false</bool>
@@ -116,6 +92,37 @@
          </property>
          <property name="value">
           <double>250.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="material_label">
+         <property name="text">
+          <string>Material:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QSpinBox" name="bin_frames">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="num_hkls_selected">
+         <property name="text">
+          <string>Number of hkls selected:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QPushButton" name="choose_hkls">
+         <property name="text">
+          <string>Choose HKLs</string>
          </property>
         </widget>
        </item>

--- a/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
@@ -7,11 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>635</width>
-    <height>232</height>
+    <height>267</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -21,7 +21,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
+   <item row="1" column="1">
     <widget class="QComboBox" name="method">
      <item>
       <property name="text">
@@ -35,14 +35,7 @@
      </item>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item row="2" column="0" colspan="2">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
       <number>1</number>
@@ -69,14 +62,48 @@
        <string>Generate</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="3" column="0">
+       <item row="4" column="0">
         <widget class="QLabel" name="bin_frames_label">
          <property name="text">
           <string>Bin Frames:</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="0" column="1">
+        <widget class="QComboBox" name="material"/>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="material_label">
+         <property name="text">
+          <string>Material:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QCheckBox" name="apply_threshold">
+         <property name="text">
+          <string>Threshold data?</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QPushButton" name="choose_hkls">
+         <property name="text">
+          <string>Choose HKLs</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QSpinBox" name="bin_frames">
+         <property name="minimum">
+          <number>1</number>
+         </property>
+         <property name="maximum">
+          <number>1000</number>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
         <widget class="QDoubleSpinBox" name="threshold">
          <property name="enabled">
           <bool>false</bool>
@@ -92,25 +119,15 @@
          </property>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QSpinBox" name="bin_frames">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>1000</number>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QCheckBox" name="apply_threshold">
-         <property name="text">
-          <string>Threshold data?</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </widget>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="method_label">
+     <property name="text">
+      <string>Method:</string>
+     </property>
     </widget>
    </item>
   </layout>
@@ -120,6 +137,8 @@
   <tabstop>tab_widget</tabstop>
   <tabstop>file_name</tabstop>
   <tabstop>select_file_button</tabstop>
+  <tabstop>material</tabstop>
+  <tabstop>choose_hkls</tabstop>
   <tabstop>apply_threshold</tabstop>
   <tabstop>threshold</tabstop>
   <tabstop>bin_frames</tabstop>

--- a/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
@@ -11,34 +11,10 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="3" column="1">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="method">
-     <item>
-      <property name="text">
-       <string>Load</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Generate</string>
-      </property>
-     </item>
-    </widget>
-   </item>
    <item row="2" column="0" colspan="2">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="load_tab">
       <attribute name="title">
@@ -62,9 +38,6 @@
        <string>Generate</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="1">
-        <widget class="QComboBox" name="material"/>
-       </item>
        <item row="5" column="0">
         <widget class="QLabel" name="bin_frames_label">
          <property name="text">
@@ -92,13 +65,6 @@
          </property>
          <property name="value">
           <double>250.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="material_label">
-         <property name="text">
-          <string>Material:</string>
          </property>
         </widget>
        </item>
@@ -137,14 +103,48 @@
      </property>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="method">
+     <item>
+      <property name="text">
+       <string>Load</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Generate</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="material_label">
+     <property name="text">
+      <string>Selected Material:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="material"/>
+   </item>
   </layout>
  </widget>
  <tabstops>
+  <tabstop>material</tabstop>
   <tabstop>method</tabstop>
   <tabstop>tab_widget</tabstop>
   <tabstop>file_name</tabstop>
   <tabstop>select_file_button</tabstop>
-  <tabstop>material</tabstop>
   <tabstop>choose_hkls</tabstop>
   <tabstop>apply_threshold</tabstop>
   <tabstop>threshold</tabstop>

--- a/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>635</width>
-    <height>241</height>
+    <height>232</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
@@ -45,7 +45,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="load_tab">
       <attribute name="title">
@@ -69,13 +69,6 @@
        <string>Generate</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="0">
-        <widget class="QLabel" name="threshold_label">
-         <property name="text">
-          <string>Threshold:</string>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="0">
         <widget class="QLabel" name="bin_frames_label">
          <property name="text">
@@ -85,6 +78,9 @@
        </item>
        <item row="1" column="1">
         <widget class="QDoubleSpinBox" name="threshold">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
          <property name="decimals">
           <number>4</number>
          </property>
@@ -106,6 +102,13 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="apply_threshold">
+         <property name="text">
+          <string>Threshold data?</string>
+         </property>
+        </widget>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -117,6 +120,7 @@
   <tabstop>tab_widget</tabstop>
   <tabstop>file_name</tabstop>
   <tabstop>select_file_button</tabstop>
+  <tabstop>apply_threshold</tabstop>
   <tabstop>threshold</tabstop>
   <tabstop>bin_frames</tabstop>
  </tabstops>
@@ -151,6 +155,22 @@
     <hint type="destinationlabel">
      <x>217</x>
      <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>apply_threshold</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>threshold</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>167</x>
+     <y>105</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>467</x>
+     <y>105</y>
     </hint>
    </hints>
   </connection>

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -99,7 +99,7 @@ class DictTreeItemModel(BaseTreeItemModel):
 
         for key in keys:
             path = self.get_path_from_root(cur_tree_item, 0) + [key]
-            if path in self.blacklisted_paths:
+            if path in self.blacklisted_paths or str(key).startswith('_'):
                 continue
 
             tree_item = self.add_tree_item(key, None, cur_tree_item)


### PR DESCRIPTION
To do:

- [x] Make thresholding optional for eta omega map generation
- [x] Make reflections table general so it can be used in other places
- [x] Have users explicitly pick material and hkls to use for eta omega map generation
- [x] In the maps viewer, make it clearer that the color map minimum is used for a threshold
- [x] In the fit grains options dialog, have the user explicitly pick hkls as well. Display the material being used.

Fixes: #829