### PR TITLE
Detector bounds

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -207,8 +207,8 @@ class ImportDataPanel(QObject):
         self.ui.bb_width.blockSignals(True)
 
         y0, y1, x0, x1 = self.it.bounds
-        self.ui.bb_width.setMaximum(x1 - x0)
-        self.ui.bb_height.setMaximum(y1 - y0)
+        self.ui.bb_width.setMaximum(self.it.img.shape[1])
+        self.ui.bb_height.setMaximum(self.it.img.shape[0])
 
         self.ui.bb_width.setValue(x1)
         self.ui.bb_height.setValue(y1)

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -1,5 +1,7 @@
 import numpy as np
 
+from PySide2.QtCore import Qt
+
 from matplotlib import patches
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
@@ -21,6 +23,8 @@ class InteractiveTemplate:
         self.shape = None
         self.press = None
         self.total_rotation = 0
+
+        self.parent.setFocusPolicy(Qt.ClickFocus)
 
     def update_image(self, img):
         self.img = img


### PR DESCRIPTION
Two minor updates:

- Remove the limitations on resizing detector bounding boxes. The size is now limited by the size of the image rather than the default template size.
- Allow the focus to be set on the canvas again by clicking on it. Before, changing the bounding ox pulled the focus to the spin box and prevented the user from using the keyboard to move the template unless they toggled the translate/rotate option.