### PR TITLE
Export indexing fitgrains config

### DIFF
--- a/hexrd/ui/async_runner.py
+++ b/hexrd/ui/async_runner.py
@@ -20,8 +20,8 @@ class AsyncRunner:
 
         self.reset_callbacks()
 
-    def run(self, f):
-        worker = AsyncWorker(f)
+    def run(self, f, *args, **kwargs):
+        worker = AsyncWorker(f, *args, **kwargs)
         self.thread_pool.start(worker)
 
         if self.success_callback:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -917,18 +917,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         }
 
         omaps = self.indexing_config['find_orientations']['orientation_maps']
-        active_hkls = omaps.get('_active_hkl_strings', None)
+        active_hkls = omaps.get('active_hkls', None)
         seed_search = self.indexing_config['find_orientations']['seed_search']
-        hkl_seeds = seed_search.get('_hkl_seed_strings', [])
         if active_hkls is None:
             cfg['find_orientations']['orientation_maps']['active_hkls'] = []
         else:
             curr_hkls = selected_material.planeData.getHKLs(asStr=True)
             hkls = [curr_hkls.index(x) for x in active_hkls if x in curr_hkls]
-            seeds = [active_hkls.index(x) for x in hkl_seeds if x in curr_hkls]
             cfg['find_orientations']['orientation_maps']['active_hkls'] = hkls
             cfg['find_orientations']['orientation_maps']['file'] = None
-            cfg['find_orientations']['seed_search']['hkl_seeds'] = seeds
+            cfg['find_orientations']['seed_search'] = seed_search
 
         cfg['material'] = material
         cfg['instrument'] = 'instrument.yml'

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -883,6 +883,30 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         recursive_key_check(self.indexing_config, cfg)
 
+        material = {
+            'definitions': 'materials.h5',
+            'active': self.active_material_name,
+            'dmin': self.active_material.dmin.getVal('angstrom'),
+            'tth_width': self.active_material.planeData.get_tThMax().tolist(),
+            'min_sfac_ratio': None
+        }
+
+        data = []
+        for det in self.detector_names:
+            data.append({'file': f'{det}.h5', 'args': {}, 'panel': det})
+
+        image_series = {
+            'format': 'hdf5',
+            'data': data
+        }
+
+        omaps = cfg['find_orientations']['orientation_maps']
+        omaps['active_hkls'] = list(
+            range(len(self.active_material.planeData.getHKLs())))
+        cfg['material'] = material
+        cfg['instrument'] = 'instrument.yml'
+        cfg['image-series'] = image_series
+
         with open(output_file, 'w') as f:
             yaml.dump(cfg, f)
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -911,13 +911,17 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         omaps = self.indexing_config['find_orientations']['orientation_maps']
         active_hkls = omaps.get('_active_hkl_strings', None)
+        seed_search = self.indexing_config['find_orientations']['seed_search']
+        hkl_seeds = seed_search.get('_hkl_seed_strings', [])
         if active_hkls is None:
             cfg['find_orientations']['orientation_maps']['active_hkls'] = []
         else:
             curr_hkls = selected_material.planeData.getHKLs(asStr=True)
             hkls = [curr_hkls.index(x) for x in active_hkls if x in curr_hkls]
+            seeds = [active_hkls.index(x) for x in hkl_seeds if x in curr_hkls]
             cfg['find_orientations']['orientation_maps']['active_hkls'] = hkls
             cfg['find_orientations']['orientation_maps']['file'] = None
+            cfg['find_orientations']['seed_search']['hkl_seeds'] = seeds
 
         cfg['material'] = material
         cfg['instrument'] = 'instrument.yml'

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -2069,7 +2069,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @property
     def is_aggregated(self):
         # Having unaggregated images implies the image series is aggregated
-        return self.unagg_images is not None
+        return self.unaggregated_images is not None
 
     def reset_unagg_imgs(self, new_imgs=False):
         if not new_imgs:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -894,7 +894,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         # we need to convert to float.
         tth_width = plane_data.tThWidth
         if isinstance(tth_width, np.float64):
-            tth_width = tth_width.item()
+            tth_width = np.degrees(tth_width).item()
 
         material = {
             'definitions': 'materials.h5',
@@ -917,6 +917,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'data': data
         }
 
+        # Find out which quaternion method was used
+        quaternion_method = self.indexing_config['find_orientations'].get(
+            '_quaternion_method')
+
         omaps = cfg['find_orientations']['orientation_maps']
         active_hkls = omaps.get('active_hkls', None)
 
@@ -926,8 +930,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         if not active_hkls:
             # Make sure this is saved as an empty list
             omaps['active_hkls'] = []
-            # Remove the seed search if present, as it will not be used
-            cfg['find_orientations'].pop('seed_search', None)
         else:
             if isinstance(active_hkls[0], int):
                 # This is a master list. Save the active hkls as the more human
@@ -935,6 +937,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 active_hkls = plane_data.getHKLs(*active_hkls).tolist()
 
             omaps['active_hkls'] = active_hkls
