### PR TITLE
Standardize intensity corrections and add Lorentz polarization correction

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -19,7 +19,6 @@ class InstrumentViewer:
     def __init__(self):
         self.type = ViewType.polar
         self.instr = create_hedm_instrument()
-        self.images_dict = HexrdConfig().current_images_dict()
 
         # Resolution settings
         # As far as I can tell, self.pixel_size won't actually change

--- a/hexrd/ui/lorentz_polarization_options_dialog.py
+++ b/hexrd/ui/lorentz_polarization_options_dialog.py
@@ -1,0 +1,43 @@
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
+
+
+class LorentzPolarizationOptionsDialog:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('lorentz_polarization_options_dialog.ui',
+                                   parent)
+
+        self.update_gui()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.accepted.connect(self.accept)
+        self.ui.horizontal.valueChanged.connect(self.horizontal_modified)
+        self.ui.vertical.valueChanged.connect(self.vertical_modified)
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    def accept(self):
+        # When the dialog is accepted, save the settings in HexrdConfig.
+        options = HexrdConfig().config['image']['lorentz_polarization']
+        options['f_hor'] = self.ui.horizontal.value()
+        options['f_vert'] = self.ui.vertical.value()
+
+    def update_gui(self):
+        options = HexrdConfig().config['image']['lorentz_polarization']
+        self.ui.horizontal.setValue(options['f_hor'])
+        self.ui.vertical.setValue(options['f_vert'])
+
+    def horizontal_modified(self, v):
+        # Set the vertical to be 1 - horizontal
+        with block_signals(self.ui.vertical):
+            self.ui.vertical.setValue(1 - v)
+
+    def vertical_modified(self, v):
+        # Set the horizontal to be 1 - vertical
+        with block_signals(self.ui.horizontal):
+            self.ui.horizontal.setValue(1 - v)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -506,8 +506,7 @@ class MainWindow(QObject):
             raise
 
     def update_color_map_bounds(self):
-        self.color_map_editor.update_bounds(
-            HexrdConfig().current_images_dict())
+        self.color_map_editor.update_bounds(HexrdConfig().images_dict)
 
     def on_action_edit_euler_angle_convention(self):
         allowed_conventions = [

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -32,6 +32,9 @@ from hexrd.ui.image_load_manager import ImageLoadManager
 from hexrd.ui.import_data_panel import ImportDataPanel
 from hexrd.ui.load_images_dialog import LoadImagesDialog
 from hexrd.ui.load_panel import LoadPanel
+from hexrd.ui.lorentz_polarization_options_dialog import (
+    LorentzPolarizationOptionsDialog
+)
 from hexrd.ui.mask_manager_dialog import MaskManagerDialog
 from hexrd.ui.mask_regions_dialog import MaskRegionsDialog
 from hexrd.ui.materials_panel import MaterialsPanel
@@ -127,6 +130,8 @@ class MainWindow(QObject):
 
         self.ui.action_apply_pixel_solid_angle_correction.setChecked(
             HexrdConfig().apply_pixel_solid_angle_correction)
+        self.ui.action_apply_lorentz_polarization_correction.setChecked(
+            HexrdConfig().apply_lorentz_polarization_correction)
 
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
         self.live_update(HexrdConfig().live_update)
@@ -254,6 +259,9 @@ class MainWindow(QObject):
 
         self.ui.action_apply_pixel_solid_angle_correction.toggled.connect(
             HexrdConfig().set_apply_pixel_solid_angle_correction)
+        self.ui.action_apply_lorentz_polarization_correction.toggled.connect(
+            self.apply_lorentz_polarization_correction_toggled)
+
         self.import_data_widget.enforce_raw_mode.connect(
             self.enforce_view_mode)
 
@@ -832,3 +840,21 @@ class MainWindow(QObject):
     def enforce_view_mode(self, raw_only):
         if raw_only:
             self.image_mode_widget.ui.tab_widget.setCurrentIndex(0)
+
+    def apply_lorentz_polarization_correction_toggled(self, b):
+        if not b:
+            # Just turn it off and return
+            HexrdConfig().apply_lorentz_polarization_correction = b
+            return
+
+        # Get the user to first select the Lorentz polarization options
+        d = LorentzPolarizationOptionsDialog(self.ui)
+        if not d.exec_():
+            # Canceled... uncheck the action.
+            action = self.ui.action_apply_lorentz_polarization_correction
+            action.setChecked(False)
+            return
+
+        # The dialog should have modified HexrdConfig's Lorentz options
+        # already. Just apply it now.
+        HexrdConfig().apply_lorentz_polarization_correction = b

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -18,3 +18,7 @@ colormap:
   min: 0
 show_detector_borders: true
 apply_pixel_solid_angle_correction: false
+apply_lorentz_polarization_correction: false
+lorentz_polarization:
+  f_hor: 1.0
+  f_vert: 0.0

--- a/hexrd/ui/resources/ui/lorentz_polarization_options_dialog.ui
+++ b/hexrd/ui/resources/ui/lorentz_polarization_options_dialog.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>lorentz_polarization_options_dialog</class>
+ <widget class="QDialog" name="lorentz_polarization_options_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>302</width>
+    <height>107</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Lorentz Polarization Options</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="horizontal_label">
+     <property name="text">
+      <string>Horizontal Fraction:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="vertical_label">
+     <property name="text">
+      <string>Vertical Fraction:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="ScientificDoubleSpinBox" name="horizontal">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="ScientificDoubleSpinBox" name="vertical">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>horizontal</tabstop>
+  <tabstop>vertical</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>lorentz_polarization_options_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>312</x>
+     <y>110</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>312</x>
+     <y>65</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>lorentz_polarization_options_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>312</x>
+     <y>110</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>312</x>
+     <y>65</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -115,13 +115,19 @@
      <addaction name="action_edit_apply_polygon_mask"/>
      <addaction name="action_open_mask_manager"/>
     </widget>
+    <widget class="QMenu" name="menu_intensity_corrections">
+     <property name="title">
+      <string>Intensity Corrections</string>
+     </property>
+     <addaction name="action_apply_pixel_solid_angle_correction"/>
+    </widget>
+    <addaction name="menu_intensity_corrections"/>
     <addaction name="action_edit_euler_angle_convention"/>
     <addaction name="action_edit_reset_instrument_config"/>
     <addaction name="menu_masks"/>
     <addaction name="action_transform_detectors"/>
     <addaction name="action_switch_workflow"/>
     <addaction name="action_edit_refinements"/>
-    <addaction name="action_apply_pixel_solid_angle_correction"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -120,6 +120,7 @@
       <string>Intensity Corrections</string>
      </property>
      <addaction name="action_apply_pixel_solid_angle_correction"/>
+     <addaction name="action_apply_lorentz_polarization_correction"/>
     </widget>
     <addaction name="menu_intensity_corrections"/>
     <addaction name="action_edit_euler_angle_convention"/>
@@ -583,6 +584,14 @@
    </property>
    <property name="text">
     <string>Apply Pixel Solid Angle Correction</string>
+   </property>
+  </action>
+  <action name="action_apply_lorentz_polarization_correction">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Apply Lorentz Polarization Correction</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This standardizes intensity corrections by always performing them in `HexrdConfig`, rather
than duplicating the code in each of the views.

This also creates a new sub-menu under "Edit" called "Intensity Corrections", where pixel
solid angles were moved.

Additionally, the option to perform Lorentz polarization correction was added and placed
under "Intensity Corrections". This pops up a dialog and gets the user to select
horizontal and vertical fractions of polarization.

Fixes: #950