### PR TITLE
Revert "Keep the powder confirmation message box in front"

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -123,10 +123,6 @@ class PowderRunner(QObject):
         box.setStandardButtons(standard_buttons.Yes | standard_buttons.No)
         box.setWindowModality(Qt.NonModal)
 
-        # Keep the message box in front
-        flags = box.windowFlags()
-        box.setWindowFlags(flags | Qt.Tool)
-
         # Add a checkbox
         cb = QCheckBox('Show auto picks?')
         cb.setStyleSheet('margin-left:50%; margin-right:50%;')


### PR DESCRIPTION
Reverts HEXRD/hexrdgui#856

The dialog no longer appeared grouped with the program in the status bar (application windows) _and_ wasn't raised so it was harder to find.