### PR TITLE
Get packaging to always use the latest hexrd

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,12 +60,9 @@ jobs:
           python packaging/github_action_version.py ${{ steps.hexrdgui_describe.outputs.version }} minor
           python packaging/github_action_version.py ${{ steps.hexrdgui_describe.outputs.version }} patch
 
-    - name: Set channel for HEXRD
-      run: echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV
-
-#    - name: Set channel for HEXRD ( hexrd or hexrd-prerelease )
-#      run: |
-#          [[ ${{ github.event_name }} = 'push' && ${{ github.ref }} = 'refs/heads/master' ]] && echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV || echo "HEXRD_PACKAGE_CHANNEL=HEXRD/label/hexrd-prerelease" >> $GITHUB_ENV
+    - name: Set channel for HEXRD ( hexrd or hexrd-prerelease )
+      run: |
+          [[ ${{ github.event_name }} = 'push' && ${{ github.ref }} = 'refs/heads/master' ]] && echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV || echo "HEXRD_PACKAGE_CHANNEL=HEXRD/label/hexrd-prerelease" >> $GITHUB_ENV
 
     - name: Create conda environment to build HEXRDGUI
       working-directory: hexrdgui

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -24,7 +24,7 @@ requirements:
     - importlib_resources
     - fabio
     - pyyaml
-    - hexrd==0.8.8
+    - hexrd=={{ hexrd_version }}
     - pyhdf
     - silx
 


### PR DESCRIPTION
For release builds, this should use the latest hexrd release.

For pre-release builds, this should use the latest hexrd pre-release.

This constraint is necessary to get the conda packaging to always use
the latest hexrd. Otherwise, conda may choose older hexrd versions,
especially if older hexrd versions allow it to use a newer version of
a different package.