### PR TITLE
Move "Subtract Minimum" to an intensity correction

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -456,6 +456,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 factor = panel.lorentz_polarization_factor(**kwargs)
                 images_dict[name] = img / factor
 
+        if HexrdConfig().intensity_subtract_minimum:
+            minimum = min([np.nanmin(x) for x in images_dict.values()])
+            for name, img in images_dict.items():
+                images_dict[name] = img - minimum
+
         return images_dict
 
     @property
@@ -1431,6 +1436,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.config['image']['apply_lorentz_polarization_correction'] = v
             self.deep_rerender_needed.emit()
 
+    def _intensity_subtract_minimum(self):
+        return self.config['image']['intensity_subtract_minimum']
+
+    def set_intensity_subtract_minimum(self, v):
+        if v != self.intensity_subtract_minimum:
+            self.config['image']['intensity_subtract_minimum'] = v
+            self.deep_rerender_needed.emit()
+
+    intensity_subtract_minimum = property(
+        _intensity_subtract_minimum,
+        set_intensity_subtract_minimum)
+
     @property
     def any_intensity_corrections(self):
         """Are we to perform any intensity corrections on the images?"""
@@ -1439,6 +1456,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         corrections = [
             'apply_pixel_solid_angle_correction',
             'apply_lorentz_polarization_correction',
+            'intensity_subtract_minimum',
         ]
 
         return any(getattr(self, x) for x in corrections)

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -271,11 +271,6 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
             self.update_progress_text('Aggregating dark images...')
             dark_images = self.aggregate_dark_multithread(dark_aggr_ops)
 
-        if 'zero-min' in self.state:
-            # Get the minimum over all the detectors
-            all_mins = [imageseries.stats.min(x) for x in ims_dict.values()]
-            global_min = min([x.min() for x in all_mins])
-
         # Apply the operations to the imageseries
         for idx, key in enumerate(ims_dict.keys()):
             ops = []
@@ -286,8 +281,6 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
                 self.get_flip_op(ops, idx)
             if 'rect' in self.state:
                 ops.append(('rectangle', self.state['rect'][idx]))
-            if 'zero-min' in self.state:
-                ops.append(('add', -global_min))
 
             frames = self.get_range(ims_dict[key])
             ims_dict[key] = imageseries.process.ProcessedImageSeries(

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -132,6 +132,8 @@ class MainWindow(QObject):
             HexrdConfig().apply_pixel_solid_angle_correction)
         self.ui.action_apply_lorentz_polarization_correction.setChecked(
             HexrdConfig().apply_lorentz_polarization_correction)
+        self.ui.action_subtract_minimum.setChecked(
+            HexrdConfig().intensity_subtract_minimum)
 
         self.ui.action_show_live_updates.setChecked(HexrdConfig().live_update)
         self.live_update(HexrdConfig().live_update)
@@ -261,6 +263,8 @@ class MainWindow(QObject):
             HexrdConfig().set_apply_pixel_solid_angle_correction)
         self.ui.action_apply_lorentz_polarization_correction.toggled.connect(
             self.apply_lorentz_polarization_correction_toggled)
+        self.ui.action_subtract_minimum.toggled.connect(
+            HexrdConfig().set_intensity_subtract_minimum)
 
         self.import_data_widget.enforce_raw_mode.connect(
             self.enforce_view_mode)

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -22,3 +22,4 @@ apply_lorentz_polarization_correction: false
 lorentz_polarization:
   f_hor: 1.0
   f_vert: 0.0
+intensity_subtract_minimum: false

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -121,6 +121,7 @@
      </property>
      <addaction name="action_apply_pixel_solid_angle_correction"/>
      <addaction name="action_apply_lorentz_polarization_correction"/>
+     <addaction name="action_subtract_minimum"/>
     </widget>
     <addaction name="menu_intensity_corrections"/>
     <addaction name="action_edit_euler_angle_convention"/>
@@ -204,7 +205,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>620</height>
+          <height>574</height>
          </rect>
         </property>
         <attribute name="label">
@@ -217,7 +218,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>620</height>
+          <height>574</height>
          </rect>
         </property>
         <attribute name="label">
@@ -230,7 +231,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>620</height>
+          <height>574</height>
          </rect>
         </property>
         <attribute name="label">
@@ -592,6 +593,14 @@
    </property>
    <property name="text">
     <string>Apply Lorentz Polarization Correction</string>
+   </property>
+  </action>
+  <action name="action_subtract_minimum">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Subtract Minimum</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/transforms_dialog.ui
+++ b/hexrd/ui/resources/ui/transforms_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>410</width>
-    <height>140</height>
+    <width>489</width>
+    <height>160</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -99,16 +99,6 @@
     </layout>
    </item>
    <item>
-    <widget class="QCheckBox" name="subtract_minimum">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Subtract the minimum value of all the data from each of the detectors.&lt;/p&gt;&lt;p&gt;This can be used to get rid of negative values, for instance.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Subtract minimum</string>
-     </property>
-    </widget>
-   </item>
-   <item>
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <spacer name="horizontalSpacer_2">
@@ -141,7 +131,6 @@
   <tabstop>update_all</tabstop>
   <tabstop>update_each</tabstop>
   <tabstop>transform_all_menu</tabstop>
-  <tabstop>subtract_minimum</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -72,9 +72,5 @@ class TransformDialog:
             'agg': state.get('agg', 0),
         }
 
-        if self.ui.subtract_minimum.isChecked():
-            new_state['zero-min'] = None
-            state['zero-min'] = None
-
         ilm.set_state(new_state)
         ilm.begin_processing(postprocess=True)


### PR DESCRIPTION
This removes the "Subtract Minimum" option from the transform dialog,
and moves it into the "Edit"->"Intensity Corrections" menu.

This means that the internal re-workings of "Subtract Minimum" have
changed as well. It used to be an operation in a `ProcessedImageSeries`,
but now it is only applied to the image the user is currently viewing,
just like the other intensity corrections do.

We may want to consider changing the intensity corrections to also use
operations in `ProcessedImageSeries` so the intensity corrections will
be applied to the whole image series if it gets passed around. Currently,
if the whole image series gets passed somewhere (like the HEDM workflow),
none of the intensity corrections will be applied.

These re-workings have also fixed #979, since "Subtract Minimum" is now
using the intensity correction framework, rather than its own framework.

Fixes: #979