### PR TITLE
Polar plot export fixes

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -78,8 +78,8 @@ class InstrumentViewer:
 
         # Prepare the data to write out
         data = {
-            'tth_coordinates': self.angular_grid[1],
-            'eta_coordinates': self.angular_grid[0],
+            'tth_coordinates': np.degrees(self.angular_grid[1]),
+            'eta_coordinates': np.degrees(self.angular_grid[0]),
             'intensities': self.img,
             'extent': np.radians(self._extent),
             'azimuthal_integration': azimuthal_integration,

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -37,8 +37,16 @@ class InstrumentViewer:
         return self.pv.angular_grid
 
     @property
+    def raw_rescaled_img(self):
+        return self.pv.raw_rescaled_img
+
+    @property
     def raw_img(self):
         return self.pv.raw_img
+
+    @property
+    def raw_mask(self):
+        return self.pv.raw_mask
 
     @property
     def snipped_img(self):
@@ -87,8 +95,8 @@ class InstrumentViewer:
         # Re-format the data so that it is in 2 columns
         azimuthal_integration = np.array(azimuthal_integration).T
 
-        intensities = self.pv.apply_rescale(self.raw_img.data)
-        intensities[self.raw_img.mask] = np.nan
+        intensities = self.raw_rescaled_img
+        intensities[self.raw_mask] = np.nan
 
         # Prepare the data to write out
         data = {

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -39,6 +39,10 @@ class InstrumentViewer:
     def img(self):
         return self.pv.img
 
+    @property
+    def snip_background(self):
+        return self.pv.snip_background
+
     def update_angular_grid(self):
         self.pv.update_angular_grid()
 
@@ -59,7 +63,6 @@ class InstrumentViewer:
         eta_max = HexrdConfig().polar_res_eta_max
 
         self._extent = [tth_min, tth_max, eta_max, eta_min]   # l, r, b, t
-        self.snip1d_background = self.pv.snip1d_background
 
     def update_overlay_data(self):
         update_overlay_data(self.instr, self.type)
@@ -81,6 +84,9 @@ class InstrumentViewer:
             'extent': np.radians(self._extent),
             'azimuthal_integration': azimuthal_integration,
         }
+
+        if self.snip_background is not None:
+            data['snip_background'] = self.snip_background
 
         # Delete the file if it already exists
         if os.path.exists(filename):

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -41,7 +41,7 @@ class PolarView:
         self.snipped_img = None
         self.processed_img = None
 
-        self.snip1d_background = None
+        self.snip_background = None
 
         self.update_angular_grid()
 
@@ -283,11 +283,11 @@ class PolarView:
             if HexrdConfig().polar_snip1d_algorithm not in no_nan_methods:
                 img[self.raw_img.mask] = np.nan
 
-            self.snip1d_background = run_snip1d(img)
+            self.snip_background = run_snip1d(img)
             # Perform the background subtraction
-            img -= self.snip1d_background
+            img -= self.snip_background
         else:
-            self.snip1d_background = None
+            self.snip_background = None
 
         return img
 

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -252,10 +252,16 @@ class PolarView:
         self.raw_img = np.ma.sum(np.ma.stack(self.warp_dict.values()), axis=0)
         self.apply_image_processing()
 
-    def apply_image_processing(self):
-        img = self.raw_img.data
+    @property
+    def raw_rescaled_img(self):
+        return self.apply_rescale(self.raw_img.data)
 
-        img = self.apply_rescale(img)
+    @property
+    def raw_mask(self):
+        return self.raw_img.mask
+
+    def apply_image_processing(self):
+        img = self.raw_rescaled_img
         img = self.apply_snip(img)
         # cache this step so we can just re-apply masks if needed
         self.snipped_img = img
@@ -281,7 +287,7 @@ class PolarView:
             no_nan_methods = [SnipAlgorithmType.Fast_SNIP_1D]
 
             if HexrdConfig().polar_snip1d_algorithm not in no_nan_methods:
-                img[self.raw_img.mask] = np.nan
+                img[self.raw_mask] = np.nan
 
             self.snip_background = run_snip1d(img)
             # Perform the background subtraction
@@ -294,7 +300,7 @@ class PolarView:
     def apply_masks(self, img):
         # Apply user-specified masks if they are present
         img = img.copy()
-        total_mask = self.raw_img.mask
+        total_mask = self.raw_mask
         for mask in HexrdConfig().visible_polar_masks:
             total_mask = np.logical_or(total_mask, ~mask)
         img[total_mask] = np.nan

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -864,8 +864,8 @@ class ImageCanvas(FigureCanvas):
             title = f'Algorithm {algorithm}'
         ax.set_title(title)
 
-        if self.iviewer.snip1d_background is not None:
-            background = self.iviewer.snip1d_background
+        if self.iviewer.snip_background is not None:
+            background = self.iviewer.snip_background
         else:
             # We have to run it ourselves...
             # It should not have already been applied to the image

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -868,15 +868,11 @@ class ImageCanvas(FigureCanvas):
             background = self.iviewer.snip_background
         else:
             # We have to run it ourselves...
-            # It should not have already been applied to the image
-            # Apply the same pre-processing to the raw data...
-            pv = self.iviewer.pv
-            img = pv.raw_img.data
-            img = pv.apply_rescale(img)
+            img = self.iviewer.raw_rescaled_img
 
             no_nan_methods = [utils.SnipAlgorithmType.Fast_SNIP_1D]
             if HexrdConfig().polar_snip1d_algorithm not in no_nan_methods:
-                img[pv.raw_img.mask] = np.nan
+                img[self.iviewer.raw_mask] = np.nan
 
             background = utils.run_snip1d(img)
 


### PR DESCRIPTION
The following changes were made:

1. The `intensities` that are saved are now the raw (but rescaled) intensities, without any masks or snip subtraction.
2. The `snip_background` is saved, if one was used. This can be subtracted from the `intensities` to get a snip-background-subtracted image.
3. All visible polar masks are saved.
4. All angle units are now in degrees for consistency.

Addresses https://github.com/HEXRD/hexrdgui/pull/812#issuecomment-887765531
Fixes: #750