### PR TITLE
Add a messages widget

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -152,8 +152,6 @@ class ColorMapEditor:
         if h - l < 5:
             h = l + 5
 
-        print('Range to be used: ', l, ' -> ', h)
-
         return l, h
 
     def reset_range(self):

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -834,7 +834,6 @@ class ImageCanvas(FigureCanvas):
             fig, ax = plt.subplots()
             ax.set_xlabel(r'2$\theta$ (deg)')
             ax.set_ylabel(r'$\eta$ (deg)')
-            fig.canvas.set_window_title('HEXRD')
             self._snip1d_figure_cache = (fig, ax)
         else:
             fig, ax = self._snip1d_figure_cache

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -282,7 +282,6 @@ class OmeMapsViewerDialog(QObject):
         ax.set_title('Eta Omega Maps')
         ax.set_xlabel(r'$\eta$ ($\deg$)')
         ax.set_ylabel(r'$\omega$ ($\deg$)')
-        fig.canvas.set_window_title('HEXRD')
         self.ui.canvas_layout.addWidget(canvas)
 
         self.toolbar = NavigationToolbar(canvas, self.ui, False)

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -1,5 +1,6 @@
 import signal
 import sys
+import traceback
 
 from PySide2.QtCore import QCoreApplication, Qt
 from PySide2.QtGui import QIcon, QPixmap
@@ -7,6 +8,7 @@ from PySide2.QtWidgets import QApplication
 
 from hexrd.ui import resource_loader
 from hexrd.ui.main_window import MainWindow
+from hexrd.ui.utils import regular_stdout_stderr
 import hexrd.ui.resources.icons
 
 
@@ -28,9 +30,16 @@ def main():
     icon = QIcon(pixmap)
     app.setWindowIcon(icon)
 
-    window = MainWindow()
-    window.set_icon(icon)
-    window.show()
+    try:
+        window = MainWindow()
+        window.set_icon(icon)
+        window.show()
+    except Exception:
+        # If an exception occurs, make sure we print it out to
+        # regular stdout and stderr.
+        with regular_stdout_stderr():
+            traceback.print_exc()
+        raise
 
     sys.exit(app.exec_())
 

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -1,6 +1,5 @@
 import signal
 import sys
-import traceback
 
 from PySide2.QtCore import QCoreApplication, Qt
 from PySide2.QtGui import QIcon, QPixmap
@@ -8,7 +7,6 @@ from PySide2.QtWidgets import QApplication
 
 from hexrd.ui import resource_loader
 from hexrd.ui.main_window import MainWindow
-from hexrd.ui.utils import regular_stdout_stderr
 import hexrd.ui.resources.icons
 
 
@@ -30,16 +28,9 @@ def main():
     icon = QIcon(pixmap)
     app.setWindowIcon(icon)
 
-    try:
-        window = MainWindow()
-        window.set_icon(icon)
-        window.show()
-    except Exception:
-        # If an exception occurs, make sure we print it out to
-        # regular stdout and stderr.
-        with regular_stdout_stderr():
-            traceback.print_exc()
-        raise
+    window = MainWindow()
+    window.set_icon(icon)
+    window.show()
 
     sys.exit(app.exec_())
 

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -1,5 +1,6 @@
 import signal
 import sys
+
 from PySide2.QtCore import QCoreApplication, Qt
 from PySide2.QtGui import QIcon, QPixmap
 from PySide2.QtWidgets import QApplication

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -35,6 +35,7 @@ from hexrd.ui.load_panel import LoadPanel
 from hexrd.ui.mask_manager_dialog import MaskManagerDialog
 from hexrd.ui.mask_regions_dialog import MaskRegionsDialog
 from hexrd.ui.materials_panel import MaterialsPanel
+from hexrd.ui.messages_widget import MessagesWidget
 from hexrd.ui.refinements_editor import RefinementsEditor
 from hexrd.ui.save_images_dialog import SaveImagesDialog
 from hexrd.ui.transform_dialog import TransformDialog
@@ -56,7 +57,7 @@ class MainWindow(QObject):
     new_mask_added = Signal(str)
 
     def __init__(self, parent=None, image_files=None):
-        super(MainWindow, self).__init__(parent)
+        super().__init__(parent)
 
         loader = UiLoader()
         self.ui = loader.load_file('main_window.ui', parent)
@@ -65,6 +66,11 @@ class MainWindow(QObject):
         self.thread_pool = QThreadPool(self)
         self.progress_dialog = ProgressDialog(self.ui)
         self.progress_dialog.setWindowTitle('Calibration Running')
