### PR TITLE
Add new options and redesign powder cal dialog

### DIFF
--- a/hexrd/ui/calibration/auto/instrument_calibrator.py
+++ b/hexrd/ui/calibration/auto/instrument_calibrator.py
@@ -73,9 +73,9 @@ class InstrumentCalibrator(object):
                 sum(resd1**2)/float(len(resd1))
 
             if delta_r > 0:
-                print('OPTIMIZATION SUCCESSFUL\nfinal ssr: %f'
-                      % sum(resd1**2)/float(len(resd1)))
-                print('delta_r: %f' % delta_r)
+                print('OPTIMIZATION SUCCESSFUL\nfinal ssr: '
+                      f'{sum(resd1**2)/float(len(resd1))}')
+                print(f'delta_r: {delta_r}')
             else:
                 print('no improvement in residual!!!')
                 step_successful = False

--- a/hexrd/ui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrd/ui/calibration/auto/powder_calibration_dialog.py
@@ -15,32 +15,31 @@ class PowderCalibrationDialog:
 
     def update_gui(self):
         options = HexrdConfig().config['calibration']['powder']
-        tth_tol = options['tth_tol']
-        eta_tol = options['eta_tol']
         pk_type = options['pk_type']
-        robust = options['use_robust_optimization']
 
-        if pk_type == 'pvoigt':
-            pk_type = 'PVoigt'
-        elif pk_type == 'gaussian':
-            pk_type = 'Gaussian'
-
-        self.ui.tth_tolerance.setValue(tth_tol)
-        self.ui.eta_tolerance.setValue(eta_tol)
-        self.ui.peak_fit_type.setCurrentText(pk_type)
-        self.ui.robust.setChecked(robust)
+        reformat = {
+            'pvoigt': 'PVoigt',
+            'gaussian': 'Gaussian',
+        }
+        self.ui.tth_tolerance.setValue(options['tth_tol'])
+        self.ui.eta_tolerance.setValue(options['eta_tol'])
+        self.ui.fit_tth_tol.setValue(options['fit_tth_tol'])
+        self.ui.max_iter.setValue(options['max_iter'])
+        self.ui.int_cutoff.setValue(options['int_cutoff'])
+        self.ui.conv_tol.setValue(options['conv_tol'])
+        self.ui.peak_fit_type.setCurrentText(reformat.get(pk_type, pk_type))
+        self.ui.robust.setChecked(options['use_robust_optimization'])
 
     def update_config(self):
-        tth_tol = self.ui.tth_tolerance.value()
-        eta_tol = self.ui.eta_tolerance.value()
-        pk_type = self.ui.peak_fit_type.currentText().lower()
-        robust = self.ui.robust.isChecked()
-
         options = HexrdConfig().config['calibration']['powder']
-        options['tth_tol'] = tth_tol
-        options['eta_tol'] = eta_tol
-        options['pk_type'] = pk_type
-        options['use_robust_optimization'] = robust
+        options['tth_tol'] = self.ui.tth_tolerance.value()
+        options['eta_tol'] = self.ui.eta_tolerance.value()
+        options['fit_tth_tol'] = self.ui.fit_tth_tol.value()
+        options['max_iter'] = self.ui.max_iter.value()
+        options['int_cutoff'] = self.ui.int_cutoff.value()
+        options['conv_tol'] = self.ui.conv_tol.value()
+        options['pk_type'] = self.ui.peak_fit_type.currentText().lower()
+        options['use_robust_optimization'] = self.ui.robust.isChecked()
 
     def exec_(self):
         if not self.ui.exec_():

--- a/hexrd/ui/calibration/auto/powder_calibrator.py
+++ b/hexrd/ui/calibration/auto/powder_calibrator.py
@@ -26,7 +26,11 @@ class PowderCalibrator(object):
         self._flags = flags
 
         # for polar interpolation
