### PR TITLE
Add safety checks for dicts in reflections table

### DIFF
--- a/hexrd/ui/reflections_table.py
+++ b/hexrd/ui/reflections_table.py
@@ -180,10 +180,24 @@ class ReflectionsTable:
     def map_rows_to_selections(self, rows):
         table = self.ui.table
         selected_hkls = [table.item(i, COLUMNS.HKL).text() for i in rows]
-        return [self.hkl_to_index_map[x] for x in selected_hkls]
+
+        ret = []
+        for x in selected_hkls:
+            if x not in self.hkl_to_index_map:
+                continue
+
+            ret.append(self.hkl_to_index_map[x])
+
+        return ret
 
     def map_selections_to_rows(self, selections):
-        selected_hkls = [self.index_to_hkl_map[x] for x in selections]
+        selected_hkls = []
+        for x in selections:
+            if x not in self.index_to_hkl_map:
+                continue
+
+            selected_hkls.append(self.index_to_hkl_map[x])
+
         table = self.ui.table
         rows = []
         for i in range(table.rowCount()):


### PR DESCRIPTION
For hexrd's PlaneData class, sometimes the exclusions list can be
longer than the hkl list that gets returned. I specifically noticed
this happening if tThMax gets reduced.

This was resulting in indexing errors in the reflections table, which
put the reflections table in a very unusable state.

To prevent this kind of thing from happening both now and in the future
(if other changes are made), add some safety checks for the dicts. This
will at least prevent the reflections table from becoming unusable.

The behavior also seems to be desirable, where even though the
exclusions are longer than the hkl list, the correct rows get selected
in the table.

Fixes: #935