+
+        if quaternion_method != 'seed_search':
+            cfg['find_orientations'].pop('seed_search', None)
+
+        if quaternion_method != 'grid_search':
             # Make sure the file is None
             omaps['file'] = None
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -893,7 +893,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         data = []
         for det in self.detector_names:
-            data.append({'file': f'{det}.h5', 'args': {}, 'panel': det})
+            data.append({
+                'file': f'{det}.h5',
+                'args': {'path': 'imageseries'},
+                'panel': det
+            })
 
         image_series = {
             'format': 'hdf5',
@@ -905,7 +909,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             range(len(self.active_material.planeData.getHKLs())))
         cfg['material'] = material
         cfg['instrument'] = 'instrument.yml'
-        cfg['image-series'] = image_series
+        cfg['image_series'] = image_series
+        cfg['working_dir'] = str(Path(output_file).parent)
 
         with open(output_file, 'w') as f:
             yaml.dump(cfg, f)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -875,11 +875,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         def recursive_key_check(d, c):
             for k, v in d.items():
-                    if isinstance(v, dict) and not k.startswith('_'):
-                            c[k] = {}
-                            recursive_key_check(v, c[k])
-                    elif not k.startswith('_'):
-                            c[k] = v
+                if isinstance(v, dict) and not k.startswith('_'):
+                    c[k] = {}
+                    recursive_key_check(v, c[k])
+                elif not k.startswith('_'):
+                    c[k] = v
 
         recursive_key_check(self.indexing_config, cfg)
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -909,9 +909,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'data': data
         }
 
-        omaps = cfg['find_orientations']['orientation_maps']
-        omaps['active_hkls'] = list(
-            range(len(self.active_material.planeData.getHKLs())))
+        omaps = self.indexing_config['find_orientations']['orientation_maps']
+        active_hkls = omaps.get('_active_hkl_strings', None)
+        if active_hkls is None:
+            cfg['find_orientations']['orientation_maps']['active_hkls'] = []
+        else:
+            curr_hkls = selected_material.planeData.getHKLs(asStr=True)
+            hkls = [curr_hkls.index(x) for x in active_hkls if x in curr_hkls]
+            cfg['find_orientations']['orientation_maps']['active_hkls'] = hkls
+            cfg['find_orientations']['orientation_maps']['file'] = None
+
         cfg['material'] = material
         cfg['instrument'] = 'instrument.yml'
         cfg['image_series'] = image_series

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -870,6 +870,22 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         return name
 
+    def save_indexing_config(self, output_file):
+        cfg = {}
+
+        def recursive_key_check(d, c):
+            for k, v in d.items():
+                    if isinstance(v, dict) and not k.startswith('_'):
+                            c[k] = {}
+                            recursive_key_check(v, c[k])
+                    elif not k.startswith('_'):
+                            c[k] = v
+
+        recursive_key_check(self.indexing_config, cfg)
+
+        with open(output_file, 'w') as f:
+            yaml.dump(cfg, f)
+
     def set_live_update(self, status):
         self.live_update = status
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -939,6 +939,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             seed_search = cfg['find_orientations']['seed_search']
             active_hkls = [active_hkls[i] for i in seed_search['hkl_seeds']]
 
+            # Renumber the hkl_seeds from 0 to len(hkl_seeds)
+            num_hkl_seeds = len(seed_search['hkl_seeds'])
+            seed_search['hkl_seeds'] = list(range(num_hkl_seeds))
+
             omaps['active_hkls'] = active_hkls
         else:
             # Do not need active hkls

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -2050,7 +2050,14 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @property
     def unagg_images(self):
-        return self.unaggregated_images
+        img_dict = self.unaggregated_images
+        if img_dict is None:
+            img_dict = self.imageseries_dict
+        return img_dict
+
+    @property
+    def agg_images(self):
+        return self.unaggregated_images is not None
 
     @property
     def is_aggregated(self):
@@ -2058,10 +2065,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self.unagg_images is not None
 
     def reset_unagg_imgs(self, new_imgs=False):
-        if self.unagg_images is not None:
-            if not new_imgs:
-                HexrdConfig().imageseries_dict = copy.copy(self.unagg_images)
-            self.unaggregated_images = None
+        if not new_imgs:
+            HexrdConfig().imageseries_dict = copy.copy(self.unagg_images)
+        self.unaggregated_images = None
 
     def set_unagg_images(self):
         self.unaggregated_images = copy.copy(self.imageseries_dict)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -922,23 +922,28 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             '_quaternion_method')
 
         omaps = cfg['find_orientations']['orientation_maps']
-        active_hkls = omaps.get('active_hkls', None)
 
-        if isinstance(active_hkls, np.ndarray):
-            active_hkls = active_hkls.tolist()
+        if quaternion_method == 'seed_search':
+            # There must be some active hkls
+            active_hkls = omaps['active_hkls']
+            if isinstance(active_hkls, np.ndarray):
+                active_hkls = active_hkls.tolist()
 
