### PR TITLE
Add a thermal factor editor to allow tensor U

### DIFF
--- a/hexrd/ui/material_properties_editor.py
+++ b/hexrd/ui/material_properties_editor.py
@@ -9,7 +9,7 @@ from hexrd.unitcell import _StiffnessDict
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.matrix_editor import MatrixEditor
 from hexrd.ui.ui_loader import UiLoader
-from hexrd.ui.utils import compose
+from hexrd.ui.utils import apply_symmetric_constraint, compose
 
 
 class MaterialPropertiesEditor:
@@ -132,12 +132,3 @@ class MaterialPropertiesEditor:
             self.ui.volume,
             self.ui.volume_per_atom,
         ]
-
-
-def apply_symmetric_constraint(x):
-    # Copy values from upper triangle to lower triangle.
-    # Only works for square matrices.
-    for i in range(x.shape[0]):
-        for j in range(i):
-            x[i, j] = x[j, i]
-    return x

--- a/hexrd/ui/material_site_editor.py
+++ b/hexrd/ui/material_site_editor.py
@@ -61,6 +61,7 @@ class MaterialSiteEditor(QObject):
         self.ui.table.selectionModel().selectionChanged.connect(
             self.selection_changed)
         self.ui.remove_atom_type.pressed.connect(self.remove_selected_atom)
+        self.ui.convert_u_to_tensors.pressed.connect(self.convert_u_to_tensors)
 
     def select_atom_types(self):
         dialog = PeriodicTableDialog(self.atom_types, self.ui)
@@ -336,6 +337,16 @@ class MaterialSiteEditor(QObject):
     @property
     def site_settings_widgets(self):
         return self.fractional_coords_widgets
+
+    def convert_u_to_tensors(self):
+        for spinbox in self.thermal_factor_spinboxes:
+            if isinstance(spinbox.value(), np.ndarray):
+                # Already a tensor
+                continue
+
+            tensor = np.zeros(6, dtype=np.float64)
+            tensor[:3] = spinbox.value()
+            spinbox.setValue(tensor)
 
 
 class ThermalFactorSpinBox(ScientificDoubleSpinBox):

--- a/hexrd/ui/material_site_editor.py
+++ b/hexrd/ui/material_site_editor.py
@@ -2,7 +2,7 @@ import copy
 
 import numpy as np
 
-from PySide2.QtCore import QItemSelectionModel, QObject, QSignalBlocker, Signal
+from PySide2.QtCore import QItemSelectionModel, QObject, Signal
 from PySide2.QtWidgets import QLineEdit, QSizePolicy, QTableWidgetItem
 
 from hexrd.material import Material
@@ -11,6 +11,7 @@ from hexrd.ui.periodic_table_dialog import PeriodicTableDialog
 from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
 from hexrd.ui.thermal_factor_editor import ThermalFactorEditor
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 COLUMNS = {
@@ -53,15 +54,13 @@ class MaterialSiteEditor(QObject):
     def setup_connections(self):
         self.ui.select_atom_types.pressed.connect(self.select_atom_types)
         self.ui.thermal_factor_type.currentIndexChanged.connect(
-            self.update_thermal_factor_header)
-        self.ui.thermal_factor_type.currentIndexChanged.connect(
-            self.update_gui)
+            self.thermal_factor_type_changed)
         for w in self.site_settings_widgets:
             w.valueChanged.connect(self.update_config)
         self.ui.table.selectionModel().selectionChanged.connect(
             self.selection_changed)
         self.ui.remove_atom_type.pressed.connect(self.remove_selected_atom)
-        self.ui.convert_u_to_tensors.pressed.connect(self.convert_u_to_tensors)
+        self.ui.convert_u_to_tensors.toggled.connect(self.convert_u_to_tensors)
 
     def select_atom_types(self):
         dialog = PeriodicTableDialog(self.atom_types, self.ui)
@@ -231,14 +230,20 @@ class MaterialSiteEditor(QObject):
         self.ui.table.clearContents()
 
     def update_gui(self):
-        widgets = self.site_settings_widgets
-        blockers = [QSignalBlocker(w) for w in widgets]  # noqa: F841
+        with block_signals(*self.site_settings_widgets):
+            for i, w in enumerate(self.fractional_coords_widgets):
+                w.setValue(self.fractional_coords[i])
 
