### PR TITLE
Add option in transform dialog to subtract minimum

### DIFF
--- a/hexrd/ui/extra_ops_processed_image_series.py
+++ b/hexrd/ui/extra_ops_processed_image_series.py
@@ -1,0 +1,15 @@
+from hexrd.imageseries.process import ProcessedImageSeries
+
+
+class ExtraOpsProcessedImageSeries(ProcessedImageSeries):
+    """This class is here to add extra ops that aren't in hexrd..."""
+
+    SUBTRACT = 'subtract'
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.addop(self.SUBTRACT, self._subtract)
+
+    def _subtract(self, img, subtrahend):
+        return img - subtrahend

--- a/hexrd/ui/resources/ui/transforms_dialog.ui
+++ b/hexrd/ui/resources/ui/transforms_dialog.ui
@@ -99,6 +99,16 @@
     </layout>
    </item>
    <item>
+    <widget class="QCheckBox" name="subtract_minimum">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subtract the minimum value of all the data from each of the detectors.&lt;/p&gt;&lt;p&gt;This can be used to get rid of negative values, for instance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Subtract minimum</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <spacer name="horizontalSpacer_2">
@@ -127,6 +137,12 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>update_all</tabstop>
+  <tabstop>update_each</tabstop>
+  <tabstop>transform_all_menu</tabstop>
+  <tabstop>subtract_minimum</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -65,8 +65,19 @@ class TransformDialog:
         else:
             for combo in self.det_cboxes:
                 trans.append(combo.currentIndex())
+
         ilm = ImageLoadManager()
         state = HexrdConfig().load_panel_state
         state['trans'] = trans
-        ilm.set_state({ 'trans': trans , 'agg': state.get('agg', 0) })
+
+        new_state = {
+            'trans': trans,
+            'agg': state.get('agg', 0),
+        }
+
+        if self.ui.subtract_minimum.isChecked():
+            new_state['zero-min'] = None
+            state['zero-min'] = None
+
+        ilm.set_state(new_state)
         ilm.begin_processing(postprocess=True)


### PR DESCRIPTION
This first computes the minimum value of all the data (all frames and
all detectors), and then subtracts all values by that minimum.

This can be helpful for getting rid of negative numbers, although it
appears that dark background subtraction will usually get rid of
negative numbers since it sets all numbers below 0 to 0.

![subtract_minimum_example](https://user-images.githubusercontent.com/9558430/112241603-91e8f800-8c18-11eb-88e8-4d104a746156.gif)

Fixes: #844