### PR TITLE
Add option to apply pixel solid angle correction

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -251,6 +251,9 @@ class InstrumentViewer:
         img = self.images_dict[detector_id]
         panel = self.instr._detectors[detector_id]
 
+        if HexrdConfig().apply_pixel_solid_angle_correction:
+            img = img / panel.pixel_solid_angles
+
         # map corners
         corners = np.vstack(
             [panel.corner_ll,

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -200,6 +200,9 @@ class PolarView:
         panel = self.detectors[det]
         img = self.images_dict[det]
 
+        if HexrdConfig().apply_pixel_solid_angle_correction:
+            img = img / panel.pixel_solid_angles
+
         gvec_angs = np.vstack([
                 angpts[1].flatten(),
                 angpts[0].flatten(),

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1363,6 +1363,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         _cartesian_plane_normal_rotate_y,
         set_cartesian_plane_normal_rotate_y)
 
+    def _apply_pixel_solid_angle_correction(self):
+        return self.config['image']['apply_pixel_solid_angle_correction']
+
+    def set_apply_pixel_solid_angle_correction(self, v):
+        if v != self.apply_pixel_solid_angle_correction:
+            self.config['image']['apply_pixel_solid_angle_correction'] = v
+            self.deep_rerender_needed.emit()
+
+    apply_pixel_solid_angle_correction = property(
+        _apply_pixel_solid_angle_correction,
+        set_apply_pixel_solid_angle_correction)
+
     def get_show_saturation_level(self):
         return self._show_saturation_level
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -115,6 +115,9 @@ class ImageCanvas(FigureCanvas):
             self.clear()
             self.mode = ViewType.raw
 
+            # This will be used for drawing the rings
+            self.iviewer = raw_iviewer()
+
             cols = 1
             if len(image_names) > 1:
                 cols = 2
@@ -124,6 +127,10 @@ class ImageCanvas(FigureCanvas):
             idx = HexrdConfig().current_imageseries_idx
             for i, name in enumerate(image_names):
                 img = HexrdConfig().image(name, idx)
+
+                if HexrdConfig().apply_pixel_solid_angle_correction:
+                    panel = self.iviewer.instr.detectors[name]
+                    img = img / panel.pixel_solid_angles
 
                 # Apply any masks
                 for mask_name, (det, mask) in HexrdConfig().raw_masks.items():
@@ -158,8 +165,6 @@ class ImageCanvas(FigureCanvas):
         # This will call self.draw_idle()
         self.show_saturation()
 
-        # This will be used for drawing the rings
-        self.iviewer = raw_iviewer()
         # Set the detectors to draw
         self.iviewer.detectors = [x.get_title() for x in self.raw_axes]
         self.update_auto_picked_data()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -116,6 +116,9 @@ class MainWindow(QObject):
 
         self.add_workflow_widgets()
 
+        self.ui.action_apply_pixel_solid_angle_correction.setChecked(
+            HexrdConfig().apply_pixel_solid_angle_correction)
+
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
         self.live_update(HexrdConfig().live_update)
 
@@ -235,6 +238,9 @@ class MainWindow(QObject):
             self.mask_manager_dialog.image_mode_changed)
 
         HexrdConfig().calibration_complete.connect(self.calibration_finished)
+
+        self.ui.action_apply_pixel_solid_angle_correction.toggled.connect(
+            HexrdConfig().set_apply_pixel_solid_angle_correction)
 
     def set_icon(self, icon):
         self.ui.setWindowIcon(icon)

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -17,3 +17,4 @@ cartesian:
 colormap:
   min: 0
 show_detector_borders: true
+apply_pixel_solid_angle_correction: false

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -121,6 +121,7 @@
     <addaction name="action_transform_detectors"/>
     <addaction name="action_switch_workflow"/>
     <addaction name="action_edit_refinements"/>
+    <addaction name="action_apply_pixel_solid_angle_correction"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -557,6 +558,14 @@
   <action name="action_edit_refinements">
    <property name="text">
     <string>Refinements</string>
+   </property>
+  </action>
+  <action name="action_apply_pixel_solid_angle_correction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Apply Pixel Solid Angle Correction</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This option currently lives under the "Edit" menu, and it applies to
all three views.

My 24 logical CPUs all run near 100% while it is being computed for
the first time, and it can freeze up for a little while, but after
they have been computed, if they are memoized in hexrd (via
hexrd/hexrd#260), it is much faster afterward, since they do
not need to be computed again.

Fixes: #851

Here's a short example (that might not be relevant for the use of the pixel solid angle correction, but it demonstrates that it works):

https://user-images.githubusercontent.com/9558430/116759921-2e9d7300-a9d9-11eb-80de-1ea41332e5ba.mp4