### PR TITLE
Masking performance improvements

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -35,12 +35,18 @@ class InstrumentViewer:
     def angular_grid(self):
         return self.pv.angular_grid
 
+    @property
+    def img(self):
+        return self.pv.img
+
     def update_angular_grid(self):
         self.pv.update_angular_grid()
 
     def update_image(self):
         self.pv.generate_image()
-        self.img = self.pv.img
+
+    def reapply_masks(self):
+        self.pv.reapply_masks()
 
     def draw_polar(self):
         """show polar view of rings"""
@@ -53,7 +59,6 @@ class InstrumentViewer:
         eta_max = HexrdConfig().polar_res_eta_max
 
         self._extent = [tth_min, tth_max, eta_max, eta_min]   # l, r, b, t
-        self.img = self.pv.img
         self.snip1d_background = self.pv.snip1d_background
 
     def update_overlay_data(self):
@@ -61,7 +66,6 @@ class InstrumentViewer:
 
     def update_detector(self, det):
         self.pv.update_detector(det)
-        self.img = self.pv.img
 
     def write_image(self, filename='polar_image.npz'):
         azimuthal_integration = HexrdConfig().last_azimuthal_integral_data

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -869,7 +869,16 @@ class ImageCanvas(FigureCanvas):
         else:
             # We have to run it ourselves...
             # It should not have already been applied to the image
-            background = utils.run_snip1d(self.iviewer.img)
+            # Apply the same pre-processing to the raw data...
+            pv = self.iviewer.pv
+            img = pv.raw_img.data
+            img = pv.apply_rescale(img)
+
+            no_nan_methods = [utils.SnipAlgorithmType.Fast_SNIP_1D]
+            if HexrdConfig().polar_snip1d_algorithm not in no_nan_methods:
+                img[pv.raw_img.mask] = np.nan
+
+            background = utils.run_snip1d(img)
 
         im = ax.imshow(background)
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -73,7 +73,7 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().rerender_auto_picked_data.connect(
             self.draw_auto_picked_data)
         HexrdConfig().beam_vector_changed.connect(self.beam_vector_changed)
-        HexrdConfig().polar_masks_changed.connect(self.update_polar)
+        HexrdConfig().polar_masks_changed.connect(self.polar_masks_changed)
 
     def __del__(self):
         # This is so that the figure can be cleaned up
@@ -647,14 +647,15 @@ class ImageCanvas(FigureCanvas):
         msg = 'Polar view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
 
-    def update_polar(self):
-        if not self.iviewer:
+    def polar_masks_changed(self):
+        if not self.iviewer or self.mode != ViewType.polar:
             return
 
-        self.iviewer.update_image()
+        self.iviewer.reapply_masks()
         self.axes_images[0].set_data(self.iviewer.img)
         self.update_azimuthal_integral_plot()
         self.update_overlays()
+        self.draw_idle()
 
     def async_worker_error(self, error):
         QMessageBox.critical(self, 'HEXRD', str(error[1]))

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -185,7 +185,6 @@ class MaskRegionsDialog(QObject):
             HexrdConfig().raw_masks_line_data[name] = [data]
             create_raw_mask(name, [data])
             HexrdConfig().visible_masks.append(name)
-            HexrdConfig().raw_masks_changed.emit()
 
         for data_coords in self.polar_masks_line_data:
             name = create_unique_name(
@@ -193,6 +192,11 @@ class MaskRegionsDialog(QObject):
             HexrdConfig().polar_masks_line_data[name] = data_coords
             create_polar_mask([data_coords], name)
             HexrdConfig().visible_masks.append(name)
+
+        if self.raw_masks_line_data:
+            HexrdConfig().raw_masks_changed.emit()
+
+        if self.polar_masks_line_data:
             HexrdConfig().polar_masks_changed.emit()
 
     def button_released(self, event):

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -217,17 +217,22 @@ class MaskRegionsDialog(QObject):
             HexrdConfig().polar_masks_changed.emit()
 
     def button_released(self, event):
-        if not self.axes or not self.press:
+        if not self.press:
             return
 
-        self.end = [event.xdata, event.ydata]
-        self.save_line_data()
+        if self.axes:
+            # Save it
+            self.end = [event.xdata, event.ydata]
+            self.save_line_data()
+            self.end.clear()
 
-        # Turn off animation so the patch will stay
-        self.patch.set_animated(False)
+            # Turn off animation so the patch will stay
+            self.patch.set_animated(False)
+        else:
+            det = self.added_patches.pop()
+            self.patches[det].pop()
 
         self.press.clear()
-        self.end.clear()
         self.det = None
         self.canvas.draw_idle()
 

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -70,6 +70,10 @@ class MaskRegionsDialog(QObject):
         self.ui.undo.clicked.connect(self.undo_selection)
         HexrdConfig().tab_images_changed.connect(self.tabbed_view_changed)
 
+    def update_undo_enable_state(self):
+        enabled = bool(self.added_patches)
+        self.ui.undo.setEnabled(enabled)
+
     def select_shape(self):
         self.selection = self.ui.shape.currentText()
         self.patch = None
@@ -144,6 +148,8 @@ class MaskRegionsDialog(QObject):
                 if a.get_title() == det:
                     a.patches.remove(last_patch)
         self.canvas.draw_idle()
+
+        self.update_undo_enable_state()
 
     def axes_entered(self, event):
         self.axes = event.inaxes
@@ -224,6 +230,8 @@ class MaskRegionsDialog(QObject):
         self.end.clear()
         self.det = None
         self.canvas.draw_idle()
+
+        self.update_undo_enable_state()
 
     def apply_masks(self):
         self.disconnect()

--- a/hexrd/ui/resources/ui/mask_regions_dialog.ui
+++ b/hexrd/ui/resources/ui/mask_regions_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>184</width>
-    <height>107</height>
+    <width>198</width>
+    <height>125</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -41,6 +41,9 @@
    </item>
    <item>
     <widget class="QPushButton" name="undo">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
       <string>Undo Last Selection</string>
      </property>


### PR DESCRIPTION
This adds several improvements to masking, primarily performance improvements.

Applying polar masks, and toggling their visibility, is now much faster, since the snipped image is cached and only the masking now changes:

https://user-images.githubusercontent.com/9558430/126709433-954befb3-97bb-48dd-8563-0e55ab7ac6df.mp4



Drawing masks via rectangles and ellipses is now animated via matplotlib's animation and blit features, and is much faster as well:

https://user-images.githubusercontent.com/9558430/126709481-9e19a4fd-8a03-4919-9995-f9e9500f038b.mp4

Fixes: #986
Also fixes the first item in #750