### PR TITLE
FF HEDM Workflow Enhancements

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -12,6 +12,7 @@ from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlays import update_overlay_data
+from hexrd.ui.utils import format_memory_int
 
 from skimage import transform as tf
 
@@ -92,22 +93,9 @@ class InstrumentViewer:
         mem_extra_buffer = 1e7
         mem_usage += mem_extra_buffer
         if mem_usage > available_mem:
-
-            def format_size(size):
-                sizes = [
-                    ('TB', 1e12),
-                    ('GB', 1e9),
-                    ('MB', 1e6),
-                    ('KB', 1e3),
-                    ('B', 1)
-                ]
-                for s in sizes:
-                    if size > s[1]:
-                        return f'{round(size / s[1], 2)} {s[0]}'
-
             msg = 'Not enough memory for Cartesian plot\n'
-            msg += f'Memory available: {format_size(available_mem)}\n'
-            msg += f'Memory required: {format_size(mem_usage)}'
+            msg += f'Memory available: {format_memory_int(available_mem)}\n'
+            msg += f'Memory required: {format_memory_int(mem_usage)}'
             raise Exception(msg)
 
     def make_dpanel(self):

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -85,6 +85,8 @@ class OmeMapsViewerDialog(QObject):
         self.color_map_editor.ui.minimum.valueChanged.connect(
             self.update_config)
 
+        self.ui.select_working_dir.pressed.connect(self.select_working_dir)
+
         self.select_hkls_widget.selection_changed.connect(self.update_config)
 
         # A plot reset is needed for log scale to handle the NaN values
@@ -488,6 +490,14 @@ class OmeMapsViewerDialog(QObject):
             # Save the raw data out...
             self.raw_data.save(selected_file)
 
+    def select_working_dir(self):
+        caption = 'Select directory to write scored orientations to'
+        d = QFileDialog.getExistingDirectory(
+            self.ui, caption, dir=self.working_dir)
+
+        if d:
+            self.working_dir = d
+
     @property
     def threshold(self):
         return self.color_map_editor.ui.minimum.value()
@@ -499,6 +509,14 @@ class OmeMapsViewerDialog(QObject):
             self.color_map_editor.ui.maximum.setValue(v + 1)
 
         self.color_map_editor.ui.minimum.setValue(v)
+
+    @property
+    def write_scored_orientations(self):
+        return self.ui.write_scored_orientations.isChecked()
+
+    @write_scored_orientations.setter
+    def write_scored_orientations(self, v):
+        self.ui.write_scored_orientations.setChecked(v)
 
     @property
     def yaml_widgets(self):
@@ -551,6 +569,11 @@ class OmeMapsViewerDialog(QObject):
 
         self.filter_maps = find_orientations['orientation_maps']['filter_maps']
 
+        key = '_write_scored_orientations'
+        self.write_scored_orientations = find_orientations.get(key, False)
+
+        self.working_dir = config.get('working_dir', HexrdConfig().working_dir)
+
     def update_config(self):
         # Update all of the config with their settings from the widgets
         config = self.config
@@ -592,6 +615,11 @@ class OmeMapsViewerDialog(QObject):
         find_orientations['threshold'] = self.threshold
         find_orientations['seed_search']['hkl_seeds'] = self.selected_hkls
         find_orientations['orientation_maps']['filter_maps'] = self.filter_maps
+
+        key = '_write_scored_orientations'
+        find_orientations[key] = self.write_scored_orientations
+
+        config['working_dir'] = self.working_dir
 
     def save_config(self):
         HexrdConfig().config['indexing'] = copy.deepcopy(self.config)

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -51,6 +51,9 @@ class Runner(QObject):
         self.accept_progress_signal.emit()
 
     def on_async_error(self, t):
+        # In case the progress dialog is open...
+        self.accept_progress()
+
         exctype, value, traceback = t
         msg = f'An ERROR occurred: {exctype}: {value}.'
         msg_box = QMessageBox(QMessageBox.Critical, 'Error', msg)
