### PR TITLE
Add ability to modify a material's charge

### DIFF
--- a/hexrd/ui/material_site_editor.py
+++ b/hexrd/ui/material_site_editor.py
@@ -24,6 +24,7 @@ COLUMNS = {
     'thermal_factor': 3
 }
 
+DEFAULT_CHARGE = '0'
 DEFAULT_U = Material.DFLT_U[0]
 
 OCCUPATION_MIN = 0
@@ -148,12 +149,17 @@ class MaterialSiteEditor(QObject):
         # Reset all the occupancies
         atoms = self.atoms
         previous_u_values = {x['symbol']: x['U'] for x in atoms}
+        previous_charges = {x['symbol']: x['charge'] for x in atoms}
         atoms.clear()
 
         for symbol in v:
-            # Use the previous U if available. Otherwise, use the default.
-            U = previous_u_values.get(symbol, DEFAULT_U)
-            atoms.append({'symbol': symbol, 'U': U})
+            # Use previous values if available. Otherwise, use the defaults.
+            atom = {
+                'symbol': symbol,
+                'U': previous_u_values.get(symbol, DEFAULT_U),
+                'charge': previous_charges.get(symbol, DEFAULT_CHARGE),
+            }
+            atoms.append(atom)
 
         self.reset_occupancies()
         self.update_table()

--- a/hexrd/ui/material_site_editor.py
+++ b/hexrd/ui/material_site_editor.py
@@ -3,8 +3,11 @@ import copy
 import numpy as np
 
 from PySide2.QtCore import QItemSelectionModel, QObject, Signal
-from PySide2.QtWidgets import QLineEdit, QSizePolicy, QTableWidgetItem
+from PySide2.QtWidgets import (
+    QComboBox, QLineEdit, QSizePolicy, QTableWidgetItem
+)
 
+from hexrd.constants import chargestate
 from hexrd.material import Material
 
 from hexrd.ui.periodic_table_dialog import PeriodicTableDialog
@@ -16,8 +19,9 @@ from hexrd.ui.utils import block_signals
 
 COLUMNS = {
     'symbol': 0,
-    'occupancy': 1,
-    'thermal_factor': 2
+    'charge': 1,
+    'occupancy': 2,
+    'thermal_factor': 3
 }
 
 DEFAULT_U = Material.DFLT_U[0]
@@ -44,6 +48,7 @@ class MaterialSiteEditor(QObject):
 
         self._site = site
 
+        self.charge_comboboxes = []
         self.occupancy_spinboxes = []
         self.thermal_factor_spinboxes = []
 
@@ -195,6 +200,22 @@ class MaterialSiteEditor(QObject):
         w = QTableWidgetItem(v)
         return w
 
+    def create_charge_combobox(self, charge, symbol):
+        cb = QComboBox(self.ui.table)
+
+        if charge not in chargestate[symbol]:
+            raise Exception(f'Invalid charge {charge} for {symbol}')
+
+        cb.addItems(chargestate[symbol])
+        cb.setCurrentText(charge)
+        cb.currentIndexChanged.connect(self.update_config)
+
+        size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        cb.setSizePolicy(size_policy)
+
+        self.charge_comboboxes.append(cb)
+        return cb
+
     def create_occupancy_spinbox(self, v):
         sb = ScientificDoubleSpinBox(self.ui.table)
         sb.setKeyboardTracking(False)
@@ -225,6 +246,7 @@ class MaterialSiteEditor(QObject):
         return sb
 
     def clear_table(self):
+        self.charge_comboboxes.clear()
         self.occupancy_spinboxes.clear()
         self.thermal_factor_spinboxes.clear()
         self.ui.table.clearContents()
@@ -260,6 +282,9 @@ class MaterialSiteEditor(QObject):
                 w = self.create_symbol_label(atom['symbol'])
                 self.ui.table.setItem(i, COLUMNS['symbol'], w)
 
+                w = self.create_charge_combobox(atom['charge'], atom['symbol'])
+                self.ui.table.setCellWidget(i, COLUMNS['charge'], w)
+
                 w = self.create_occupancy_spinbox(atom['occupancy'])
                 self.ui.table.setCellWidget(i, COLUMNS['occupancy'], w)
 
