### PR TITLE
De-select toolbar options if toolbar is toggled off

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -143,12 +143,14 @@ class ImportDataPanel(QObject):
             self.ui.detectors.setCurrentIndex(0)
             self.enable_widgets(self.ui.file_selection, self.ui.transform_img,
                                 enabled=False)
+            self.parent().action_show_toolbar.setChecked(True)
         else:
             self.import_in_progress = True
             self.enforce_raw_mode.emit(True)
             self.load_instrument_config()
             self.enable_widgets(self.ui.raw_image, self.ui.config,
                                 self.ui.file_selection, enabled=True)
+            self.parent().action_show_toolbar.setChecked(False)
             self.ui.config_file_label.setToolTip(
                 'Defaults to currently loaded configuration')
 
@@ -246,9 +248,7 @@ class ImportDataPanel(QObject):
             self.ui.files_label.setText(', '.join(file_names))
             self.enable_widgets(self.ui.transform_img, self.ui.association,
                                 self.ui.finalize, enabled=True)
-            self.enable_widgets(self.parent().action_show_toolbar,
-                                self.ui.data, enabled=False)
-            self.parent().action_show_toolbar.setChecked(False)
+            self.enable_widgets(self.ui.data, enabled=False)
 
     def add_transform(self):
         # Prevent color map reset on transform

--- a/hexrd/ui/load_images_dialog.py
+++ b/hexrd/ui/load_images_dialog.py
@@ -152,7 +152,10 @@ class LoadImagesDialog:
                     table.cellWidget(row, 1).setCurrentText(trans)
                     break
         else:
-            det = table.cellWidget(row, 0).currentText()
+            try:
+                det = table.cellWidget(row, 0).currentText()
+            except Exception:
+                det = table.item(row, 0).text()
             for i in range(table.rowCount()):
                 if i != row and table.cellWidget(i, 0).currentText() == det:
                     table.cellWidget(i, 1).setCurrentText(val)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -218,6 +218,8 @@ class MainWindow(QObject):
             self.load_dummy_images)
         self.config_loaded.connect(
             self.import_data_widget.config_loaded_from_menu)
+        self.ui.action_show_toolbar.toggled.connect(
+            self.ui.image_tab_widget.toggle_off_toolbar)
 
         self.image_mode_widget.polar_show_snip1d.connect(
             self.ui.image_tab_widget.polar_show_snip1d)


### PR DESCRIPTION
Make sure that zoom and pan have been toggled off before hiding the toolbar.

This showed up as a bug in the import panel (once the import was started the boundary could not be moved if pan or zoom had been left selected) but this could also cause confusion in other cases if the user toggles the toolbar off from the menu.

Always de-select options to be safe.