### PR TITLE
Save/load .hexrd instrument config files

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -10,7 +10,7 @@ from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlays import default_overlay_refinements
-from hexrd.ui.utils import convert_tilt_convention
+from hexrd.ui.utils import instr_to_internal_dict
 
 from hexrd.ui.calibration.auto import (
     InstrumentCalibrator,
@@ -172,20 +172,7 @@ class PowderRunner(QObject):
         msg_box.setDetailedText(self.results_message)
         msg_box.exec_()
 
-        instr = self.instr
-        iconfig = HexrdConfig().instrument_config_none_euler_convention
-        cal_crystal = iconfig.get('calibration_crystal')
-        output_dict = instr.write_config(calibration_dict=cal_crystal)
-
-        # Convert back to whatever convention we were using before
-        eac = HexrdConfig().euler_angle_convention
-        if eac is not None:
-            convert_tilt_convention(output_dict, None, eac)
-
-        # Add the saturation levels, as they seem to be missing
-        sl = 'saturation_level'
-        for det in output_dict['detectors'].keys():
-            output_dict['detectors'][det][sl] = iconfig['detectors'][det][sl]
+        output_dict = instr_to_internal_dict(self.instr)
 
         # Save the previous iconfig to restore the statuses
         prev_iconfig = HexrdConfig().config['instrument']

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -6,7 +6,7 @@ from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.line_picker_dialog import LinePickerDialog
 from hexrd.ui.overlays import default_overlay_refinements
-from hexrd.ui.utils import convert_tilt_convention
+from hexrd.ui.utils import instr_to_internal_dict
 
 
 class CalibrationRunner:
@@ -242,21 +242,7 @@ class CalibrationRunner:
         HexrdConfig().calibration_complete.emit()
 
     def write_instrument_to_hexrd_config(self, instr):
-        iconfig = HexrdConfig().instrument_config_none_euler_convention
-
-        # Add this so the calibration crystal gets written
-        cal_crystal = iconfig.get('calibration_crystal')
-        output_dict = instr.write_config(calibration_dict=cal_crystal)
-
-        # Convert back to whatever convention we were using before
-        eac = HexrdConfig().euler_angle_convention
-        if eac is not None:
-            convert_tilt_convention(output_dict, None, eac)
-
-        # Add the saturation levels, as they seem to be missing
-        sl = 'saturation_level'
-        for det in output_dict['detectors'].keys():
-            output_dict['detectors'][det][sl] = iconfig['detectors'][det][sl]
+        output_dict = instr_to_internal_dict(instr)
 
         # Save the previous iconfig to restore the statuses
         prev_iconfig = HexrdConfig().config['instrument']

--- a/hexrd/ui/calibration/line_picked_calibration.py
+++ b/hexrd/ui/calibration/line_picked_calibration.py
@@ -6,7 +6,7 @@ from scipy import stats
 from hexrd import instrument
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.utils import convert_tilt_convention
+from hexrd.ui.utils import instr_to_internal_dict
 
 # =============================================================================
 # %% Functions and parameters
@@ -168,19 +168,7 @@ def run_line_picked_calibration(line_data):
 
     print('Optimization succeeded!')
 
-    # Add this so the calibration crystal gets written
-    cal_crystal = iconfig.get('calibration_crystal')
-    output_dict = instr.write_config(calibration_dict=cal_crystal)
-
-    # Convert back to whatever convention we were using before
-    eac = HexrdConfig().euler_angle_convention
-    if eac is not None:
-        convert_tilt_convention(output_dict, None, eac)
-
-    # Add the saturation levels, as they seem to be missing
-    sl = 'saturation_level'
-    for det in output_dict['detectors'].keys():
-        output_dict['detectors'][det][sl] = iconfig['detectors'][det][sl]
+    output_dict = instr_to_internal_dict(instr)
 
     print('Updating the config')
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -441,13 +441,13 @@ class HexrdConfig(QObject, metaclass=Singleton):
                 conf = yaml.load(f, Loader=NumPyIncludeLoader)
 
             instr = HEDMInstrument(conf, tilt_calibration_mapping=rme)
-            return instr.write_config()
+            return utils.instr_to_internal_dict(instr)
 
         def read_hexrd():
             with h5py.File(path, 'r') as f:
                 instr = HEDMInstrument(f, tilt_calibration_mapping=rme)
 
-            return instr.write_config()
+            return utils.instr_to_internal_dict(instr)
 
         formats = {
             '.yml': read_yaml,
@@ -459,11 +459,6 @@ class HexrdConfig(QObject, metaclass=Singleton):
             raise Exception(f'Unknown extension: {ext}')
 
         self.config['instrument'] = formats[ext]()
-
-        eac = self.euler_angle_convention
-        if eac is not None:
-            # Convert it to whatever convention we are using
-            utils.convert_tilt_convention(self.config['instrument'], None, eac)
 
         # Set any required keys that might be missing to prevent key errors
         self.set_defaults_if_missing()

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -52,15 +52,8 @@
      <property name="title">
       <string>&amp;Open</string>
      </property>
-     <widget class="QMenu" name="menu_load_config">
-      <property name="title">
-       <string>Configuration</string>
-      </property>
-      <addaction name="action_open_config_yaml"/>
-      <addaction name="action_open_config_dir"/>
-     </widget>
      <addaction name="action_open_images"/>
-     <addaction name="menu_load_config"/>
+     <addaction name="action_open_config_file"/>
      <addaction name="action_open_materials"/>
      <addaction name="action_open_aps_imageseries"/>
      <addaction name="separator"/>
@@ -74,8 +67,8 @@
       <property name="title">
        <string>&amp;Configuration</string>
       </property>
+      <addaction name="action_save_config_hexrd"/>
       <addaction name="action_save_config_yaml"/>
-      <addaction name="action_save_config_dir"/>
      </widget>
      <addaction name="action_save_imageseries"/>
      <addaction name="menu_save_config"/>
@@ -493,24 +486,14 @@
     <string>Apply Laue Mask to Polar</string>
    </property>
   </action>
-  <action name="action_open_config_yaml">
+  <action name="action_open_config_file">
    <property name="text">
-    <string>YAML</string>
-   </property>
-  </action>
-  <action name="action_open_config_dir">
-   <property name="text">
-    <string>HEXRD Directory</string>
+    <string>Configuration</string>
    </property>
   </action>
   <action name="action_save_config_yaml">
    <property name="text">
     <string>YAML</string>
-   </property>
-  </action>
-  <action name="action_save_config_dir">
-   <property name="text">
-    <string>HEXRD Directory</string>
    </property>
   </action>
   <action name="action_open_manager">
@@ -557,6 +540,11 @@
    </property>
    <property name="text">
     <string>Fit Grains</string>
+   </property>
+  </action>
+  <action name="action_save_config_hexrd">
+   <property name="text">
+    <string>HEXRD</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
These are HDF5 files that hexrd is now capable of saving/loading.

This is now the default instrument config file type, but yaml files
can still be loaded as well.

Now also, the way the files are saved/loaded internally has been changed.
Before, a dict was just written out to a yaml file. Now, an HEDMInstrument
object is created and used to write out either the yaml/hdf5 file.

Also, save/load of .hexrd directories is no longer supported, since it is
not needed anymore.

A util function was also added to extract out the config dict from an
HEDMInstrument object and perform any necessary conversions.