### PR TITLE
Import tool

### DIFF
--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -146,6 +146,9 @@ class ImageStackDialog(QObject):
         self.state[det]['search'] = self.ui.search_text.text()
         if not (search := self.ui.search_text.text()):
             search = '*'
+        if self.detector in search:
+            pattern = search.split(self.detector)
+            search = f'{pattern[0]}{det}{pattern[1]}'
         if directory := self.state[det]['directory']:
             if files := list(Path(directory).glob(search)):
                 files = [f for f in files if f.is_file()]
@@ -272,17 +275,17 @@ class ImageStackDialog(QObject):
 
     def search_directories(self):
         pattern = self.ui.detector_search.text()
-        for det in self.detectors:
-            p = f'{pattern}/{det}' if Path(pattern).is_dir() else f'{pattern}_{det}'
-            if Path(p).exists():
-                p = f'{pattern}/{det}'
+        if Path(pattern).is_dir():
+            p = pattern
+            for det in self.detectors:
+                if Path(f'{pattern}/{det}').exists():
+                    p = f'{pattern}/{det}'
                 self.state[det]['directory'] = p
                 if det == self.ui.detectors.currentText():
                     self.ui.current_directory.setText(p)
-            else:
-                msg = (f'Could not find the directory for {det}:\n{p}')
-                QMessageBox.warning(self.ui, 'HEXRD', msg)
-                break
+        else:
+            msg = (f'Could not find directory:\n{p}')
+            QMessageBox.warning(self.ui, 'HEXRD', msg)
 
     def get_files(self):
         imgs = []

--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -53,6 +53,7 @@ class ImageStackDialog(QObject):
         self.ui.clear_file_selections.clicked.connect(
             self.clear_selected_files)
         self.clear_images.connect(self.load_panel.clear_from_stack_dialog)
