### PR TITLE
Install QDialog enter key filter upon Ui load

### DIFF
--- a/hexrd/ui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrd/ui/calibration/auto/powder_calibration_dialog.py
@@ -1,7 +1,5 @@
 import numpy as np
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -11,7 +9,6 @@ class PowderCalibrationDialog:
     def __init__(self, material, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('powder_calibration_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.material = material
 

--- a/hexrd/ui/calibration/panel_buffer_dialog.py
+++ b/hexrd/ui/calibration/panel_buffer_dialog.py
@@ -4,8 +4,6 @@ from PySide2.QtCore import Signal, QObject, QSignalBlocker
 from PySide2.QtWidgets import QFileDialog, QMessageBox
 import numpy as np
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -25,7 +23,6 @@ class PanelBufferDialog(QObject):
         self.detector = detector
         loader = UiLoader()
         self.ui = loader.load_file('panel_buffer_dialog.ui')
-        self.ui.installEventFilter(enter_key_filter)
 
         # Hide the tab bar. It gets selected by changes to the combo box.
         self.ui.tab_widget.tabBar().hide()

--- a/hexrd/ui/calibration/wppf_options_dialog.py
+++ b/hexrd/ui/calibration/wppf_options_dialog.py
@@ -16,7 +16,6 @@ from hexrd.material import _angstroms
 from hexrd.WPPF import LeBail, Rietveld, \
     Parameters, _lpname, _rqpDict,  _getnumber, _nameU
 from hexrd import constants
-from hexrd.ui import enter_key_filter
 
 import hexrd.ui.resources.calibration as calibration_resources
 from hexrd.ui.constants import OverlayType
@@ -48,7 +47,6 @@ class WppfOptionsDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('wppf_options_dialog.ui', parent)
         self.ui.setWindowTitle('WPPF Options Dialog')
-        self.ui.installEventFilter(enter_key_filter)
 
         self.reset_initial_params()
         self.load_settings()

--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -7,8 +7,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Cursor
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
 
@@ -23,7 +21,6 @@ class HandDrawnMaskDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('hand_drawn_mask_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.canvas = canvas
         self.ring_data = []

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -2,8 +2,6 @@ from PySide2.QtCore import (
     QItemSelectionModel, QObject, QSignalBlocker, Qt, Signal)
 from PySide2.QtWidgets import QDialogButtonBox, QHeaderView
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
@@ -27,7 +25,6 @@ class FitGrainsOptionsDialog(QObject):
         self.ui = loader.load_file('fit_grains_options_dialog.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.setup_material_options()
 

--- a/hexrd/ui/indexing/fit_grains_select_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_select_dialog.py
@@ -5,7 +5,6 @@ import numpy as np
 from PySide2.QtCore import QObject, QSignalBlocker, Signal
 from PySide2.QtWidgets import QFileDialog, QMessageBox
 
-from hexrd.ui import enter_key_filter
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.indexing.utils import generate_grains_table
@@ -25,7 +24,6 @@ class FitGrainsSelectDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('fit_grains_select_dialog.ui', parent)
         self.ui.setWindowTitle('Select Grains to Fit')
-        self.ui.installEventFilter(enter_key_filter)
 
         # Hide the tab bar. It gets selected by changes to the combo box.
         self.ui.tab_widget.tabBar().hide()

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -3,8 +3,6 @@ import os
 from PySide2.QtCore import Signal, QObject, QSignalBlocker
 from PySide2.QtWidgets import QFileDialog, QMessageBox
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
@@ -21,7 +19,6 @@ class OmeMapsSelectDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('ome_maps_select_dialog.ui', parent)
         self.ui.setWindowTitle('Load/Generate Eta Omega Maps')
-        self.ui.installEventFilter(enter_key_filter)
 
         # Hide the tab bar. It gets selected by changes to the combo box.
         self.ui.tab_widget.tabBar().hide()

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -19,7 +19,7 @@ from hexrd.findorientations import (
 )
 from hexrd.imageutil import find_peaks_2d
 
-from hexrd.ui import enter_key_filter, resource_loader
+from hexrd.ui import resource_loader
 
 from hexrd.ui.color_map_editor import ColorMapEditor
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -45,7 +45,6 @@ class OmeMapsViewerDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('ome_maps_viewer_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.data = data
         self.cmap = hexrd.ui.constants.DEFAULT_CMAP

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -9,8 +9,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Cursor
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.zoom_canvas import ZoomCanvas
@@ -46,7 +44,6 @@ class LinePickerDialog(QObject):
 
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.ring_data = []
         self.linebuilder = None

--- a/hexrd/ui/load_hdf5_dialog.py
+++ b/hexrd/ui/load_hdf5_dialog.py
@@ -3,8 +3,6 @@ import os
 
 from PySide2.QtWidgets import QDialog, QListWidgetItem, QMessageBox
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.ui_loader import UiLoader
 
 class LoadHDF5Dialog:
@@ -15,7 +13,6 @@ class LoadHDF5Dialog:
 
     loader = UiLoader()
     self.ui = loader.load_file('load_hdf5_dialog.ui', parent)
-    self.ui.installEventFilter(enter_key_filter)
 
     self.get_paths(f)
 

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -4,8 +4,6 @@ import os
 
 from PySide2.QtWidgets import QMessageBox, QTableWidgetItem, QComboBox
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -17,7 +15,6 @@ class LoadImagesDialog:
 
         loader = UiLoader()
         self.ui = loader.load_file('load_images_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.setup_connections()
         self.setup_state()

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -6,8 +6,6 @@ from PySide2.QtWidgets import (
     QCheckBox, QFileDialog, QMenu, QPushButton, QTableWidgetItem)
 from PySide2.QtGui import QCursor
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.utils import create_unique_name
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
@@ -25,7 +23,6 @@ class MaskManagerDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('mask_manager_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
         self.create_masks_list()
         self.threshold = False
         self.image_mode = ViewType.raw

--- a/hexrd/ui/overlay_style_picker.py
+++ b/hexrd/ui/overlay_style_picker.py
@@ -4,8 +4,6 @@ from PySide2.QtCore import QObject, QSignalBlocker
 from PySide2.QtGui import QColor
 from PySide2.QtWidgets import QColorDialog
 
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
@@ -18,7 +16,6 @@ class OverlayStylePicker(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('overlay_style_picker.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
 
         self.original_style = copy.deepcopy(overlay['style'])
         self.overlay = overlay

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -1,5 +1,3 @@
-from hexrd.ui import enter_key_filter
-
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_load_manager import ImageLoadManager
 from hexrd.ui.ui_loader import UiLoader
@@ -11,7 +9,6 @@ class TransformDialog:
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('transforms_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
         self.det_labels = []
         self.det_cboxes = []
 

--- a/hexrd/ui/ui_loader.py
+++ b/hexrd/ui/ui_loader.py
@@ -1,7 +1,8 @@
 from PySide2.QtCore import QBuffer, QByteArray
 from PySide2.QtUiTools import QUiLoader
+from PySide2.QtWidgets import QDialog
 
-from hexrd.ui import resource_loader
+from hexrd.ui import enter_key_filter, resource_loader
 
 from hexrd.ui.image_canvas import ImageCanvas
 from hexrd.ui.image_tab_widget import ImageTabWidget
@@ -34,4 +35,17 @@ class UiLoader(QUiLoader, metaclass=QSingleton):
         """Load a UI file from a string and return the widget"""
         data = QByteArray(string.encode('utf-8'))
         buf = QBuffer(data)
-        return self.load(buf, parent)
+        ui = self.load(buf, parent)
+
+        # Perform any custom processing on the ui
+        self.process_ui(ui)
+        return ui
+
+    def process_ui(self, ui):
+        """Perform any additional processing on loaded UI objects
+
+        Currently: it installs an enter key filter for QDialogs to prevent
+        the enter key from closing them.
+        """
+        if isinstance(ui, QDialog):
+            ui.installEventFilter(enter_key_filter)

--- a/hexrd/ui/workflow_selection_dialog.py
+++ b/hexrd/ui/workflow_selection_dialog.py
@@ -1,6 +1,6 @@
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
-from hexrd.ui import constants, enter_key_filter
+from hexrd.ui import constants
 
 
 class WorkflowSelectionDialog:
@@ -8,7 +8,6 @@ class WorkflowSelectionDialog:
     def __init__(self, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('workflow_selection_dialog.ui', parent)
-        self.ui.installEventFilter(enter_key_filter)
         self.init_gui()
         self.update_gui_from_config()
         self.setup_connections()


### PR DESCRIPTION
This removes the need to install this filter in every dialog's
__init__ method.

Now, any QDialog generated via the UiLoader will automatically install
the enter key filter. Any QDialog not generated via the UiLoader may
need to still install the enter key filter manually.