### PR TITLE
Allow clearing selected files in image stack dialog

### DIFF
--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -166,6 +166,8 @@ class ImageStackDialog(QObject):
 
     def detector_selection(self, checked):
         self.state['all_detectors'] = checked
+        self.ui.single_detector.setChecked(not checked)
+        self.ui.search_directories.setEnabled(checked)
         self.ui.detector_search.setEnabled(checked)
         self.ui.detectors.setDisabled(checked)
         self.ui.select_directory.setDisabled(checked)

--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -115,11 +115,12 @@ class ImageStackDialog(QObject):
                 }
 
     def set_wedges(self):
-        for i, wedge in enumerate(self.state['wedges']):
-            self.ui.omega_wedges.insertRow(i)
-            for j, value in enumerate(wedge):
-                self.ui.omega_wedges.setItem(
-                    i, j, QTableWidgetItem(str(value)))
+        if self.ui.omega_wedges.rowCount() == 0:
+            for i, wedge in enumerate(self.state['wedges']):
+                self.ui.omega_wedges.insertRow(i)
+                for j, value in enumerate(wedge):
+                    self.ui.omega_wedges.setItem(
+                        i, j, QTableWidgetItem(str(value)))
 
     def select_directory(self):
         d = QFileDialog.getExistingDirectory(

--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -87,7 +87,7 @@ class ImageStackDialog(QObject):
                 or 'max_frame_file' in self.state.keys()):
             self.state.clear()
         if self.state:
-            self.select_files_manually(self.state[self.detector]['files'])
+            self.find_previous_images(self.state[self.detector]['files'])
             self.load_omega_from_file(self.state['omega_from_file'])
             self.file_selection_changed(self.state['manual_file'])
             self.detector_selection(self.state['all_detectors'])
@@ -225,6 +225,8 @@ class ImageStackDialog(QObject):
             self.state[self.detector]['files'] = files
             self.state[self.detector]['file_count'] = len(files)
             self.ui.file_count.setText(str(len(files)))
+
+    def find_previous_images(self, files):
         try:
             ims = ImageFileManager().open_file(files[0])
             frames = len(ims) if len(ims) else 1
@@ -234,7 +236,10 @@ class ImageStackDialog(QObject):
             self.state['total_frames'] = frames
             self.total_frames()
         except Exception as e:
-            print('Unable to open previously loaded images: ', e)
+            msg = (
+                f'Unable to open previously loaded images, please make sure '
+                f'directory path is correct and that images still exist.')
+            QMessageBox.warning(self.parent(), 'HEXRD', msg)
             for det in self.detectors:
                 self.state[det]['files'] = ''
                 self.state[det]['file_count'] = 0

--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -45,7 +45,8 @@ class ImageStackDialog:
         self.ui.omega_wedges.cellChanged.connect(self.update_wedges)
         self.ui.all_detectors.toggled.connect(self.detector_selection)
         self.ui.search_directories.clicked.connect(self.search_directories)
-        self.ui.clear_file_selections.clicked.connect(self.clear_selected_files)
+        self.ui.clear_file_selections.clicked.connect(
+            self.clear_selected_files)
 
     def setup_gui(self):
         self.ui.current_directory.setText(

--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -45,6 +45,7 @@ class ImageStackDialog:
         self.ui.omega_wedges.cellChanged.connect(self.update_wedges)
         self.ui.all_detectors.toggled.connect(self.detector_selection)
         self.ui.search_directories.clicked.connect(self.search_directories)
+        self.ui.clear_file_selections.clicked.connect(self.clear_selected_files)
 
     def setup_gui(self):
         self.ui.current_directory.setText(
@@ -266,6 +267,12 @@ class ImageStackDialog:
         num_files = len(imgs[0])
         return imgs, num_files
 
+    def clear_selected_files(self):
+        for det in self.detectors:
+            self.state[det]['files'].clear()
+            self.state[det]['file_count'] = 0
+        self.ui.file_count.setText('0')
+
     def get_omega_values(self, num_files):
         if self.state['omega_from_file'] and self.state['omega']:
             omega = np.load(self.state['omega'])
@@ -338,6 +345,11 @@ class ImageStackDialog:
                         f'The directory have not been set for '
                         f'the following detector(s):\n{" ".join(dets)}.')
                     QMessageBox.warning(self.ui, 'HEXRD', msg)
+                    error = True
+                    continue
+                if idx := [i for i, n in enumerate(f) if f[0] == 0]:
+                    msg = (f'No files have been selected for the detectors.')
+                    QMessageBox.warning(None, 'HEXRD', msg)
                     error = True
                     continue
                 if idx := [i for i, n in enumerate(f) if f[0] != n]:

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -221,6 +221,11 @@ class LoadPanel(QObject):
         self.files = []
         self.frame_data = None
 
+    def clear_from_stack_dialog(self):
+        self.reset_data()
+        self.ui.file_options.setRowCount(0)
+        self.enable_read()
+
     def enable_aggregations(self, row, column):
         if not (column == 1 or column == 2):
             return
@@ -361,12 +366,12 @@ class LoadPanel(QObject):
 
     def enable_read(self):
         files = self.yml_files if self.ext in YAML_EXTS else self.files
-        enabled = True
+        enabled = len(files) > 0
         if len(files) and all(len(f) for f in files):
             if (self.state['dark'][self.idx] == UI_DARK_INDEX_FILE
                     and self.dark_files[self.idx] is None):
                 enabled = False
-            self.ui.read.setEnabled(enabled)
+        self.ui.read.setEnabled(enabled)
 
     # Handle table setup and changes
 
@@ -501,7 +506,7 @@ class LoadPanel(QObject):
         ImageLoadManager().read_data(self.files, data, self.parent())
 
     def load_image_stacks(self):
-        if data := ImageStackDialog(self.parent()).exec_():
+        if data := ImageStackDialog(self.parent(), self).exec_():
             self.files = data['files']
             self.omega_min = data['omega_min']
             self.omega_max = data['omega_max']

--- a/hexrd/ui/resources/ui/image_stack_dialog.ui
+++ b/hexrd/ui/resources/ui/image_stack_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>471</width>
-    <height>599</height>
+    <width>476</width>
+    <height>607</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -83,7 +83,7 @@
         </attribute>
        </widget>
       </item>
-      <item row="1" column="3">
+      <item row="1" column="3" alignment="Qt::AlignHCenter">
        <widget class="QCheckBox" name="apply_to_all">
         <property name="enabled">
          <bool>false</bool>
@@ -116,6 +116,13 @@
        <widget class="QLabel" name="file_count">
         <property name="text">
          <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QPushButton" name="clear_file_selections">
+        <property name="text">
+         <string>Clear Selections</string>
         </property>
        </widget>
       </item>
@@ -469,11 +476,11 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="detector_options"/>
   <buttongroup name="file_options">
    <property name="exclusive">
     <bool>true</bool>
    </property>
   </buttongroup>
-  <buttongroup name="detector_options"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
@joelvbernier This adds a clear option for selected files in the image stack dialog. This does not clear the load panel if images were previously selected. Do we want the load panel table to be cleared as well?