-        if not active_hkls:
-            # Make sure this is saved as an empty list
-            omaps['active_hkls'] = []
-        else:
             if isinstance(active_hkls[0], int):
                 # This is a master list. Save the active hkls as the more human
                 # readable (h, k, l) tuples instead.
                 active_hkls = plane_data.getHKLs(*active_hkls).tolist()
 
-            omaps['active_hkls'] = active_hkls
+            # Do not save all active hkls, but only the ones used in the seed
+            # search. Those are the only ones we need.
+            seed_search = cfg['find_orientations']['seed_search']
+            active_hkls = [active_hkls[i] for i in seed_search['hkl_seeds']]
 
-        if quaternion_method != 'seed_search':
+            omaps['active_hkls'] = active_hkls
+        else:
+            # Do not need active hkls
+            omaps['active_hkls'] = []
+            # Seed search settings are not needed
             cfg['find_orientations'].pop('seed_search', None)
 
         if quaternion_method != 'grid_search':

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -888,11 +888,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         current_material = self.indexing_config['_selected_material']
         selected_material = self.material(current_material)
+
+        # tThMax can be None, bool or np.float64, in the case of np.float64 we
+        # need to convert to float
+        t_th_max = selected_material.planeData.get_tThMax()
+        if isinstance(t_th_max, np.float64):
+            t_th_max = t_th_max.item()
+
         material = {
             'definitions': 'materials.h5',
             'active': current_material,
             'dmin': selected_material.dmin.getVal('angstrom'),
-            'tth_width': selected_material.planeData.get_tThMax().item(),
+            'tth_width': t_th_max,
             'min_sfac_ratio': None
         }
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -875,19 +875,24 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         def recursive_key_check(d, c):
             for k, v in d.items():
-                if isinstance(v, dict) and not k.startswith('_'):
+                if k.startswith('_'):
+                    continue
+
+                if isinstance(v, dict):
                     c[k] = {}
                     recursive_key_check(v, c[k])
-                elif not k.startswith('_'):
+                else:
                     c[k] = v
 
         recursive_key_check(self.indexing_config, cfg)
 
+        current_material = self.indexing_config['_selected_material']
+        selected_material = self.material(current_material)
         material = {
             'definitions': 'materials.h5',
-            'active': self.active_material_name,
-            'dmin': self.active_material.dmin.getVal('angstrom'),
-            'tth_width': self.active_material.planeData.get_tThMax().tolist(),
+            'active': current_material,
+            'dmin': selected_material.dmin.getVal('angstrom'),
+            'tth_width': selected_material.planeData.get_tThMax().item(),
             'min_sfac_ratio': None
         }
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -891,15 +891,15 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         # tThMax can be None, bool or np.float64, in the case of np.float64 we
         # need to convert to float
-        t_th_max = selected_material.planeData.get_tThMax()
-        if isinstance(t_th_max, np.float64):
-            t_th_max = t_th_max.item()
+        tth_width = selected_material.planeData.tThWidth
+        if isinstance(tth_width, np.float64):
+            tth_width = tth_width.item()
 
         material = {
             'definitions': 'materials.h5',
             'active': current_material,
             'dmin': selected_material.dmin.getVal('angstrom'),
-            'tth_width': t_th_max,
+            'tth_width': tth_width,
             'min_sfac_ratio': None
         }
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -2067,10 +2067,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return img_dict
 
     @property
-    def agg_images(self):
-        return self.unaggregated_images is not None
-
-    @property
     def is_aggregated(self):
         # Having unaggregated images implies the image series is aggregated
         return self.unagg_images is not None

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -11,22 +11,25 @@ from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 
 
-def create_indexing_config():
-    # Creates a hexrd.config class from the indexing configuration
-
-    # Make a copy to modify
-    indexing_config = copy.deepcopy(HexrdConfig().indexing_config)
-    available_materials = list(HexrdConfig().materials.keys())
+def get_indexing_material():
+    indexing_config = HexrdConfig().indexing_config
+    available_materials = list(HexrdConfig().materials)
     selected_material = indexing_config.get('_selected_material')
 
     if selected_material not in available_materials:
         raise Exception(f'Selected material {selected_material} not available')
 
-    material = HexrdConfig().material(selected_material)
+    return HexrdConfig().material(selected_material)
+
+
+def create_indexing_config():
+    # Creates a hexrd.config class from the indexing configuration
+
+    material = get_indexing_material()
     pd = material.planeData
 
-    omaps = indexing_config['find_orientations']['orientation_maps']
-    omaps['active_hkls'] = pd.getHKLID(pd.getHKLs().T, master=True)
+    # Make a copy to modify
+    indexing_config = copy.deepcopy(HexrdConfig().indexing_config)
 
     # Set the active material on the config
     tmp = indexing_config.setdefault('material', {})

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -594,17 +594,15 @@ class FitGrainsResultsDialog(QObject):
 
     def _save_workflow_files(self, selected_directory):
         if selected_directory:
-            parent = Path(selected_directory)/'workflow'
-            Path.mkdir(parent)
             HexrdConfig().working_dir = selected_directory
