### PR TITLE
Use pattern matching for dark subtraction files

### DIFF
--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -107,7 +107,8 @@ class LoadPanel(QObject):
             'trans', [UI_TRANS_INDEX_NONE for x in range(self.num_dets)])
         self.state.setdefault(
             'dark', [UI_DARK_INDEX_NONE for x in range(self.num_dets)])
-        self.state.setdefault('dark_files', [None for x in range(self.num_dets)])
+        self.state.setdefault(
+            'dark_files', [None for x in range(self.num_dets)])
 
     # Handle GUI changes
 
@@ -204,10 +205,10 @@ class LoadPanel(QObject):
                     self.dark_files = [selected_file] * self.num_dets
                     self.state['dark_files'] = [selected_file] * self.num_dets
                     msg = (
-                        f'Unable to match files - using the same dark file for '
-                        f'each detector.\nIf this is incorrect please de-select'
-                        f' \"Apply Selections to All Detectors\" and select '
-                        f'the dark file manually for each detector.')
+                        f'Unable to match files - using the same dark file'
+                        f'for each detector.\nIf this is incorrect please '
+                        f'de-select \"Apply Selections to All Detectors\" and '
+                        f'select the dark file manually for each detector.')
                     QMessageBox.warning(self.ui, 'HEXRD', msg)
             else:
                 self.dark_files[self.idx] = selected_file

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -101,13 +101,13 @@ class LoadPanel(QObject):
 
     def setup_processing_options(self):
         self.state = HexrdConfig().load_panel_state
-        num_dets = len(HexrdConfig().detector_names)
+        self.num_dets = len(HexrdConfig().detector_names)
         self.state.setdefault('agg', UI_AGG_INDEX_NONE)
         self.state.setdefault(
-            'trans', [UI_TRANS_INDEX_NONE for x in range(num_dets)])
+            'trans', [UI_TRANS_INDEX_NONE for x in range(self.num_dets)])
         self.state.setdefault(
-            'dark', [UI_DARK_INDEX_NONE for x in range(num_dets)])
-        self.state.setdefault('dark_files', [None for x in range(num_dets)])
+            'dark', [UI_DARK_INDEX_NONE for x in range(self.num_dets)])
+        self.state.setdefault('dark_files', [None for x in range(self.num_dets)])
 
     # Handle GUI changes
 
@@ -160,13 +160,16 @@ class LoadPanel(QObject):
             self.ui.transform.setCurrentIndex(self.state['trans'][self.idx])
             if self.ui.darkMode.isEnabled():
                 self.ui.darkMode.setCurrentIndex(self.state['dark'][self.idx])
-                self.dark_mode_changed()
+        self.dark_mode_changed()
         self.create_table()
 
     def apply_to_all_changed(self, checked):
         HexrdConfig().load_panel_state['apply_to_all'] = checked
         if not checked:
             self.switch_detector()
+        elif self.state['dark'][self.idx] == UI_DARK_INDEX_FILE:
+            self.select_dark_img(self.dark_files[self.idx])
+
 
     def select_folder(self, new_dir=None):
         # This expects to define the root image folder.
@@ -182,15 +185,34 @@ class LoadPanel(QObject):
             self.parent_dir = new_dir
             self.dir_changed()
 
-    def select_dark_img(self):
-        # This takes one image to use for dark subtraction.
-        caption = HexrdConfig().images_dirtion = 'Select image file'
-        selected_file, selected_filter = QFileDialog.getOpenFileNames(
-            self.ui, caption, dir=self.parent_dir)
+    def select_dark_img(self, selected_file=False):
+        if not selected_file:
+            # This takes one image to use for dark subtraction.
+            caption = HexrdConfig().images_dirtion = 'Select image file'
+            selected_file, selected_filter = QFileDialog.getOpenFileName(
+                self.ui, caption, dir=self.parent_dir)
 
         if selected_file:
-            self.dark_files[self.idx] = selected_file[0]
-            self.state['dark_files'][self.idx] = self.dark_files[self.idx]
+            if self.ui.all_detectors.isChecked():
+                files = ImageLoadManager().match_files([selected_file])
+                if files and all(len(f) for f in files):
+                    files.sort()
+                    for i, f in enumerate(files):
+                        self.dark_files[i] = files[i][0]
+                        self.state['dark_files'][i] = files[i][0]
+                else:
+                    self.dark_files = [selected_file] * self.num_dets
+                    self.state['dark_files'] = [selected_file] * self.num_dets
+                    msg = (
+                        f'Unable to match files - using the same dark file for '
+                        f'each detector.\nIf this is incorrect please de-select'
+                        f' \"Apply Selections to All Detectors\" and select '
+                        f'the dark file manually for each detector.')
+                    QMessageBox.warning(self.ui, 'HEXRD', msg)
+            else:
+                self.dark_files[self.idx] = selected_file
+                self.state['dark_files'][self.idx] = selected_file
+
             self.dark_mode_changed()
             self.enable_read()
 
@@ -230,7 +252,7 @@ class LoadPanel(QObject):
         if total_frames - self.empty_frames < 2:
             enable = False
         self.ui.aggregation.setEnabled(enable)
-        for i in range(4):
+        for i in [1, 2, 3]:
             self.ui.darkMode.model().item(i).setEnabled(enable)
 
         if not enable:


### PR DESCRIPTION
Fixes #891

This branch adds the ability to select dark files for detectors using pattern matching. The current behavior is as follows:

- If the `Apply Selections to All Detectors` option is _not_ selected the user is expected to set the dark file for each detector manually.
- If the `Apply Selections to All Detectors` _is_ selected, selecting a dark subtraction file for one detector will try to set the dark subtraction files for each detector using pattern matching. This means that it expects to find the detector name in each file, or else it will fail to find matches.
  - If the pattern matching fails the user is warned with a dialog and instead the selected file will be used for all detectors. The warning dialog informs the user that they must de-select the `Apply Selections to All Detectors` option and set each file manually if they do not want to use the same file for each detector.