### PR TITLE
Add flush() method to messages widget Writer

### DIFF
--- a/hexrd/ui/messages_widget.py
+++ b/hexrd/ui/messages_widget.py
@@ -158,3 +158,11 @@ class Writer(QObject):
             self.call_stack[i - 1].write(text)
 
         self.text_received.emit(text)
+
+    def flush(self):
+        if self in self.call_stack:
+            # Flush the previous writer.
+            i = self.call_stack.index(self)
+            self.call_stack[i - 1].flush()
+
+        # We don't need to flush the Writer class...


### PR DESCRIPTION
pytest tries to call flush() on stdout and stderr directly, so we
need to add a flush() method or there will be an attribute error when
running pytest...

We should add any other attributes as well as we encounter them...