### PR TITLE
Get OmeMapsViewerDialog to appear in front on Mac

### DIFF
--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -7,7 +7,7 @@ from matplotlib.figure import Figure
 import numpy as np
 import yaml
 
-from PySide2.QtCore import Signal, QObject, QSignalBlocker, Qt
+from PySide2.QtCore import Signal, QObject, QSignalBlocker, QTimer, Qt
 from PySide2.QtWidgets import (
     QCheckBox, QComboBox, QDoubleSpinBox, QFileDialog, QMessageBox,
     QSizePolicy, QSpinBox
@@ -184,6 +184,13 @@ class OmeMapsViewerDialog(QObject):
     def show(self):
         self.update_plot()
         self.ui.show()
+
+    def show_later(self):
+        # In case this was called in a separate thread (which will
+        # happen if the maps were generated), post the show() to the
+        # event loop. Otherwise, on Mac, the dialog will not move to
+        # the front.
+        QTimer.singleShot(0, lambda: self.show())
 
     def on_accepted(self):
         # Update the config just in case...

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -125,7 +125,8 @@ class IndexingRunner(Runner):
         dialog = OmeMapsViewerDialog(self.ome_maps, self.parent)
         dialog.accepted.connect(self.ome_maps_viewed)
         dialog.rejected.connect(self.clear)
-        dialog.show()
+        # Show later so the dialog will move to the front on Mac
+        dialog.show_later()
 
         self.ome_maps_viewer_dialog = dialog
 


### PR DESCRIPTION
Apparently, if we call `show()` from a separate thread (other than the
GUI thread), on Mac, the dialog will not appear in front. To avoid
this issue, post the `show()` to the event loop, so it will appear in
front.

Fixes: #920