+
+        self.messages_widget = MessagesWidget(self.ui)
+        dock_widget_contents = self.ui.messages_dock_widget_contents
+        dock_widget_contents.layout().addWidget(self.messages_widget.ui)
+        self.ui.resizeDocks([self.ui.messages_dock_widget], [80], Qt.Vertical)
 
         # Let the left dock widget take up the whole left side
         self.ui.setCorner(Qt.TopLeftCorner, Qt.LeftDockWidgetArea)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -68,6 +68,7 @@ class MainWindow(QObject):
         self.progress_dialog.setWindowTitle('Calibration Running')
 
         self.messages_widget = MessagesWidget(self.ui)
+        self.messages_widget.capture_output()
         dock_widget_contents = self.ui.messages_dock_widget_contents
         dock_widget_contents.layout().addWidget(self.messages_widget.ui)
         self.ui.resizeDocks([self.ui.messages_dock_widget], [80], Qt.Vertical)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -68,7 +68,6 @@ class MainWindow(QObject):
         self.progress_dialog.setWindowTitle('Calibration Running')
 
         self.messages_widget = MessagesWidget(self.ui)
-        self.messages_widget.capture_output()
         dock_widget_contents = self.ui.messages_dock_widget_contents
         dock_widget_contents.layout().addWidget(self.messages_widget.ui)
         self.ui.resizeDocks([self.ui.messages_dock_widget], [80], Qt.Vertical)

--- a/hexrd/ui/messages_widget.py
+++ b/hexrd/ui/messages_widget.py
@@ -1,0 +1,114 @@
+from contextlib import contextmanager
+import sys
+
+from PySide2.QtCore import QObject, Qt, Signal
+from PySide2.QtGui import QColor
+
+from hexrd.ui.ui_loader import UiLoader
+
+
+STDOUT_COLOR = 'green'
+STDERR_COLOR = 'red'
+
+
+class MessagesWidget:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('messages_widget.ui', parent)
+
+        self.stdout_writer = Writer(self.write_stdout, self.ui)
+        self.stderr_writer = Writer(self.write_stderr, self.ui)
+
+        self.prev_stdout = None
+        self.prev_stderr = None
+
+        self.capture_output()
+
+        self.setup_connections()
+
+    def __del__(self):
+        self.release_output()
+
+    def setup_connections(self):
+        self.ui.clear.pressed.connect(self.clear_text)
+        self.ui.destroyed.connect(self.release_output)
+
+    def capture_output(self):
+        self.prev_stdout = sys.stdout
+        self.prev_stderr = sys.stderr
+
+        sys.stdout = self.stdout_writer
+        sys.stderr = self.stderr_writer
+
+    def release_output(self):
+        if self.prev_stdout is not None:
+            sys.stdout = self.prev_stdout
+            self.prev_stdout = None
+
+        if self.prev_stderr is not None:
+            sys.stderr = self.prev_stderr
+            self.prev_stderr = None
+
+    def insert_text(self, text):
+        # Autoscroll if the scrollbar is at the end. Otherwise, do not.
+        scrollbar = self.ui.text.verticalScrollBar()
+        current = scrollbar.value()
+        autoscroll = current == scrollbar.maximum()
+
+        self.ui.text.insertPlainText(text)
+
+        # Autoscroll
+        scrollbar.setValue(scrollbar.maximum() if autoscroll else current)
+
+    def write_stdout(self, text):
+        with self.with_color(STDOUT_COLOR):
+            self.insert_text(text)
+
+        # Also write to the previous stdout
+        if self.prev_stdout is not None:
+            self.prev_stdout.write(text)
+
+    def write_stderr(self, text):
+        with self.with_color(STDERR_COLOR):
+            self.insert_text(text)
+
+        # Also write to the regular stderr
+        if self.prev_stderr is not None:
+            self.prev_stderr.write(text)
+
+    def clear_text(self):
+        self.ui.text.clear()
+
+    @contextmanager
+    def with_color(self, color):
+        text_edit = self.ui.text
+        prev_qcolor = text_edit.textColor()
+        text_edit.setTextColor(QColor(color))
+        try:
+            yield
+        finally:
+            text_edit.setTextColor(prev_qcolor)
+
+
+class Writer(QObject):
+
+    text_received = Signal(str)
+
+    def __init__(self, write_func, parent=None):
+        super().__init__(parent)
+        self.write_func = write_func
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        # Always do a queued connection so the messages are
+        # printed in the order they are received (regardless of which
+        # thread they are coming from)
+        self.text_received.connect(self.on_text_received, Qt.QueuedConnection)
+
+    def on_text_received(self, text):
+        self.write_func(text)
+
+    def write(self, text):
+        self.text_received.emit(text)

