### PR TITLE
Add basic refinements editor

### DIFF
--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -301,6 +301,12 @@ class MaterialsPanel(QObject):
     def update_table(self):
         self.materials_table.update_table()
 
+    def update_overlay_editor(self):
+        if not hasattr(self, '_overlay_manager'):
+            return
+
+        self._overlay_manager.update_overlay_editor()
+
     def update_refinement_options(self):
         if not hasattr(self, '_overlay_manager'):
             return

--- a/hexrd/ui/refinements_editor.py
+++ b/hexrd/ui/refinements_editor.py
@@ -176,10 +176,24 @@ class RefinementsEditor:
     @property
     def actions(self):
         return {
+            'Clear refinements': self.clear_refinements,
             'Mirror first detector': self.mirror_first_detector,
         }
 
     # Refinement actions
+    def clear_refinements(self):
+        def recurse(x):
+            if '_refinable' in x:
+                x['_refinable'] = False
+
+            for key in x:
+                if isinstance(x[key], dict):
+                    recurse(x[key])
+
+        recurse(self.dict)
+
+        self.update_tree_view()
+
     def mirror_first_detector(self):
         detectors = self.dict['instrument']['detectors']
         first = next(iter(detectors.values()))

--- a/hexrd/ui/refinements_editor.py
+++ b/hexrd/ui/refinements_editor.py
@@ -1,0 +1,314 @@
+import copy
+
+import numpy as np
+
+from hexrd.ui.constants import DEFAULT_CRYSTAL_PARAMS, OverlayType
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.tree_views.multi_column_dict_tree_view import (
+    MultiColumnDictTreeView)
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import convert_angle_convention
+
+
+class RefinementsEditor:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('refinements_editor.ui', parent)
+
+        self.dict = {}
+        self.reset_dict()
+
+        columns = {
+            'Value': '_value',
+            'Refinable': '_refinable',
+        }
+        self.tree_view = MultiColumnDictTreeView(self.dict, columns, parent)
+        self.ui.tree_view_layout.addWidget(self.tree_view)
+
+        self.iconfig_values_modified = False
+        self.material_values_modified = False
+
+        self.setup_actions()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.apply_action.pressed.connect(self.apply_action)
+        self.ui.reset.pressed.connect(self.reset_dict)
+
+        self.ui.button_box.accepted.connect(self.update_config)
+        self.ui.button_box.accepted.connect(self.ui.accept)
+        self.ui.button_box.rejected.connect(self.ui.reject)
+
+    def reset_dict(self):
+        config = {}
+        config['instrument'] = self.create_instrument_dict()
+        config['materials'] = self.create_materials_dict()
+
+        self.dict.clear()
+        self.dict.update(config)
+
+        self.update_tree_view()
+
+    def update_tree_view(self):
+        if not hasattr(self, 'tree_view'):
+            return
+
+        sb = self.tree_view.verticalScrollBar()
+        prev_pos = sb.value()
+        self.tree_view.reset_gui()
+        sb.setValue(prev_pos)
+
+    def create_instrument_dict(self):
+        iconfig = HexrdConfig().config['instrument']
+
+        # Recurse through it, setting all status keys and renaming them to
+        # "_refinable".
+        blacklisted = ['saturation_level', 'buffer', 'pixels', 'id']
+
+        def recurse(cur, idict):
+            if 'status' in cur:
+                if isinstance(cur['status'], list):
+                    for i, b in enumerate(cur['status']):
+                        idict[i] = {}
+                        idict[i]['_value'] = cur['value'][i]
+                        idict[i]['_refinable'] = bool(b)
+                else:
+                    idict['_value'] = cur['value']
+                    idict['_refinable'] = bool(cur['status'])
+                return
+
+            for key, v in cur.items():
+                if key in blacklisted:
+                    continue
+
+                if (key == 'tilt' and
+                        HexrdConfig().rotation_matrix_euler() is not None):
+                    # Display tilts as degrees
+                    v = copy.deepcopy(v)
+                    v['value'] = [np.degrees(x).item() for x in v['value']]
+
+                idict[key] = {}
+                recurse(v, idict[key])
+
+        idict = {}
+        recurse(iconfig, idict)
+        return idict
+
+    def create_materials_dict(self):
+        mdict = {}
+        for overlay in self.overlays:
+            name = unique_overlay_name(overlay)
+            values = refinement_values(overlay)
+            mdict[name] = {}
+            for rname, b in overlay['refinements']:
+                mdict[name][rname] = {}
+                mdict[name][rname]['_refinable'] = b
+                mdict[name][rname]['_value'] = values[rname]
+
+        return mdict
+
+    def update_config(self):
+        self.update_instrument_config()
+        self.update_materials_config()
+
+    def update_instrument_config(self):
+        iconfig = HexrdConfig().config['instrument']
+        idict = self.dict['instrument']
+
+        def recurse(cur, idict):
+            if 'status' in cur:
+                if isinstance(cur['status'], list):
+                    for i in range(len(cur['status'])):
+                        cur['status'][i] = int(idict[i]['_refinable'])
+                        if not are_close(cur['value'][i], idict[i]['_value']):
+                            self.iconfig_values_modified = True
+                            cur['value'][i] = idict[i]['_value']
+                else:
+                    cur['status'] = int(idict['_refinable'])
+                    if not are_close(cur['value'], idict['_value']):
+                        self.iconfig_values_modified = True
+                        cur['value'] = idict['_value']
+                return
+
+            for key, v in idict.items():
+                if key not in cur:
+                    continue
+
+                if (key == 'tilt' and
+                        HexrdConfig().rotation_matrix_euler() is not None):
+                    # Store tilts as radians
+                    v = copy.deepcopy(v)
+                    for i in range(len(v)):
+                        v[i]['_value'] = np.radians(v[i]['_value']).item()
+
+                recurse(cur[key], v)
+
+        recurse(iconfig, idict)
+
+    def update_materials_config(self):
+        mdict = self.dict['materials']
+        for overlay in self.overlays:
+            name = unique_overlay_name(overlay)
+            values = []
+            for i, ref in enumerate(overlay['refinements']):
+                new = (ref[0], mdict[name][ref[0]]['_refinable'])
+                overlay['refinements'][i] = new
+                values.append(mdict[name][ref[0]]['_value'])
+            any_modified = set_refinement_values(overlay, values)
+            if any_modified:
+                self.material_values_modified = True
+
+    @property
+    def overlays(self):
+        return HexrdConfig().overlays
+
+    def setup_actions(self):
+        labels = list(self.actions.keys())
+        self.ui.action.clear()
+        self.ui.action.addItems(labels)
+
+    def apply_action(self):
+        action = self.ui.action.currentText()
+        func = self.actions[action]
+        func()
+
+    @property
+    def actions(self):
+        return {
+            'Mirror first detector': self.mirror_first_detector,
+        }
+
+    # Refinement actions
+    def mirror_first_detector(self):
+        detectors = self.dict['instrument']['detectors']
+        first = next(iter(detectors.values()))
+
+        def set_refinements(det):
+            def recurse(cur1, cur2):
+                if '_refinable' in cur1:
+                    cur2['_refinable'] = cur1['_refinable']
+
+                for key in cur1:
+                    if isinstance(cur1[key], dict):
+                        recurse(cur1[key], cur2[key])
+
+            recurse(first, det)
+
+        for key, det in detectors.items():
+            if det is first:
+                continue
+
+            set_refinements(det)
+
+        self.update_tree_view()
+
+
+def unique_overlay_name(overlay):
+    mat_name = overlay['material']
+    all_overlays = HexrdConfig().overlays
+    same_material = [x for x in all_overlays if x['material'] == mat_name]
+
+    if len(same_material) == 1:
+        return mat_name
+
+    for i, o in enumerate(same_material, 1):
+        if o is overlay:
+            return f'{mat_name}_{i}'
+
+
+def refinement_values(overlay):
+    ret = {}
+    refinements = overlay['refinements']
+
+    def powder_values():
+        material = HexrdConfig().material(overlay['material'])
+        reduced_lparms = material.reduced_lattice_parameters
+
+        # These params should be in the same order as the refinements
+        for i, (rname, _) in enumerate(refinements):
+            x = reduced_lparms[i]
+            units = 'angstrom' if x.isLength() else 'degrees'
+            ret[rname] = to_native(x.getVal(units))
+
+        return ret
+
+    def laue_values():
+        options = overlay.setdefault('options', {})
+        params = options.get('crystal_params', DEFAULT_CRYSTAL_PARAMS.copy())
+        # These params should be in the same order as the refinements
+        params = np.array(params)
+        params[:3] = to_convention(params[:3])
+        for i, (rname, _) in enumerate(refinements):
+            ret[rname] = to_native(params[i])
+
+        return ret
+
+    func_dict = {
+        OverlayType.powder: powder_values,
+        OverlayType.laue: laue_values,
+    }
+
+    return func_dict[overlay['type']]()
+
+
+def set_refinement_values(overlay, values):
+    def set_powder():
+        material = HexrdConfig().material(overlay['material'])
+        prev_lparms = material.lparms
+        material.latticeParameters = values
+        lparms = material.lparms
+
+        # Indicate whether the data was modified
+        return any(not are_close(x, y) for x, y in zip(prev_lparms, lparms))
+
+    def set_laue():
+        nonlocal values
+        options = overlay.setdefault('options', {})
+        params = options.get('crystal_params', DEFAULT_CRYSTAL_PARAMS.copy())
+        values = np.array(values)
+        values[:3] = from_convention(values[:3])
+        if any(not are_close(x, y) for x, y in zip(params, values)):
+            options['crystal_params'] = values
+            return True
+
+        return False
+
+    func_dict = {
+        OverlayType.powder: set_powder,
+        OverlayType.laue: set_laue,
+    }
+
+    return func_dict[overlay['type']]()
+
+
+def to_native(x):
+    if isinstance(x, np.generic):
+        return x.item()
+
+    return x
+
+
+def are_close(v1, v2, tol=1.e-8):
+    if isinstance(v1, (float, np.floating)):
+        return abs(v1 - v2) < tol
+
+    return v1 == v2
+
+
+def from_convention(v):
+    convention = HexrdConfig().euler_angle_convention
+    if convention is not None:
+        v = np.radians(v)
+        v = convert_angle_convention(v, convention, None)
+
+    return v
+
+
+def to_convention(v):
+    convention = HexrdConfig().euler_angle_convention
+    if convention is not None:
+        v = convert_angle_convention(v, None, convention)
+        v = np.degrees(v)
+
+    return v

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -114,6 +114,7 @@
     <addaction name="menu_masks"/>
     <addaction name="action_transform_detectors"/>
     <addaction name="action_switch_workflow"/>
