### PR TITLE
Use draw_idle() everywhere instead of draw()

### DIFF
--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -66,7 +66,7 @@ class HandDrawnMaskDialog(QObject):
 
         self.canvas.mpl_disconnect(self.bp_id)
         self.bp_id = None
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def start(self):
         if self.canvas.mode != ViewType.polar:
@@ -94,7 +94,7 @@ class HandDrawnMaskDialog(QObject):
                         linestyle=linestyle)
         self.linebuilder = LineBuilder(line)
         self.lines.append(line)
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def line_finished(self):
         # append to ring_data
@@ -179,4 +179,4 @@ class LineBuilder(QObject):
 
     def update_line_data(self):
         self.line.set_data(self.xs, self.ys)
-        self.canvas.draw()
+        self.canvas.draw_idle()

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -201,7 +201,7 @@ class FitGrainsResultsDialog(QObject):
         }
         self.scatter_artist = self.ax.scatter3D(*coords, **kwargs)
         self.colorbar = self.fig.colorbar(self.scatter_artist, shrink=0.8)
-        self.draw()
+        self.draw_idle()
 
     def on_export_button_pressed(self):
         selected_file, selected_filter = QFileDialog.getSaveFileName(
@@ -262,7 +262,7 @@ class FitGrainsResultsDialog(QObject):
 
     def projection_changed(self):
         self.ax.set_proj_type(self.projection)
-        self.draw()
+        self.draw_idle()
 
     def cylindrical_reference_toggled(self):
         self.update_axes_labels()
@@ -369,7 +369,7 @@ class FitGrainsResultsDialog(QObject):
         if self.axes_visible:
             self.hide_axis(direction)
 
-        self.draw()
+        self.draw_idle()
 
         # As soon as the image is re-drawn, the perpendicular axis will
         # be visible again.
@@ -400,7 +400,7 @@ class FitGrainsResultsDialog(QObject):
         for name in ('x', 'y', 'z'):
             self.set_axis_visible(name, self.axes_visible)
 
-        self.draw()
+        self.draw_idle()
 
     def update_axes_labels(self):
         axes = ('x', 'y', 'z')
@@ -512,7 +512,7 @@ class FitGrainsResultsDialog(QObject):
         # buttons will know about the range change.
         self.toolbar.push_current()
 
-        self.draw()
+        self.draw_idle()
 
     def update_ranges_mpl(self):
         self.ranges_mpl = self.ranges_gui
@@ -563,7 +563,7 @@ class FitGrainsResultsDialog(QObject):
             self.update_plot()
 
     def draw(self):
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
 
 if __name__ == '__main__':

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -562,7 +562,7 @@ class FitGrainsResultsDialog(QObject):
         if update_plot:
             self.update_plot()
 
-    def draw(self):
+    def draw_idle(self):
         self.canvas.draw_idle()
 
 

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -426,7 +426,7 @@ class OmeMapsViewerDialog(QObject):
 
         self.draw_idle()
 
-    def draw(self):
+    def draw_idle(self):
         self.fig.canvas.draw_idle()
 
     @property

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -380,7 +380,7 @@ class OmeMapsViewerDialog(QObject):
     def update_spots(self):
         self.clear_spot_lines()
         if not self.display_spots:
-            self.draw()
+            self.draw_idle()
             return
 
         self.create_spots()
@@ -394,7 +394,7 @@ class OmeMapsViewerDialog(QObject):
             }
             self._spot_lines = self.ax.scatter(**kwargs)
 
-        self.draw()
+        self.draw_idle()
 
     def update_plot(self):
         ax = self.ax
@@ -424,10 +424,10 @@ class OmeMapsViewerDialog(QObject):
         ax.autoscale_view()
         ax.axis('auto')
 
-        self.draw()
+        self.draw_idle()
 
     def draw(self):
-        self.fig.canvas.draw()
+        self.fig.canvas.draw_idle()
 
     @property
     def current_hkl_index(self):
@@ -437,13 +437,13 @@ class OmeMapsViewerDialog(QObject):
         self.cmap = cmap
         if hasattr(self, 'im'):
             self.im.set_cmap(cmap)
-            self.draw()
+            self.draw_idle()
 
     def set_norm(self, norm):
         self.norm = norm
         if hasattr(self, 'im'):
             self.im.set_norm(norm)
-            self.draw()
+            self.draw_idle()
 
     def create_spots(self):
         data = self.image_data

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -131,7 +131,7 @@ class InteractiveTemplate:
         return all_paths
 
     def redraw(self):
