### PR TITLE
Add a column for hkl ids in the reflections table

### DIFF
--- a/hexrd/ui/resources/ui/reflections_table.ui
+++ b/hexrd/ui/resources/ui/reflections_table.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>545</width>
-    <height>173</height>
+    <width>600</width>
+    <height>210</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -53,7 +53,7 @@
       <number>5</number>
      </property>
      <property name="columnCount">
-      <number>5</number>
+      <number>6</number>
      </property>
      <attribute name="horizontalHeaderCascadingSectionResizes">
       <bool>true</bool>
@@ -67,11 +67,19 @@
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
      </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
      <row/>
      <row/>
      <row/>
      <row/>
      <row/>
+     <column>
+      <property name="text">
+       <string>ID</string>
+      </property>
+     </column>
      <column>
       <property name="text">
        <string>{hkl}</string>


### PR DESCRIPTION
This also removes the vertical header (which displayed indices)
since that does not seem necessary with the hkl ids.

This also resizes the reflections table a little bit.

This also gets the columns to automatically resize based upon
the contents of the table.

![image](https://user-images.githubusercontent.com/9558430/124985003-85d64a00-dfff-11eb-917d-d7f063aff81d.png)