+    <addaction name="action_edit_refinements"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -545,6 +546,11 @@
   <action name="action_save_config_hexrd">
    <property name="text">
     <string>HEXRD</string>
+   </property>
+  </action>
+  <action name="action_edit_refinements">
+   <property name="text">
+    <string>Refinements</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/refinements_editor.ui
+++ b/hexrd/ui/resources/ui/refinements_editor.ui
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>refinements_editor</class>
+ <widget class="QDialog" name="refinements_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>635</width>
+    <height>700</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="3" column="1" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="reset">
+     <property name="text">
+      <string>Reset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QGroupBox" name="refinement_actions_group">
+     <property name="title">
+      <string>Refinement Actions</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QComboBox" name="action"/>
+      </item>
+      <item>
+       <widget class="QPushButton" name="apply_action">
+        <property name="text">
+         <string>Apply Action</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="3">
+    <layout class="QVBoxLayout" name="tree_view_layout"/>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>action</tabstop>
+  <tabstop>apply_action</tabstop>
+  <tabstop>reset</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -1,0 +1,260 @@
+from functools import partial
+
+from PySide2.QtCore import QModelIndex, Qt, Signal
+from PySide2.QtGui import QCursor
+from PySide2.QtWidgets import QMenu, QMessageBox, QTreeView
+
+from hexrd.ui.tree_views.base_tree_item_model import BaseTreeItemModel
+from hexrd.ui.utils import is_int
+
+
+# Global constants
+KEY_COL = BaseTreeItemModel.KEY_COL
+
+
+class BaseDictTreeItemModel(BaseTreeItemModel):
+
+    dict_modified = Signal()
+
+    def __init__(self, dictionary, parent=None):
+        super().__init__(parent)
+
+        # These can be modified anytime
+        self.lists_resizable = True
+        self._blacklisted_paths = []
+
+        self.config = dictionary
+
+    def setData(self, index, value, role):
+        item = self.get_item(index)
+
+        # If they are identical, don't do anything
+        if value == item.data(index.column()):
+            return True
+
+        path = self.path_to_value(item, index.column())
+        if index.column() != KEY_COL:
+            old_value = self.config_val(path)
+
+            # As a validation step, ensure that the new value can be
+            # converted to the old value's type
+            try:
+                value = type(old_value)(value)
+            except ValueError:
+                msg = (f'Could not convert {value} to type '
+                       f'{type(old_value).__name__}')
+                QMessageBox.warning(None, 'HEXRD', msg)
+                return False
+
+        item.set_data(index.column(), value)
+
+        if item.child_count() == 0:
+            self.set_config_val(path, value)
+            self.dict_modified.emit()
+
+        return True
+
+    def flags(self, index):
+        if not index.isValid():
+            return Qt.NoItemFlags
+
+        flags = super().flags(index)
+
+        item = self.get_item(index)
+        if index.column() != KEY_COL and item.child_count() == 0:
+            # All columns after the first with no children are editable
+            flags = flags | Qt.ItemIsEditable
+
+        return flags
+
+    def rebuild_tree(self):
+        # Rebuild the tree from scratch
+        self.clear()
+        for key in self.config:
+            tree_item = self.add_tree_item(key, None, self.root_item)
+            self.recursive_add_tree_items(self.config[key], tree_item)
+
+    def path_to_item(self, tree_item):
+        path = []
+        cur_tree_item = tree_item
+        while True:
+            text = cur_tree_item.data(KEY_COL)
+            text = int(text) if is_int(text) else text
+            path.insert(0, text)
+            cur_tree_item = cur_tree_item.parent_item
+            if cur_tree_item is self.root_item:
+                break
+
+        return path
+
+    def config_val(self, path):
+        """This obtains a dict value from a path list"""
+        cur_val = self.config
+        try:
+            for val in path:
+                cur_val = cur_val[val]
+        except KeyError:
+            msg = f'Path: {path}\nwas not found in dict: {self.config}'
+            raise Exception(msg)
+
+        return cur_val
+
+    def set_config_val(self, path, value):
+        """This sets a value from a path list"""
+        cur_val = self.config
+        try:
+            for val in path[:-1]:
+                cur_val = cur_val[val]
+
+            cur_val[path[-1]] = value
+        except KeyError:
+            msg = f'Path: {path}\nwas not found in dict: {self.config}'
+            raise Exception(msg)
+
+    @property
+    def blacklisted_paths(self):
+        return self._blacklisted_paths
+
+    @blacklisted_paths.setter
+    def blacklisted_paths(self, v):
+        # Make sure it is a list of lists, so we can do things like
+        # "x in self.blacklisted_paths", where x is a list.
+        self._blacklisted_paths = [list(x) for x in v]
+        self.rebuild_tree()
+
+
+class BaseDictTreeView(QTreeView):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self._combo_keys = []
+
+    def rebuild_tree(self):
+        self.model().rebuild_tree()
+
+    def expand_rows(self, parent=QModelIndex()):
+        # Recursively expands all rows
+        for i in range(self.model().rowCount(parent)):
+            index = self.model().index(i, KEY_COL, parent)
+            self.expand(index)
+            self.expand_rows(index)
+
+    @property
+    def lists_resizable(self):
+        return self.model().lists_resizable
+
+    @property
+    def blacklisted_paths(self):
+        return self.model().blacklisted_paths
+
+    @blacklisted_paths.setter
+    def blacklisted_paths(self, v):
+        self.model().blacklisted_paths = v
+        self.expand_rows()
+
+    @property
+    def combo_keys(self):
+        return self._combo_keys
+
+    @combo_keys.setter
+    def combo_keys(self, v):
+        """Should have the following structure:
+            {
+                ('path', 'to', 'parent'): {
+                    'option1': option1_defaults,
+                    'option2': option2_defaults,
+                }
+            }
+        """
+
+        self._combo_keys = v
+        self.rebuild_tree()
+        self.expand_rows()
+
+    def contextMenuEvent(self, event):
+        # Generate the actions
+        actions = {}
+
+        index = self.indexAt(event.pos())
+        model = self.model()
+        item = model.get_item(index)
+        path = tuple(model.path_to_value(item, index.column()))
+        parent_element = model.config_val(path[:-1]) if path else None
+        menu = QMenu(self)
+
+        # Helper functions
+        def add_actions(d: dict):
+            actions.update({menu.addAction(k): v for k, v in d.items()})
+
+        def add_separator():
+            if not actions:
+                return
+            menu.addSeparator()
+
+        def rebuild_gui():
+            self.rebuild_tree()
+            self.expand_rows()
+
+        # Callbacks for different actions
+        def insert_list_item():
+            value_type = type(parent_element[0]) if parent_element else int
+            parent_element.insert(path[-1], value_type(0))
+            rebuild_gui()
+
+        def remove_list_item():
+            parent_element.pop(path[-1])
+            rebuild_gui()
+
+        def change_combo_item(old, new, value):
+            del parent_element[old]
+            parent_element[new] = value
+            rebuild_gui()
+
+        # Add any actions that need to be added
+        if isinstance(path[-1], int) and self.lists_resizable:
+            # The item right-clicked is part of a list
+            new_actions = {
+                'Insert Item': insert_list_item,
+            }
+
+            # Don't let the user remove the last item from the list,
+            # or they may get stuck with an invalid config.
+            if len(parent_element) > 1:
+                new_actions['Remove Item'] = remove_list_item
+
+            add_separator()
+            add_actions(new_actions)
+
+        # "path" must be a tuple for this to work
+        if path[:-1] in self.combo_keys:
+            options = self.combo_keys[path[:-1]]
+            old_key = path[-1]
+            if old_key in options:
+                new_actions = {}
+                for name, default in options.items():
+                    if name == old_key:
+                        continue
+
+                    label = f'Change to {name}'
+                    func = partial(change_combo_item, old_key, name, default)
+                    new_actions[label] = func
+
+                add_separator()
+                add_actions(new_actions)
+
+        if not actions:
+            # No context menu
+            return super().contextMenuEvent(event)
+
+        # Open up the context menu
+        action_chosen = menu.exec_(QCursor.pos())
+
+        if action_chosen is None:
+            # No action chosen
+            return super().contextMenuEvent(event)
+
+        # Run the function for the action that was chosen
+        actions[action_chosen]()
+
+        return super().contextMenuEvent(event)

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -48,9 +48,8 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
 
         item.set_data(index.column(), value)
 
