### PR TITLE
Add polar binary erosion to remove edge artifacts

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -1,6 +1,8 @@
 import numpy as np
 
 from skimage.exposure import rescale_intensity
+from skimage.filters.edges import binary_erosion
+from skimage.morphology import disk
 
 from hexrd.transforms.xfcapi import detectorXYToGvec, mapAngle
 
@@ -8,7 +10,7 @@ from hexrd import constants as ct
 from hexrd.xrdutil import _project_on_detector_plane
 
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.utils import SnipAlgorithmType, run_snip1d
+from hexrd.ui.utils import SnipAlgorithmType, run_snip1d, snip_width_pixels
 
 tvec_c = ct.zeros_3
 
@@ -286,6 +288,12 @@ class PolarView:
             self.snip1d_background = run_snip1d(img)
             # Perform the background subtraction
             img -= self.snip1d_background
+
+            if HexrdConfig().polar_apply_erosion:
+                mask = binary_erosion(
+                    ~self.raw_img.mask, structure=disk(2 * snip_width_pixels())
+                )
+                img[~mask] = 0
         else:
             self.snip1d_background = None
 

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from skimage.exposure import rescale_intensity
 from skimage.filters.edges import binary_erosion
-from skimage.morphology import disk
+from skimage.morphology import rectangle
 
 from hexrd.transforms.xfcapi import detectorXYToGvec, mapAngle
 
@@ -290,9 +290,12 @@ class PolarView:
             img -= self.snip1d_background
 
             if HexrdConfig().polar_apply_erosion:
-                mask = binary_erosion(
-                    ~self.raw_img.mask, structure=disk(2 * snip_width_pixels())
+                niter = HexrdConfig().polar_snip1d_numiter
+                structure = rectangle(
+                    1,
+                    int(2.1 * niter * snip_width_pixels()),
                 )
+                mask = binary_erosion(~self.raw_img.mask, structure)
                 img[~mask] = 0
         else:
             self.snip1d_background = None

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1337,6 +1337,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     polar_apply_snip1d = property(_polar_apply_snip1d,
                                   set_polar_apply_snip1d)
 
+    def _polar_apply_erosion(self):
+        return self.config['image']['polar']['apply_erosion']
+
+    def set_polar_apply_erosion(self, v):
+        self.config['image']['polar']['apply_erosion'] = v
+        self.rerender_needed.emit()
+
+    polar_apply_erosion = property(_polar_apply_erosion,
+                                   set_polar_apply_erosion)
+
     def _polar_snip1d_algorithm(self):
         return self.config['image']['polar']['snip1d_algorithm']
 

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -80,6 +80,8 @@ class ImageModeWidget(QObject):
             HexrdConfig().set_polar_snip1d_width)
         self.ui.polar_snip1d_numiter.valueChanged.connect(
             HexrdConfig().set_polar_snip1d_numiter)
+        self.ui.polar_apply_erosion.toggled.connect(
+            HexrdConfig().set_polar_apply_erosion)
         HexrdConfig().instrument_config_loaded.connect(
             self.auto_generate_cartesian_params)
         HexrdConfig().instrument_config_loaded.connect(
@@ -122,7 +124,8 @@ class ImageModeWidget(QObject):
             self.ui.polar_snip1d_algorithm,
             self.ui.polar_snip1d_width,
             self.ui.polar_snip1d_numiter,
-            self.ui.polar_show_snip1d
+            self.ui.polar_show_snip1d,
+            self.ui.polar_apply_erosion,
         ]
 
         return widgets
@@ -163,6 +166,8 @@ class ImageModeWidget(QObject):
             HexrdConfig().polar_snip1d_width)
         self.ui.polar_snip1d_numiter.setValue(
             HexrdConfig().polar_snip1d_numiter)
+        self.ui.polar_apply_erosion.setChecked(
+            HexrdConfig().polar_apply_erosion)
 
         self.update_enable_states()
 
@@ -170,6 +175,7 @@ class ImageModeWidget(QObject):
         apply_snip1d = self.ui.polar_apply_snip1d.isChecked()
         self.ui.polar_snip1d_width.setEnabled(apply_snip1d)
         self.ui.polar_snip1d_numiter.setEnabled(apply_snip1d)
+        self.ui.polar_apply_erosion.setEnabled(apply_snip1d)
 
     def auto_generate_cartesian_params(self):
         # This will automatically generate and set values for the

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -9,6 +9,7 @@ polar:
   snip1d_algorithm: 0
   snip1d_width: 0.2
   snip1d_numiter: 2
+  apply_erosion: false
 cartesian:
   pixel_size: 0.5
   virtual_plane_distance: 1000.0

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>508</width>
-    <height>159</height>
+    <width>596</width>
+    <height>187</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
@@ -749,6 +749,19 @@
                 </property>
                </widget>
               </item>
+              <item row="4" column="7">
+               <widget class="QCheckBox" name="polar_apply_erosion">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Apply binary erosion to eliminate edge artifacts.</string>
+                </property>
+                <property name="text">
+                 <string>Apply erosion?</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>
@@ -786,14 +799,25 @@
   <tabstop>tab_widget</tabstop>
   <tabstop>raw_tabbed_view</tabstop>
   <tabstop>raw_show_saturation</tabstop>
+  <tabstop>raw_threshold_mask</tabstop>
+  <tabstop>raw_threshold_comparison</tabstop>
+  <tabstop>raw_threshold_value</tabstop>
   <tabstop>cartesian_pixel_size</tabstop>
-  <tabstop>cartesian_plane_normal_rotate_x</tabstop>
   <tabstop>cartesian_virtual_plane_distance</tabstop>
+  <tabstop>cartesian_plane_normal_rotate_x</tabstop>
   <tabstop>cartesian_plane_normal_rotate_y</tabstop>
   <tabstop>polar_pixel_size_tth</tabstop>
   <tabstop>polar_pixel_size_eta</tabstop>
   <tabstop>polar_res_tth_min</tabstop>
   <tabstop>polar_res_tth_max</tabstop>
+  <tabstop>polar_res_eta_min</tabstop>
+  <tabstop>polar_res_eta_max</tabstop>
+  <tabstop>polar_apply_snip1d</tabstop>
+  <tabstop>polar_snip1d_width</tabstop>
+  <tabstop>polar_snip1d_numiter</tabstop>
+  <tabstop>polar_snip1d_algorithm</tabstop>
+  <tabstop>polar_show_snip1d</tabstop>
+  <tabstop>polar_apply_erosion</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
This adds an "Apply erosion?" checkbox to the polar tab of the
image mode widget, which can only be checked if "Apply SNIP?" is
checked.

If checked, a binary erosion is applied to the panel buffer mask, and
it uses 2x the snip width for the structure. This sets edge artifacts
to zero.

Here is an example:

No erosion
=========
![no_erosion](https://user-images.githubusercontent.com/9558430/127042752-775848c1-d85b-4202-8d20-b82b4a6ab754.png)

With erosion
==========
![with_erosion](https://user-images.githubusercontent.com/9558430/127042765-602f9a32-8d06-49f5-a0fd-4d5bd743a657.png)

Fixes: #990