--- a/hexrd/ui/messages_widget.py
+++ b/hexrd/ui/messages_widget.py
@@ -96,6 +96,7 @@ class MessagesWidget(QObject):
         self.ui.clear.setVisible(b)
 
     def clear_text(self):
+        self._holding_return = False
         self.ui.text.clear()
 
     @contextmanager

--- a/hexrd/ui/progress_dialog.py
+++ b/hexrd/ui/progress_dialog.py
@@ -11,7 +11,6 @@ class ProgressDialog:
         self.ui = loader.load_file('progress_dialog.ui', parent)
 
         self.messages_widget = MessagesWidget(self.ui)
-        self.messages_widget.capture_output()
         # Disable the clear button
         self.messages_widget.allow_clear = False
         self.ui.messages_widget_layout.addWidget(self.messages_widget.ui)
@@ -31,6 +30,7 @@ class ProgressDialog:
         self.setup_connections()
 
     def setup_connections(self):
+        # Show the messages widget if a message is received
         self.messages_widget.message_written.connect(self.show_messages_widget)
 
     def show_messages_widget(self):

--- a/hexrd/ui/progress_dialog.py
+++ b/hexrd/ui/progress_dialog.py
@@ -1,28 +1,78 @@
-from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QProgressDialog
+from PySide2.QtCore import QEvent, QObject, QTimer, Qt
+
+from hexrd.ui.messages_widget import MessagesWidget
+from hexrd.ui.ui_loader import UiLoader
 
 
-class ProgressDialog(QProgressDialog):
+class ProgressDialog:
 
     def __init__(self, parent=None):
-        super(ProgressDialog, self).__init__(parent)
+        loader = UiLoader()
+        self.ui = loader.load_file('progress_dialog.ui', parent)
+
+        self.messages_widget = MessagesWidget(self.ui)
+        self.messages_widget.capture_output()
+        # Disable the clear button
+        self.messages_widget.allow_clear = False
+        self.ui.messages_widget_layout.addWidget(self.messages_widget.ui)
 
         # Some default window title and text
         self.setWindowTitle('Hexrd')
         self.setLabelText('Please wait...')
 
-        # No cancel button
-        self.setCancelButton(None)
+        self.block_escape_key_filter = BlockEscapeKeyFilter(self.ui)
+        self.ui.installEventFilter(self.block_escape_key_filter)
 
         # No close button in the corner
-        self.setWindowFlags((self.windowFlags() | Qt.CustomizeWindowHint) &
-                            ~Qt.WindowCloseButtonHint)
+        flags = self.ui.windowFlags()
+        self.ui.setWindowFlags((flags | Qt.CustomizeWindowHint) &
+                               ~Qt.WindowCloseButtonHint)
 
-        # This is necessary to prevent the dialog from automatically
-        # appearing after it is initialized
-        self.reset()
+        self.setup_connections()
 
-    def keyPressEvent(self, e):
-        # Do not let the user close the dialog by pressing escape
-        if e.key() != Qt.Key_Escape:
-            super(ProgressDialog, self).keyPressEvent(e)
+    def setup_connections(self):
+        self.messages_widget.message_written.connect(self.show_messages_widget)
+
+    def show_messages_widget(self):
+        self.messages_widget.ui.show()
+
+    def clear_messages(self):
+        self.messages_widget.clear_text()
+
+    def shrink_later(self):
+        QTimer.singleShot(0, lambda: self.ui.adjustSize())
+
+    # We are copying some of the functions of QProgressDialog to ease
+    # the transition to this...
+    def setWindowTitle(self, title):
+        self.ui.setWindowTitle(title)
+
+    def setLabelText(self, text):
+        self.ui.progress_label.setText(text)
+
+    def setRange(self, minimum, maximum):
+        self.ui.progress_bar.setRange(minimum, maximum)
+
+    def setValue(self, value):
+        self.ui.progress_bar.setValue(value)
+
+    def accept(self):
+        self.ui.accept()
+
+    def exec_(self):
+        self.clear_messages()
+        # Hide the messages widget until a message is received
+        self.messages_widget.ui.hide()
+
+        # Shrink the dialog to the size of the contents
+        self.shrink_later()
+
+        self.ui.exec_()
+
+
+class BlockEscapeKeyFilter(QObject):
+    # Prevent the user from closing the dialog with the escape key
+    def eventFilter(self, obj, event):
+        if event.type() == QEvent.KeyPress and event.key() == Qt.Key_Escape:
+            return True
+        return super().eventFilter(obj, event)

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -196,7 +196,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>708</height>
+          <height>620</height>
          </rect>
         </property>
         <attribute name="label">