+        self.ui.add_omega.toggled.connect(self.add_omega_toggled)
 
     def setup_gui(self):
         self.ui.current_directory.setText(
@@ -73,6 +74,7 @@ class ImageStackDialog(QObject):
         self.ui.file_count.setText(str(file_count))
         self.ui.apply_to_all.setChecked(self.state['apply_to_all'])
         self.ui.all_detectors.setChecked(self.state['all_detectors'])
+        self.ui.add_omega.setChecked(self.state['add_omega_data'])
         self.ui.total_frames.setText(
             str(self.state['total_frames'] * file_count))
         self.set_ranges(
@@ -88,7 +90,7 @@ class ImageStackDialog(QObject):
             self.state.clear()
         if self.state:
             self.find_previous_images(self.state[self.detector]['files'])
-            self.load_omega_from_file(self.state['omega_from_file'])
+            self.add_omega_toggled(self.state.get('add_omega_data', True))
             self.file_selection_changed(self.state['manual_file'])
             self.detector_selection(self.state['all_detectors'])
         else:
@@ -104,7 +106,8 @@ class ImageStackDialog(QObject):
                 'total_frames': 1,
                 'manual_file': True,
                 'apply_to_all': True,
-                'wedges': []
+                'wedges': [],
+                'add_omega_data': True
             }
             for det in self.detectors:
                 self.state[det] = {
@@ -295,27 +298,43 @@ class ImageStackDialog(QObject):
         self.ui.file_count.setText('0')
         self.clear_images.emit()
 
+    def add_omega_toggled(self, checked):
+        self.state['add_omega_data'] = checked
+        self.ui.omega_from_file.setEnabled(checked)
+        if checked:
+            self.load_omega_from_file(self.ui.omega_from_file.isChecked())
+        else:
+            self.ui.omega_wedges.setEnabled(checked)
+            self.ui.add_wedge.setEnabled(checked)
+            self.ui.clear_wedges.setEnabled(checked)
+            self.ui.load_omega_file.setEnabled(checked)
+            self.ui.omega_file.setEnabled(checked)
+
+
     def get_omega_values(self, num_files):
         if self.state['omega_from_file'] and self.state['omega']:
             omega = np.load(self.state['omega'])
-        elif not self.state['omega_from_file']:
+        else:
             omega = []
             nframes = int(self.ui.total_frames.text()) // num_files
-            nsteps = [w[2] for w in self.state['wedges']]
-            if len(nsteps) != num_files:
-                nsteps = [sum(nsteps) / num_files] * num_files
-            row_count = self.ui.omega_wedges.rowCount()
-            length = num_files if row_count == 1 else 1
-            for i in range(row_count):
-                start = float(self.ui.omega_wedges.item(i, 0).text())
-                stop = float(self.ui.omega_wedges.item(i, 1).text())
-                steps = int(float(self.ui.omega_wedges.item(i, 2).text()))
-                delta = (stop - start) / length
-                omega.extend(np.linspace(
-                    [start, start + delta],
-                    [stop - delta, stop],
-                    length))
-            omega = np.array(omega)
+            if self.state["wedges"]:
+                nsteps = [w[2] for w in self.state['wedges']]
+                if len(nsteps) != num_files:
+                    nsteps = [sum(nsteps) / num_files] * num_files
+                row_count = self.ui.omega_wedges.rowCount()
+                length = num_files if row_count == 1 else 1
+                for i in range(row_count):
+                    start = float(self.ui.omega_wedges.item(i, 0).text())
+                    stop = float(self.ui.omega_wedges.item(i, 1).text())
+                    steps = int(float(self.ui.omega_wedges.item(i, 2).text()))
+                    delta = (stop - start) / length
+                    omega.extend(np.linspace(
+                        [start, start + delta],
+                        [stop - delta, stop],
+                        length))
+                omega = np.array(omega)
+            else:
+                nsteps = [nframes] * num_files
         if not len(omega):
             delta = MAXIMUM_OMEGA_RANGE / num_files
             omega = np.linspace(
@@ -347,7 +366,7 @@ class ImageStackDialog(QObject):
 
     def check_steps(self):
         if self.ui.omega_from_file.isChecked():
-            return
+            return (-1, -1) if self.state['omega'] else (0, 0)
         steps = 0
         for i in range(self.ui.omega_wedges.rowCount()):
             for j in range(self.ui.omega_wedges.columnCount()):
@@ -362,7 +381,7 @@ class ImageStackDialog(QObject):
         if self.ui.max_file_frames.value() != 0:
             total_frames = min(
                 total_frames, self.ui.max_file_frames.value() * file_count)
-        return (steps, total_frames) if total_frames != steps else (0, 0)
+        return (steps, total_frames) if total_frames != steps else (-1, -1)
 
     def exec_(self):
         while True:
@@ -393,7 +412,7 @@ class ImageStackDialog(QObject):
                     error = True
                     continue
                 steps, total_frames = self.check_steps()
-                if steps != 0:
+                if steps >= 0 and self.state['add_omega_data']:
                     if steps > 0:
                         msg = (
                             f'The total number of steps must be equal to the '

--- a/hexrd/ui/image_stack_dialog.py
+++ b/hexrd/ui/image_stack_dialog.py
@@ -301,7 +301,9 @@ class ImageStackDialog(QObject):
         elif not self.state['omega_from_file']:
             omega = []
             nframes = int(self.ui.total_frames.text()) // num_files
-            nsteps = [w[2] for w in self.state['wedges']] * num_files
+            nsteps = [w[2] for w in self.state['wedges']]
+            if len(nsteps) != num_files:
+                nsteps = [sum(nsteps) / num_files] * num_files
             row_count = self.ui.omega_wedges.rowCount()
             length = num_files if row_count == 1 else 1
             for i in range(row_count):

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -431,8 +431,7 @@ class LoadPanel(QObject):
             self.ui.file_options.item(i, 2).setText(str(self.total_frames[i]))
             self.ui.file_options.item(i, 3).setText(str(self.omega_min[i]))
             self.ui.file_options.item(i, 4).setText(str(self.omega_max[i]))
-            self.ui.file_options.item(i, 5).setText(
-                str(self.total_frames[i] - self.empty_frames))
+            self.ui.file_options.item(i, 5).setText(str(self.nsteps[i]))
 
             # Set tooltips
             self.ui.file_options.item(i, 0).setToolTip(Path(curr).name)

--- a/hexrd/ui/resources/ui/image_stack_dialog.ui
+++ b/hexrd/ui/resources/ui/image_stack_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>476</width>
-    <height>607</height>
+    <height>636</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -226,7 +226,7 @@
       <string>Omega</string>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0" colspan="2">
+      <item row="1" column="0" colspan="2">
        <widget class="QCheckBox" name="omega_from_file">
         <property name="text">
          <string>Load from File</string>
@@ -236,7 +236,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="5">
+      <item row="3" column="5">
        <widget class="QPushButton" name="add_wedge">
         <property name="enabled">
          <bool>false</bool>
@@ -246,14 +246,14 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
+      <item row="1" column="2">
        <widget class="QPushButton" name="load_omega_file">
         <property name="text">
          <string>Select File</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="3" colspan="3">
+      <item row="1" column="3" colspan="3">
        <widget class="QLineEdit" name="omega_file">
         <property name="text">
          <string>(No File Selected)</string>
@@ -263,7 +263,30 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="6">
+      <item row="3" column="0">
+       <widget class="QPushButton" name="clear_wedges">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="add_omega">
+        <property name="text">
+         <string>Add Omega Data</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">omega_options</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="6">
        <widget class="QTableWidget" name="omega_wedges">
         <property name="enabled">
          <bool>false</bool>
@@ -309,14 +332,14 @@
         </column>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QPushButton" name="clear_wedges">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+      <item row="0" column="2">
+       <widget class="QRadioButton" name="no_omega">
         <property name="text">
-         <string>Clear</string>
+         <string>No Omega Data</string>
         </property>
+        <attribute name="buttonGroup">
+         <string notr="true">omega_options</string>
+        </attribute>
        </widget>
       </item>
      </layout>
@@ -467,11 +490,12 @@
   </connection>
  </connections>
  <buttongroups>
+  <buttongroup name="detector_options"/>
   <buttongroup name="file_options">
    <property name="exclusive">
     <bool>true</bool>
    </property>
   </buttongroup>
-  <buttongroup name="detector_options"/>
+  <buttongroup name="omega_options"/>
  </buttongroups>
 </ui>


### PR DESCRIPTION
Addresses the issues listed in #980 

@joelvbernier Previously it was assumed that all images would be in a separate directory for each detector. This has been updated now to instead check to see if the directory is a parent (and therefore contains a directory for each detector) and if that is not the case will instead assume that the same directory should be used for each detector.