-            HexrdConfig().save_indexing_config(f'{str(parent)}/workflow.yml')
-            HexrdConfig().save_materials(f'{str(parent)}/materials.h5')
-            HexrdConfig().save_instrument_config(f'{str(parent)}/instrument.yml')
+            HexrdConfig().save_indexing_config(f'{str(selected_directory)}/workflow.yml')
+            HexrdConfig().save_materials(f'{str(selected_directory)}/materials.h5')
+            HexrdConfig().save_instrument_config(f'{str(selected_directory)}/instrument.yml')
             ims_dict = HexrdConfig().unagg_images
             if ims_dict is None:
                 ims_dict = HexrdConfig().imageseries_dict
             for det in HexrdConfig().detector_names:
-                path = f'{str(parent)}/{det}.h5'
+                path = f'{str(selected_directory)}/{det}.h5'
                 kwargs = {'path': 'imageseries'}
                 HexrdConfig().save_imageseries(
                     ims_dict.get(det), det, path, 'hdf5', **kwargs)

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -601,8 +601,6 @@ class FitGrainsResultsDialog(QObject):
             HexrdConfig().save_instrument_config(
                 f'{selected_directory}/instrument.yml')
             ims_dict = HexrdConfig().unagg_images
-            if ims_dict is None:
-                ims_dict = HexrdConfig().imageseries_dict
             for det in HexrdConfig().detector_names:
                 path = f'{selected_directory}/{det}.h5'
                 kwargs = {'path': 'imageseries'}

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -634,7 +634,7 @@ class FitGrainsResultsDialog(QObject):
 
         worker = AsyncWorker(self._save_workflow_files, selected_directory)
         self.thread_pool.start(worker)
-        self.progress_dialog.setWindowTitle(f'Saving worflow configuration')
+        self.progress_dialog.setWindowTitle(f'Saving workflow configuration')
         self.progress_dialog.setRange(0, 0)
         worker.signals.finished.connect(self.progress_dialog.accept)
         self.progress_dialog.exec_()

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -609,26 +609,6 @@ class FitGrainsResultsDialog(QObject):
                     ims_dict.get(det), det, path, 'hdf5', **kwargs)
 
     def on_export_workflow_selected(self):
-        idx_cfg = HexrdConfig().indexing_config
-        omaps = idx_cfg['find_orientations']['orientation_maps']
-        active = omaps.get("_active_hkl_strings", [])
-        current = self.material.planeData.getHKLs(asStr=True)
-        missing = [a for a in active if a not in current]
-
-        if missing:
-            msg = (
-                f'The following HKLs are excluded: {(", ").join(missing)}.'
-                f' Would you like to remove them from the exclusions list?')
-            response = QMessageBox.question(
-                self.ui, 'HEXRD', msg, (QMessageBox.Yes | QMessageBox.No))
-            if response == QMessageBox.Yes:
-                exclusions = self.material.planeData.exclusions
-                hkls = self.material.planeData.getHKLs(
-                    asStr=True, allHKLs=True)
-                idx = [hkls.index(m) for m in missing]
-                exclusions[idx] = False
-                self.material.planeData.exclusions = exclusions
-
         selected_directory = QFileDialog.getExistingDirectory(
                 self.ui, 'Select directory', HexrdConfig().working_dir)
 

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -14,19 +14,17 @@ from matplotlib.figure import Figure
 
 from PySide2.QtCore import QObject, QTimer, Qt, Signal
 from PySide2.QtWidgets import QFileDialog, QMenu, QMessageBox, QSizePolicy
-from PySide2.QtCore import QThreadPool
 
 from hexrd.matrixutil import vecMVToSymm
 from hexrd.rotations import rotMatOfExpMap
 
 import hexrd.ui.constants
+from hexrd.ui.async_runner import AsyncRunner
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.indexing.grains_table_model import GrainsTableModel
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
-from hexrd.ui.async_worker import AsyncWorker
-from hexrd.ui.progress_dialog import ProgressDialog
 
 
 COORDS_SLICE = slice(6, 9)
@@ -41,9 +39,9 @@ COLOR_ORIENTATIONS_IND = 23
 class FitGrainsResultsDialog(QObject):
     finished = Signal()
 
-    def __init__(self, data, material=None,
-                    parent=None, allow_export_workflow=True):
-        super().__init__()
+    def __init__(self, data, material=None, parent=None,
+                 allow_export_workflow=True):
+        super().__init__(parent)
 
         if material is None:
             # Assume the active material is the correct one.
@@ -53,6 +51,8 @@ class FitGrainsResultsDialog(QObject):
                 # Warn the user so this is clear.
                 print(f'Assuming material of {material.name} for needed '
                       'computations')
+
+        self.async_runner = AsyncRunner(parent)
 
         self.ax = None
         self.cmap = hexrd.ui.constants.DEFAULT_CMAP
@@ -70,8 +70,6 @@ class FitGrainsResultsDialog(QObject):
         self.ui.splitter.setStretchFactor(0, 1)
         self.ui.splitter.setStretchFactor(1, 10)
         self.ui.export_workflow.setEnabled(allow_export_workflow)
