### PR TITLE
Force upload packages to anaconda

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,7 +128,7 @@ jobs:
       run: |
           conda activate hexrdgui-package
           conda install anaconda scikit-learn==0.24.1
-          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user HEXRD --label ${HEXRDGUI_PACKAGE_LABEL} output/**/*.tar.bz2
+          anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD --label ${HEXRDGUI_PACKAGE_LABEL} output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.
       shell: bash -l {0}


### PR DESCRIPTION
Before this commit, if we re-run the GitHub actions workflow (which may
be done if a workflow failed for a network issue, for instance), the
workflow will fail when it tries to upload the anaconda package because
the anaconda package already exists on anaconda.

Force the upload so that this error does not happen, and so that the
packages on anaconda are generated from the latest workflow that was ran.