### PR TITLE
Add view menu actions to show/hide dock widgets

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -5,8 +5,8 @@ import numpy as np
 
 from PySide2.QtCore import QEvent, QObject, Qt, QThreadPool, Signal, QTimer
 from PySide2.QtWidgets import (
-    QApplication, QFileDialog, QInputDialog, QMainWindow, QMessageBox,
-    QVBoxLayout
+    QApplication, QDockWidget, QFileDialog, QInputDialog, QMainWindow,
+    QMessageBox, QVBoxLayout
 )
 
 from hexrd.ui.calibration_config_widget import CalibrationConfigWidget
@@ -129,6 +129,8 @@ class MainWindow(QObject):
         # the first paint event has occurred (see MainWindow.eventFilter).
 
         self.workflow_selection_dialog = WorkflowSelectionDialog(self.ui)
+
+        self.add_view_dock_widget_actions()
 
     def setup_connections(self):
         """This is to setup connections for non-gui objects"""
@@ -798,3 +800,10 @@ class MainWindow(QObject):
 
     def on_action_open_mask_manager_triggered(self):
         self.mask_manager_dialog.show()
+
+    def add_view_dock_widget_actions(self):
+        # Add actions to show/hide all of the dock widgets
+        dock_widgets = self.ui.findChildren(QDockWidget)
+        titles = [w.windowTitle() for w in dock_widgets]
+        for title, w in sorted(zip(titles, dock_widgets)):
+            self.ui.view_dock_widgets.addAction(w.toggleViewAction())

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -86,10 +86,16 @@
     <addaction name="separator"/>
     <addaction name="actionQuit"/>
    </widget>
-   <widget class="QMenu" name="menuView">
+   <widget class="QMenu" name="menu_view">
     <property name="title">
      <string>View</string>
     </property>
+    <widget class="QMenu" name="view_dock_widgets">
+     <property name="title">
+      <string>Dock Widgets</string>
+     </property>
+    </widget>
+    <addaction name="view_dock_widgets"/>
     <addaction name="action_show_toolbar"/>
     <addaction name="action_show_live_updates"/>
     <addaction name="action_show_detector_borders"/>
@@ -129,7 +135,7 @@
    </widget>
    <addaction name="menu_file"/>
    <addaction name="menu_edit"/>
-   <addaction name="menuView"/>
+   <addaction name="menu_view"/>
    <addaction name="menu_run"/>
   </widget>
   <widget class="QStatusBar" name="status_bar">


### PR DESCRIPTION
This automatically adds view menu actions for all of the dock widgets
to show/hide them.

![show_hide_dock_widgets](https://user-images.githubusercontent.com/9558430/116418484-ccd6e080-a801-11eb-8a69-70b8f20b6ba1.gif)

Fixes: #599