### PR TITLE
Pin the hexrd version in conda

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,12 @@ jobs:
           python packaging/github_action_version.py ${{ steps.hexrdgui_describe.outputs.version }} minor
           python packaging/github_action_version.py ${{ steps.hexrdgui_describe.outputs.version }} patch
 
-    - name: Set channel for HEXRD ( hexrd or hexrd-prerelease )
-      run: |
-          [[ ${{ github.event_name }} = 'push' && ${{ github.ref }} = 'refs/heads/master' ]] && echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV || echo "HEXRD_PACKAGE_CHANNEL=HEXRD/label/hexrd-prerelease" >> $GITHUB_ENV
+    - name: Set channel for HEXRD
+      run: echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV
+
+#    - name: Set channel for HEXRD ( hexrd or hexrd-prerelease )
+#      run: |
+#          [[ ${{ github.event_name }} = 'push' && ${{ github.ref }} = 'refs/heads/master' ]] && echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV || echo "HEXRD_PACKAGE_CHANNEL=HEXRD/label/hexrd-prerelease" >> $GITHUB_ENV
 
     - name: Create conda environment to build HEXRDGUI
       working-directory: hexrdgui

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - importlib_resources
     - fabio
     - pyyaml
-    - hexrd
+    - hexrd=0.8.8
     - pyhdf
     - silx
 


### PR DESCRIPTION
This is to make sure the packaging uses the right version.

We'll have to remember to update this every time we are pushing a
new hexrdgui tag, or come with an easier way so we won't have to
remember...