### PR TITLE
Save spots

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -175,11 +175,10 @@ class FitGrainsOptionsDialog(QObject):
         self.tolerances_model.copy_to_config(config)
 
         indexing_config = HexrdConfig().indexing_config
-        indexing_config['analysis_name'] = Path(self.working_dir).stem
-        indexing_config['working_dir'] = str(Path(self.working_dir).parent)
+        indexing_config['analysis_name'] = Path(self.spots_path).stem
+        indexing_config['working_dir'] = str(Path(self.spots_path).parent)
         indexing_config['_selected_material'] = self.selected_material
         indexing_config['_write_spots'] = self.ui.write_out_spots.isChecked()
-        indexing_config['_spots_path'] = self.spots_path
 
     def update_gui_from_config(self, config):
         blocked = [QSignalBlocker(x) for x in self.all_widgets()]
@@ -214,11 +213,11 @@ class FitGrainsOptionsDialog(QObject):
 
         indexing_config = HexrdConfig().indexing_config
         self.selected_material = indexing_config.get('_selected_material')
-        working_dir = indexing_config.get('working_dir', str(Path(HexrdConfig().working_dir).parent))
-        analysis_name = indexing_config.get('analysis_name', Path(HexrdConfig().working_dir).stem)
-        self.working_dir = str(Path(working_dir) / analysis_name)
-        self.spots_path = indexing_config.get(
-            '_spots_path', HexrdConfig().working_dir)
+        working_dir = indexing_config.get(
+            'working_dir', str(Path(HexrdConfig().working_dir).parent))
+        analysis_name = indexing_config.get(
+            'analysis_name', Path(HexrdConfig().working_dir).stem)
+        self.spots_path = str(Path(working_dir) / analysis_name)
         write_spots = indexing_config.get('_write_spots', False)
         self.ui.write_out_spots.setChecked(write_spots)
 

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -213,7 +213,8 @@ class FitGrainsOptionsDialog(QObject):
 
         indexing_config = HexrdConfig().indexing_config
         self.selected_material = indexing_config.get('_selected_material')
-        self.working_dir = indexing_config.get('working_dir', HexrdConfig().working_dir)
+        self.working_dir = indexing_config.get(
+            'working_dir', HexrdConfig().working_dir)
         write_spots = indexing_config.get('_write_spots', False)
         self.ui.write_out_spots.setChecked(write_spots)
 

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -1,6 +1,6 @@
 from PySide2.QtCore import (
     QItemSelectionModel, QObject, QSignalBlocker, Qt, Signal)
-from PySide2.QtWidgets import QDialogButtonBox, QHeaderView
+from PySide2.QtWidgets import QDialogButtonBox, QFileDialog, QHeaderView
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.reflections_table import ReflectionsTable
@@ -8,6 +8,8 @@ from hexrd.ui.ui_loader import UiLoader
 
 from hexrd.ui.indexing.fit_grains_tolerances_model import (
     FitGrainsToleranceModel)
+
+from pathlib import Path
 
 
 class FitGrainsOptionsDialog(QObject):
@@ -56,6 +58,8 @@ class FitGrainsOptionsDialog(QObject):
         self.ui.material.currentIndexChanged.connect(
             self.selected_material_changed)
         self.ui.choose_hkls.pressed.connect(self.choose_hkls)
+
+        self.ui.set_spots_directory.clicked.connect(self.set_working_dir)
 
         HexrdConfig().overlay_config_changed.connect(self.update_num_hkls)
 
@@ -171,7 +175,10 @@ class FitGrainsOptionsDialog(QObject):
         self.tolerances_model.copy_to_config(config)
 
         indexing_config = HexrdConfig().indexing_config
+        indexing_config['analysis_name'] = self.working_dir
+        indexing_config['working_dir'] = str(Path(self.working_dir).parent)
         indexing_config['_selected_material'] = self.selected_material
+        indexing_config['_write_spots'] = self.ui.write_out_spots.isChecked()
 
     def update_gui_from_config(self, config):
         blocked = [QSignalBlocker(x) for x in self.all_widgets()]
@@ -206,6 +213,9 @@ class FitGrainsOptionsDialog(QObject):
 
         indexing_config = HexrdConfig().indexing_config
         self.selected_material = indexing_config.get('_selected_material')
+        self.working_dir = indexing_config.get('working_dir', HexrdConfig().working_dir)
+        write_spots = indexing_config.get('_write_spots', False)
+        self.ui.write_out_spots.setChecked(write_spots)
 
         self.update_num_hkls()
 
@@ -271,3 +281,11 @@ class FitGrainsOptionsDialog(QObject):
         num_hkls = len(self.material.planeData.getHKLs())
         text = f'Number of hkls selected:  {num_hkls}'
         self.ui.num_hkls_selected.setText(text)
+
+    def set_working_dir(self):
+        caption = 'Select directory to write sports files to'
+        d = QFileDialog.getExistingDirectory(
+            self.ui, caption, dir=self.working_dir)
+
+        if d:
+            self.working_dir = d

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -175,10 +175,11 @@ class FitGrainsOptionsDialog(QObject):
         self.tolerances_model.copy_to_config(config)
 
         indexing_config = HexrdConfig().indexing_config
-        indexing_config['analysis_name'] = self.working_dir
+        indexing_config['analysis_name'] = Path(self.working_dir).stem
         indexing_config['working_dir'] = str(Path(self.working_dir).parent)
         indexing_config['_selected_material'] = self.selected_material
         indexing_config['_write_spots'] = self.ui.write_out_spots.isChecked()
