### PR TITLE
Downgrade scikit-learn to avoid Windows error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
       working-directory: hexrdgui/packaging
       run: |
           conda activate hexrdgui-package
-          conda install anaconda
+          conda install anaconda scikit-learn==0.24.1
           anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --user HEXRD --label ${HEXRDGUI_PACKAGE_LABEL} output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.


### PR DESCRIPTION
Downgrade scikit-learn to 0.24.1 to avoid installation error during
`conda install anaconda` for the github actions packaging.

This error only happens for scikit-learn that is installed from
anaconda, and for scikit-learn 0.24.2, and for windows-latest on
GitHub actions.