-        self.thread_pool = QThreadPool()
-        self.progress_dialog = ProgressDialog(self.ui)
 
         self.setup_tableview()
         self.load_cmaps()
@@ -311,7 +309,7 @@ class FitGrainsResultsDialog(QObject):
         self.ui.cylindrical_reference.toggled.connect(
             self.cylindrical_reference_toggled)
         self.ui.export_workflow.clicked.connect(
-            self.on_export_workflow_selected)
+            self.on_export_workflow_clicked)
 
         for name in ('x', 'y', 'z'):
             action = getattr(self, f'set_view_{name}')
@@ -594,30 +592,59 @@ class FitGrainsResultsDialog(QObject):
         self.update_plot()
 
     def _save_workflow_files(self, selected_directory):
-        if selected_directory:
-            HexrdConfig().working_dir = selected_directory
-            HexrdConfig().save_indexing_config(
-                f'{selected_directory}/workflow.yml')
-            HexrdConfig().save_materials(f'{selected_directory}/materials.h5')
-            HexrdConfig().save_instrument_config(
-                f'{selected_directory}/instrument.yml')
-            ims_dict = HexrdConfig().unagg_images
-            for det in HexrdConfig().detector_names:
-                path = f'{selected_directory}/{det}.h5'
-                kwargs = {'path': 'imageseries'}
-                HexrdConfig().save_imageseries(
-                    ims_dict.get(det), det, path, 'hdf5', **kwargs)
 
-    def on_export_workflow_selected(self):
+        def full_path(file_name):
+            # Convenience function to generate full path via pathlib
+            return str(Path(selected_directory) / file_name)
+
+        HexrdConfig().working_dir = selected_directory
+
+        HexrdConfig().save_indexing_config(full_path('workflow.yml'))
+        HexrdConfig().save_materials(full_path('materials.h5'))
+        HexrdConfig().save_instrument_config(full_path('instrument.yml'))
+
+        ims_dict = HexrdConfig().unagg_images
+        for det in HexrdConfig().detector_names:
+            kwargs = {
+                'ims': ims_dict.get(det),
+                'name': det,
+                'write_file': full_path(f'{det}.h5'),
+                'selected_format': 'hdf5',
+                'path': 'imageseries',
+            }
+            HexrdConfig().save_imageseries(**kwargs)
+
+    def on_export_workflow_clicked(self):
         selected_directory = QFileDialog.getExistingDirectory(
-                self.ui, 'Select directory', HexrdConfig().working_dir)
+                self.ui, 'Select Directory', HexrdConfig().working_dir)
 
-        worker = AsyncWorker(self._save_workflow_files, selected_directory)
-        self.thread_pool.start(worker)
-        self.progress_dialog.setWindowTitle(f'Saving workflow configuration')
-        self.progress_dialog.setRange(0, 0)
-        worker.signals.finished.connect(self.progress_dialog.accept)
-        self.progress_dialog.exec_()
+        if not selected_directory:
+            # User canceled
+            return
+
+        # Warn the user if any files will be over-written
+        write_files = [
+            'workflow.yml',
+            'materials.h5',
+            'instrument.yml',
+        ] + [f'{det}.h5' for det in HexrdConfig().detector_names]
+
+        overwrite_files = []
+        for f in write_files:
+            full_path = Path(selected_directory) / f
+            if full_path.exists():
+                overwrite_files.append(str(full_path))
+
+        if overwrite_files:
+            msg = 'The following files will be overwritten:\n\n'
+            msg += '\n'.join(overwrite_files)
+            msg += '\n\nProceed?'
+            response = QMessageBox.question(self.parent(), 'WARNING', msg)
+            if response == QMessageBox.No:
+                return
+
+        self.async_runner.progress_title = 'Saving workflow configuration'
+        self.async_runner.run(self._save_workflow_files, selected_directory)
 
 if __name__ == '__main__':
     from PySide2.QtCore import QCoreApplication

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -38,7 +38,7 @@ COLOR_ORIENTATIONS_IND = 23
 class FitGrainsResultsDialog(QObject):
     finished = Signal()
 
-    def __init__(self, data, material=None, parent=None):
+    def __init__(self, data, material=None, parent=None, full_workflow=True):
         super().__init__()
 
         if material is None:
@@ -65,6 +65,7 @@ class FitGrainsResultsDialog(QObject):
 
         self.ui.splitter.setStretchFactor(0, 1)
         self.ui.splitter.setStretchFactor(1, 10)
+        self.ui.export_workflow.setEnabled(full_workflow)
 
         self.setup_tableview()
         self.load_cmaps()
@@ -303,6 +304,7 @@ class FitGrainsResultsDialog(QObject):
         self.ui.reset_glyph_size.clicked.connect(self.reset_glyph_size)
         self.ui.cylindrical_reference.toggled.connect(
             self.cylindrical_reference_toggled)
+        self.ui.export_workflow.clicked.connect(self.on_export_workflow_selected)
 
         for name in ('x', 'y', 'z'):
             action = getattr(self, f'set_view_{name}')

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -607,6 +607,15 @@ class FitGrainsResultsDialog(QObject):
                 exclusions[idx] = False
                 self.material.planeData.exclusions = exclusions
 