@@ -107,6 +110,7 @@ class IndexingRunner(Runner):
             self.thread_pool.start(worker)
 
             worker.signals.result.connect(self.ome_maps_loaded)
+            worker.signals.error.connect(self.on_async_error)
             worker.signals.finished.connect(self.accept_progress)
             self.progress_dialog.exec_()
 
@@ -144,7 +148,7 @@ class IndexingRunner(Runner):
         self.thread_pool.start(worker)
 
         worker.signals.result.connect(self.orientation_fibers_generated)
-        worker.signals.error.connect(self.accept_progress)
+        worker.signals.error.connect(self.on_async_error)
         self.progress_dialog.exec_()
 
     def generate_orientation_fibers(self, config):
@@ -172,7 +176,7 @@ class IndexingRunner(Runner):
         self.thread_pool.start(worker)
 
         worker.signals.result.connect(self.indexer_finished)
-        worker.signals.error.connect(self.accept_progress)
+        worker.signals.error.connect(self.on_async_error)
 
     def run_indexer(self):
         config = create_indexing_config()
@@ -230,6 +234,7 @@ class IndexingRunner(Runner):
         worker.signals.result.connect(self.start_fit_grains_runner,
                                       Qt.QueuedConnection)
         worker.signals.finished.connect(self.accept_progress)
+        worker.signals.error.connect(self.on_async_error)
 
     def run_cluster(self):
         config = create_indexing_config()

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -144,11 +144,18 @@ class IndexingRunner(Runner):
         self.progress_dialog.setWindowTitle('Find Orientations')
         self.progress_dialog.setRange(0, 0)  # no numerical updates
 
-        worker = AsyncWorker(self.generate_orientation_fibers, config)
-        self.thread_pool.start(worker)
+        find_orientations = HexrdConfig().indexing_config['find_orientations']
+        if find_orientations['use_quaternion_grid']:
+            # Load qfib from a numpy file
+            self.qfib = np.load(find_orientations['use_quaternion_grid'])
+            self.orientation_fibers_generated()
+        else:
+            worker = AsyncWorker(self.generate_orientation_fibers, config)
+            self.thread_pool.start(worker)
 
-        worker.signals.result.connect(self.orientation_fibers_generated)
-        worker.signals.error.connect(self.on_async_error)
+            worker.signals.result.connect(self.orientation_fibers_generated)
+            worker.signals.error.connect(self.on_async_error)
+
         self.progress_dialog.exec_()
 
     def generate_orientation_fibers(self, config):

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -243,8 +243,21 @@ class IndexingRunner(Runner):
         worker.signals.finished.connect(self.accept_progress)
         worker.signals.error.connect(self.on_async_error)
 
+    @property
+    def clustering_needs_min_samples(self):
+        # Determine whether we need the min_samples for clustering
+        find_orientations = HexrdConfig().indexing_config['find_orientations']
+        return all((
+            find_orientations['use_quaternion_grid'] is None,
+            find_orientations['clustering']['algorithm'] != 'fclusterdata',
+        ))
+
     def run_cluster_functions(self):
-        self.create_clustering_parameters()
+        if self.clustering_needs_min_samples:
+            self.create_clustering_parameters()
+        else:
+            self.min_samples = 1
+
         self.run_cluster()
 
     def create_clustering_parameters(self):

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -235,7 +235,7 @@ class IndexingRunner(Runner):
                 self.view_ome_maps()
                 return
 