-        if item.child_count() == 0:
-            self.set_config_val(path, value)
-            self.dict_modified.emit()
+        self.set_config_val(path, value)
+        self.dict_modified.emit()
 
         return True
 
@@ -71,7 +70,8 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
         # Rebuild the tree from scratch
         self.clear()
         for key in self.config:
-            tree_item = self.add_tree_item(key, None, self.root_item)
+            data = [key, None]
+            tree_item = self.add_tree_item(data, self.root_item)
             self.recursive_add_tree_items(self.config[key], tree_item)
 
     def path_to_item(self, tree_item):

--- a/hexrd/ui/tree_views/base_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_tree_item_model.py
@@ -71,7 +71,5 @@ class BaseTreeItemModel(QAbstractItemModel):
         root.clear_children()
         self.endRemoveRows()
 
-    def add_tree_item(self, key, value, parent):
-        data = [key, value]
-        tree_item = TreeItem(data, parent)
-        return tree_item
+    def add_tree_item(self, data, parent):
+        return TreeItem(data, parent)

--- a/hexrd/ui/tree_views/base_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_tree_item_model.py
@@ -3,13 +3,11 @@ from PySide2.QtCore import QAbstractItemModel, QModelIndex, Qt
 from hexrd.ui.tree_views.tree_item import TreeItem
 
 KEY_COL = 0
