### PR TITLE
Put powder confirmation message box in front

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -118,9 +118,10 @@ class PowderRunner(QObject):
 
     def ask_if_lines_are_acceptable(self):
         msg = 'Perform calibration with the points drawn?'
-        box = QMessageBox(QMessageBox.Question, 'HEXRD', msg)
         standard_buttons = QMessageBox.StandardButton
-        box.setStandardButtons(standard_buttons.Yes | standard_buttons.No)
+        buttons = standard_buttons.Yes | standard_buttons.No
+        box = QMessageBox(QMessageBox.Question, 'HEXRD', msg, buttons,
+                          self.parent)
         box.setWindowModality(Qt.NonModal)
 
         # Add a checkbox

--- a/hexrd/ui/materials_table.py
+++ b/hexrd/ui/materials_table.py
@@ -246,5 +246,8 @@ def sorting_disabled(table):
 
 
 def rescale_structure_factors(sf):
+    if len(sf) == 0:
+        return
+
     # Rescale the structure factors to be between 0 and 100
     sf[:] = np.interp(sf, (sf.min(), sf.max()), (0, 100))


### PR DESCRIPTION
Give the powder confirmation message box a parent of QMainWindow
so it will be in front of it.

This was tested on Windows and seems to work.

Fixes: #854