### PR TITLE
Change peakfunctions import path back to fitting

### DIFF
--- a/hexrd/ui/calibration/auto/powder_calibrator.py
+++ b/hexrd/ui/calibration/auto/powder_calibrator.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from hexrd.matrixutil import findDuplicateVectors
 from hexrd.fitting import fitpeak
-from hexrd.wppf.peakfunctions import mpeak_nparams_dict
+from hexrd.fitting.peakfunctions import mpeak_nparams_dict
 
 nfields_data = 8
 


### PR DESCRIPTION
In hexrd master, the peakfunctions import path is in hexrd.fitting...