### PR TITLE
Support all config formats

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -407,7 +407,7 @@ class ImportDataPanel(QObject):
 
         for det in self.completed_detectors:
             transform = detectors[det].setdefault('transform', {})
-            *zx, z = transform['tilt']
+            *zx, z = [float(v) for v in transform['tilt']]
             transform['tilt'] = (
                 [*zx, (z + float(self.edited_images[det]['tilt']))])
             files.append([self.edited_images[det]['img']])

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -336,8 +336,11 @@ class ImportDataPanel(QObject):
         detectors = self.detector_defaults['default_config'].get(
             'detectors', {})
         det = detectors.setdefault(self.detector, {})
-        width = det.setdefault('pixels', {}).get('columns', 0)
-        height = det.setdefault('pixels', {}).get('rows', 0)
+        width = det.setdefault('pixels', {}).get('columns', {})
+        height = det.setdefault('pixels', {}).get('rows', {})
+        if isinstance(width, dict):
+            width = width.get('value', 0)
+            height = height.get('value', 0)
 
         if self.instrument == 'PXRDIP':
             # Boundary is currently rotated 90 degrees

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -144,9 +144,6 @@ class ImportDataPanel(QObject):
             self.load_instrument_config()
             self.enable_widgets(self.ui.raw_image, self.ui.config,
                                 self.ui.file_selection, enabled=True)
-            if self.instrument == 'PXRDIP':
-                HexrdConfig().load_panel_state['trans'] = (
-                    [UI_TRANS_INDEX_FLIP_HORIZONTALLY])
 
     def set_convention(self):
         new_conv = {'axes_order': 'zxz', 'extrinsic': False}
@@ -196,6 +193,10 @@ class ImportDataPanel(QObject):
         self.it.scale_template(sx=scale)
 
     def load_images(self):
+        if self.instrument == 'PXRDIP':
+            HexrdConfig().load_panel_state['trans'] = (
+                [UI_TRANS_INDEX_FLIP_HORIZONTALLY])
+
         caption = HexrdConfig().images_dirtion = 'Select file(s)'
         selected_file, selected_filter = QFileDialog.getOpenFileName(
             self.ui, caption, dir=HexrdConfig().images_dir)
@@ -399,6 +400,11 @@ class ImportDataPanel(QObject):
                             self.ui.config_file_label, self.ui.config,
                             enabled=False)
         self.enable_widgets(self.ui.data, self.ui.file_selection, enabled=True)
+        select_config = self.ui.select_config.isChecked()
+        self.ui.default_config.setEnabled(select_config)
+        not_default = select_config and not self.ui.default_config.isChecked()
+        self.ui.load_config.setEnabled(not_default)
+        self.ui.config_file_label.setEnabled(not_default)
         self.completed_detectors = []
         self.defaults.clear()
         self.config_file = None

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -88,7 +88,7 @@ class ImportDataPanel(QObject):
     def get_instrument_defaults(self):
         self.detector_defaults.clear()
         not_default = (self.ui.current_config.isChecked()
-                        or not self.ui.default_config.isChecked())
+                       or not self.ui.default_config.isChecked())
         if self.config_file and not_default:
             if os.path.splitext(self.config_file)[1] in YAML_EXTS:
                 with open(self.config_file, 'r') as f:
@@ -145,7 +145,8 @@ class ImportDataPanel(QObject):
             self.load_instrument_config()
             self.enable_widgets(self.ui.raw_image, self.ui.config,
                                 self.ui.file_selection, enabled=True)
-            self.ui.config_file_label.setToolTip('Defaults to currently loaded configuration')
+            self.ui.config_file_label.setToolTip(
+                'Defaults to currently loaded configuration')
 
     def set_convention(self):
         new_conv = {'axes_order': 'zxz', 'extrinsic': False}
@@ -407,7 +408,8 @@ class ImportDataPanel(QObject):
         self.ui.load_config.setEnabled(not_default)
         self.ui.config_file_label.setEnabled(not_default)
         self.ui.config_file_label.setText('No File Selected')
-        self.ui.config_file_label.setToolTip('Defaults to currently loaded configuration')
+        self.ui.config_file_label.setToolTip(
+            'Defaults to currently loaded configuration')
         self.completed_detectors = []
         self.defaults.clear()
         self.config_file = None

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -38,6 +38,7 @@ class ImportDataPanel(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('import_data_panel.ui', parent)
         self.it = None
+        self.instrument = None
         self.edited_images = {}
         self.completed_detectors = []
         self.canvas = parent.image_tab_widget.image_canvases[0]
@@ -169,6 +170,11 @@ class ImportDataPanel(QObject):
             for overlay in HexrdConfig().overlays:
                 overlay['visible'] = False
             HexrdConfig().load_instrument_config(f, import_raw=True)
+
+    def config_loaded_from_menu(self):
+        if self.instrument is None:
+            return
+        self.load_instrument_config()
 
     def detector_selected(self, selected):
         self.ui.instrument.setDisabled(selected)

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -139,7 +139,10 @@ class ImportDataPanel(QObject):
         else:
             self.load_instrument_config()
             self.enable_widgets(self.ui.raw_image, self.ui.config,
-                                enabled=True)
+                                self.ui.file_selection, enabled=True)
+            if self.instrument == 'PXRDIP':
+                HexrdConfig().load_panel_state['trans'] = (
+                    [UI_TRANS_INDEX_FLIP_HORIZONTALLY])
 
     def set_convention(self):
         new_conv = {'axes_order': 'zxz', 'extrinsic': False}

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -56,6 +56,9 @@ class MainWindow(QObject):
     # Emitted when a new mask is added
     new_mask_added = Signal(str)
 
+    # Emitted when a new configuration is loaded
+    config_loaded = Signal()
+
     def __init__(self, parent=None, image_files=None):
         super().__init__(parent)
 
@@ -213,6 +216,8 @@ class MainWindow(QObject):
             self.update_config_gui)
         self.import_data_widget.cancel_workflow.connect(
             self.load_dummy_images)
+        self.config_loaded.connect(
+            self.import_data_widget.config_loaded_from_menu)
 
         self.image_mode_widget.polar_show_snip1d.connect(
             self.ui.image_tab_widget.polar_show_snip1d)
@@ -659,6 +664,7 @@ class MainWindow(QObject):
             self.calibration_config_widget.update_gui_from_config()
         elif current_widget is self.calibration_slider_widget.ui:
             self.calibration_slider_widget.update_gui_from_config()
+        self.config_loaded.emit()
 
     def eventFilter(self, target, event):
         if type(target) == QMainWindow and event.type() == QEvent.Close:

--- a/hexrd/ui/resources/ui/import_data_panel.ui
+++ b/hexrd/ui/resources/ui/import_data_panel.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>476</width>
-    <height>640</height>
+    <height>652</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -409,6 +409,9 @@
            <property name="enabled">
             <bool>false</bool>
            </property>
+           <property name="toolTip">
+            <string extracomment="Defaults to currently loaded configuration"/>
+           </property>
            <property name="text">
             <string>No File Selected</string>
            </property>
@@ -745,7 +748,7 @@
  <resources/>
  <connections/>
  <buttongroups>
-  <buttongroup name="adjust_template"/>
   <buttongroup name="buttonGroup"/>
+  <buttongroup name="adjust_template"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
It seems that some configuration files store the height and width for each detector as dicts and some store them as values. Make sure we handle both cases.

Fixes #917 