+        selected_file, selected_filter = QFileDialog.getSaveFileName(
+            self.ui, 'Save Workflow', HexrdConfig().working_dir, 'YAML files (*.yml)')
+
+        if selected_file:
+            if Path(selected_file).suffix != '.yml':
+                selected_file += '.yml'
+
+            HexrdConfig().working_dir = str(Path(selected_file).parent)
+            return HexrdConfig().save_indexing_config(selected_file)
 
 if __name__ == '__main__':
     from PySide2.QtCore import QCoreApplication

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -70,6 +70,13 @@ class FitGrainsResultsDialog(QObject):
         self.ui.splitter.setStretchFactor(0, 1)
         self.ui.splitter.setStretchFactor(1, 10)
         self.ui.export_workflow.setEnabled(allow_export_workflow)
+        if not allow_export_workflow:
+            # Give some possible reasons
+            self.ui.export_workflow.setToolTip(
+                'Currently only supported if a full HEDM workflow was '
+                'performed (including indexing) and the quaternion '
+                'generation method was a seed search.'
+            )
 
         self.setup_tableview()
         self.load_cmaps()

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -595,9 +595,12 @@ class FitGrainsResultsDialog(QObject):
     def _save_workflow_files(self, selected_directory):
         if selected_directory:
             HexrdConfig().working_dir = selected_directory
-            HexrdConfig().save_indexing_config(f'{str(selected_directory)}/workflow.yml')
-            HexrdConfig().save_materials(f'{str(selected_directory)}/materials.h5')
-            HexrdConfig().save_instrument_config(f'{str(selected_directory)}/instrument.yml')
+            HexrdConfig().save_indexing_config(
+                f'{str(selected_directory)}/workflow.yml')
+            HexrdConfig().save_materials(
+                f'{str(selected_directory)}/materials.h5')
+            HexrdConfig().save_instrument_config(
+                f'{str(selected_directory)}/instrument.yml')
             ims_dict = HexrdConfig().unagg_images
             if ims_dict is None:
                 ims_dict = HexrdConfig().imageseries_dict
@@ -622,7 +625,8 @@ class FitGrainsResultsDialog(QObject):
                 self.ui, 'HEXRD', msg, (QMessageBox.Yes | QMessageBox.No))
             if response == QMessageBox.Yes:
                 exclusions = self.material.planeData.exclusions
-                hkls = self.material.planeData.getHKLs(asStr=True, allHKLs=True)
+                hkls = self.material.planeData.getHKLs(
+                    asStr=True, allHKLs=True)
                 idx = [hkls.index(m) for m in missing]
                 exclusions[idx] = False
                 self.material.planeData.exclusions = exclusions

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -41,7 +41,8 @@ COLOR_ORIENTATIONS_IND = 23
 class FitGrainsResultsDialog(QObject):
     finished = Signal()
 
-    def __init__(self, data, material=None, parent=None, allow_export_workflow=True):
+    def __init__(self, data, material=None,
+                    parent=None, allow_export_workflow=True):
         super().__init__()
 
         if material is None:

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -98,18 +98,19 @@ class IndexingRunner(Runner):
         if dialog is None:
             return
 
+        indexing_config = HexrdConfig().indexing_config
+        omaps = indexing_config['find_orientations']['orientation_maps']
         if dialog.method_name == 'load':
             self.ome_maps = EtaOmeMaps(dialog.file_name)
             self.ome_maps_select_dialog = None
             self.ome_maps_loaded()
+            omaps['_active_hkl_strings'] = None
         else:
             # Create a full indexing config
             config = create_indexing_config()
             # Save the hkls strings for future comparison
-            indexing_config = HexrdConfig().indexing_config
             selected_material = indexing_config.get('_selected_material')
             material = HexrdConfig().material(selected_material)
-            omaps = indexing_config['find_orientations']['orientation_maps']
             omaps['_active_hkl_strings'] = material.planeData.getHKLs(asStr=True)
 
             # Setup to generate maps in background

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -156,6 +156,13 @@ class IndexingRunner(Runner):
 
         # Create a full indexing config
         config = create_indexing_config()
+        # Save the hkls seeds for future comparison
+        indexing_config = HexrdConfig().indexing_config
+        omaps = indexing_config['find_orientations']['orientation_maps']
+        seed_search = indexing_config['find_orientations']['seed_search']
+        active = omaps['_active_hkl_strings']
+        seeds = seed_search['hkl_seeds']
+        seed_search['_hkl_seed_strings'] = [active[idx] for idx in seeds]
 
         # Hexrd normally applies filtering immediately after eta omega
         # maps are loaded. We will perform the user-selected filtering now.

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -514,8 +514,16 @@ class FitGrainsRunner(Runner):
         for result in self.fit_grains_results:
             print(result)
 
+        find_orientations = HexrdConfig().indexing_config['find_orientations']
+        quaternion_method = find_orientations.get('_quaternion_method')
+        allow_export_workflow = (
+            self.started_from_indexing and
+            quaternion_method == 'seed_search'
+        )
+
         kwargs = {
             'grains_table': self.result_grains_table,
+            'allow_export_workflow': allow_export_workflow,
             'parent': self.parent,
         }
         dialog = create_fit_grains_results_dialog(**kwargs)