-VALUE_COL = 1
 
 
 class BaseTreeItemModel(QAbstractItemModel):
 
     KEY_COL = KEY_COL
-    VALUE_COL = VALUE_COL
 
     def columnCount(self, parent):
         return self.root_item.column_count()
@@ -19,6 +17,16 @@ class BaseTreeItemModel(QAbstractItemModel):
             return self.root_item.data(section)
 
         return None
+
+    def data(self, index, role):
+        if not index.isValid():
+            return
+
+        if role not in (Qt.DisplayRole, Qt.EditRole):
+            return
+
+        item = self.get_item(index)
+        return item.data(index.column())
 
     def index(self, row, column, parent):
         if not self.hasIndex(row, column, parent):
@@ -67,13 +75,3 @@ class BaseTreeItemModel(QAbstractItemModel):
         data = [key, value]
         tree_item = TreeItem(data, parent)
         return tree_item
-
-    def set_value(self, key, cur_config, cur_tree_item):
-        if isinstance(cur_config, list):
-            children = cur_tree_item.child_items
-            for child in children:
-                value = cur_config[child.data(KEY_COL)]
-                child.set_data(VALUE_COL, value)
-        else:
-            cur_tree_item.set_data(VALUE_COL, cur_config)
-        return

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -1,91 +1,24 @@
-from functools import partial
+from PySide2.QtWidgets import QDialog, QVBoxLayout
 