-        for i, w in enumerate(self.fractional_coords_widgets):
-            w.setValue(self.fractional_coords[i])
+            self.update_total_occupancy()
+            self.update_table()
+            self.reset_scalar_tensor_toggle()
 
-        self.update_total_occupancy()
-        self.update_table()
+    def reset_scalar_tensor_toggle(self):
+        any_scalars = any(not isinstance(w.value(), np.ndarray)
+                          for w in self.thermal_factor_spinboxes)
+
+        with block_signals(self.ui.convert_u_to_tensors):
+            self.ui.convert_u_to_tensors.setChecked(not any_scalars)
 
     def update_table(self):
         prev_selected = self.selected_row
@@ -247,30 +252,38 @@ class MaterialSiteEditor(QObject):
             self.ui.table,
             self.ui.table.selectionModel()
         ]
-        blockers = [QSignalBlocker(x) for x in block_list]  # noqa: F841
+        with block_signals(*block_list):
+            atoms = self.site['atoms']
+            self.clear_table()
+            self.ui.table.setRowCount(len(atoms))
+            for i, atom in enumerate(atoms):
+                w = self.create_symbol_label(atom['symbol'])
+                self.ui.table.setItem(i, COLUMNS['symbol'], w)
 
-        atoms = self.site['atoms']
-        self.clear_table()
-        self.ui.table.setRowCount(len(atoms))
-        for i, atom in enumerate(atoms):
-            w = self.create_symbol_label(atom['symbol'])
-            self.ui.table.setItem(i, COLUMNS['symbol'], w)
+                w = self.create_occupancy_spinbox(atom['occupancy'])
+                self.ui.table.setCellWidget(i, COLUMNS['occupancy'], w)
 
-            w = self.create_occupancy_spinbox(atom['occupancy'])
-            self.ui.table.setCellWidget(i, COLUMNS['occupancy'], w)
+                v = self.thermal_factor(atom)
+                w = self.create_thermal_factor_spinbox(v)
+                self.ui.table.setCellWidget(i, COLUMNS['thermal_factor'], w)
 
-            w = self.create_thermal_factor_spinbox(self.thermal_factor(atom))
-            self.ui.table.setCellWidget(i, COLUMNS['thermal_factor'], w)
+            self.update_occupancy_validity()
 
-        self.update_occupancy_validity()
+            if prev_selected is not None:
+                select_row = (prev_selected if prev_selected < self.num_rows
+                              else self.num_rows - 1)
+                self.select_row(select_row)
 
-        if prev_selected is not None:
-            select_row = (prev_selected if prev_selected < self.num_rows
-                          else self.num_rows - 1)
-            self.select_row(select_row)
+            # Just in case the selection actually changed...
+            self.selection_changed()
 
-        # Just in case the selection actually changed...
-        self.selection_changed()
+    def thermal_factor_type_changed(self):
+        self.update_thermal_factor_header()
+        self.update_table()
+
+        # Update the text for the tensor toggle as well
+        text = f'Convert {self.thermal_factor_type} to tensors'
+        self.ui.convert_u_to_tensors.setText(text)
 
     def update_thermal_factor_header(self):
         w = self.ui.table.horizontalHeaderItem(COLUMNS['thermal_factor'])
@@ -338,15 +351,37 @@ class MaterialSiteEditor(QObject):
     def site_settings_widgets(self):
         return self.fractional_coords_widgets
 
-    def convert_u_to_tensors(self):
-        for spinbox in self.thermal_factor_spinboxes:
+    def convert_u_to_tensors(self, b):
+
+        def scalar_to_tensor(spinbox):
             if isinstance(spinbox.value(), np.ndarray):
                 # Already a tensor
-                continue
+                return
 
             tensor = np.zeros(6, dtype=np.float64)
             tensor[:3] = spinbox.value()
             spinbox.setValue(tensor)
