### PR TITLE
Fix hexrd version in packaging as well

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - importlib_resources
     - fabio
     - pyyaml
-    - hexrd=0.8.8
+    - hexrd==0.8.8
     - pyhdf
     - silx
 

--- a/packaging/package.py
+++ b/packaging/package.py
@@ -146,6 +146,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
         '--channel', 'cjh1',
         '--channel', 'anaconda',
         '--channel', 'conda-forge',
+        'hexrd==0.8.8',
         'hexrdgui'
     ]
     Conda.run_command(*params)


### PR DESCRIPTION
This also uses the exact constraint instead of the fuzzy constraint
for the version matching.

The hexrd version will be programmatically set in the future.