@@ -534,7 +542,8 @@ def create_grains_table(fit_grains_results):
     return grains_table
 
 
-def create_fit_grains_results_dialog(grains_table, parent=None):
+def create_fit_grains_results_dialog(grains_table, parent=None,
+                                     allow_export_workflow=True):
     # Use the material to compute stress from strain
     indexing_config = HexrdConfig().indexing_config
     name = indexing_config.get('_selected_material')
@@ -543,7 +552,13 @@ def create_fit_grains_results_dialog(grains_table, parent=None):
     material = HexrdConfig().material(name)
 
     # Create the dialog
-    dialog = FitGrainsResultsDialog(grains_table, material, parent)
+    kwargs = {
+        'data': grains_table,
+        'material': material,
+        'parent': parent,
+        'allow_export_workflow': allow_export_workflow,
+    }
+    dialog = FitGrainsResultsDialog(**kwargs)
     dialog.ui.resize(1200, 800)
 
     return dialog

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -111,7 +111,8 @@ class IndexingRunner(Runner):
             # Save the hkls strings for future comparison
             selected_material = indexing_config.get('_selected_material')
             material = HexrdConfig().material(selected_material)
-            omaps['_active_hkl_strings'] = material.planeData.getHKLs(asStr=True)
+            omaps['_active_hkl_strings'] = (
+                material.planeData.getHKLs(asStr=True))
 
             # Setup to generate maps in background
             self.progress_dialog.setWindowTitle('Generating Eta Omega Maps')

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -105,6 +105,12 @@ class IndexingRunner(Runner):
         else:
             # Create a full indexing config
             config = create_indexing_config()
+            # Save the hkls strings for future comparison
+            indexing_config = HexrdConfig().indexing_config
+            selected_material = indexing_config.get('_selected_material')
+            material = HexrdConfig().material(selected_material)
+            omaps = indexing_config['find_orientations']['orientation_maps']
+            omaps['_active_hkl_strings'] = material.planeData.getHKLs()
 
             # Setup to generate maps in background
             self.progress_dialog.setWindowTitle('Generating Eta Omega Maps')

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -104,15 +104,12 @@ class IndexingRunner(Runner):
             self.ome_maps = EtaOmeMaps(dialog.file_name)
             self.ome_maps_select_dialog = None
             self.ome_maps_loaded()
-            omaps['_active_hkl_strings'] = None
         else:
             # Create a full indexing config
             config = create_indexing_config()
             # Save the hkls strings for future comparison
             selected_material = indexing_config.get('_selected_material')
             material = HexrdConfig().material(selected_material)
-            omaps['_active_hkl_strings'] = (
-                material.planeData.getHKLs(asStr=True))
 
             # Setup to generate maps in background
             self.progress_dialog.setWindowTitle('Generating Eta Omega Maps')
@@ -157,13 +154,6 @@ class IndexingRunner(Runner):
 
         # Create a full indexing config
         config = create_indexing_config()
-        # Save the hkls seeds for future comparison
-        indexing_config = HexrdConfig().indexing_config
-        omaps = indexing_config['find_orientations']['orientation_maps']
-        seed_search = indexing_config['find_orientations']['seed_search']
-        active = omaps['_active_hkl_strings']
-        seeds = seed_search['hkl_seeds']
-        seed_search['_hkl_seed_strings'] = [active[idx] for idx in seeds]
 
         # Hexrd normally applies filtering immediately after eta omega
         # maps are loaded. We will perform the user-selected filtering now.

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -110,7 +110,7 @@ class IndexingRunner(Runner):
             selected_material = indexing_config.get('_selected_material')
             material = HexrdConfig().material(selected_material)
             omaps = indexing_config['find_orientations']['orientation_maps']
-            omaps['_active_hkl_strings'] = material.planeData.getHKLs()
+            omaps['_active_hkl_strings'] = material.planeData.getHKLs(asStr=True)
 
             # Setup to generate maps in background
             self.progress_dialog.setWindowTitle('Generating Eta Omega Maps')

--- a/hexrd/ui/indexing/utils.py
+++ b/hexrd/ui/indexing/utils.py
@@ -18,3 +18,23 @@ def generate_grains_table(qbar):
         gw.dump_grain(i, 1, 0, grain_params)
     gw.close()
     return grains_table
