### PR TITLE
Support empty frames for hdf5 and npz files

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -336,7 +336,13 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
             ims_dict[key].metadata['omega'] = omw.omegas
 
     def get_range(self, ims):
-        return range(len(ims))
+        start = 0
+        if len(ims) != self.data.get('total_frames', [len(ims)])[0]:
+            # In the case of hdf5 and npz files we need to handle empty
+            # frames via the ProcessedImageSeries 'frame_list' arg to slice
+            # the frame list
+            start = self.data.get('empty_frames', 0)
+        return range(start, len(ims))
 
     def get_flip_op(self, oplist, idx):
         if self.data:

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -337,7 +337,8 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
 
     def get_range(self, ims):
         start = 0
-        if len(ims) != self.data.get('total_frames', [len(ims)])[0]:
+        nsteps = sum(self.data.get('nsteps', [len(ims)]))
+        if len(ims) != nsteps:
             # In the case of hdf5 and npz files we need to handle empty
             # frames via the ProcessedImageSeries 'frame_list' arg to slice
             # the frame list


### PR DESCRIPTION
Fixes #910 

@joelvbernier This should solve the issue of setting empty frames on files that don't use the `image-files` adapter.