### PR TITLE
Remove "Reflections Table" focus in powder editor

### DIFF
--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -153,6 +153,9 @@
    </item>
    <item row="0" column="1" colspan="4">
     <widget class="QPushButton" name="reflections_table">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
      <property name="text">
       <string>Reflections Table</string>
      </property>


### PR DESCRIPTION
Previously, it always had focus, and it could be triggered with
the enter key.

Remove its focus.