### PR TITLE
Set panel buffer

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -362,11 +362,12 @@ class ImportDataPanel(QObject):
             width, height = height, width
         self.it.cropped_image(height, width)
 
-        img = self.it.masked_image
+        img, panel_buffer = self.it.masked_image
 
         self.edited_images[self.detector] = {
             'img': img,
-            'tilt': self.it.rotation
+            'tilt': self.it.rotation,
+            'panel_buffer': panel_buffer,
         }
 
         self.it.completed()
@@ -432,6 +433,8 @@ class ImportDataPanel(QObject):
             *zx, z = transform['tilt']
             transform['tilt'] = (
                 [*zx, (z + float(self.edited_images[det]['tilt']))])
+            panel_buffer = detectors[det].setdefault('panel_buffer', [])
+            panel_buffer = self.edited_images[det]['panel_buffer']
             files.append([self.edited_images[det]['img']])
 
         temp = tempfile.NamedTemporaryFile(delete=False, suffix='.yml')

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -70,8 +70,8 @@ class InteractiveTemplate:
 
     @property
     def masked_image(self):
-        self.mask()
-        return self.img
+        mask = self.mask()
+        return self.img, mask
 
     @property
     def bounds(self):
@@ -160,6 +160,7 @@ class InteractiveTemplate:
             mask[rr, cc] = True
             master_mask = np.logical_xor(master_mask, mask)
         self.img[~master_mask] = 0
+        return master_mask
 
     def get_paths(self):
         all_paths = []


### PR DESCRIPTION
Fixes #932 

@joelvbernier The only change that this makes is saving the panel buffer in the config from the mask that is created in the LLNL Import Panel - the image is still being masked. If that is indeed the correct way to handle the masking then this should be ready to go