### PR TITLE
Use only required params for default refinements

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -232,7 +232,7 @@ class PowderRunner(QObject):
     def overlay_refinements(self, overlay):
         refinements = overlay.get('refinements')
         if refinements is None:
-            refinements = default_overlay_refinements(overlay['type'])
+            refinements = default_overlay_refinements(overlay)
         return refinements
 
     @property

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -139,7 +139,7 @@ class CalibrationRunner:
     def get_refinements(self, overlay):
         refinements = overlay.get('refinements')
         if refinements is None:
-            refinements = default_overlay_refinements(overlay['type'])
+            refinements = default_overlay_refinements(overlay)
         return refinements
 
     def generate_pick_results(self):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1124,9 +1124,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
             'style': style,
             'visible': visible,
             'options': overlays.default_overlay_options(type),
-            'refinements': overlays.default_overlay_refinements(type),
-            'data': {}
+            'data': {},
         }
+        overlay['refinements'] = overlays.default_overlay_refinements(overlay)
         self.overlays.append(overlay)
         self.overlay_config_changed.emit()
 
@@ -1143,7 +1143,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
         overlay['type'] = type
         overlay['style'] = overlays.default_overlay_style(type)
         overlay['options'] = overlays.default_overlay_options(type)
-        overlay['refinements'] = overlays.default_overlay_refinements(type)
+        overlay['refinements'] = overlays.default_overlay_refinements(overlay)
         overlay['update_needed'] = True
 
     def clear_overlay_data(self):

--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -1,5 +1,7 @@
 import copy
 
+from hexrd import unitcell
+
 from hexrd.ui.overlays.laue_diffraction import LaueSpotOverlay
 from hexrd.ui.overlays.mono_rotation_series import (
     MonoRotationSeriesSpotOverlay
@@ -51,7 +53,12 @@ def default_overlay_options(overlay_type):
     return copy.deepcopy(default_options[overlay_type])
 
 
-def default_overlay_refinements(overlay_type):
+def default_overlay_refinements(overlay):
+    from hexrd.ui.hexrd_config import HexrdConfig
+
+    material = HexrdConfig().material(overlay['material'])
+    overlay_type = overlay['type']
+
     default_refinements = {
         OverlayType.powder: constants.DEFAULT_POWDER_REFINEMENTS,
         OverlayType.laue: constants.DEFAULT_CRYSTAL_REFINEMENTS,
@@ -61,7 +68,12 @@ def default_overlay_refinements(overlay_type):
     if overlay_type not in default_refinements:
         raise Exception(f'Unknown overlay type: {overlay_type}')
 
-    return copy.deepcopy(default_refinements[overlay_type])
+    refinements = copy.deepcopy(default_refinements[overlay_type])
+
+    # Only give it the required indices
+    indices = unitcell._rqpDict[material.unitcell.latticeType][0]
+
+    return [refinements[i] for i in indices]
 
 
 def update_overlay_data(instr, display_mode):


### PR DESCRIPTION
Before, it was adding all of the parameters to the default refinements.

Now, it should be making better defaults based upon which lattice
parameters are required.

Now, the default overlay refinements function accepts a whole overlay
dict, and it extracts from it the type and the material name in order
to come up with better default refinements.