### PR TITLE
Add X-Ray Energy Selection via a Table

### DIFF
--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -7,9 +7,10 @@ from PySide2.QtWidgets import (
 import numpy as np
 
 from hexrd.ui import constants
-from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.calibration.panel_buffer_dialog import PanelBufferDialog
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.xray_energy_selection_dialog import XRayEnergySelectionDialog
+from hexrd.ui.ui_loader import UiLoader
 
 
 class CalibrationConfigWidget(QObject):
@@ -18,7 +19,7 @@ class CalibrationConfigWidget(QObject):
     gui_data_changed = Signal()
 
     def __init__(self, parent=None):
-        super(CalibrationConfigWidget, self).__init__(parent)
+        super().__init__(parent)
 
         self.cfg = HexrdConfig()
 
@@ -39,6 +40,8 @@ class CalibrationConfigWidget(QObject):
         self.ui.cal_energy.valueChanged.connect(self.on_energy_changed)
         self.ui.cal_energy_wavelength.valueChanged.connect(
             self.on_energy_wavelength_changed)
+        self.ui.xray_energies_table.pressed.connect(
+            self.open_xray_energies_dialog)
 
         self.ui.cal_det_current.currentIndexChanged.connect(
             self.on_detector_changed)
@@ -91,6 +94,14 @@ class CalibrationConfigWidget(QObject):
             self.ui.cal_energy.setValue(new_energy)
         finally:
             self.ui.cal_energy.blockSignals(block_signals)
+
+    def open_xray_energies_dialog(self):
+        dialog = XRayEnergySelectionDialog(self.ui)
+        if not dialog.exec_():
+            return
+
+        # The table has units in eV. Convert to keV.
+        self.ui.cal_energy.setValue(dialog.selected_energy / 1e3)
 
     def on_detector_changed(self):
         self.update_detector_from_config()

--- a/hexrd/ui/indexing/fit_grains_tree_view_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_tree_view_dialog.py
@@ -7,3 +7,4 @@ class FitGrainsTreeViewDialog(DictTreeViewDialog):
         config = HexrdConfig().indexing_config['fit_grains']
         super().__init__(config, parent)
         self.setWindowTitle('Fit Grains Config')
+        self.expand_rows()

--- a/hexrd/ui/indexing/indexing_tree_view_dialog.py
+++ b/hexrd/ui/indexing/indexing_tree_view_dialog.py
@@ -19,6 +19,7 @@ class IndexingTreeViewDialog(DictTreeViewDialog):
             ('seed_search', 'method'): self.seed_search_defaults,
         }
         self.dict_tree_view.combo_keys = combo_keys
+        self.expand_rows()
 
     @lazy_property
     def seed_search_defaults(self):

--- a/hexrd/ui/indexing/indexing_tree_view_dialog.py
+++ b/hexrd/ui/indexing/indexing_tree_view_dialog.py
@@ -18,7 +18,7 @@ class IndexingTreeViewDialog(DictTreeViewDialog):
         combo_keys = {
             ('seed_search', 'method'): self.seed_search_defaults,
         }
-        self.dict_tree_view.combo_keys = combo_keys
+        self.tree_view.combo_keys = combo_keys
         self.expand_rows()
 
     @lazy_property

--- a/hexrd/ui/resources/ui/calibration_config_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_config_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>560</width>
-    <height>595</height>
+    <width>678</width>
+    <height>726</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -52,10 +52,7 @@
         <property name="title">
          <string>Energy</string>
         </property>
-        <layout class="QHBoxLayout" name="horizontalLayout_2">
-         <property name="spacing">
-          <number>0</number>
-         </property>
+        <layout class="QGridLayout" name="gridLayout_3">
          <property name="leftMargin">
           <number>0</number>
          </property>
@@ -68,7 +65,35 @@
          <property name="bottomMargin">
           <number>0</number>
          </property>
-         <item>
+         <item row="0" column="2">
+          <widget class="ScientificDoubleSpinBox" name="cal_energy">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string> keV</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>0.000001000000000</double>
+           </property>
+           <property name="maximum">
+            <double>1000000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+           <property name="value">
+            <double>55.618000000000002</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
           <widget class="ScientificDoubleSpinBox" name="cal_energy_wavelength">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -96,31 +121,10 @@
            </property>
           </widget>
          </item>