+
+        def tensor_to_scalar(spinbox):
+            value = spinbox.value()
+            if not isinstance(value, np.ndarray):
+                # Already a scalar
+                return
+
+            # Use the previous spinbox value if available
+            scalar = spinbox.editor.ui.scalar_value.value()
+            if (np.isclose(scalar, 0) and np.allclose(value[:3], value[0]) and
+                    np.allclose(value[3:], 0)):
+                # If the previous value is zero, and the tensor is diagonal,
+                # use the diagonal value
+                scalar = value[0]
+
+            spinbox.setValue(scalar)
+
+        f = scalar_to_tensor if b else tensor_to_scalar
+
+        for spinbox in self.thermal_factor_spinboxes:
+            f(spinbox)
 
 
 class ThermalFactorSpinBox(ScientificDoubleSpinBox):

--- a/hexrd/ui/resources/ui/material_site_editor.ui
+++ b/hexrd/ui/resources/ui/material_site_editor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>562</width>
+    <width>752</width>
     <height>502</height>
    </rect>
   </property>
@@ -198,6 +198,13 @@
         </item>
        </widget>
       </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QPushButton" name="convert_u_to_tensors">
+        <property name="text">
+         <string>Convert to Tensors</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -216,6 +223,7 @@
   <tabstop>coords_y</tabstop>
   <tabstop>coords_z</tabstop>
   <tabstop>thermal_factor_type</tabstop>
+  <tabstop>convert_u_to_tensors</tabstop>
   <tabstop>table</tabstop>
   <tabstop>select_atom_types</tabstop>
   <tabstop>remove_atom_type</tabstop>

--- a/hexrd/ui/resources/ui/material_site_editor.ui
+++ b/hexrd/ui/resources/ui/material_site_editor.ui
@@ -106,8 +106,55 @@
         </property>
        </widget>
       </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="thermal_factor_type">
+        <item>
+         <property name="text">
+          <string>U</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>B</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="total_occupancy_label">
+        <property name="text">
+         <string>Total Occupancy:</string>
+        </property>
+       </widget>
+      </item>
       <item row="1" column="1">
        <widget class="ScientificDoubleSpinBox" name="coords_x">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="fractional_coordinates_label">
+        <property name="text">
+         <string>Fractional Coords:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="ScientificDoubleSpinBox" name="coords_y">
         <property name="keyboardTracking">
          <bool>false</bool>
         </property>
@@ -132,25 +179,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
-       <widget class="ScientificDoubleSpinBox" name="coords_y">
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="minimum">
-         <double>-10000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>10000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="3">
        <widget class="ScientificDoubleSpinBox" name="coords_z">
         <property name="keyboardTracking">
@@ -170,38 +198,13 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="total_occupancy_label">
-        <property name="text">
-         <string>Total Occupancy:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="fractional_coordinates_label">
-        <property name="text">
-         <string>Fractional Coords:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QComboBox" name="thermal_factor_type">
-        <item>
-         <property name="text">
-          <string>U</string>
-         </property>
-        </item>
-        <item>
-         <property name="text">
-          <string>B</string>
-         </property>
-        </item>
-       </widget>
-      </item>
       <item row="2" column="2" colspan="2">
-       <widget class="QPushButton" name="convert_u_to_tensors">
+       <widget class="QCheckBox" name="convert_u_to_tensors">
+        <property name="toolTip">
+         <string>When toggled, this will convert all thermal factor values to tensors if checked, or scalars if unchecked.</string>
+        </property>
         <property name="text">
-         <string>Convert to Tensors</string>
+         <string>Convert U to tensors</string>
         </property>
        </widget>
       </item>

