### PR TITLE
Fix calibration errors if detector without overlay

### DIFF
--- a/hexrd/ui/calibration/auto/powder_calibrator.py
+++ b/hexrd/ui/calibration/auto/powder_calibrator.py
@@ -309,6 +309,9 @@ class PowderCalibrator(object):
         # build residual
         retval = []
         for det_key, panel in self.instr.detectors.items():
+            if len(data_dict[det_key]) == 0:
+                continue
+
             pdata = np.vstack(data_dict[det_key])
             if len(pdata) > 0:
                 hkls = pdata[:, 3:6]

--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -108,7 +108,14 @@ class PowderRunner(QObject):
 
     @property
     def data_xys(self):
-        return {k: np.vstack(v)[:, :2] for k, v in self.data_dict.items()}
+        ret = {}
+        for k, v in self.data_dict.items():
+            if len(v) == 0:
+                v = np.empty((0, 2))
+            else:
+                v = np.vstack(v)[:, :2]
+            ret[k] = v
+        return ret
 
     def show_lines(self, b):
         self.draw_lines() if b else self.remove_lines()

--- a/hexrd/ui/calibration/pick_based_calibration.py
+++ b/hexrd/ui/calibration/pick_based_calibration.py
@@ -296,6 +296,9 @@ class PowderCalibrator(object):
         for det_key, panel in self.instr.detectors.items():
             # !!! now grabbing this from picks
             hkls_ref = np.asarray(data_dict['hkls'][det_key], dtype=int)
+            if len(hkls_ref) == 0:
+                continue
+
             gvecs = np.dot(hkls_ref, bmatx.T)
             dsp_ref = 1./xfcapi.rowNorm(gvecs)
 
@@ -319,7 +322,9 @@ class PowderCalibrator(object):
                              np.tile(np.hstack(hkld), (npts, 1))]
                         )
                     )
-            # pdata = np.vstack(data_dict[det_key])
+            if len(pdata) == 0:
+                continue
+
             pdata = np.vstack(pdata)
             if len(pdata) > 0:
                 hkls = pdata[:, 4:7]


### PR DESCRIPTION
Some errors would occur if one of the detectors in the image did not
get intersected by an overlay. This fixes the errors that would occur
both in the auto powder calibration and in the line picked calibration.