### PR TITLE
Get pdb to interpret arrow keys and tab correctly

### DIFF
--- a/hexrd/ui/fix_pdb.py
+++ b/hexrd/ui/fix_pdb.py
@@ -1,0 +1,34 @@
+import pdb
+import sys
+
+
+class FixedPdb(pdb.Pdb):
+    """
+    Since we re-direct stdout and stderr in other parts of the
+    application, pdb can't interpret things like arrow keys
+    and auto-complete correctly.
+    This class fixes the issue by getting pdb to always use
+    the default stdout and stderr.
+    """
+    def set_trace(self, *args, **kwargs):
+        self._use_default_stdout_stderr()
+        return super().set_trace(*args, **kwargs)
+
+    def do_continue(self, *args, **kwargs):
+        self._restore_stdout_stderr()
+        return super().do_continue(*args, **kwargs)
+
+    def _use_default_stdout_stderr(self):
+        self._prev_stdout = sys.stdout
+        self._prev_stderr = sys.stderr
+        sys.stdout = sys.__stdout__
+        sys.stderr = sys.__stderr__
+
+    def _restore_stdout_stderr(self):
+        sys.stdout = self._prev_stdout
+        sys.stderr = self._prev_stderr
+
+
+def fix_pdb():
+    if not isinstance(pdb.Pdb, FixedPdb):
+        pdb.Pdb = FixedPdb

--- a/hexrd/ui/messages_widget.py
+++ b/hexrd/ui/messages_widget.py
@@ -4,6 +4,7 @@ import sys
 from PySide2.QtCore import QObject, Qt, Signal
 from PySide2.QtGui import QColor
 
+from hexrd.ui.fix_pdb import fix_pdb
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -47,6 +48,9 @@ class MessagesWidget(QObject):
         self.ui.destroyed.connect(self.release_output)
 
     def capture_output(self):
+        # Get pdb to always use the default stdout and stderr
+        fix_pdb()
+
         if self.stdout_writer not in self.STDOUT_CALL_STACK:
             self.stdout_writer.call_stack = self.STDOUT_CALL_STACK
             sys.stdout = self.stdout_writer

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -316,8 +316,8 @@ def reversed_enumerate(sequence):
 
 
 @contextmanager
-def regular_stdout_stderr():
-    # Ensure we are using regular stdout and stderr in the context
+def default_stdout_stderr():
+    # Ensure we are using default stdout and stderr in the context
     prev_stdout = sys.stdout
     prev_stderr = sys.stderr
     sys.stdout = sys.__stdout__


### PR DESCRIPTION
Because we are now re-directing stdout and stderr, pdb can't
interpret things like arrow keys and the tab key correctly.

To fix this, get pdb to always use the default stdout and stderr
when it is running.