### PR TITLE
Display values in tree view when loaded with hdf5

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -45,6 +45,12 @@ class CalTreeItemModel(BaseTreeItemModel):
                 return value
             if role == Qt.DisplayRole:
                 return None
+
+        if isinstance(value, np.generic):
+            # Get a native python type for display. Otherwise,
+            # it won't display anything...
+            value = value.item()
+
         return value
 
     def setData(self, index, value, role):

--- a/hexrd/ui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrd/ui/tree_views/multi_column_dict_tree_view.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from PySide2.QtCore import Signal, QModelIndex, Qt
 from PySide2.QtWidgets import (
     QCheckBox, QDialog, QItemEditorFactory, QStyledItemDelegate, QVBoxLayout
@@ -31,6 +33,11 @@ class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
             # If it's a bool, we want to display a checkbox via
             # a persistent editor, rather than the default display.
             return
+
+        if isinstance(value, np.generic):
+            # Get a native python type for display. Otherwise,
+            # it won't display anything..
+            value = value.item()
 
         return value
 


### PR DESCRIPTION
Before, if the instrument config was loaded with an hdf5 file,
there would be no values displayed in the tree view, since Qt did
not know how to display numpy types.

This converts the data from a numpy type to a native type so that
Qt will know how to display it.