-from PySide2.QtCore import QModelIndex, Qt
-from PySide2.QtGui import QCursor
-from PySide2.QtWidgets import (
-    QDialog, QMenu, QMessageBox, QTreeView, QVBoxLayout
+from hexrd.ui.tree_views.base_dict_tree_item_model import (
+    BaseTreeItemModel, BaseDictTreeItemModel, BaseDictTreeView
 )
-
-from hexrd.ui.tree_views.base_tree_item_model import BaseTreeItemModel
 from hexrd.ui.tree_views.tree_item import TreeItem
 from hexrd.ui.tree_views.value_column_delegate import ValueColumnDelegate
 
 
 # Global constants
 KEY_COL = BaseTreeItemModel.KEY_COL
-VALUE_COL = BaseTreeItemModel.VALUE_COL
+VALUE_COL = KEY_COL + 1
 
 
-class DictTreeItemModel(BaseTreeItemModel):
+class DictTreeItemModel(BaseDictTreeItemModel):
 
     def __init__(self, dictionary, parent=None):
-        super().__init__(parent)
-
-        # These can be modified anytime
-        self.lists_resizable = True
-        self._blacklisted_paths = []
+        super().__init__(dictionary, parent)
 
         self.root_item = TreeItem(['key', 'value'])
-        self.config = dictionary
         self.rebuild_tree()
-
-    def data(self, index, role):
-        if not index.isValid():
-            return
-
-        if role != Qt.DisplayRole and role != Qt.EditRole:
-            return
-
-        item = self.get_item(index)
-        return item.data(index.column())
-
-    def setData(self, index, value, role):
-        item = self.get_item(index)
-        path = self.get_path_from_root(item, index.column())
-
-        # If they are identical, don't do anything
-        if value == item.data(index.column()):
-            return True
-
-        if index.column() == VALUE_COL:
-            old_value = self.get_config_val(path)
-
-            # As a validation step, ensure that the new value can be
-            # converted to the old value's type
-            try:
-                value = type(old_value)(value)
-            except ValueError:
-                msg = (f'Could not convert {value} to type '
-                       f'{type(old_value).__name__}')
-                QMessageBox.warning(None, 'HEXRD', msg)
-                return False
-
-        item.set_data(index.column(), value)
-
-        if item.child_count() == 0:
-            self.set_config_val(path, value)
-
-        return True
-
-    def flags(self, index):
-        if not index.isValid():
-            return Qt.NoItemFlags
-
-        flags = super().flags(index)
-
-        item = self.get_item(index)
-        if index.column() == VALUE_COL and item.child_count() == 0:
-            # The second column with no children is editable
-            flags = flags | Qt.ItemIsEditable
-
-        return flags
-
-    def rebuild_tree(self):
-        # Rebuild the tree from scratch
-        self.clear()
-        for key in self.config:
-            tree_item = self.add_tree_item(key, None, self.root_item)
-            self.recursive_add_tree_items(self.config[key], tree_item)
 
     def recursive_add_tree_items(self, cur_config, cur_tree_item):
         if isinstance(cur_config, dict):
@@ -98,68 +31,21 @@ class DictTreeItemModel(BaseTreeItemModel):
             return
 
         for key in keys:
-            path = self.get_path_from_root(cur_tree_item, 0) + [key]
+            path = self.path_to_value(cur_tree_item, 0) + [key]
             if path in self.blacklisted_paths or str(key).startswith('_'):
                 continue
 
             tree_item = self.add_tree_item(key, None, cur_tree_item)
             self.recursive_add_tree_items(cur_config[key], tree_item)
 
-    def get_path_from_root(self, tree_item, column):
-        path = []
-        cur_tree_item = tree_item
-        while True:
-            text = cur_tree_item.data(KEY_COL)
-            text = int(text) if _is_int(text) else text
-            path.insert(0, text)
-            cur_tree_item = cur_tree_item.parent_item
-            if cur_tree_item is self.root_item:
-                break
-
-        return path
-
-    def get_config_val(self, path):
-        """This obtains a dict value from a path list"""
-        cur_val = self.config
-        try:
-            for val in path:
-                cur_val = cur_val[val]
-        except KeyError:
-            msg = f'Path: {path}\nwas not found in dict: {self.config}'
-            raise Exception(msg)
-
-        return cur_val
-
-    def set_config_val(self, path, value):
-        """This sets a value from a path list"""
-        cur_val = self.config
-        try:
-            for val in path[:-1]:
-                cur_val = cur_val[val]
-
-            cur_val[path[-1]] = value
-        except KeyError:
-            msg = f'Path: {path}\nwas not found in dict: {self.config}'
-            raise Exception(msg)
-
-    @property
-    def blacklisted_paths(self):
-        return self._blacklisted_paths
-
-    @blacklisted_paths.setter
-    def blacklisted_paths(self, v):
-        # Make sure it is a list of lists, so we can do things like
-        # "x in self.blacklisted_paths", where x is a list.
-        self._blacklisted_paths = [list(x) for x in v]
-        self.rebuild_tree()
+    def path_to_value(self, tree_item, column):
+        return self.path_to_item(tree_item)
 
 
-class DictTreeView(QTreeView):
+class DictTreeView(BaseDictTreeView):
 
     def __init__(self, dictionary, parent=None):
         super().__init__(parent)
-
-        self._combo_keys = []
 
         self.setModel(DictTreeItemModel(dictionary, parent=self))
         self.setItemDelegateForColumn(
@@ -173,135 +59,6 @@ class DictTreeView(QTreeView):
 
         self.expand_rows()
 
-    def rebuild_tree(self):
-        self.model().rebuild_tree()
-
-    def expand_rows(self, parent=QModelIndex()):
-        # Recursively expands all rows
-        for i in range(self.model().rowCount(parent)):
-            index = self.model().index(i, KEY_COL, parent)
-            self.expand(index)
-            self.expand_rows(index)
-
-    @property
-    def lists_resizable(self):
-        return self.model().lists_resizable
-
-    @property
-    def blacklisted_paths(self):
-        return self.model().blacklisted_paths
-
-    @blacklisted_paths.setter
-    def blacklisted_paths(self, v):
-        self.model().blacklisted_paths = v
-        self.expand_rows()
-
-    @property
-    def combo_keys(self):
-        return self._combo_keys
-
-    @combo_keys.setter
-    def combo_keys(self, v):
-        """Should have the following structure:
-            {
-                ('path', 'to', 'parent'): {
-                    'option1': option1_defaults,
-                    'option2': option2_defaults,
-                }
-            }
-        """
-
-        self._combo_keys = v
-        self.rebuild_tree()
-        self.expand_rows()
-
-    def contextMenuEvent(self, event):
-        # Generate the actions
-        actions = {}
-
-        index = self.indexAt(event.pos())
-        model = self.model()
-        item = model.get_item(index)
-        path = tuple(model.get_path_from_root(item, index.column()))
-        parent_element = model.get_config_val(path[:-1]) if path else None
-        menu = QMenu(self)
-
-        # Helper functions
-        def add_actions(d: dict):
-            actions.update({menu.addAction(k): v for k, v in d.items()})
-
-        def add_separator():
-            if not actions:
-                return
-            menu.addSeparator()
-
-        def rebuild_gui():
-            self.rebuild_tree()
-            self.expand_rows()
-
-        # Callbacks for different actions
-        def insert_list_item():
-            value_type = type(parent_element[0]) if parent_element else int
-            parent_element.insert(path[-1], value_type(0))
-            rebuild_gui()
-
-        def remove_list_item():
-            parent_element.pop(path[-1])
-            rebuild_gui()
-
-        def change_combo_item(old, new, value):
-            del parent_element[old]
-            parent_element[new] = value
-            rebuild_gui()
-
-        # Add any actions that need to be added
-        if isinstance(path[-1], int) and self.lists_resizable:
-            # The item right-clicked is part of a list
-            new_actions = {
-                'Insert Item': insert_list_item,
-            }
-
-            # Don't let the user remove the last item from the list,
-            # or they may get stuck with an invalid config.
-            if len(parent_element) > 1:
-                new_actions['Remove Item'] = remove_list_item
-
-            add_separator()
-            add_actions(new_actions)
-
-        # "path" must be a tuple for this to work
-        if path[:-1] in self.combo_keys:
-            options = self.combo_keys[path[:-1]]
-            old_key = path[-1]
-            if old_key in options:
-                new_actions = {}
-                for name, default in options.items():
-                    if name == old_key:
-                        continue
-
-                    label = f'Change to {name}'
-                    func = partial(change_combo_item, old_key, name, default)
-                    new_actions[label] = func
-
-                add_separator()
-                add_actions(new_actions)
-
-        if not actions:
-            # No context menu
-            return super().contextMenuEvent(event)
-
-        # Open up the context menu
-        action_chosen = menu.exec_(QCursor.pos())
-
-        if action_chosen is None:
-            # No action chosen
-            return super().contextMenuEvent(event)
-
-        # Run the function for the action that was chosen
-        actions[action_chosen]()
-
-        return super().contextMenuEvent(event)
-
 
 class DictTreeViewDialog(QDialog):
 
@@ -314,11 +71,3 @@ class DictTreeViewDialog(QDialog):
         self.layout().addWidget(self.dict_tree_view)
 
         self.resize(500, 500)
-
-
-def _is_int(s):
-    try:
-        int(s)
-        return True
-    except ValueError:
-        return False

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -35,7 +35,8 @@ class DictTreeItemModel(BaseDictTreeItemModel):
             if path in self.blacklisted_paths or str(key).startswith('_'):
                 continue
 
-            tree_item = self.add_tree_item(key, None, cur_tree_item)
+            data = [key, None]
+            tree_item = self.add_tree_item(data, cur_tree_item)
             self.recursive_add_tree_items(cur_config[key], tree_item)
 
     def path_to_value(self, tree_item, column):

--- a/hexrd/ui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrd/ui/tree_views/multi_column_dict_tree_view.py
@@ -99,9 +99,11 @@ class MultiColumnDictTreeView(BaseDictTreeView):
         self.setModel(MultiColumnDictTreeItemModel(dictionary, columns,
                                                    parent=self))
 
-        for i in range(len(columns) + 1):
+        self.resizeColumnToContents(0)
+        self.header().resizeSection(0, 200)
+        for i in range(1, len(columns) + 1):
             self.resizeColumnToContents(i)
-            self.header().resizeSection(i, 100)
+            self.header().resizeSection(i, 150)
             self.setItemDelegateForColumn(i, ColumnDelegate(self))
 
         self.open_persistent_editors()
@@ -131,6 +133,11 @@ class MultiColumnDictTreeView(BaseDictTreeView):
 
     def setup_connections(self):
         self.model().dict_modified.connect(self.dict_modified.emit)
+
+    def reset_gui(self):
+        self.rebuild_tree()
+        self.open_persistent_editors()
+        self.expand_rows()
 
 
 class MultiColumnDictTreeViewDialog(QDialog):

--- a/hexrd/ui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrd/ui/tree_views/multi_column_dict_tree_view.py
@@ -1,0 +1,244 @@
+from PySide2.QtCore import Signal, QModelIndex, Qt
+from PySide2.QtWidgets import (
+    QCheckBox, QDialog, QItemEditorFactory, QStyledItemDelegate, QVBoxLayout
+)
+
+from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
+from hexrd.ui.tree_views.base_dict_tree_item_model import (
+    BaseDictTreeItemModel, BaseTreeItemModel, BaseDictTreeView
+)
+from hexrd.ui.tree_views.tree_item import TreeItem
+
+# Global constants
+KEY_COL = BaseTreeItemModel.KEY_COL
+
+
+class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
+
+    def __init__(self, dictionary, columns, parent=None):
+        super().__init__(dictionary, parent)
+
+        self.column_labels = list(columns.keys())
+        self.column_keys = list(columns.values())
+
+        self.root_item = TreeItem(['Key'] + self.column_labels)
+        self.rebuild_tree()
+
+    def data(self, index, role):
+        value = super().data(index, role)
+
+        if isinstance(value, bool) and role == Qt.DisplayRole:
+            # If it's a bool, we want to display a checkbox via
+            # a persistent editor, rather than the default display.
+            return
+
+        return value
+
+    def flags(self, index):
+        if not index.isValid():
+            return Qt.NoItemFlags
+
+        flags = super().flags(index)
+
+        column = index.column()
+        item = self.get_item(index)
+        if column != KEY_COL and item.data(column) is not None:
+            # All columns after the first that isn't set to None is editable
+            flags = flags | Qt.ItemIsEditable
+
+        return flags
+
+    def rebuild_tree(self):
+        # Rebuild the tree from scratch
+        self.clear()
+        for key in self.config:
+            data = [key] + [None] * len(self.column_keys)
+            tree_item = self.add_tree_item(data, self.root_item)
+            self.recursive_add_tree_items(self.config[key], tree_item)
+
+    def recursive_add_tree_items(self, cur_config, cur_tree_item):
+        def add_columns():
+            for col, key in enumerate(self.column_keys, KEY_COL + 1):
+                if key not in cur_config:
+                    continue
+
+                cur_tree_item.set_data(col, cur_config[key])
+
+        def non_column_keys():
+            keys = list(cur_config.keys())
+            return [x for x in keys if x not in self.column_keys]
+
+        if isinstance(cur_config, dict):
+            add_columns()
+            keys = non_column_keys()
+        elif isinstance(cur_config, list):
+            keys = range(len(cur_config))
+        else:
+            return
+
+        for key in keys:
+            path = self.path_to_item(cur_tree_item) + [key]
+            if path in self.blacklisted_paths or str(key).startswith('_'):
+                continue
+
+            data = [key] + [None] * len(self.column_keys)
+            tree_item = self.add_tree_item(data, cur_tree_item)
+            self.recursive_add_tree_items(cur_config[key], tree_item)
+
+    def path_to_value(self, tree_item, column):
+        return self.path_to_item(tree_item) + [self.column_keys[column - 1]]
+
+
+class MultiColumnDictTreeView(BaseDictTreeView):
+
+    dict_modified = Signal()
+
+    def __init__(self, dictionary, columns, parent=None):
+        super().__init__(parent)
+
+        self.setModel(MultiColumnDictTreeItemModel(dictionary, columns,
+                                                   parent=self))
+
+        for i in range(len(columns) + 1):
+            self.resizeColumnToContents(i)
+            self.header().resizeSection(i, 100)
+            self.setItemDelegateForColumn(i, ColumnDelegate(self))
+
+        self.open_persistent_editors()
+        self.expand_rows()
+        self.setup_connections()
+
+    def open_persistent_editors(self, parent=QModelIndex()):
+        # If the data type is one of these, open the persistent editor
+        persistent_editor_data_types = (
+            bool,
+        )
+
+        rows = self.model().rowCount(parent)
+        cols = self.model().columnCount(parent)
+
+        for i in range(rows):
+            key_index = self.model().index(i, KEY_COL, parent)
+            item = self.model().get_item(key_index)
+            for j in range(cols):
+                data = item.data(j)
+                if isinstance(data, persistent_editor_data_types):
+                    data_index = self.model().index(i, j, parent)
+                    self.openPersistentEditor(data_index)
+
+            if item.child_count() != 0:
+                self.open_persistent_editors(key_index)
+
+    def setup_connections(self):
+        self.model().dict_modified.connect(self.dict_modified.emit)
+
+
+class MultiColumnDictTreeViewDialog(QDialog):
+
+    dict_modified = Signal()
+
+    def __init__(self, dictionary, columns, parent=None):
+        super().__init__(parent)
+
+        self.setLayout(QVBoxLayout(self))
+
+        self.dict_tree_view = MultiColumnDictTreeView(dictionary, columns,
+                                                      self)
+        self.layout().addWidget(self.dict_tree_view)
+
+        self.resize(500, 500)
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.dict_tree_view.dict_modified.connect(self.dict_modified.emit)
+
+
+class ColumnDelegate(QStyledItemDelegate):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        editor_factory = ColumnEditorFactory(self, parent)
+        self.setItemEditorFactory(editor_factory)
+
+    def state_changed(self):
+        self.commitData.emit(self.sender())
+
+
+class ColumnEditorFactory(QItemEditorFactory):
+    def __init__(self, delegate, parent=None):
+        super().__init__(self, parent)
+        self.delegate = delegate
+
+    def createEditor(self, user_type, parent):
+        # Normally in Qt, we'd use QVariant (like QVariant::Double) to compare
+        # with the user_type integer. However, QVariant is not available in
+        # PySide2, making us use roundabout methods to get the integer like
+        # below.
+        def utype(w):
+            return w.staticMetaObject.userProperty().userType()
+
+        bool_type = utype(QCheckBox)
+        float_type = utype(ScientificDoubleSpinBox)
+        if user_type == bool_type:
+            cb = QCheckBox(parent)
+            # Force an update when the check state changes
+            cb.toggled.connect(self.delegate.state_changed)
+            return cb
+        if user_type == float_type:
+            return ScientificDoubleSpinBox(parent)
+
+        return super().createEditor(user_type, parent)
+
+
+if __name__ == '__main__':
+    import json
+    import sys
+
+    from PySide2.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    columns = {
+        'Value': '_value',
+        'Status': '_status',
+        'Constrained': '_constrained',
+    }
+
+    config = {
+        'root_key1': {
+            '_status': True,
+            'child_key1': {
+                '_value': 3,
+                '_status': False,
+                '_constrained': True,
+            }
+        },
+        'root_key2': {
+            '_value': 4.2,
+            '_status': False,
+            '_constrained': True,
+        },
+        'root_key3': {
+            'child_key2': {
+                'child_key3': {
+                    '_value': 92,
+                    '_status': True,
+                    '_constrained': False,
+                },
+            },
+            'child_key4': {
+                '_value': 8.4,
+                '_status': True,
+                '_constrained': True,
+            },
+        }
+    }
+
+    dialog = MultiColumnDictTreeViewDialog(config, columns)
+
+    dialog.dict_modified.connect(lambda: print(json.dumps(config, indent=4)))
+
+    dialog.finished.connect(app.quit)
+    dialog.show()
+    app.exec_()

--- a/hexrd/ui/tree_views/value_column_delegate.py
+++ b/hexrd/ui/tree_views/value_column_delegate.py
@@ -39,7 +39,7 @@ class ValueColumnDelegate(QStyledItemDelegate):
                 _set_enable(False)
 
                 # Extract out the detector, so we can update the right config
-                path = model.get_path_from_root(item, index.column())
+                path = model.path_to_value(item, index.column())
                 detector = path[path.index('detectors') + 1]
                 dialog = PanelBufferDialog(detector, self)
                 dialog.show()

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -281,3 +281,12 @@ def instr_to_internal_dict(instr, calibration_dict=None):
         convert_tilt_convention(config, None, eac)
 
     return config
+
+
+def is_int(s):
+    """Check if a string is an int"""
+    try:
+        int(s)
+        return True
+    except ValueError:
+        return False


### PR DESCRIPTION
This adds a basic refinements editor under the "Edit"->"Refinements"
menu item. It allows the user to edit both the refinements and values
of refinable parameters that are used for calibration.

It additionally comes with a combo box of actions to automatically set 
refinements. Currently, the only action is "Mirror first detector", which
causes the refinement settings of all of the detectors to match what is
currently set for the first detector.

It is hopefully made in a way so it will be easily extensible to include
additional things such as lower bounds and upper bounds, and other
types of constraints.


https://user-images.githubusercontent.com/9558430/114899027-3f929580-9dd8-11eb-8569-966b7d209409.mp4