### PR TITLE
Snip preview fixes

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -850,6 +850,7 @@ class ImageCanvas(FigureCanvas):
         if not hasattr(self, '_snip1d_figure_cache'):
             # Create the figure and axes to use
             fig, ax = plt.subplots()
+            fig.canvas.manager.set_window_title('SNIP Background')
             ax.set_xlabel(r'2$\theta$ (deg)')
             ax.set_ylabel(r'$\eta$ (deg)')
             self._snip1d_figure_cache = (fig, ax)

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -847,15 +847,11 @@ class ImageCanvas(FigureCanvas):
 
         extent = self.iviewer._extent
 
-        if not hasattr(self, '_snip1d_figure_cache'):
-            # Create the figure and axes to use
-            fig, ax = plt.subplots()
-            fig.canvas.manager.set_window_title('SNIP Background')
-            ax.set_xlabel(r'2$\theta$ (deg)')
-            ax.set_ylabel(r'$\eta$ (deg)')
-            self._snip1d_figure_cache = (fig, ax)
-        else:
-            fig, ax = self._snip1d_figure_cache
+        # Create the figure and axes to use
+        fig, ax = plt.subplots()
+        fig.canvas.manager.set_window_title('SNIP Background')
+        ax.set_xlabel(r'2$\theta$ (deg)')
+        ax.set_ylabel(r'$\eta$ (deg)')
 
         algorithm = HexrdConfig().polar_snip1d_algorithm
         titles = ['Fast SNIP 1D', 'SNIP 1D', 'SNIP 2D']


### PR DESCRIPTION
1. Set window title for snip background preview

This was previously being set to "Figure 1".

2. Re-create SNIP preview plot each time

Re-using the figure and the axis seemed to be a reasonable thing to
do. However, it is causing issues for when the user re-shows it. 
On Linux, the user can't change the color map the second time they
show it. On Mac, it doesn't re-appear at all.

Instead of re-using, we will now re-create the figure from scratch each
time. It is not very resource intensive to do this, and figuring out 
why we can't re-use the figure and axis do not seem worth the effort.

Fixes: #204
Fixes: #522
Fixes: #999