### PR TITLE
Capture hexrd logging output as well

### DIFF
--- a/hexrd/ui/messages_widget.py
+++ b/hexrd/ui/messages_widget.py
@@ -5,6 +5,7 @@ from PySide2.QtCore import QObject, Qt, Signal
 from PySide2.QtGui import QColor
 
 from hexrd.ui.fix_pdb import fix_pdb
+from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -61,6 +62,8 @@ class MessagesWidget(QObject):
             sys.stderr = self.stderr_writer
             self.STDERR_CALL_STACK.append(self.stderr_writer)
 
+        self.update_logging_streams()
+
     def release_output(self):
         stack = self.STDOUT_CALL_STACK
         if self.stdout_writer in stack:
@@ -73,6 +76,12 @@ class MessagesWidget(QObject):
             i = stack.index(self.stderr_writer)
             sys.stderr = stack[i - 1]
             stack.pop(i)
+
+        self.update_logging_streams()
+
+    def update_logging_streams(self):
+        HexrdConfig().logging_stdout_stream = sys.stdout
+        HexrdConfig().logging_stderr_stream = sys.stderr
 
     def insert_text(self, text):
         # Remove trailing returns so there isn't extra white


### PR DESCRIPTION
In addition to other kinds of stdout and stderr, capture hexrd logging
output as well. In the messages widget, this will print out INFO and
DEBUG levels in green, and WARNING, ERROR, and CRITICAL levels in red.
The default logging level is INFO. The logging output also gets printed
to the console.

Unlike hexrd CLI, this only prints the message, and not the time of
the message. This is because the messages widget is not very big, and
the output looks a little nicer without the times. However, this can be
changed.

Here's an example of the output from the HEDM procedure with these changes:
![example](https://user-images.githubusercontent.com/9558430/122593070-bcd1c500-d02a-11eb-84de-7f2f16932761.png)