+
+
+def hkl_in_list(hkl, hkl_list):
+    def hkls_equal(hkl_a, hkl_b):
+        return all(x == y for x, y in zip(hkl_a, hkl_b))
+
+    for hkl_b in hkl_list:
+        if hkls_equal(hkl, hkl_b):
+            return True
+
+    return False
+
+
+def hkls_missing_in_list(hkls, hkl_list):
+    missing = []
+    for hkl in hkls:
+        if not hkl_in_list(hkl, hkl_list):
+            missing.append(hkl)
+
+    return missing

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -354,7 +354,7 @@ class MainWindow(QObject):
 
             data = np.loadtxt(selected_file, ndmin=2)
             dialog = FitGrainsResultsDialog(
-                data, parent=self.ui, full_workflow=False)
+                data, parent=self.ui, allow_export_workflow=False)
             dialog.show()
             self._fit_grains_results_dialog = dialog
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -542,6 +542,7 @@ class MainWindow(QObject):
         kwargs = {
             'grains_table': None,
             'indexing_runner': getattr(self, '_indexing_runner', None),
+            'started_from_indexing': False,
             'parent': self.ui,
         }
         runner = self._grain_fitting_runner = FitGrainsRunner(**kwargs)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -973,9 +973,6 @@ class MainWindow(QObject):
             action.setEnabled(False)
 
         image_series_dict = HexrdConfig().unagg_images
-        if image_series_dict is None:
-            image_series_dict = HexrdConfig().imageseries_dict
-
         if not image_series_dict:
             return
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -353,7 +353,8 @@ class MainWindow(QObject):
             HexrdConfig().working_dir = str(path.parent)
 
             data = np.loadtxt(selected_file, ndmin=2)
-            dialog = FitGrainsResultsDialog(data, parent=self.ui)
+            dialog = FitGrainsResultsDialog(
+                data, parent=self.ui, full_workflow=False)
             dialog.show()
             self._fit_grains_results_dialog = dialog
 

--- a/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
@@ -544,22 +544,33 @@
     <layout class="QVBoxLayout" name="toolbar_layout"/>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QPushButton" name="export_workflow">
+       <property name="text">
+        <string>Export Full Workflow</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Close</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <customwidgets>
   <customwidget>
    <class>ScientificDoubleSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>hexrd/ui/scientificspinbox</header>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>

--- a/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>826</height>
+    <height>830</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -92,7 +92,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Export</string>
+             <string>Export Grains Table</string>
             </property>
            </widget>
           </item>
@@ -313,7 +313,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="singleStep">
-                   <number>0</number>
+                   <double>0.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -329,7 +329,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="singleStep">
-                   <number>0</number>
+                   <double>0.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -345,7 +345,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="singleStep">
-                   <number>0</number>
+                   <double>0.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -361,7 +361,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="singleStep">
-                   <number>0</number>
+                   <double>0.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -409,7 +409,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="singleStep">
-                   <number>0</number>
+                   <double>0.000000000000000</double>
                   </property>
                  </widget>
                 </item>
@@ -438,7 +438,7 @@
                    <bool>false</bool>
                   </property>
                   <property name="singleStep">
-                   <number>0</number>
+                   <double>0.000000000000000</double>
                   </property>
                  </widget>
                 </item>

--- a/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>635</width>
-    <height>267</height>
+    <width>649</width>
+    <height>295</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
@@ -20,14 +20,27 @@
       <attribute name="title">
        <string>Load</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QLineEdit" name="file_name"/>
-       </item>
-       <item>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="1" column="2">
         <widget class="QPushButton" name="select_file_button">
          <property name="text">
           <string>Select File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QLineEdit" name="file_name"/>
+       </item>
+       <item row="2" column="0" colspan="3">
+        <widget class="QLabel" name="load_note">
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;The selected material must exactly match the one used to generate this file&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
          </property>
         </widget>
        </item>

--- a/hexrd/ui/save_images_dialog.py
+++ b/hexrd/ui/save_images_dialog.py
@@ -26,7 +26,7 @@ class SaveImagesDialog:
         self.ui.detectors.addItems(HexrdConfig().detector_names)
         self.ui.pwd.setText(self.parent_dir)
         self.ui.pwd.setToolTip(self.parent_dir)
-        if HexrdConfig().unagg_images:
+        if HexrdConfig().agg_images:
             self.ui.ignore_agg.setEnabled(True)
 
     def setup_connections(self):

--- a/hexrd/ui/save_images_dialog.py
+++ b/hexrd/ui/save_images_dialog.py
@@ -26,7 +26,7 @@ class SaveImagesDialog:
         self.ui.detectors.addItems(HexrdConfig().detector_names)
         self.ui.pwd.setText(self.parent_dir)
         self.ui.pwd.setToolTip(self.parent_dir)
-        if HexrdConfig().agg_images:
+        if HexrdConfig().is_aggregated:
             self.ui.ignore_agg.setEnabled(True)
 
     def setup_connections(self):


### PR DESCRIPTION
This PR addresses #946

- This adds an `Export Workflow` option to the `Fit Grains Results` dialog. The option to save the workflow is only available when the user completes the entire workflow (so it will be disabled when using the `File`->`Open`->`Grain Fitting Results` path).
- When the user exports the workflow the hkls that were selected during the indexing step are compared to the current active hkls, and if there are any that are missing the user is warned with a dialog and given the option to include them. I struggled a bit with the wording in this dialog and would be open to improvements to make it clearer.
![export_workflow](https://user-images.githubusercontent.com/51238406/123642010-d4f6d080-d7f0-11eb-8bf3-c9dc81d1b245.png)