-        worker = AsyncWorker(self.run_cluster)
+        worker = AsyncWorker(self.run_cluster_functions)
         self.thread_pool.start(worker)
 
         worker.signals.result.connect(self.start_fit_grains_runner,
@@ -243,17 +243,27 @@ class IndexingRunner(Runner):
         worker.signals.finished.connect(self.accept_progress)
         worker.signals.error.connect(self.on_async_error)
 
-    def run_cluster(self):
-        config = create_indexing_config()
-        min_samples, mean_rpg = create_clustering_parameters(config,
-                                                             self.ome_maps)
+    def run_cluster_functions(self):
+        self.create_clustering_parameters()
+        self.run_cluster()
 
+    def create_clustering_parameters(self):
+        print('Creating cluster parameters...')
+        self.update_progress_text('Creating cluster parameters')
+        config = create_indexing_config()
+        self.min_samples, mean_rpg = create_clustering_parameters(
+            config, self.ome_maps)
+
+    def run_cluster(self):
+        print('Running cluster...')
+        self.update_progress_text('Running cluster')
+        config = create_indexing_config()
         kwargs = {
             'compl': self.completeness,
             'qfib': self.qfib,
             'qsym': config.material.plane_data.getQSym(),
             'cfg': config,
-            'min_samples': min_samples,
+            'min_samples': self.min_samples,
             'compl_thresh': config.find_orientations.clustering.completeness,
             'radius': config.find_orientations.clustering.radius
         }

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -4,6 +4,7 @@ from PySide2.QtCore import QObject, QThreadPool, Signal
 from PySide2.QtWidgets import QMessageBox
 
 from hexrd import indexer, instrument
+from hexrd.cli.find_orientations import write_scored_orientations
 from hexrd.cli.fit_grains import write_results as write_fit_grains_results
 from hexrd.findorientations import (
     create_clustering_parameters, filter_maps_if_requested,
@@ -155,6 +156,18 @@ class IndexingRunner(Runner):
             doMultiProc=ncpus > 1,
             nCPUs=ncpus)
         print('paintGrid complete')
+
+        orientations_cfg = HexrdConfig().indexing_config['find_orientations']
+        if orientations_cfg.get('_write_scored_orientations'):
+            # Write out the scored orientations
+            results = {}
+            results['scored_orientations'] = {
+                'test_quaternions': self.qfib,
+                'score': self.completeness
+            }
+            print(f'Writing scored orientations in {config.working_dir} ...')
+            write_scored_orientations(results, config)
+
         self.run_clustering()
 
     def run_clustering(self):

--- a/hexrd/ui/progress_dialog.py
+++ b/hexrd/ui/progress_dialog.py
@@ -75,8 +75,7 @@ class ProgressDialog:
         self.ui.exec_()
 
     def exec_later(self):
-        self.reset_messages()
-        QTimer.singleShot(0, lambda: self.ui.exec_())
+        QTimer.singleShot(0, lambda: self.exec_())
 
 
 class BlockEscapeKeyFilter(QObject):

--- a/hexrd/ui/progress_dialog.py
+++ b/hexrd/ui/progress_dialog.py
@@ -62,7 +62,7 @@ class ProgressDialog:
     def accept(self):
         self.ui.accept()
 
-    def exec_(self):
+    def reset_messages(self):
         self.clear_messages()
         # Hide the messages widget until a message is received
         self.messages_widget.ui.hide()
@@ -70,7 +70,13 @@ class ProgressDialog:
         # Shrink the dialog to the size of the contents
         self.shrink_later()
 
+    def exec_(self):
+        self.reset_messages()
         self.ui.exec_()
+
+    def exec_later(self):
+        self.reset_messages()
+        QTimer.singleShot(0, lambda: self.ui.exec_())
 
 
 class BlockEscapeKeyFilter(QObject):

--- a/hexrd/ui/resources/indexing/default_indexing_config.yml
+++ b/hexrd/ui/resources/indexing/default_indexing_config.yml
@@ -27,7 +27,7 @@ find_orientations:
   # either search full quaternion grid, or seed search based on sparse
   # orientation maps.  For input search space:
   #
-  # use_quaternion_grid: some/file/name
+  use_quaternion_grid: null
   #
   # otherwise defaults to seeded search:
   seed_search: # this section is ignored if use_quaternion_grid is defined

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -11,7 +11,99 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="1">
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="write_scored_orientations">
+     <property name="text">
+      <string>Write scored orientations?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3" rowspan="3">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+   <item row="5" column="3">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3" rowspan="2">
+    <layout class="QGridLayout" name="grid_layout">
+     <item row="2" column="2">
+      <widget class="QCheckBox" name="label_spots">
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Label Spots</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QPushButton" name="export_button">
+       <property name="text">
+        <string>Export</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" rowspan="4">
+      <layout class="QVBoxLayout" name="color_map_editor_layout"/>
+     </item>
+     <item row="1" column="2">
+      <widget class="QComboBox" name="active_hkl">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="active_hkl_label">
+       <property name="text">
+        <string>Displayed hkl</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1" rowspan="4">
+      <widget class="QGroupBox" name="select_hkls_group">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="title">
+        <string>HKL Seeds</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <layout class="QVBoxLayout" name="select_hkls_widget_layout"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="select_working_dir">
+     <property name="text">
+      <string>Select Directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
     <widget class="QGroupBox" name="seed_search_group_box">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -660,72 +752,7 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="2" rowspan="2">
-    <layout class="QGridLayout" name="grid_layout">
-     <item row="2" column="2">
-      <widget class="QCheckBox" name="label_spots">
-       <property name="layoutDirection">
-        <enum>Qt::LeftToRight</enum>
-       </property>
-       <property name="text">
-        <string>Label Spots</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QPushButton" name="export_button">
-       <property name="text">
-        <string>Export</string>
-       </property>
-       <property name="autoDefault">
-        <bool>false</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" rowspan="4">
-      <layout class="QVBoxLayout" name="color_map_editor_layout"/>
-     </item>
-     <item row="1" column="2">
-      <widget class="QComboBox" name="active_hkl">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="active_hkl_label">
-       <property name="text">
-        <string>Displayed hkl</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1" rowspan="4">
-      <widget class="QGroupBox" name="select_hkls_group">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="title">
-        <string>HKL Seeds</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout">
-        <item>
-         <layout class="QVBoxLayout" name="select_hkls_widget_layout"/>
-        </item>
-       </layout>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="0" column="1" rowspan="2">
+   <item row="0" column="1" rowspan="2" colspan="2">
     <widget class="QGroupBox" name="filtering_group">
      <property name="title">
       <string>Filtering</string>
@@ -789,19 +816,6 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2" rowspan="3">
-    <layout class="QVBoxLayout" name="canvas_layout"/>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -836,6 +850,8 @@
   <tabstop>clustering_radius</tabstop>
   <tabstop>clustering_completeness</tabstop>
   <tabstop>clustering_algorithm</tabstop>
+  <tabstop>write_scored_orientations</tabstop>
+  <tabstop>select_working_dir</tabstop>
   <tabstop>active_hkl</tabstop>
   <tabstop>label_spots</tabstop>
   <tabstop>export_button</tabstop>

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -7,21 +7,11 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>868</height>
+    <height>944</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="1">
-    <widget class="QCheckBox" name="write_scored_orientations">
-     <property name="text">
-      <string>Write scored orientations?</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3" rowspan="3">
-    <layout class="QVBoxLayout" name="canvas_layout"/>
-   </item>
-   <item row="5" column="3">
+   <item row="7" column="3">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -29,6 +19,583 @@
      <property name="centerButtons">
       <bool>false</bool>
      </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QGroupBox" name="eta_group_box">
+     <property name="title">
+      <string>Eta</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_8">
+      <item row="0" column="0">
+       <widget class="QLabel" name="eta_tolerance_label">
+        <property name="text">
+         <string>Tolerance:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ScientificDoubleSpinBox" name="eta_tolerance">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="eta_mask_label">
+        <property name="text">
+         <string>Mask:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ScientificDoubleSpinBox" name="eta_mask">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QGroupBox" name="quaternion_method_group">
+     <property name="title">
+      <string>Quaternion Method</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_11">
+      <item row="1" column="0">
+       <widget class="QTabWidget" name="quaternion_method_tab_widget">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="seed_search_tab">
+         <attribute name="title">
+          <string>Seed Search</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_12">
+          <item row="0" column="0" rowspan="2" colspan="2">
+           <widget class="QGroupBox" name="seed_search_method_group_box">
+            <property name="title">
+             <string>Method</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
+             <item row="1" column="1">
+              <widget class="QTabWidget" name="seed_search_method_tab_widget">
+               <property name="enabled">
+                <bool>true</bool>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>240</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="currentIndex">
+                <number>0</number>
+               </property>
+               <widget class="QWidget" name="label_tab">
+                <attribute name="title">
+                 <string>Label</string>
+                </attribute>
+                <layout class="QGridLayout" name="gridLayout_2">
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="label_threshold_label">
+                   <property name="text">
+                    <string>Threshold:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="filter_radius_label">
+                   <property name="text">
+                    <string>Filter Radius: </string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <spacer name="verticalSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Vertical</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>40</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                 <item row="0" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="filter_radius">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="maximum">
+                    <double>10000000.000000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>1.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="label_threshold">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>1.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+               <widget class="QWidget" name="blob_dog_tab">
+                <attribute name="title">
+                 <string>Blob Dog</string>
+                </attribute>
+                <layout class="QGridLayout" name="gridLayout_3">
+                 <item row="0" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bd_min_sigma">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>0.500000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="bd_sigma_ratio_label">
+                   <property name="text">
+                    <string>Sigma Ratio:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="bd_max_sigma_label">
+                   <property name="text">
+                    <string>Max Sigma:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bd_max_sigma">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>5.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0">
+                  <widget class="QLabel" name="bd_min_sigma_label">
+                   <property name="text">
+                    <string>Min Sigma:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bd_sigma_ratio">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>1.600000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="bd_threshold_label">
+                   <property name="text">
+                    <string>Threshold:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bd_threshold">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.010000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>0.010000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="0">
+                  <widget class="QLabel" name="bd_overlap_label">
+                   <property name="text">
+                    <string>Overlap:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bd_overlap">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+               <widget class="QWidget" name="blob_log_tab">
+                <attribute name="title">
+                 <string>Blob Log</string>
+                </attribute>
+                <layout class="QGridLayout" name="gridLayout_5">
+                 <item row="3" column="0">
+                  <widget class="QLabel" name="bl_sum_sigma_label">
+                   <property name="text">
+                    <string>Num Sigma:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="5" column="0">
+                  <widget class="QLabel" name="bl_overlap_label">
+                   <property name="text">
+                    <string>Overlap:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bl_max_sigma">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>5.000000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="2" column="0">
+                  <widget class="QLabel" name="bl_max_sigma_label">
+                   <property name="text">
+                    <string>Max Sigma:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="0">
+                  <widget class="QLabel" name="bl_threshold_label">
+                   <property name="text">
+                    <string>Threshold:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0">
+                  <widget class="QLabel" name="bl_min_sigma_label">
+                   <property name="text">
+                    <string>Min Sigma:</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bl_min_sigma">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.100000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>0.500000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="3" column="1">
+                  <widget class="QSpinBox" name="bl_num_sigma">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="minimum">
+                    <number>1</number>
+                   </property>
+                   <property name="maximum">
+                    <number>1000</number>
+                   </property>
+                   <property name="value">
+                    <number>10</number>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="4" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bl_threshold">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="singleStep">
+                    <double>0.010000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>0.010000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="5" column="1">
+                  <widget class="ScientificDoubleSpinBox" name="bl_overlap">
+                   <property name="keyboardTracking">
+                    <bool>false</bool>
+                   </property>
+                   <property name="decimals">
+                    <number>8</number>
+                   </property>
+                   <property name="minimum">
+                    <double>-1000000.000000000000000</double>
+                   </property>
+                   <property name="maximum">
+                    <double>1000000.000000000000000</double>
+                   </property>
+                   <property name="value">
+                    <double>0.100000000000000</double>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QComboBox" name="seed_search_method">
+               <item>
+                <property name="text">
+                 <string>Label</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Blob Dog</string>
+                </property>
+               </item>
+               <item>
+                <property name="text">
+                 <string>Blob Log</string>
+                </property>
+               </item>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="fiber_step_label">
+            <property name="text">
+             <string>Fiber Step:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="ScientificDoubleSpinBox" name="fiber_step">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="decimals">
+             <number>8</number>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.500000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="grid_search_tab">
+         <attribute name="title">
+          <string>Grid Search</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_6">
+          <item row="0" column="1">
+           <widget class="QGroupBox" name="groupBox">
+            <property name="title">
+             <string>Quaternion Grid File</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_13">
+             <item row="1" column="1">
+              <widget class="QLineEdit" name="quaternion_grid_file"/>
+             </item>
+             <item row="1" column="2">
+              <widget class="QPushButton" name="select_quaternion_grid_file">
+               <property name="text">
+                <string>Select File</string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="1" colspan="2">
+              <spacer name="verticalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QComboBox" name="quaternion_method">
+        <item>
+         <property name="text">
+          <string>Seed Search</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Grid Search</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="0" column="3" rowspan="2">
@@ -96,33 +663,21 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="2">
-    <widget class="QPushButton" name="select_working_dir">
-     <property name="text">
-      <string>Select Directory</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QGroupBox" name="seed_search_group_box">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
+   <item row="3" column="1" colspan="2">
+    <widget class="QGroupBox" name="omega_group_box">
      <property name="title">
-      <string>Seed Search</string>
+      <string>Omega</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout_6">
-      <item row="2" column="1">
-       <widget class="ScientificDoubleSpinBox" name="fiber_step">
+     <layout class="QGridLayout" name="gridLayout_7">
+      <item row="0" column="0">
+       <widget class="QLabel" name="tolerance_label">
+        <property name="text">
+         <string>Tolerance:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ScientificDoubleSpinBox" name="omega_tolerance">
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -142,611 +697,8 @@
          <double>0.100000000000000</double>
         </property>
         <property name="value">
-         <double>0.500000000000000</double>
+         <double>1.000000000000000</double>
         </property>
-       </widget>
-      </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QGroupBox" name="method_group_box">
-        <property name="title">
-         <string>Method</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_4">
-         <item row="1" column="1">
-          <widget class="QTabWidget" name="tab_widget">
-           <property name="enabled">
-            <bool>true</bool>
-           </property>
-           <property name="minimumSize">
-            <size>
-             <width>240</width>
-             <height>0</height>
-            </size>
-           </property>
-           <property name="currentIndex">
-            <number>2</number>
-           </property>
-           <widget class="QWidget" name="label_tab">
-            <attribute name="title">
-             <string>Label</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout_2">
-             <item row="1" column="0">
-              <widget class="QLabel" name="label_threshold_label">
-               <property name="text">
-                <string>Threshold:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="filter_radius_label">
-               <property name="text">
-                <string>Filter Radius: </string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <spacer name="verticalSpacer">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>40</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-             <item row="0" column="1">
-              <widget class="ScientificDoubleSpinBox" name="filter_radius">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="maximum">
-                <double>10000000.000000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="ScientificDoubleSpinBox" name="label_threshold">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="blob_dog_tab">
-            <attribute name="title">
-             <string>Blob Dog</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout_3">
-             <item row="0" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bd_min_sigma">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.500000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="bd_sigma_ratio_label">
-               <property name="text">
-                <string>Sigma Ratio:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="bd_max_sigma_label">
-               <property name="text">
-                <string>Max Sigma:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bd_max_sigma">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>5.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="0">
-              <widget class="QLabel" name="bd_min_sigma_label">
-               <property name="text">
-                <string>Min Sigma:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bd_sigma_ratio">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>1.600000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <widget class="QLabel" name="bd_threshold_label">
-               <property name="text">
-                <string>Threshold:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bd_threshold">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="bd_overlap_label">
-               <property name="text">
-                <string>Overlap:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bd_overlap">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="blob_log_tab">
-            <attribute name="title">
-             <string>Blob Log</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout_5">
-             <item row="3" column="0">
-              <widget class="QLabel" name="bl_sum_sigma_label">
-               <property name="text">
-                <string>Num Sigma:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0">
-              <widget class="QLabel" name="bl_overlap_label">
-               <property name="text">
-                <string>Overlap:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bl_max_sigma">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>5.000000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="bl_max_sigma_label">
-               <property name="text">
-                <string>Max Sigma:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="0">
-              <widget class="QLabel" name="bl_threshold_label">
-               <property name="text">
-                <string>Threshold:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0">
-              <widget class="QLabel" name="bl_min_sigma_label">
-               <property name="text">
-                <string>Min Sigma:</string>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bl_min_sigma">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.100000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.500000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="1">
-              <widget class="QSpinBox" name="bl_num_sigma">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="minimum">
-                <number>1</number>
-               </property>
-               <property name="maximum">
-                <number>1000</number>
-               </property>
-               <property name="value">
-                <number>10</number>
-               </property>
-              </widget>
-             </item>
-             <item row="4" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bl_threshold">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="singleStep">
-                <double>0.010000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.010000000000000</double>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="1">
-              <widget class="ScientificDoubleSpinBox" name="bl_overlap">
-               <property name="keyboardTracking">
-                <bool>false</bool>
-               </property>
-               <property name="decimals">
-                <number>8</number>
-               </property>
-               <property name="minimum">
-                <double>-1000000.000000000000000</double>
-               </property>
-               <property name="maximum">
-                <double>1000000.000000000000000</double>
-               </property>
-               <property name="value">
-                <double>0.100000000000000</double>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="method">
-           <item>
-            <property name="text">
-             <string>Label</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Blob Dog</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>Blob Log</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="fiber_step_label">
-        <property name="text">
-         <string>Fiber Step:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="0" colspan="2">
-       <widget class="QGroupBox" name="eta_group_box">
-        <property name="title">
-         <string>Eta</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_8">
-         <item row="0" column="0">
-          <widget class="QLabel" name="eta_tolerance_label">
-           <property name="text">
-            <string>Tolerance:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="ScientificDoubleSpinBox" name="eta_tolerance">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>0.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>360.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="eta_mask_label">
-           <property name="text">
-            <string>Mask:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="ScientificDoubleSpinBox" name="eta_mask">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>0.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>360.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QGroupBox" name="omega_group_box">
-        <property name="title">
-         <string>Omega</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_7">
-         <item row="0" column="0">
-          <widget class="QLabel" name="tolerance_label">
-           <property name="text">
-            <string>Tolerance:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="ScientificDoubleSpinBox" name="omega_tolerance">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>0.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>360.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
-       </widget>
-      </item>
-      <item row="5" column="0" colspan="2">
-       <widget class="QGroupBox" name="clustering_group_box">
-        <property name="title">
-         <string>Clustering</string>
-        </property>
-        <layout class="QGridLayout" name="gridLayout_9">
-         <item row="1" column="0">
-          <widget class="QLabel" name="clustering_completeness_label">
-           <property name="text">
-            <string>Completeness:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="clustering_algorithm_label">
-           <property name="text">
-            <string>Algorithm:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="clustering_radius_label">
-           <property name="text">
-            <string>Radius:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="ScientificDoubleSpinBox" name="clustering_radius">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="maximum">
-            <double>10000000.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>1.000000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QComboBox" name="clustering_algorithm">
-           <item>
-            <property name="text">
-             <string>DBScan</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>SPH-DBScan</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>ORT-DBScan</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
-             <string>FClusterData</string>
-            </property>
-           </item>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="ScientificDoubleSpinBox" name="clustering_completeness">
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="maximum">
-            <double>1.000000000000000</double>
-           </property>
-           <property name="value">
-            <double>0.850000000000000</double>
-           </property>
-          </widget>
-         </item>
-        </layout>
        </widget>
       </item>
      </layout>
@@ -816,6 +768,109 @@
      </layout>
     </widget>
    </item>
+   <item row="7" column="2">
+    <widget class="QPushButton" name="select_working_dir">
+     <property name="text">
+      <string>Select Directory</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="3" rowspan="5">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+   <item row="7" column="1">
+    <widget class="QCheckBox" name="write_scored_orientations">
+     <property name="text">
+      <string>Write scored orientations?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QGroupBox" name="clustering_group_box">
+     <property name="title">
+      <string>Clustering</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_9">
+      <item row="1" column="0">
+       <widget class="QLabel" name="clustering_completeness_label">
+        <property name="text">
+         <string>Completeness:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="clustering_algorithm_label">
+        <property name="text">
+         <string>Algorithm:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="clustering_radius_label">
+        <property name="text">
+         <string>Radius:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ScientificDoubleSpinBox" name="clustering_radius">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="clustering_algorithm">
+        <item>
+         <property name="text">
+          <string>DBScan</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>SPH-DBScan</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>ORT-DBScan</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>FClusterData</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ScientificDoubleSpinBox" name="clustering_completeness">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.850000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -829,8 +884,10 @@
   <tabstop>apply_filtering</tabstop>
   <tabstop>filtering_apply_gaussian_laplace</tabstop>
   <tabstop>filtering_fwhm</tabstop>
-  <tabstop>method</tabstop>
-  <tabstop>tab_widget</tabstop>
+  <tabstop>quaternion_method</tabstop>
+  <tabstop>quaternion_method_tab_widget</tabstop>
+  <tabstop>seed_search_method</tabstop>
+  <tabstop>seed_search_method_tab_widget</tabstop>
   <tabstop>filter_radius</tabstop>
   <tabstop>label_threshold</tabstop>
   <tabstop>bd_min_sigma</tabstop>

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -69,21 +69,16 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
     def rebuild_tree(self):
         # Rebuild the tree from scratch
         self.clear()
-        for key in self.config:
-            data = [key, None]
-            tree_item = self.add_tree_item(data, self.root_item)
-            self.recursive_add_tree_items(self.config[key], tree_item)
+        self.recursive_add_tree_items(self.config, self.root_item)
 
     def path_to_item(self, tree_item):
         path = []
         cur_tree_item = tree_item
-        while True:
+        while cur_tree_item is not self.root_item:
             text = cur_tree_item.data(KEY_COL)
             text = int(text) if is_int(text) else text
             path.insert(0, text)
             cur_tree_item = cur_tree_item.parent_item
-            if cur_tree_item is self.root_item:
-                break
 
         return path
 

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -363,9 +363,9 @@ def unique_array_list(array_list):
 def format_big_int(x, decimals=2):
     labels = [
         (1e12, 'trillion'),
-        (1e9, 'billion'),
-        (1e6, 'million'),
-        (1e3, 'thousand'),
+        (1e9,  'billion'),
+        (1e6,  'million'),
+        (1e3,  'thousand'),
     ]
 
     for divisor, label in labels:
@@ -373,3 +373,19 @@ def format_big_int(x, decimals=2):
             return f'{round(x / divisor, decimals)} {label}'
 
     return f'{x}'
+
+
+def format_memory_int(x, decimals=2):
+    labels = [
+        (1e12, 'TB'),
+        (1e9,  'GB'),
+        (1e6,  'MB'),
+        (1e3,  'KB'),
+        (1e0,  'B'),
+    ]
+
+    for divisor, label in labels:
+        if x > divisor:
+            return f'{round(x / divisor, decimals)} {label}'
+
+    return f'{x} B'

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -358,3 +358,18 @@ def unique_array_list(array_list):
             ret.append(array)
 
     return ret
+
+
+def format_big_int(x, decimals=2):
+    labels = [
+        (1e12, 'trillion'),
+        (1e9, 'billion'),
+        (1e6, 'million'),
+        (1e3, 'thousand'),
+    ]
+
+    for divisor, label in labels:
+        if x > divisor:
+            return f'{round(x / divisor, decimals)} {label}'
+
+    return f'{x}'


### PR DESCRIPTION
This adds several enhancements to the HEDM workflow that were mentioned in #952. Namely:

1. Added ability to save the scored orientations. This is currently in the bottom left corner of the eta omega maps viewer.
2. Allow loading a list of quaternions instead of performing a seed search.
2. Warn if more than 5e7 quaternions were generated in the seed search process, and ask if the user wants to proceed anyways. If they choose "no", the user will be taken back to the eta omega maps viewer so they can choose different settings, which will hopefully result in fewer quaternions.
3. Warn if more than 1e6 quaternions are staged for clustering, done in a similar way as 2.

Fixes several items in #952