-        self._tth_tol = tth_tol or np.degrees(plane_data.tThWidth)
+        if tth_tol is None:
+            self._tth_tol = np.degrees(plane_data.tThWidth)
+        else:
+            self._tth_tol = tth_tol
+            self._plane_data.tThWidth = np.radians(tth_tol)
         self._eta_tol = eta_tol
 
         # for peak fitting
@@ -44,6 +48,7 @@ class PowderCalibrator(object):
     @property
     def plane_data(self):
         self._plane_data.wavelength = self._instr.beam_energy
+        self._plane_data.tThWidth = np.radians(self.tth_tol)
         return self._plane_data
 
     @property

--- a/hexrd/ui/calibration/auto/powder_calibrator.py
+++ b/hexrd/ui/calibration/auto/powder_calibrator.py
@@ -17,7 +17,7 @@ class PowderCalibrator(object):
         self._plane_data = plane_data
         self._plane_data.wavelength = self._instr.beam_energy  # force
         self._img_dict = img_dict
-        self._params = np.asarray(self.plane_data.lparms, dtype=float)
+        self._params = np.asarray(plane_data.lparms, dtype=float)
         self._full_params = np.hstack(
             [self._instr.calibration_parameters, self._params]
         )

--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -50,7 +50,7 @@ class PowderRunner(QObject):
 
     def _run(self):
         # First, have the user pick some options
-        if not PowderCalibrationDialog(self.parent).exec_():
+        if not PowderCalibrationDialog(self.material, self.parent).exec_():
             # User canceled...
             return
 
@@ -70,7 +70,6 @@ class PowderRunner(QObject):
             'plane_data': self.material.planeData,
             'img_dict': img_dict,
             'flags': self.refinement_flags,
-            'tth_tol': options['tth_tol'],
             'eta_tol': options['eta_tol'],
             'pktype': options['pk_type'],
         }

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -134,6 +134,9 @@ class HexrdConfig(QObject, metaclass=Singleton):
     """Emitted when a material is removed"""
     material_removed = Signal()
 
+    """Emitted to update the tth width in the powder overlay editor"""
+    material_tth_width_modified = Signal(str)
+
     """Emitted when a new raw mask has been created"""
     raw_masks_changed = Signal()
 

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -41,6 +41,9 @@ class PowderOverlayEditor:
         self.refinements_selector.selection_changed.connect(
             self.update_refinements)
 
+        HexrdConfig().material_tth_width_modified.connect(
+            self.material_tth_width_modified_externally)
+
     def update_refinement_options(self):
         if self.overlay is None:
             return
@@ -137,6 +140,9 @@ class PowderOverlayEditor:
 
         self.material.planeData.tThWidth = v
 
+        # All overlays that use this material will be affected
+        HexrdConfig().flag_overlay_updates_for_material(self.material.name)
+
     @property
     def tth_width_gui(self):
         if not self.ui.enable_width.isChecked():
@@ -190,3 +196,9 @@ class PowderOverlayEditor:
             self.ui.enable_width,
             self.ui.tth_width
         ] + self.offset_widgets
+
+    def material_tth_width_modified_externally(self, material_name):
+        if material_name != self.material.name:
+            return
+
+        self.update_gui()

--- a/hexrd/ui/resources/calibration/default_calibration_config.yml
+++ b/hexrd/ui/resources/calibration/default_calibration_config.yml
@@ -1,5 +1,4 @@
 powder:
-  tth_tol: 0.2
   eta_tol: 2.0
   fit_tth_tol: 0.05
   max_iter: 5

--- a/hexrd/ui/resources/calibration/default_calibration_config.yml
+++ b/hexrd/ui/resources/calibration/default_calibration_config.yml
@@ -1,6 +1,10 @@
 powder:
   tth_tol: 0.2
   eta_tol: 2.0
+  fit_tth_tol: 0.05
+  max_iter: 5
+  int_cutoff: 0.0001
+  conv_tol: 0.0001
   pk_type: 'pvoigt'
   use_robust_optimization: false
 crystal:

