### PR TITLE
Save panel buffer for images loaded through import panel

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1644,8 +1644,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.rerender_auto_picked_data.emit()
 
     def boundary_position(self, instrument, detector):
-        return self.llnl_boundary_positions.get(
+        det_bounds = self.llnl_boundary_positions.get(
             instrument, {}).get(detector, None)
+        if not isinstance(det_bounds, dict):
+            return None
+        return det_bounds
 
     def set_boundary_position(self, instrument, detector, position):
         self.llnl_boundary_positions.setdefault(instrument, {})

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -442,6 +442,7 @@ class ImportDataPanel(QObject):
                 self.edited_images[det]['panel_buffer'])
             files.append([self.edited_images[det]['img']])
 
+        self.detector_defaults['detectors'] = detectors
         temp = tempfile.NamedTemporaryFile(delete=False, suffix='.hexrd')
         try:
             instr = HEDMInstrument(
@@ -449,6 +450,7 @@ class ImportDataPanel(QObject):
             instr.write_config(temp.name, style='hdf5')
             HexrdConfig().load_instrument_config(temp.name)
         finally:
+            temp.close()
             Path(temp.name).unlink()
 
         self.set_convention()

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -23,7 +23,7 @@ from hexrd.ui.constants import (
     UI_TRANS_INDEX_ROTATE_90, UI_TRANS_INDEX_FLIP_HORIZONTALLY, YAML_EXTS)
 import hexrd.ui.resources.calibration
 
-from hexrd.ui.utils import convert_tilt_convention
+from hexrd.ui.utils import convert_tilt_convention, instr_to_internal_dict
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 
 class ImportDataPanel(QObject):
@@ -99,8 +99,8 @@ class ImportDataPanel(QObject):
             else:
                 try:
                     with h5py.File(self.config_file, 'r') as f:
-                        instr = create_hedm_instrument()
-                        instr.unwrap_h5_to_dict(f, self.defaults)
+                        instr = HEDMInstrument(f)
+                        self.defaults = instr_to_internal_dict(instr)
                 except Exception as e:
                     msg = (
                         f'ERROR - Could not read file: \n {e} \n'
@@ -173,7 +173,7 @@ class ImportDataPanel(QObject):
                             enabled=not checked)
 
     def load_instrument_config(self):
-        temp = tempfile.NamedTemporaryFile(delete=False, suffix='.yml')
+        temp = tempfile.NamedTemporaryFile(delete=False, suffix='.hexrd')
         self.config_file = temp.name
         HexrdConfig().save_instrument_config(self.config_file)
         fname = f'default_{self.instrument.lower()}_config.yml'

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -429,7 +429,8 @@ class ImportDataPanel(QObject):
         self.check_for_unsaved_changes()
 
         files = []
-        detectors = self.detector_defaults['default_config'].setdefault('detectors', {})
+        detectors = self.detector_defaults['default_config'].setdefault(
+            'detectors', {})
         not_set = [d for d in detectors if d not in self.completed_detectors]
         for det in not_set:
             del(self.detector_defaults['default_config']['detectors'][det])

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -100,7 +100,8 @@ class ImportDataPanel(QObject):
                 try:
                     with h5py.File(self.config_file, 'r') as f:
                         instr = HEDMInstrument(f)
-                        self.defaults = instr_to_internal_dict(instr)
+                        self.defaults = instr_to_internal_dict(
+                            instr, convert_tilts=False)
                 except Exception as e:
                     msg = (
                         f'ERROR - Could not read file: \n {e} \n'

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -97,7 +97,9 @@ class ImportDataPanel(QObject):
         if self.config_file and not_default:
             if os.path.splitext(self.config_file)[1] in YAML_EXTS:
                 with open(self.config_file, 'r') as f:
-                    self.defaults = yaml.load(f, Loader=yaml.FullLoader)
+                    instr = HEDMInstrument(f)
+                    self.defaults = instr_to_internal_dict(
+                        instr, convert_tilts=False)
             else:
                 try:
                     with h5py.File(self.config_file, 'r') as f:

--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -341,8 +341,9 @@ class ImportDataPanel(QObject):
         self.it.clear()
 
     def save_boundary_position(self):
+        position = {'coords': self.it.template.xy, 'angle': self.it.rotation}
         HexrdConfig().set_boundary_position(
-            self.instrument, self.detector, self.it.template.xy)
+            self.instrument, self.detector, position)
         if self.it.shape:
             self.it.save_boundary(self.outline_color)
 

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -59,7 +59,8 @@ class InteractiveTemplate:
     def update_position(self, instr, det):
         pos = HexrdConfig().boundary_position(instr, det)
         if pos is not None:
-            self.shape.set_xy(pos)
+            self.shape.set_xy(pos['coords'])
+            self.total_rotation = pos['angle']
             self.center = self.get_midpoint()
         elif instr == 'PXRDIP':
             self.rotate_shape(angle=90)

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -249,7 +249,7 @@ def has_nan(x):
     return np.isnan(np.min(x))
 
 
-def instr_to_internal_dict(instr, calibration_dict=None):
+def instr_to_internal_dict(instr, calibration_dict=None, convert_tilts=True):
     from hexrd.ui.hexrd_config import HexrdConfig
 
     # Convert an HEDMInstrument object into an internal dict we can
@@ -279,7 +279,7 @@ def instr_to_internal_dict(instr, calibration_dict=None):
 
     # Convert to the selected tilt convention
     eac = HexrdConfig().euler_angle_convention
-    if eac is not None:
+    if convert_tilts and eac is not None:
         convert_tilt_convention(config, None, eac)
 
     return config


### PR DESCRIPTION
Fix bug that was writing to copy of object rather than original object. Write temp file to `hdf5` rather than `yaml`.

Attached are the images and config files for before processing through the import panel and after.
[data.zip](https://github.com/HEXRD/hexrdgui/files/6881384/data.zip)