-         <item>
-          <widget class="ScientificDoubleSpinBox" name="cal_energy">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string> keV</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>0.000001000000000</double>
-           </property>
-           <property name="maximum">
-            <double>1000000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-           <property name="value">
-            <double>55.618000000000002</double>
+         <item row="1" column="1" colspan="2">
+          <widget class="QPushButton" name="xray_energies_table">
+           <property name="text">
+            <string>Select Energy from X-Ray Table</string>
            </property>
           </widget>
          </item>
@@ -1051,6 +1055,7 @@
  <tabstops>
   <tabstop>cal_energy_wavelength</tabstop>
   <tabstop>cal_energy</tabstop>
+  <tabstop>xray_energies_table</tabstop>
   <tabstop>cal_vector_azimuth</tabstop>
   <tabstop>cal_vector_polar</tabstop>
   <tabstop>cal_det_current</tabstop>

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -182,6 +182,23 @@ class BaseDictTreeView(QTreeView):
     def editable(self, v):
         self.model().editable = v
 
+    @property
+    def selection_mode(self):
+        return self.selectionMode()
+
+    @selection_mode.setter
+    def selection_mode(self, v):
+        self.setSelectionMode(v)
+
+    def set_single_selection_mode(self):
+        self.selection_mode = QTreeView.SingleSelection
+
+    def set_multi_selection_mode(self):
+        self.selection_mode = QTreeView.MultiSelection
+
+    def set_extended_selection_mode(self):
+        self.selection_mode = QTreeView.ExtendedSelection
+
     def contextMenuEvent(self, event):
         # Generate the actions
         actions = {}

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -61,6 +61,17 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
         flags = super().flags(index)
         item = self.get_item(index)
 
