### PR TITLE
Check for np.ndarray when making status lists

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -570,7 +570,7 @@ class HexrdConfig(QObject, metaclass=Singleton):
             if isinstance(value, dict):
                 self.add_status(value)
             else:
-                if isinstance(value, list):
+                if isinstance(value, (list, np.ndarray)):
                     stat_default = [0] * len(value)
                 else:
                     stat_default = 0


### PR DESCRIPTION
It looks like in some cases, the instrument config value lists can be
np.ndarray now. We noticed this specifically for distortion parameters.

Add a check for np.ndarray as well when creating statuses, so that a
list of statuses will be properly created when it receives an np.ndarray.

Fixes: #876