### PR TITLE
Better cleanup for re-entering PowderRunner...

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -32,6 +32,11 @@ class PowderRunner(QObject):
     def clear(self):
         self.remove_lines()
 
+        if hasattr(self, '_ask_if_lines_are_acceptable_box'):
+            # Remove the box if it is still there...
+            self._ask_if_lines_are_acceptable_box.reject()
+            del self._ask_if_lines_are_acceptable_box
+
     def run(self):
         try:
             self.validate()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -691,6 +691,9 @@ class MainWindow(QObject):
             QMessageBox.warning(self.ui, 'HEXRD', msg)
             return
 
+        if hasattr(self, '_powder_runner'):
+            self._powder_runner.clear()
+
         self._powder_runner = PowderRunner(self.ui)
         self._powder_runner.finished.connect(self.finish_powder_calibration)
         self._powder_runner.run()


### PR DESCRIPTION
This checks to see if there is a PowderRunner already active, and if there
is, it will clear it. Clearing it will also reject a dialog box asking if
the points look okay...