### PR TITLE
Reset memo hkls before indexing

### DIFF
--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -56,6 +56,9 @@ class IndexingRunner(Runner):
         self.ome_maps = None
         self.grains_table = None
 
+        # Reset memo hkls in case they were set earlier with different hkls
+        _memo_hkls.clear()
+
     def run(self):
         # We will go through these steps:
         # 1. Have the user select/generate eta omega maps
@@ -223,6 +226,8 @@ class FitGrainsRunner(Runner):
         self.fit_grains_select_dialog = None
         self.fit_grains_options_dialog = None
         self.fit_grains_results = None
+
+        # Reset memo hkls in case they were set earlier with different hkls
         _memo_hkls.clear()
 
     def run(self):


### PR DESCRIPTION
This is to avoid potential issues where the hkls get memoized from
running fit grains, then if a user goes back to run indexing, it
may use the memoized ones, which may be different.