--- a/hexrd/ui/resources/ui/thermal_factor_editor.ui
+++ b/hexrd/ui/resources/ui/thermal_factor_editor.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>thermal_factor_editor</class>
+ <widget class="QDialog" name="thermal_factor_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>276</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Thermal Factor</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QCheckBox" name="is_tensor">
+     <property name="text">
+      <string>Tensor</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="scalar_tab">
+      <attribute name="title">
+       <string>Scalar</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="ScientificDoubleSpinBox" name="scalar_value">
+         <property name="decimals">
+          <number>8</number>
+         </property>
+         <property name="minimum">
+          <double>-1000000.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tensor_tab">
+      <attribute name="title">
+       <string>Tensor</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="tensor_editor_layout"/>
+       </item>
+       <item row="1" column="0">
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>is_tensor</tabstop>
+  <tabstop>tab_widget</tabstop>
+  <tabstop>scalar_value</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>thermal_factor_editor</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>565</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>273</x>
+     <y>295</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>thermal_factor_editor</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>565</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>273</x>
+     <y>295</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/thermal_factor_editor.py
+++ b/hexrd/ui/thermal_factor_editor.py
@@ -1,0 +1,90 @@
+import numpy as np
+
+from hexrd.ui.matrix_editor import MatrixEditor
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import apply_symmetric_constraint
+
+
+class ThermalFactorEditor:
+    def __init__(self, value, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('thermal_factor_editor.ui', parent)
+
+        self.ui.tab_widget.tabBar().hide()
+
+        self.tensor_editor = MatrixEditor(np.zeros((3, 3)), parent)
+        self.tensor_editor.enabled_elements = list(zip(*np.triu_indices(3)))
+        self.tensor_editor.apply_constraints_func = apply_symmetric_constraint
+        self.ui.tensor_editor_layout.addWidget(self.tensor_editor)
+
+        self.value = value
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.is_tensor.toggled.connect(self.update_tab_widget)
+
+    def update_tab_widget(self):
+        prefix = 'tensor' if self.is_tensor else 'scalar'
+        tab = getattr(self.ui, f'{prefix}_tab')
+        self.ui.tab_widget.setCurrentWidget(tab)
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    @property
+    def value(self):
+        if self.is_tensor:
+            return compress_symmetric_tensor(self.tensor_editor.data)
+        else:
+            return self.ui.scalar_value.value()
+
+    @value.setter
+    def value(self, v):
+        if isinstance(v, (int, float)):
+            self.is_tensor = False
+            self.ui.scalar_value.setValue(v)
+        elif isinstance(v, np.ndarray):
+            if v.shape != (6, ):
+                raise Exception(f'Invalid shape: {v.shape}')
+            self.is_tensor = True
+            self.tensor_editor.data = expand_symmetric_tensor(v)
+        else:
+            raise Exception(f'Unrecognized type: {type(v)}')
+
+    @property
+    def is_tensor(self):
+        return self.ui.is_tensor.isChecked()
+
+    @is_tensor.setter
+    def is_tensor(self, v):
+        self.ui.is_tensor.setChecked(v)
+
+
+thermal_factor_tensor_mapping = {
+    0: (0, 0),
+    1: (1, 1),
+    2: (2, 2),
+    3: (0, 1),
+    4: (0, 2),
+    5: (1, 2),
+}
+
+
+def expand_symmetric_tensor(x):
+    ret = np.zeros((3, 3), dtype=np.float64)
+
+    for k, v in thermal_factor_tensor_mapping.items():
+        ret[v] = x[k]
+
+    apply_symmetric_constraint(ret)
+    return ret
+
+
+def compress_symmetric_tensor(x):
+    ret = np.zeros(6, dtype=np.float64)
+
+    for k, v in thermal_factor_tensor_mapping.items():
+        ret[k] = x[v]
+
+    return ret

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -389,3 +389,12 @@ def format_memory_int(x, decimals=2):
             return f'{round(x / divisor, decimals)} {label}'
 
     return f'{x} B'
+
+
+def apply_symmetric_constraint(x):
+    # Copy values from upper triangle to lower triangle.
+    # Only works for square matrices.
+    for i in range(x.shape[0]):
+        for j in range(i):
+            x[i, j] = x[j, i]
+    return x


### PR DESCRIPTION
This allows the thermal factor (U/B) to be either a tensor or a scalar.

As a scalar, the user can modify U in its spinbox as normal. If the
user wishes to convert it to a tensor, they must double-click the
spinbox, and then the thermal factor editor will appear, allowing
them to convert it into a tensor.

If U is a tensor, the spinbox text will just display "Tensor", and
the user must click on it in order to bring up the thermal factor
editor, in order to edit it.

This was tested via round-tripping (creating a tensor U, writing
it out to a materials file, resetting the application, and then
loading the materials file again, to ensure that the tensor U
was saved and loaded properly).

https://user-images.githubusercontent.com/9558430/124174052-7c823600-da71-11eb-920e-9e49100da719.mp4

Fixes: #513