### PR TITLE
Make UiLoader a Singleton

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -19,27 +19,15 @@ from hexrd.ui import constants
 from hexrd.ui import overlays
 from hexrd.ui import resource_loader
 from hexrd.ui import utils
+from hexrd.ui.singletons import QSingleton
 
 import hexrd.ui.resources.calibration
 import hexrd.ui.resources.indexing
 import hexrd.ui.resources.materials
 
 
-# This metaclass must inherit from `type(QObject)` for classes that use
-# it to inherit from QObject.
-class Singleton(type(QObject)):
-
-    _instances = {}
-
-    def __call__(cls, *args, **kwargs):
-        if cls not in cls._instances:
-            cls._instances[cls] = super(Singleton, cls).__call__(*args,
-                                                                 **kwargs)
-        return cls._instances[cls]
-
-
 # This is a singleton class that contains the configuration
-class HexrdConfig(QObject, metaclass=Singleton):
+class HexrdConfig(QObject, metaclass=QSingleton):
     """The central configuration class for the program
 
     This class contains properties where possible, and it uses the

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -10,17 +10,7 @@ from hexrd import imageseries
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.load_hdf5_dialog import LoadHDF5Dialog
-
-
-class Singleton(type):
-
-    _instance = None
-
-    def __call__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(Singleton, cls).__call__(*args, **kwargs)
-
-        return cls._instance
+from hexrd.ui.singletons import Singleton
 
 
 class ImageFileManager(metaclass=Singleton):

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -17,22 +17,14 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_file_manager import ImageFileManager
 from hexrd.ui.progress_dialog import ProgressDialog
 from hexrd.ui.constants import *
+from hexrd.ui.singletons import QSingleton
 
-
-class Singleton(type(QObject)):
-
-    _instance = None
-
-    def __call__(cls, *args, **kwargs):
-        if cls._instance is None:
-            cls._instance = super(Singleton, cls).__call__(*args, **kwargs)
-
-        return cls._instance
 
 class NoEmptyFramesException(Exception):
     pass
 
-class ImageLoadManager(QObject, metaclass=Singleton):
+
+class ImageLoadManager(QObject, metaclass=QSingleton):
 
     # Emitted when new images are loaded
     progress_text = Signal(str)

--- a/hexrd/ui/singletons.py
+++ b/hexrd/ui/singletons.py
@@ -1,0 +1,25 @@
+from PySide2.QtCore import QObject
+
+
+class Singleton(type):
+
+    _instance = None
+
+    def __call__(cls, *args, **kwargs):
+        if cls._instance is None:
+            cls._instance = super().__call__(*args, **kwargs)
+
+        return cls._instance
+
+
+# This metaclass must inherit from `type(QObject)` for classes that use
+# it to inherit from QObject.
+class QSingleton(type(QObject)):
+
+    _instances = {}
+
+    def __call__(cls, *args, **kwargs):
+        if cls not in cls._instances:
+            cls._instances[cls] = super().__call__(*args, **kwargs)
+
+        return cls._instances[cls]

--- a/hexrd/ui/ui_loader.py
+++ b/hexrd/ui/ui_loader.py
@@ -3,16 +3,17 @@ from PySide2.QtUiTools import QUiLoader
 
 from hexrd.ui import resource_loader
 
-from .image_canvas import ImageCanvas
-from .image_tab_widget import ImageTabWidget
-from .scientificspinbox import ScientificDoubleSpinBox
+from hexrd.ui.image_canvas import ImageCanvas
+from hexrd.ui.image_tab_widget import ImageTabWidget
+from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
+from hexrd.ui.singletons import QSingleton
 
 import hexrd.ui.resources.ui
 
 
-class UiLoader(QUiLoader):
+class UiLoader(QUiLoader, metaclass=QSingleton):
     def __init__(self, parent=None):
-        super(UiLoader, self).__init__(parent)
+        super().__init__(parent)
 
         self.registerCustomWidget(ImageCanvas)
         self.registerCustomWidget(ImageTabWidget)


### PR DESCRIPTION
We don't need to instantiate a new Uiloader object for every widget we create. Make UiLoader a singleton instead.

This also moves all the singleton classes to a single file and imports them to avoid code duplication.