+        indexing_config['_spots_path'] = self.spots_path
 
     def update_gui_from_config(self, config):
         blocked = [QSignalBlocker(x) for x in self.all_widgets()]
@@ -213,8 +214,11 @@ class FitGrainsOptionsDialog(QObject):
 
         indexing_config = HexrdConfig().indexing_config
         self.selected_material = indexing_config.get('_selected_material')
-        self.working_dir = indexing_config.get(
-            'working_dir', HexrdConfig().working_dir)
+        working_dir = indexing_config.get('working_dir', str(Path(HexrdConfig().working_dir).parent))
+        analysis_name = indexing_config.get('analysis_name', Path(HexrdConfig().working_dir).stem)
+        self.working_dir = str(Path(working_dir) / analysis_name)
+        self.spots_path = indexing_config.get(
+            '_spots_path', HexrdConfig().working_dir)
         write_spots = indexing_config.get('_write_spots', False)
         self.ui.write_out_spots.setChecked(write_spots)
 
@@ -284,9 +288,9 @@ class FitGrainsOptionsDialog(QObject):
         self.ui.num_hkls_selected.setText(text)
 
     def set_working_dir(self):
-        caption = 'Select directory to write sports files to'
+        caption = 'Select directory to write spots files to'
         d = QFileDialog.getExistingDirectory(
-            self.ui, caption, dir=self.working_dir)
+            self.ui, caption, dir=self.spots_path)
 
         if d:
-            self.working_dir = d
+            self.spots_path = d

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -281,7 +281,7 @@ class FitGrainsRunner(Runner):
         kwargs = {
             'cfg': create_indexing_config(),
             'grains_table': self.grains_table,
-            'write_spots_files': False,
+            'write_spots_files': HexrdConfig().indexing_config['_write_spots'],
         }
         self.fit_grains_results = fit_grains(**kwargs)
         print('Fit Grains Complete')

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -22,6 +22,7 @@ from hexrd.ui.indexing.ome_maps_viewer_dialog import OmeMapsViewerDialog
 from hexrd.ui.indexing.utils import generate_grains_table
 from hexrd.ui.progress_dialog import ProgressDialog
 
+
 class Runner(QObject):
     progress_text = Signal(str)
 

--- a/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
@@ -16,6 +16,20 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="4" column="0">
+      <widget class="QLabel" name="refit_pixel_labe">
+       <property name="text">
+        <string>Refit pixel scale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="num_hkls_selected">
+       <property name="text">
+        <string>Number of hkls selected:</string>
+       </property>
+      </widget>
+     </item>
      <item row="8" column="0">
       <widget class="QRadioButton" name="tth_max_specify">
        <property name="enabled">
@@ -32,78 +46,10 @@
        </attribute>
       </widget>
      </item>
-     <item row="7" column="0">
-      <widget class="QRadioButton" name="tth_max_instrument">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">padding-left: 20px;
-</string>
-       </property>
+     <item row="3" column="0">
+      <widget class="QLabel" name="threshold_label">
        <property name="text">
-        <string>Instrument</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-       <attribute name="buttonGroup">
-        <string notr="true">buttonGroup</string>
-       </attribute>
-      </widget>
-     </item>
-     <item row="8" column="1">
-      <widget class="ScientificDoubleSpinBox" name="tth_max_value">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="decimals">
-        <number>8</number>
-       </property>
-       <property name="maximum">
-        <double>1000000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>20.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QCheckBox" name="tth_max_enable">
-       <property name="text">
-        <string>tth max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="material"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="npdiv_label">
-       <property name="text">
-        <string>Number of polar subdivisions</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QSpinBox" name="npdiv">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>80</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="value">
-        <number>2</number>
+        <string>Threshold</string>
        </property>
       </widget>
      </item>
@@ -133,17 +79,43 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="threshold_label">
-       <property name="text">
-        <string>Threshold</string>
+     <item row="8" column="1">
+      <widget class="ScientificDoubleSpinBox" name="tth_max_value">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="decimals">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <double>1000000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>20.000000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="material_label">
+     <item row="0" column="1">
+      <widget class="QComboBox" name="material"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="npdiv_label">
        <property name="text">
-        <string>Selected Material:</string>
+        <string>Number of polar subdivisions</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QPushButton" name="choose_hkls">
+       <property name="text">
+        <string>Choose HKLs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QCheckBox" name="tth_max_enable">
+       <property name="text">
+        <string>tth max</string>
        </property>
       </widget>
      </item>
@@ -173,24 +145,66 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="refit_pixel_labe">
+     <item row="0" column="0">
+      <widget class="QLabel" name="material_label">
        <property name="text">
-        <string>Refit pixel scale</string>
+        <string>Selected Material:</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="num_hkls_selected">
-       <property name="text">
-        <string>Number of hkls selected:</string>
+     <item row="2" column="1">
+      <widget class="QSpinBox" name="npdiv">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>80</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>1</number>
+       </property>
+       <property name="value">
+        <number>2</number>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QPushButton" name="choose_hkls">
+     <item row="7" column="0">
+      <widget class="QRadioButton" name="tth_max_instrument">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="styleSheet">
+        <string notr="true">padding-left: 20px;
+</string>
+       </property>
        <property name="text">
-        <string>Choose HKLs</string>
+        <string>Instrument</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QPushButton" name="set_spots_directory">
+       <property name="text">
+        <string>Select Directory</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QCheckBox" name="write_out_spots">
+       <property name="text">
+        <string>Write out spots files</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Fixes #944 

@joelvbernier This adds the option to write out the spots files by providing a checkbox and option to set the directory where they should be saved. Previous selections are remembered between uses.