### PR TITLE
Add a "Copy" button to the messages widget

### DIFF
--- a/hexrd/ui/messages_widget.py
+++ b/hexrd/ui/messages_widget.py
@@ -3,6 +3,7 @@ import sys
 
 from PySide2.QtCore import QObject, Qt, Signal
 from PySide2.QtGui import QColor
+from PySide2.QtWidgets import QApplication
 
 from hexrd.ui.fix_pdb import fix_pdb
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -45,6 +46,7 @@ class MessagesWidget(QObject):
         self.release_output()
 
     def setup_connections(self):
+        self.ui.copy.pressed.connect(self.copy_text)
         self.ui.clear.pressed.connect(self.clear_text)
         self.ui.destroyed.connect(self.release_output)
 
@@ -115,6 +117,18 @@ class MessagesWidget(QObject):
             self.insert_text(text)
 
         self.message_written.emit('stderr', text)
+
+    @property
+    def allow_copy(self):
+        return self.ui.copy.isVisible()
+
+    @allow_copy.setter
+    def allow_copy(self, b):
+        self.ui.copy.setVisible(b)
+
+    def copy_text(self):
+        clipboard = QApplication.clipboard()
+        clipboard.setText(self.ui.text.toPlainText())
 
     @property
     def allow_clear(self):

--- a/hexrd/ui/progress_dialog.py
+++ b/hexrd/ui/progress_dialog.py
@@ -11,7 +11,8 @@ class ProgressDialog:
         self.ui = loader.load_file('progress_dialog.ui', parent)
 
         self.messages_widget = MessagesWidget(self.ui)
-        # Disable the clear button
+        # Disable message widget buttons
+        self.messages_widget.allow_copy = False
         self.messages_widget.allow_clear = False
         self.ui.messages_widget_layout.addWidget(self.messages_widget.ui)
 

--- a/hexrd/ui/resources/ui/messages_widget.ui
+++ b/hexrd/ui/resources/ui/messages_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>119</height>
+    <height>144</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -16,18 +16,25 @@
     <height>0</height>
    </size>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
-   <item>
-    <widget class="QTextEdit" name="text">
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="1">
     <widget class="QPushButton" name="clear">
      <property name="text">
       <string>Clear</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="copy">
+     <property name="text">
+      <string>Copy</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QTextEdit" name="text">
+     <property name="readOnly">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
@@ -35,6 +42,7 @@
  </widget>
  <tabstops>
   <tabstop>text</tabstop>
+  <tabstop>copy</tabstop>
   <tabstop>clear</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This copies the text in the messages widget to the user's clipboard.

It is there for convenience, so that the user doesn't have to highlight
the text before copying.