-        self.parent.draw()
+        self.parent.draw_idle()
 
     def scale_template(self, sx=1, sy=1):
         xy = self.shape.xy

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -110,7 +110,7 @@ class LinePickerDialog(QObject):
 
         self.canvas.mpl_disconnect(self.bp_id)
         self.bp_id = None
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def zoom_width_changed(self):
         self.zoom_canvas.tth_tol = self.ui.zoom_tth_width.value()
@@ -176,7 +176,7 @@ class LinePickerDialog(QObject):
         self.update_enable_states()
 
         self.lines.append(line)
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def line_finished(self):
         linebuilder = self.linebuilder
@@ -274,4 +274,4 @@ class LineBuilder(QObject):
 
     def update_line_data(self):
         self.line.set_data(self.xs, self.ys)
-        self.canvas.draw()
+        self.canvas.draw_idle()

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -138,7 +138,7 @@ class MaskRegionsDialog(QObject):
             for a in self.canvas.raw_axes:
                 if a.get_title() == det:
                     a.patches.remove(last_patch)
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def axes_entered(self, event):
         self.axes = event.inaxes
@@ -161,14 +161,14 @@ class MaskRegionsDialog(QObject):
         if not self.det:
             self.det = self.image_mode
         self.create_patch()
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def drag_motion(self, event):
         if not self.axes or not self.press:
             return
 
         self.update_patch(event)
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def save_line_data(self):
         data_coords = self.patch.get_patch_transform().transform(
@@ -205,7 +205,7 @@ class MaskRegionsDialog(QObject):
         self.press.clear()
         self.end.clear()
         self.det = None
-        self.canvas.draw()
+        self.canvas.draw_idle()
 
     def apply_masks(self):
         self.disconnect()
@@ -231,4 +231,4 @@ class MaskRegionsDialog(QObject):
                     axes.patches.clear()
 
         self.disconnect()
-        self.canvas.draw()
+        self.canvas.draw_idle()

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -93,18 +93,18 @@ class ZoomCanvas(FigureCanvas):
         # Clear the crosshairs when the mouse is moving over the canvas
         self.clear_crosshairs()
         self.update_vhlines(event)
-        self.draw_idle()
+
+        # Can't use draw_idle() since the Cursor has useblit=True
+        self.draw()
 
     def update_vhlines(self, event):
         # These are vertical and horizontal lines on the integral axes
         if any(not x for x in [self.vhlines, self.axes]):
             return
 
-        _, a2, a3 = self.axes
         vline, hline = self.vhlines
-
-        vline.set_data([event.xdata] * 2, a2.get_ylim())
-        hline.set_data(a3.get_xlim(), [event.ydata] * 2)
+        vline.set_xdata(event.xdata)
+        hline.set_ydata(event.ydata)
 
     def main_canvas_mouse_moved(self, event):
         if event.inaxes is None:
@@ -211,8 +211,8 @@ class ZoomCanvas(FigureCanvas):
             self.grid = grid
 
             # These are vertical and horizontal lines on the integral axes
-            vline, = a2.plot([], [], color='red', linewidth=1)
-            hline, = a3.plot([], [], color='red', linewidth=1)
+            vline = a2.axvline(0, color='red', linewidth=1)
+            hline = a3.axhline(0, color='red', linewidth=1)
             self.vhlines = [vline, hline]
         else:
             # Make sure we update the color map and norm each time
@@ -236,5 +236,6 @@ class ZoomCanvas(FigureCanvas):
         ys = np.append(roi_deg[:, 1], roi_deg[0, 1])
         self.box_overlay_line.set_data(xs, ys)
 
-        self.main_canvas.draw_idle()
+        # Can't use draw_idle() since the Cursor has useblit=True
+        self.main_canvas.draw()
         self.draw_idle()

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -93,7 +93,7 @@ class ZoomCanvas(FigureCanvas):
         # Clear the crosshairs when the mouse is moving over the canvas
         self.clear_crosshairs()
         self.update_vhlines(event)
-        self.draw()
+        self.draw_idle()
 
     def update_vhlines(self, event):
         # These are vertical and horizontal lines on the integral axes
@@ -236,5 +236,5 @@ class ZoomCanvas(FigureCanvas):
         ys = np.append(roi_deg[:, 1], roi_deg[0, 1])
         self.box_overlay_line.set_data(xs, ys)
 
-        self.main_canvas.draw()
-        self.draw()
+        self.main_canvas.draw_idle()
+        self.draw_idle()


### PR DESCRIPTION
draw_idle() will perform a draw() when control returns to the Qt
event loop. It has the potential for major performance increases
because multiple calls to draw_idle() functions in a slot will
only result in one draw() when control returns to the event loop.

It resulted in major performance boosts for the brightness and
contrast editor, and I'm hoping it will give performance boosts
elsewhere as well. Just need to double check that we didn't call
draw_idle() on some object that doesn't have that function...

Fixes: #654