--- a/hexrd/ui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrd/ui/resources/ui/powder_calibration_dialog.ui
@@ -155,6 +155,9 @@
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="2" column="1">
        <widget class="ScientificDoubleSpinBox" name="tth_tolerance">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modifying this will also modify the 2θ width of the material's PlaneData.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="decimals">
          <number>8</number>
         </property>

--- a/hexrd/ui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrd/ui/resources/ui/powder_calibration_dialog.ui
@@ -6,84 +6,138 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>302</width>
-    <height>163</height>
+    <width>571</width>
+    <height>319</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
-   <item>
-    <layout class="QGridLayout" name="gridLayout">
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="eta_tolerance">
-       <property name="maximum">
-        <double>1000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="value">
-        <double>2.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QComboBox" name="peak_fit_type">
-       <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="3" column="0" colspan="3">
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Optimization Parameters:</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_5">
+      <item row="0" column="0">
+       <widget class="QLabel" name="conv_tol_label">
         <property name="text">
-         <string>PVoigt</string>
+         <string>Convergence Tolerance (Δr):</string>
         </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="max_iter">
+        <property name="minimum">
+         <number>1</number>
+        </property>
+        <property name="maximum">
+         <number>10000000</number>
+        </property>
+        <property name="value">
+         <number>5</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ScientificDoubleSpinBox" name="conv_tol">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.000100000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="max_iter_label">
         <property name="text">
-         <string>Gaussian</string>
+         <string>Max iterations:</string>
         </property>
-       </item>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QDoubleSpinBox" name="tth_tolerance">
-       <property name="maximum">
-        <double>1000.000000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.100000000000000</double>
-       </property>
-       <property name="value">
-        <double>0.200000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Peak fitting type:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="tth_label">
-       <property name="text">
-        <string>2θ tolerance:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="eta_label">
-       <property name="text">
-        <string>η tolerance:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0" colspan="2">
-      <widget class="QCheckBox" name="robust">
-       <property name="text">
-        <string>Use robust optimization?</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="robust">
+        <property name="text">
+         <string>Use robust optimization?</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
    </item>
-   <item>
+   <item row="0" column="1" rowspan="2" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Peak Fitting:</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="2" column="2">
+       <widget class="QLabel" name="int_cutoff_label">
+        <property name="text">
+         <string>Min Peak Amplitude:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="ScientificDoubleSpinBox" name="int_cutoff">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.000100000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QLabel" name="fit_tth_tol_label">
+        <property name="text">
+         <string>Fit 2θ Tolerance:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="ScientificDoubleSpinBox" name="fit_tth_tol">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.050000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QComboBox" name="peak_fit_type">
+        <item>
+         <property name="text">
+          <string>PVoigt</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Gaussian</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="peak_fit_type_label">
+        <property name="text">
+         <string>Peak fitting type:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -93,12 +147,78 @@
      </property>
     </widget>
    </item>
+   <item row="0" column="0" rowspan="2">
+    <widget class="QGroupBox" name="annular_sector_widths_group">
+     <property name="title">
+      <string>Annular Sector Widths:</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="2" column="1">
+       <widget class="ScientificDoubleSpinBox" name="tth_tolerance">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.200000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="tth_label">
+        <property name="text">
+         <string>2θ:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QLabel" name="eta_label">
+        <property name="text">
+         <string>η:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="1">
+       <widget class="ScientificDoubleSpinBox" name="eta_tolerance">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>2.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>tth_tolerance</tabstop>
   <tabstop>eta_tolerance</tabstop>
+  <tabstop>fit_tth_tol</tabstop>
+  <tabstop>int_cutoff</tabstop>
   <tabstop>peak_fit_type</tabstop>
+  <tabstop>conv_tol</tabstop>
+  <tabstop>max_iter</tabstop>
   <tabstop>robust</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This re-designs the powder calibration dialog and adds four new
widgets:

1. Fit TTh tolerance
2. Min peak amplitude
3. Max iterations
4. Convergence Tolerance

![image](https://user-images.githubusercontent.com/9558430/112090469-9d2d1c80-8b61-11eb-8a7d-eba340af4f8f.png)