@@ -209,7 +209,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>708</height>
+          <height>620</height>
          </rect>
         </property>
         <attribute name="label">
@@ -222,7 +222,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>708</height>
+          <height>620</height>
          </rect>
         </property>
         <attribute name="label">
@@ -317,6 +317,17 @@
       <number>0</number>
      </property>
     </layout>
+   </widget>
+  </widget>
+  <widget class="QDockWidget" name="messages_dock_widget">
+   <property name="windowTitle">
+    <string>Messages</string>
+   </property>
+   <attribute name="dockWidgetArea">
+    <number>1</number>
+   </attribute>
+   <widget class="QWidget" name="messages_dock_widget_contents">
+    <layout class="QVBoxLayout" name="verticalLayout_3"/>
    </widget>
   </widget>
   <action name="action_tabbed_view">

--- a/hexrd/ui/resources/ui/messages_widget.ui
+++ b/hexrd/ui/resources/ui/messages_widget.ui
@@ -16,14 +16,7 @@
     <height>0</height>
    </size>
   </property>
-  <property name="windowTitle">
-   <string>Edit Overlay</string>
-  </property>
-  <property name="styleSheet">
-   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
-</string>
-  </property>
-  <layout class="QVBoxLayout" name="verticalLayout_2">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QTextEdit" name="text">
      <property name="readOnly">

--- a/hexrd/ui/resources/ui/messages_widget.ui
+++ b/hexrd/ui/resources/ui/messages_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>149</height>
+    <height>119</height>
    </rect>
   </property>
   <property name="minimumSize">

--- a/hexrd/ui/resources/ui/messages_widget.ui
+++ b/hexrd/ui/resources/ui/messages_widget.ui
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>messages_widget</class>
+ <widget class="QWidget" name="messages_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>149</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QTextEdit" name="text">
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="clear">
+     <property name="text">
+      <string>Clear</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>text</tabstop>
+  <tabstop>clear</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/progress_dialog.ui
+++ b/hexrd/ui/resources/ui/progress_dialog.ui
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>progress_dialog</class>
+ <widget class="QDialog" name="progress_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>300</width>
+    <height>80</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>300</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Hexrd</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QLabel" name="progress_label">
+     <property name="text">
+      <string>Please wait...</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QProgressBar" name="progress_bar">
+     <property name="value">
+      <number>24</number>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <layout class="QVBoxLayout" name="messages_widget_layout">
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>10</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -4,11 +4,12 @@ from contextlib import contextmanager
 from enum import IntEnum
 from functools import reduce
 import math
+import sys
+
+import matplotlib.transforms as mtransforms
 import numpy as np
 
 from PySide2.QtCore import QObject, QSignalBlocker
-
-import matplotlib.transforms as mtransforms
 
 from hexrd import imageutil
 from hexrd.rotations import angleAxisOfRotMat, RotMatEuler
@@ -312,3 +313,17 @@ def reversed_enumerate(sequence):
         reversed(range(len(sequence))),
         reversed(sequence),
     )
+
+
+@contextmanager
+def regular_stdout_stderr():
+    # Ensure we are using regular stdout and stderr in the context
+    prev_stdout = sys.stdout
+    prev_stderr = sys.stderr
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
+    try:
+        yield
+    finally:
+        sys.stdout = prev_stdout
+        sys.stderr = prev_stderr


### PR DESCRIPTION
This adds a messages widget that is being used both in a dock widget and in the progress dialog.

The messages widget picks up messages from `stdout` and `stderr`, whether the messages come
from `print()`, a logger, or something else. `stdout` messages appear in green, and `stderr` messages
appear in red. All messages print to all currently open messages widgets, and to the regular `stdout` and `stderr`.

The progress dialog hides its messages widget until a message is received, and then it shows it.

The dock widget messages widget is always open, and can be cleared. It can also be hidden/shown via
the "View"->"Dock Widgets" menu.

An example involving generating eta omega maps is shown below.

https://user-images.githubusercontent.com/9558430/116967367-bef8e380-ac77-11eb-926d-5538203fdfd4.mp4

Fixes: #549