### PR TITLE
Mask out NaNs in the Cartesian view

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -291,6 +291,10 @@ class InstrumentViewer:
         for key in self.images_dict.keys():
             img += self.warp_dict[key]
 
+        # In case there were any nans...
+        nan_mask = np.isnan(img)
+        img = np.ma.masked_array(img, mask=nan_mask, fill_value=0.)
+
         # Rescale the data to match the scale of the original dataset
         # TODO: try to get create_calibration_image to not rescale the
         # result to be between 0 and 1 in the first place so this will

--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -299,7 +299,10 @@ class InstrumentViewer:
         # TODO: try to get create_calibration_image to not rescale the
         # result to be between 0 and 1 in the first place so this will
         # not be necessary.
-        self.img = np.interp(img, (img.min(), img.max()), (self.min, self.max))
+        img = np.interp(img, (img.min(), img.max()), (self.min, self.max))
+
+        # Re-mask...
+        self.img = np.ma.masked_array(img, mask=nan_mask, fill_value=0.)
 
     def update_detector(self, det):
         # First, convert to the "None" angle convention


### PR DESCRIPTION
This PR results in the Cartesian view returning masked arrays instead
of regular numpy arrays, where the NaNs are masked out.

This prevents an issue where the whole Cartesian view would be NaNs
if there were any NaNs in the view.

Fixes: #929