### PR TITLE
Add ellipsoidal ranges for laue overlays

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -145,7 +145,8 @@ DEFAULT_LAUE_OPTIONS = {
     'min_energy': 5,
     'max_energy': 35,
     'tth_width': None,
-    'eta_width': None
+    'eta_width': None,
+    'width_shape': 'ellipse',
 }
 
 DEFAULT_MONO_ROTATION_SERIES_OPTIONS = {}

--- a/hexrd/ui/laue_overlay_editor.py
+++ b/hexrd/ui/laue_overlay_editor.py
@@ -78,8 +78,8 @@ class LaueOverlayEditor:
             self.ui.tth_width.setValue(np.degrees(options['tth_width']))
         if options.get('eta_width') is not None:
             self.ui.eta_width.setValue(np.degrees(options['eta_width']))
-        if options.get('width_shape') is not None:
-            self.width_shape = options['width_shape']
+
+        self.width_shape = options.get('width_shape', LaueRangeShape.rectangle)
 
         widths = ['tth_width', 'eta_width']
         enable_widths = all(options.get(x) is not None for x in widths)

--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -11,8 +11,8 @@ from hexrd.ui.constants import ViewType
 
 
 class LaueRangeShape(str, Enum):
-    rectangle = 'rectangle'
     ellipse = 'ellipse'
+    rectangle = 'rectangle'
 
 
 class LaueSpotOverlay:

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>535</width>
-    <height>331</height>
+    <width>767</width>
+    <height>385</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -174,7 +174,7 @@
             <property name="minimumSize">
              <size>
               <width>0</width>
-              <height>128</height>
+              <height>153</height>
              </size>
             </property>
             <property name="title">

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -10,6 +10,12 @@
     <height>602</height>
    </rect>
   </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
@@ -76,20 +82,14 @@
       <string>Widths</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="1" column="1">
-       <widget class="QLabel" name="tth_width_label">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enable_widths">
         <property name="text">
-         <string>2θ</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         <string>Enable Widths</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="3" column="3">
        <widget class="ScientificDoubleSpinBox" name="eta_width">
         <property name="enabled">
          <bool>false</bool>
@@ -111,7 +111,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="1" column="3">
        <widget class="ScientificDoubleSpinBox" name="tth_width">
         <property name="enabled">
          <bool>false</bool>
@@ -133,7 +133,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="2">
        <widget class="QLabel" name="eta_width_label">
         <property name="enabled">
          <bool>false</bool>
@@ -146,32 +146,42 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="enable_widths">
-        <property name="text">
-         <string>Enable Widths</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="QComboBox" name="width_shape">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QLabel" name="width_shape_label">
+      <item row="1" column="2">
+       <widget class="QLabel" name="tth_width_label">
         <property name="enabled">
          <bool>false</bool>
         </property>
         <property name="text">
-         <string>Width Shape:</string>
+         <string>2θ</string>
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
        </widget>
+      </item>
+      <item row="3" column="0">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="width_shape_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Width Shape:</string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="width_shape">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -205,9 +215,9 @@
   <tabstop>min_energy</tabstop>
   <tabstop>max_energy</tabstop>
   <tabstop>enable_widths</tabstop>
+  <tabstop>width_shape</tabstop>
   <tabstop>tth_width</tabstop>
   <tabstop>eta_width</tabstop>
-  <tabstop>width_shape</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>502</height>
+    <height>602</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -24,25 +24,58 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="crystal_editor_layout"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="max_energy_label">
+     <property name="text">
+      <string>Max Energy:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="min_energy_label">
+     <property name="text">
+      <string>Min Energy:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="ScientificDoubleSpinBox" name="max_energy">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>100000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>35.000000000000000</double>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="ranges_group_box">
      <property name="title">
       <string>Widths</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="2" column="1">
-       <widget class="QLabel" name="eta_width_label">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>η</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QLabel" name="tth_width_label">
         <property name="enabled">
@@ -53,35 +86,6 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="enable_widths">
-        <property name="text">
-         <string>Enable Widths</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="ScientificDoubleSpinBox" name="tth_width">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="suffix">
-         <string>°</string>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="maximum">
-         <double>360.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>5.000000000000000</double>
         </property>
        </widget>
       </item>
@@ -107,37 +111,69 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="2">
+       <widget class="ScientificDoubleSpinBox" name="tth_width">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>5.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLabel" name="eta_width_label">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>η</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="enable_widths">
+        <property name="text">
+         <string>Enable Widths</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QComboBox" name="width_shape">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QLabel" name="width_shape_label">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Width Shape:</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+       </widget>
+      </item>
      </layout>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="ScientificDoubleSpinBox" name="max_energy">
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="maximum">
-      <double>100000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>35.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="min_energy_label">
-     <property name="text">
-      <string>Min Energy:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="max_energy_label">
-     <property name="text">
-      <string>Max Energy:</string>
-     </property>
     </widget>
    </item>
    <item row="0" column="1">
@@ -156,22 +192,6 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <layout class="QVBoxLayout" name="crystal_editor_layout"/>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -187,6 +207,7 @@
   <tabstop>enable_widths</tabstop>
   <tabstop>tth_width</tabstop>
   <tabstop>eta_width</tabstop>
+  <tabstop>width_shape</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/overlay_editor.ui
+++ b/hexrd/ui/resources/ui/overlay_editor.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>700</height>
+    <height>600</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>0</height>
+    <height>600</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/hexrd/ui/resources/ui/overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/overlay_style_picker.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>476</width>
-    <height>214</height>
+    <width>632</width>
+    <height>246</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -151,6 +151,9 @@
       </item>
       <item row="0" column="7">
        <widget class="ScientificDoubleSpinBox" name="range_size">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
         <property name="decimals">
          <number>8</number>
         </property>


### PR DESCRIPTION
Ellipsoidal ranges are closer to reality than rectangular ranges, so
the laue overlays now use ellipsoidal ranges by default, but the user
can still change them to use rectangular ranges via the laue overlay
editor.
    
The ellipses are generated via the equation of an ellipse in polar
space coordinates. `panel.angles_to_cart()` and
`panel.panel.cartToPixel()` are used to convert the ellipses for
display in the cartesian and raw views.
    
It appears that masking via the ellipse ranges is working properly.

https://user-images.githubusercontent.com/9558430/127193100-d4b428c1-4870-4758-8c01-20df69b65acf.mp4