### PR TITLE
Add ability to set data range in B&C editor

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -76,6 +76,9 @@ class ColorMapEditor:
         self.ui.bc_editor_button.setEnabled(has_data)
 
     def bc_editor_button_pressed(self):
+        if self.bc_editor:
+            self.bc_editor.ui.reject()
+
         bc = self.bc_editor = BrightnessContrastEditor(self.ui)
         bc.data = self.data
         bc.edited.connect(self.bc_editor_modified)

--- a/hexrd/ui/range_widget.py
+++ b/hexrd/ui/range_widget.py
@@ -1,0 +1,40 @@
+from hexrd.ui.ui_loader import UiLoader
+
+
+class RangeWidget:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('range_widget.ui', parent)
+
+    @property
+    def min(self):
+        return self.ui.min.value()
+
+    @min.setter
+    def min(self, v):
+        self.ui.min.setValue(v)
+
+    @property
+    def max(self):
+        return self.ui.max.value()
+
+    @max.setter
+    def max(self, v):
+        self.ui.max.setValue(v)
+
+    @property
+    def range(self):
+        return (self.min, self.max)
+
+    @property
+    def bounds(self):
+        return (self.ui.min.minimum(), self.ui.max.maximum())
+
+    @bounds.setter
+    def bounds(self, v):
+        self.ui.min.setMinimum(v[0])
+        self.ui.max.setMaximum(v[1])
+
+        self.ui.min.setToolTip(f'Min: {v[0]}')
+        self.ui.max.setToolTip(f'Max: {v[1]}')

--- a/hexrd/ui/resources/ui/brightness_contrast_editor.ui
+++ b/hexrd/ui/resources/ui/brightness_contrast_editor.ui
@@ -17,86 +17,34 @@
    </size>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="2" column="0">
-    <widget class="QLabel" name="minimum_label">
-     <property name="text">
-      <string>Minimum:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="brightness_label">
-     <property name="text">
-      <string>Brightness:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
+   <item row="8" column="1">
     <widget class="QPushButton" name="reset">
      <property name="text">
       <string>Reset</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QPushButton" name="auto_button">
+   <item row="3" column="0">
+    <widget class="QLabel" name="minimum_label">
      <property name="text">
-      <string>Auto</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QSlider" name="contrast">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="maximum_label">
-     <property name="text">
-      <string>Maximum:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QSlider" name="brightness">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="contrast_label">
-     <property name="text">
-      <string>Contrast:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QSlider" name="minimum">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <string>Minimum:</string>
      </property>
     </widget>
    </item>
    <item row="0" column="0" colspan="2">
     <layout class="QVBoxLayout" name="plot_layout"/>
    </item>
-   <item row="4" column="1">
+   <item row="5" column="1">
     <widget class="QSlider" name="maximum">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="min_label">
+   <item row="5" column="0">
+    <widget class="QLabel" name="maximum_label">
      <property name="text">
-      <string/>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <string>Maximum:</string>
      </property>
     </widget>
    </item>
@@ -110,8 +58,75 @@
      </property>
     </widget>
    </item>
+   <item row="6" column="1">
+    <widget class="QSlider" name="brightness">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QPushButton" name="auto_button">
+     <property name="text">
+      <string>Auto</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QSlider" name="minimum">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QLabel" name="brightness_label">
+     <property name="text">
+      <string>Brightness:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="min_label">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="contrast_label">
+     <property name="text">
+      <string>Contrast:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QSlider" name="contrast">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="0" colspan="2">
+    <widget class="QPushButton" name="set_data_range">
+     <property name="text">
+      <string>Set Data Range</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>minimum</tabstop>
+  <tabstop>maximum</tabstop>
+  <tabstop>brightness</tabstop>
+  <tabstop>contrast</tabstop>
+  <tabstop>auto_button</tabstop>
+  <tabstop>reset</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/hexrd/ui/resources/ui/range_widget.ui
+++ b/hexrd/ui/resources/ui/range_widget.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>range_widget</class>
+ <widget class="QWidget" name="range_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>235</width>
+    <height>71</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="ScientificDoubleSpinBox" name="min">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QLabel" name="hyphen">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>-</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="ScientificDoubleSpinBox" name="max">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+       <horstretch>10</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="minimumSize">
+      <size>
+       <width>100</width>
+       <height>0</height>
+      </size>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>min</tabstop>
+  <tabstop>max</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This modifies the range of the data in the B&C editor so that users
can "zoom in" on the most relevant region of data. Modifying the
data range affects:

1. The histogram at the top
2. The auto button's functionality
3. The values that the sliders are mapped to