@@ -292,6 +317,9 @@ class MaterialSiteEditor(QObject):
     def update_config(self):
         for i, w in enumerate(self.fractional_coords_widgets):
             self.fractional_coords[i] = w.value()
+
+        for atom, combobox in zip(self.atoms, self.charge_comboboxes):
+            atom['charge'] = combobox.currentText()
 
         for atom, spinbox in zip(self.atoms, self.occupancy_spinboxes):
             atom['occupancy'] = spinbox.value()

--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -253,13 +253,7 @@ class MaterialStructureEditor(QObject):
                 U_array[i] = scalar_to_tensor(U)
 
         mat = self.material
-        mat._set_atomdata(type_array, info_array, U_array)
-        mat.charge = charge_array
-
-        # Must force an update of the unit cell and structure factor
-        # for the change in the charge array.
-        mat._newUnitcell()
-        mat.update_structure_factor()
+        mat._set_atomdata(type_array, info_array, U_array, charge_array)
 
         self.material_modified.emit()
 

--- a/hexrd/ui/material_structure_editor.py
+++ b/hexrd/ui/material_structure_editor.py
@@ -23,11 +23,13 @@ DEFAULT_SITE = {
     'atoms': [
         {
             'symbol': 'O',
+            'charge': '0',
             'occupancy': 0.5,
             'U': 1e-6
         },
         {
             'symbol': 'Ce',
+            'charge': '0',
             'occupancy': 0.5,
             'U': 1e-6
         }
@@ -234,6 +236,7 @@ class MaterialStructureEditor(QObject):
         # Convert the sites back to the material data format
         info_array = []
         type_array = []
+        charge_array = []
         U_array = []
 
         for site in self.sites:
@@ -241,6 +244,7 @@ class MaterialStructureEditor(QObject):
                 info_array.append((*site['fractional_coords'],
                                    atom['occupancy']))
                 type_array.append(ptable[atom['symbol']])
+                charge_array.append(atom['charge'])
                 U_array.append(atom['U'])
 
         if any(isinstance(x, np.ndarray) for x in U_array):
@@ -250,6 +254,12 @@ class MaterialStructureEditor(QObject):
 
         mat = self.material
         mat._set_atomdata(type_array, info_array, U_array)
+        mat.charge = charge_array
+
+        # Must force an update of the unit cell and structure factor
+        # for the change in the charge array.
+        mat._newUnitcell()
+        mat.update_structure_factor()
 
         self.material_modified.emit()
 
@@ -263,11 +273,13 @@ class MaterialStructureEditor(QObject):
             'atoms': [
                 {
                     'symbol': 'Na',
+                    'charge': '0',
                     'occupancy': 0.5,
                     'U': 4.18e-7
                 },
                 {
                     'symbol': 'Br',
+                    'charge': '0',
                     'occupancy': 0.5,
                     'U': 4.18e-7
                 }
@@ -287,6 +299,7 @@ class MaterialStructureEditor(QObject):
 
         info_array = mat._atominfo
         type_array = mat._atomtype
+        charge_array = mat.charge
         U_array = mat._U
 
         if any(isinstance(x, np.ndarray) for x in U_array):
@@ -322,6 +335,7 @@ class MaterialStructureEditor(QObject):
             for i in indices:
                 atom = {
                     'symbol': ptableinverse[type_array[i]],
+                    'charge': charge_array[i],
                     'occupancy': info_array[i][3],
                     'U': U_array[i]
                 }

--- a/hexrd/ui/resources/ui/material_site_editor.ui
+++ b/hexrd/ui/resources/ui/material_site_editor.ui
@@ -54,6 +54,11 @@
         </column>
         <column>
          <property name="text">
+          <string>Charge</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
           <string>Occupancy</string>
          </property>
         </column>


### PR DESCRIPTION
Note that we have to update the unit cell and structure factor
manually [since the material is not currently doing that](https://github.com/HEXRD/hexrd/blob/300f43ffe35cdbd0a7827b80d0b9209f196771a0/hexrd/material.py#L864-L866).

Maybe we should just add the charge as an argument to
[`set_atomdata()`](https://github.com/HEXRD/hexrd/blob/300f43ffe35cdbd0a7827b80d0b9209f196771a0/hexrd/material.py#L942)?

Fixes: #886

Depends on: hexrd/hexrd#301