### PR TITLE
Add a "Reflections Table" button to powder editor

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -136,6 +136,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when point picked calibration is complete"""
     calibration_complete = Signal()
 
+    """Emitted when reflections tables for a given material should update
+
+    The string argument is the material name.
+    """
+    update_reflections_tables = Signal(str)
+
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -5,7 +5,7 @@ from PySide2.QtWidgets import QDialogButtonBox, QHeaderView
 from hexrd.ui import enter_key_filter
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.materials_table import MaterialsTable
+from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
 
 from hexrd.ui.indexing.fit_grains_tolerances_model import (
@@ -267,7 +267,7 @@ class FitGrainsOptionsDialog(QObject):
             'title_prefix': 'Select hkls for grain fitting: ',
             'parent': self.ui,
         }
-        self._table = MaterialsTable(**kwargs)
+        self._table = ReflectionsTable(**kwargs)
         self._table.show()
 
     def update_num_hkls(self):

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -6,7 +6,7 @@ from PySide2.QtWidgets import QFileDialog, QMessageBox
 from hexrd.ui import enter_key_filter
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.materials_table import MaterialsTable
+from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -191,7 +191,7 @@ class OmeMapsSelectDialog(QObject):
             'title_prefix': 'Select hkls for eta omega map generation: ',
             'parent': self.ui,
         }
-        self._table = MaterialsTable(**kwargs)
+        self._table = ReflectionsTable(**kwargs)
         self._table.show()
 
     def update_num_hkls(self):

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -300,7 +300,7 @@ class MaterialsPanel(QObject):
         self._overlay_manager.show()
 
     def update_table(self):
-        self.reflections_table.update_table()
+        HexrdConfig().update_reflections_tables.emit(self.current_material())
 
     def update_overlay_editor(self):
         if not hasattr(self, '_overlay_manager'):

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -8,7 +8,7 @@ from PySide2.QtWidgets import QComboBox, QFileDialog, QMenu, QMessageBox
 from hexrd.material import Material
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.materials_table import MaterialsTable
+from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.material_editor_widget import MaterialEditorWidget
 from hexrd.ui.material_properties_editor import MaterialPropertiesEditor
 from hexrd.ui.material_structure_editor import MaterialStructureEditor
@@ -26,7 +26,7 @@ class MaterialsPanel(QObject):
 
         m = HexrdConfig().active_material
         self.material_editor_widget = MaterialEditorWidget(m, self.ui)
-        self.materials_table = MaterialsTable(m, parent=self.ui)
+        self.reflections_table = ReflectionsTable(m, parent=self.ui)
 
         self.ui.material_editor_layout.addWidget(
             self.material_editor_widget.ui)
@@ -77,7 +77,8 @@ class MaterialsPanel(QObject):
         self.material_editor_widget.material_modified.connect(
             self.material_edited)
 
-        self.ui.show_materials_table.pressed.connect(self.show_materials_table)
+        self.ui.show_reflections_table.pressed.connect(
+            self.show_reflections_table)
         self.ui.show_overlay_manager.pressed.connect(self.show_overlay_manager)
 
         self.ui.show_overlays.toggled.connect(HexrdConfig()._set_show_overlays)
@@ -227,7 +228,7 @@ class MaterialsPanel(QObject):
         HexrdConfig().active_material = self.current_material()
 
     def active_material_changed(self):
-        self.materials_table.material = HexrdConfig().active_material
+        self.reflections_table.material = HexrdConfig().active_material
         self.update_gui_from_config()
         self.update_structure_tab()
         self.update_properties_tab()
@@ -287,8 +288,8 @@ class MaterialsPanel(QObject):
         # Update the text of the combo box item in the list
         combo.setItemText(combo.currentIndex(), new_name)
 
-    def show_materials_table(self):
-        self.materials_table.show()
+    def show_reflections_table(self):
+        self.reflections_table.show()
 
     def show_overlay_manager(self):
         if hasattr(self, '_overlay_manager'):
@@ -299,7 +300,7 @@ class MaterialsPanel(QObject):
         self._overlay_manager.show()
 
     def update_table(self):
-        self.materials_table.update_table()
+        self.reflections_table.update_table()
 
     def update_overlay_editor(self):
         if not hasattr(self, '_overlay_manager'):

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -9,6 +9,7 @@ from hexrd import unitcell
 
 from hexrd.ui.constants import DEFAULT_POWDER_REFINEMENTS
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.select_items_widget import SelectItemsWidget
 from hexrd.ui.ui_loader import UiLoader
 
@@ -40,6 +41,8 @@ class PowderOverlayEditor:
         self.ui.enable_width.toggled.connect(self.update_enable_states)
         self.refinements_selector.selection_changed.connect(
             self.update_refinements)
+
+        self.ui.reflections_table.pressed.connect(self.show_reflections_table)
 
         HexrdConfig().material_tth_width_modified.connect(
             self.material_tth_width_modified_externally)
@@ -110,6 +113,7 @@ class PowderOverlayEditor:
 
         self.update_enable_states()
         self.update_refinement_options()
+        self.update_reflections_table()
 
     def update_config(self):
         self.tth_width_config = self.tth_width_gui
@@ -202,3 +206,20 @@ class PowderOverlayEditor:
             return
 
         self.update_gui()
+
+    def update_reflections_table(self):
+        if hasattr(self, '_table'):
+            self._table.material = self.material
+
+    def show_reflections_table(self):
+        if not hasattr(self, '_table'):
+            kwargs = {
+                'material': self.material,
+                'parent': self.ui,
+            }
+            self._table = ReflectionsTable(**kwargs)
+        else:
+            # Make sure the material is up to date
+            self._table.material = self.material
+
+        self._table.show()

--- a/hexrd/ui/reflections_table.py
+++ b/hexrd/ui/reflections_table.py
@@ -40,6 +40,8 @@ class ReflectionsTable:
         HexrdConfig().active_material_modified.connect(
             self.active_material_modified)
         HexrdConfig().material_renamed.connect(self.update_material_name)
+        HexrdConfig().update_reflections_tables.connect(
+            self.update_table_if_name_matches)
 
     @property
     def material(self):
@@ -111,6 +113,10 @@ class ReflectionsTable:
 
     def active_material_modified(self):
         if HexrdConfig().active_material is self.material:
+            self.update_table()
+
+    def update_table_if_name_matches(self, name):
+        if self.material.name == name:
             self.update_table()
 
     def update_table(self):

--- a/hexrd/ui/reflections_table.py
+++ b/hexrd/ui/reflections_table.py
@@ -19,11 +19,11 @@ class COLUMNS:
     MULTIPLICITY = 4
 
 
-class MaterialsTable:
+class ReflectionsTable:
 
     def __init__(self, material, title_prefix='', parent=None):
         loader = UiLoader()
-        self.ui = loader.load_file('materials_table.ui', parent)
+        self.ui = loader.load_file('reflections_table.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
         self.setup_connections()

--- a/hexrd/ui/resources/ui/materials_panel.ui
+++ b/hexrd/ui/resources/ui/materials_panel.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>382</width>
+    <width>440</width>
     <height>241</height>
    </rect>
   </property>
@@ -117,9 +117,9 @@
           </widget>
          </item>
          <item row="0" column="0" colspan="4">
-          <widget class="QPushButton" name="show_materials_table">
+          <widget class="QPushButton" name="show_reflections_table">
            <property name="text">
-            <string>Materials Table</string>
+            <string>Reflections Table</string>
            </property>
           </widget>
          </item>
@@ -291,7 +291,7 @@
   <tabstop>materials_combo</tabstop>
   <tabstop>materials_tool_button</tabstop>
   <tabstop>tab_widget</tabstop>
-  <tabstop>show_materials_table</tabstop>
+  <tabstop>show_reflections_table</tabstop>
   <tabstop>show_overlay_manager</tabstop>
   <tabstop>show_overlays</tabstop>
   <tabstop>limit_active</tabstop>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>548</width>
+    <width>626</width>
     <height>502</height>
    </rect>
   </property>
@@ -151,6 +151,13 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QPushButton" name="reflections_table">
+     <property name="text">
+      <string>Reflections Table</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -161,6 +168,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>reflections_table</tabstop>
   <tabstop>enable_width</tabstop>
   <tabstop>tth_width</tabstop>
   <tabstop>offset_0</tabstop>

--- a/hexrd/ui/resources/ui/reflections_table.ui
+++ b/hexrd/ui/resources/ui/reflections_table.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>materials_table</class>
- <widget class="QDialog" name="materials_table">
+ <class>reflections_table</class>
+ <widget class="QDialog" name="reflections_table">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
This will bring up the reflections table for the material that is
currently being edited in the powder editor.
    
This PR also adds some new mechanics so that all reflections tables
matching the active material will update when the materials panel is
edited. This will hopefully keep them all up-to-date.

This PR also renames "Materials Table" => "Reflections Table".

Fixes: #874