### PR TITLE
Add ability to specify two theta limits for WPPF

### DIFF
--- a/hexrd/ui/resources/ui/wppf_options_dialog.ui
+++ b/hexrd/ui/resources/ui/wppf_options_dialog.ui
@@ -14,72 +14,24 @@
    <string>WPPF Options Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="3" column="1" colspan="2">
-    <widget class="QComboBox" name="peak_shape"/>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSpinBox" name="refinement_steps">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10000000</number>
-     </property>
-     <property name="value">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="2">
-    <widget class="QPushButton" name="select_experiment_file_button">
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="experiment_file">
      <property name="enabled">
       <bool>false</bool>
      </property>
      <property name="text">
-      <string>Select File</string>
+      <string/>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="refinement_steps_label">
+   <item row="0" column="0" colspan="3">
+    <widget class="QPushButton" name="select_materials_button">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Refinement Steps:</string>
+      <string>Select Materials</string>
      </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="3">
-    <widget class="QTableWidget" name="table">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Value</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Minimum</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Maximum</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Vary</string>
-      </property>
-     </column>
     </widget>
    </item>
    <item row="6" column="0" colspan="3">
@@ -92,55 +44,7 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
-    <widget class="QCheckBox" name="use_experiment_file">
-     <property name="text">
-      <string>Use Experiment File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0" colspan="3">
-    <widget class="QPushButton" name="reset_table_to_defaults">
-     <property name="text">
-      <string>Reset Table to Defaults</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QComboBox" name="method">
-     <item>
-      <property name="text">
-       <string>LeBail</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Rietveld</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="background_method"/>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="method_label">
-     <property name="text">
-      <string>WPPF Method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QLineEdit" name="experiment_file">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="3">
+   <item row="15" column="0" colspan="3">
     <layout class="QHBoxLayout" name="button_layout">
      <item>
       <widget class="QPushButton" name="save_plot">
@@ -213,6 +117,40 @@
      </item>
     </layout>
    </item>
+   <item row="14" column="0" colspan="3">
+    <widget class="QPushButton" name="reset_table_to_defaults">
+     <property name="text">
+      <string>Reset Table to Defaults</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="peak_shape"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="refinement_steps_label">
+     <property name="text">
+      <string>Refinement Steps:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="2">
+    <widget class="QPushButton" name="select_experiment_file_button">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Select File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="method_label">
+     <property name="text">
+      <string>WPPF Method:</string>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="0">
     <widget class="QLabel" name="peak_shape_label">
      <property name="text">
@@ -220,7 +158,27 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="3">
+   <item row="7" column="0">
+    <widget class="QCheckBox" name="use_experiment_file">
+     <property name="text">
+      <string>Use Experiment File</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="refinement_steps">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000000</number>
+     </property>
+     <property name="value">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="3">
     <layout class="QHBoxLayout" name="plot_options_layout">
      <item>
       <widget class="QCheckBox" name="display_wppf_plot">
@@ -238,18 +196,132 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QPushButton" name="select_materials_button">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Select Materials</string>
-     </property>
+   <item row="4" column="1" colspan="2">
+    <widget class="QComboBox" name="background_method"/>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QComboBox" name="method">
+     <item>
+      <property name="text">
+       <string>LeBail</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Rietveld</string>
+      </property>
+     </item>
     </widget>
+   </item>
+   <item row="13" column="0" colspan="3">
+    <widget class="QTableWidget" name="table">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Value</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Minimum</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Maximum</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Vary</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="8" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="limit_tth_layout">
+     <item>
+      <widget class="QCheckBox" name="limit_tth">
+       <property name="text">
+        <string>Limit 2θ?</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ScientificDoubleSpinBox" name="min_tth">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="suffix">
+        <string>°</string>
+       </property>
+       <property name="decimals">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="limit_tth_hyphen">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>-</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="ScientificDoubleSpinBox" name="max_tth">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
+       </property>
+       <property name="suffix">
+        <string>°</string>
+       </property>
+       <property name="decimals">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.py</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>select_materials_button</tabstop>
   <tabstop>method</tabstop>
@@ -259,6 +331,9 @@
   <tabstop>use_experiment_file</tabstop>
   <tabstop>experiment_file</tabstop>
   <tabstop>select_experiment_file_button</tabstop>
+  <tabstop>limit_tth</tabstop>
+  <tabstop>min_tth</tabstop>
+  <tabstop>max_tth</tabstop>
   <tabstop>display_wppf_plot</tabstop>
   <tabstop>edit_plot_style</tabstop>
   <tabstop>table</tabstop>
@@ -299,6 +374,54 @@
     <hint type="destinationlabel">
      <x>625</x>
      <y>192</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>limit_tth</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>min_tth</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>109</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>310</x>
+     <y>254</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>limit_tth</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>limit_tth_hyphen</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>109</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>417</x>
+     <y>254</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>limit_tth</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>max_tth</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>109</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>525</x>
+     <y>254</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
If the user checks the box to limit two theta, then the azimuthal
integral data that gets passed to WPPF will be limited to the
specified two theta range. WPPF will then operate on this limited
range.

Here's a (non-realistic) example that shows that it works:
![example](https://user-images.githubusercontent.com/9558430/127261456-86dac602-51b3-41d9-98ab-b982ed68b2ad.png)

Fixes: #985