### PR TITLE
Sync transform changes

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -38,6 +38,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
     new_images_loaded = Signal()
     images_transformed = Signal()
     live_update_status = Signal(bool)
+    state_updated = Signal()
 
     def __init__(self):
         super(ImageLoadManager, self).__init__(None)
@@ -165,6 +166,7 @@ class ImageLoadManager(QObject, metaclass=Singleton):
             self.state = HexrdConfig().load_panel_state
         else:
             self.state = state
+        self.state_updated.emit()
 
     def process_ims(self, postprocess, update_progress):
         self.update_progress = update_progress

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -61,8 +61,10 @@ class LoadPanel(QObject):
 
         self.ui.all_detectors.setChecked(self.state.get('apply_to_all', False))
         self.ui.aggregation.setCurrentIndex(self.state['agg'])
-        self.ui.transform.setCurrentIndex(self.state['trans'][self.ui.detector.currentIndex()])
-        self.ui.darkMode.setCurrentIndex(self.state['dark'][self.ui.detector.currentIndex()])
+        self.ui.transform.setCurrentIndex(
+            self.state['trans'][self.ui.detector.currentIndex()])
+        self.ui.darkMode.setCurrentIndex(
+            self.state['dark'][self.ui.detector.currentIndex()])
         self.dark_files = self.state['dark_files']
 
         self.dark_mode_changed()

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -51,6 +51,7 @@ class LoadPanel(QObject):
         self.progress_macro_steps = 0
 
         self.setup_gui()
+        self.detectors_changed()
         self.setup_connections()
 
     # Setup GUI
@@ -60,8 +61,8 @@ class LoadPanel(QObject):
 
         self.ui.all_detectors.setChecked(self.state.get('apply_to_all', False))
         self.ui.aggregation.setCurrentIndex(self.state['agg'])
-        self.ui.transform.setCurrentIndex(self.state['trans'][0])
-        self.ui.darkMode.setCurrentIndex(self.state['dark'][0])
+        self.ui.transform.setCurrentIndex(self.state['trans'][self.ui.detector.currentIndex()])
+        self.ui.darkMode.setCurrentIndex(self.state['dark'][self.ui.detector.currentIndex()])
         self.dark_files = self.state['dark_files']
 
         self.dark_mode_changed()
@@ -73,7 +74,6 @@ class LoadPanel(QObject):
                 directory = str(Path(directory).parent)
             self.ui.img_directory.setText(directory)
 
-        self.detectors_changed()
         self.ui.file_options.resizeColumnsToContents()
 
     def setup_connections(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -225,6 +225,7 @@ class MainWindow(QObject):
         ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)
         ImageLoadManager().images_transformed.connect(self.update_config_gui)
         ImageLoadManager().live_update_status.connect(self.live_update)
+        ImageLoadManager().state_updated.connect(self.load_widget.setup_gui)
 
         self.ui.action_switch_workflow.triggered.connect(
             self.on_action_switch_workflow_triggered)

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -20,8 +20,8 @@ class TransformDialog:
 
     def update_gui(self):
         options = [
-            '(None)', 'Flip Vertically', 'Flip Horizontally', 'Transpose',
-            'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
+            '(None)', 'Mirror about Vertical', 'Mirror about Horizontal',
+            'Transpose', 'Rotate 90°', 'Rotate 180°', 'Rotate 270°']
         for i, det in enumerate(HexrdConfig().detector_names):
             hbox = QHBoxLayout()
             # Add label
@@ -67,5 +67,6 @@ class TransformDialog:
                 trans.append(combo.currentIndex())
         ilm = ImageLoadManager()
         state = HexrdConfig().load_panel_state
+        state['trans'] = trans
         ilm.set_state({ 'trans': trans , 'agg': state.get('agg', 0) })
         ilm.begin_processing(postprocess=True)


### PR DESCRIPTION
Transform changes are reflected in image load dialog and transform dialog, but not vice versa. Make sure load panel reflects any transform changes made in the load or transform dialogs.

![transforms](https://user-images.githubusercontent.com/51238406/112047258-70f2ab00-8b23-11eb-9331-6bea31df20c8.gif)