+        # Items are selectable if they have no children
+        # and none of the data values in the row are `None`.
+        is_selectable = all((
+            item.child_count() == 0,
+            not any(x is None for x in item.data_list),
+        ))
+        if is_selectable:
+            flags = flags | Qt.ItemIsSelectable
+        else:
+            flags = flags & ~Qt.ItemIsSelectable
+
         is_editable = all((
             index.column() != KEY_COL,
             item.child_count() == 0,

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -210,6 +210,11 @@ class BaseDictTreeView(QTreeView):
     def set_extended_selection_mode(self):
         self.selection_mode = QTreeView.ExtendedSelection
 
+    @property
+    def selected_items(self):
+        selected_rows = self.selectionModel().selectedRows()
+        return [self.model().get_item(x) for x in selected_rows]
+
     def contextMenuEvent(self, event):
         # Generate the actions
         actions = {}

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -22,6 +22,7 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
         # These can be modified anytime
         self.lists_resizable = True
         self._blacklisted_paths = []
+        self.editable = True
 
         self.config = dictionary
 
@@ -58,9 +59,15 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
             return Qt.NoItemFlags
 
         flags = super().flags(index)
-
         item = self.get_item(index)
-        if index.column() != KEY_COL and item.child_count() == 0:
+
+        is_editable = all((
+            index.column() != KEY_COL,
+            item.child_count() == 0,
+            self.editable,
+        ))
+
+        if is_editable:
             # All columns after the first with no children are editable
             flags = flags | Qt.ItemIsEditable
 
@@ -166,6 +173,14 @@ class BaseDictTreeView(QTreeView):
         self._combo_keys = v
         self.rebuild_tree()
         self.expand_rows()
+
+    @property
+    def editable(self):
+        return self.model().editable
+
+    @editable.setter
+    def editable(self, v):
+        self.model().editable = v
 
     def contextMenuEvent(self, event):
         # Generate the actions

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -87,3 +87,12 @@ class DictTreeViewDialog(QDialog):
     @editable.setter
     def editable(self, v):
         self.dict_tree_view.editable = v
+
+    def set_single_selection_mode(self):
+        self.dict_tree_view.set_single_selection_mode()
+
+    def set_multi_selection_mode(self):
+        self.dict_tree_view.set_multi_selection_mode()
+
+    def set_extended_selection_mode(self):
+        self.dict_tree_view.set_extended_selection_mode()

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -1,3 +1,5 @@
+import numpy as np
+
 from PySide2.QtWidgets import QDialog, QVBoxLayout
 
 from hexrd.ui.tree_views.base_dict_tree_item_model import (
@@ -26,8 +28,12 @@ class DictTreeItemModel(BaseDictTreeItemModel):
         elif isinstance(cur_config, list):
             keys = range(len(cur_config))
         else:
-            # This must be a value. Set it.
-            cur_tree_item.set_data(VALUE_COL, cur_config)
+            # This must be a value.
+            val = cur_config
+            if isinstance(val, np.ndarray) and val.size == 1:
+                # Convert to native python type
+                val = val.item()
+            cur_tree_item.set_data(VALUE_COL, val)
             return
 
         for key in keys:

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -79,3 +79,11 @@ class DictTreeViewDialog(QDialog):
 
     def expand_rows(self):
         return self.dict_tree_view.expand_rows()
+
+    @property
+    def editable(self):
+        return self.dict_tree_view.editable
+
+    @editable.setter
+    def editable(self, v):
+        self.dict_tree_view.editable = v

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -72,31 +72,31 @@ class DictTreeViewDialog(QDialog):
 
         self.setLayout(QVBoxLayout(self))
 
-        self.dict_tree_view = DictTreeView(dictionary, self)
-        self.layout().addWidget(self.dict_tree_view)
+        self.tree_view = DictTreeView(dictionary, self)
+        self.layout().addWidget(self.tree_view)
 
         self.resize(500, 500)
 
     def expand_rows(self):
-        return self.dict_tree_view.expand_rows()
+        return self.tree_view.expand_rows()
 
     @property
     def editable(self):
-        return self.dict_tree_view.editable
+        return self.tree_view.editable
 
     @editable.setter
     def editable(self, v):
-        self.dict_tree_view.editable = v
+        self.tree_view.editable = v
 
     def set_single_selection_mode(self):
-        self.dict_tree_view.set_single_selection_mode()
+        self.tree_view.set_single_selection_mode()
 
     def set_multi_selection_mode(self):
-        self.dict_tree_view.set_multi_selection_mode()
+        self.tree_view.set_multi_selection_mode()
 
     def set_extended_selection_mode(self):
-        self.dict_tree_view.set_extended_selection_mode()
+        self.tree_view.set_extended_selection_mode()
 
     @property
     def selected_items(self):
-        return self.dict_tree_view.selected_items
+        return self.tree_view.selected_items

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -58,8 +58,6 @@ class DictTreeView(BaseDictTreeView):
         self.header().resizeSection(KEY_COL, 200)
         self.header().resizeSection(VALUE_COL, 200)
 
-        self.expand_rows()
-
 
 class DictTreeViewDialog(QDialog):
 
@@ -72,3 +70,6 @@ class DictTreeViewDialog(QDialog):
         self.layout().addWidget(self.dict_tree_view)
 
         self.resize(500, 500)
+
+    def expand_rows(self):
+        return self.dict_tree_view.expand_rows()

--- a/hexrd/ui/tree_views/dict_tree_view.py
+++ b/hexrd/ui/tree_views/dict_tree_view.py
@@ -96,3 +96,7 @@ class DictTreeViewDialog(QDialog):
 
     def set_extended_selection_mode(self):
         self.dict_tree_view.set_extended_selection_mode()
+
+    @property
+    def selected_items(self):
+        return self.dict_tree_view.selected_items

--- a/hexrd/ui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrd/ui/tree_views/multi_column_dict_tree_view.py
@@ -156,16 +156,15 @@ class MultiColumnDictTreeViewDialog(QDialog):
 
         self.setLayout(QVBoxLayout(self))
 
-        self.dict_tree_view = MultiColumnDictTreeView(dictionary, columns,
-                                                      self)
-        self.layout().addWidget(self.dict_tree_view)
+        self.tree_view = MultiColumnDictTreeView(dictionary, columns, self)
+        self.layout().addWidget(self.tree_view)
 
         self.resize(500, 500)
 
         self.setup_connections()
 
     def setup_connections(self):
-        self.dict_tree_view.dict_modified.connect(self.dict_modified.emit)
+        self.tree_view.dict_modified.connect(self.dict_modified.emit)
 
 
 class ColumnDelegate(QStyledItemDelegate):

--- a/hexrd/ui/xray_energy_selection_dialog.py
+++ b/hexrd/ui/xray_energy_selection_dialog.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+import io
+
+import h5py
+import numpy as np
+
+from PySide2.QtWidgets import QDialogButtonBox, QMessageBox
+
+from hexrd.instrument import unwrap_h5_to_dict
+import hexrd.resources
+from hexrd.utils.decorators import memoize
+
+from hexrd.ui.resource_loader import load_resource
+from hexrd.ui.tree_views.dict_tree_view import DictTreeViewDialog
+
+
+class XRayEnergySelectionDialog(DictTreeViewDialog):
+
+    def __init__(self, parent=None):
+        # Load the data
+        self.load_xray_dict()
+        super().__init__(self.xray_dict, parent)
+
+        self.selected_energy = None
+        self.editable = False
+        self.set_extended_selection_mode()
+
+        # Set the headers
+        root_item = self.tree_view.model().root_item
+        root_item.set_data(0, 'Key')
+        root_item.set_data(1, 'Energy (eV)')
+
+        # Resize the key column
+        self.tree_view.setColumnWidth(0, 250)
+
+        # Set the tooltip
+        tooltip = 'Select an energy, or multiple energies to average'
+        self.tree_view.setToolTip(tooltip)
+
+        # Add the dialog buttons
+        buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        button_box = QDialogButtonBox(buttons, self)
+        button_box.accepted.connect(self.accept)
+        button_box.rejected.connect(self.reject)
+        self.layout().addWidget(button_box)
+
+    def load_xray_dict(self):
+        self.xray_dict = _load_xray_dict()
+
+    def accept(self):
+        items = self.selected_items
+        names = [self.generate_item_name(x) for x in items]
+        values = [x.data(1) for x in items]
+
+        if len(values) == 0:
+            msg = 'No values selected'
+            QMessageBox.critical(self, 'HEXRD', msg)
+            return
+
+        if np.isnan(values).any():
+            msg = 'Selected energy is NaN'
+            QMessageBox.critical(self, 'HEXRD', msg)
+            return
+
+        if len(values) == 1:
+            self.selected_energy = values[0]
+            super().accept()
+            return
+
+        mean = np.mean(values)
+
+        msg = 'Selected entries:\n\n'
+        for n, v in zip(names, values):
+            msg += f'{n: <30}: {v:>10.2f}\n'
+
+        msg += f'\nProduces mean energy: {mean:.2f} eV\n\n'
+        msg += 'Accept?'
+
+        response = QMessageBox.question(self, 'HEXRD', msg)
+        if response == QMessageBox.No:
+            return
+
+        self.selected_energy = mean
+        super().accept()
+
+    @staticmethod
+    def generate_item_name(item, delimiter='.'):
+        name = item.data(0)
+        while item.parent_item:
+            item = item.parent_item
+            if item.data(0) == 'key':
+                # Assume this is the root item, and break
+                break
+
+            name = f'{item.data(0)}{delimiter}{name}'
+
+        return name
+
+
+@memoize(maxsize=1)
+def _load_xray_dict():
+    # Load the data from the file
+    filename = 'characteristic_xray_energies.h5'
+    h5_data = load_resource(hexrd.resources, filename, binary=True)
+    io_data = io.BytesIO(h5_data)
+
+    # Unwrap the h5 file to a dict
+    xray_dict = {}
+    with h5py.File(io_data, 'r') as f:
+        unwrap_h5_to_dict(f, xray_dict)
+
+    # Sort the keys in the dict
+    def sort(x):
+        return int(x) if x.isdigit() else 0
+
+    sorted_keys = sorted(xray_dict.keys(), key=sort)
+    return {k: xray_dict[k] for k in sorted_keys}
+
+
+if __name__ == '__main__':
+    import sys
+
+    from PySide2.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    dialog = XRayEnergySelectionDialog()
+
+    def finished():
+        print(f'Selected value was: {dialog.selected_energy}')
+        app.exit()
+
+    dialog.accepted.connect(finished)
+    dialog.show()
+    app.exec_()


### PR DESCRIPTION
This adds a button to the form view which allows the user to pick an
energy (or multiple energies to average) from a table.

The `characteristic_xray_energies.h5` from hexrd is being used to
generate this table.

The table is currently sorted so that atomic symbols come first,
and are sorted in alphabetical order, followed by atomic numbers.

https://user-images.githubusercontent.com/9558430/127437453-82adc761-239e-4c36-b7bc-e62635d6b73a.mp4

Fixes: #894