### PR TITLE
Use conda-forge instead of anaconda channels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -127,7 +127,7 @@ jobs:
       working-directory: hexrdgui/packaging
       run: |
           conda activate hexrdgui-package
-          conda install anaconda scikit-learn==0.24.1
+          conda install --override-channels -c conda-forge anaconda-client
           anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD --label ${HEXRDGUI_PACKAGE_LABEL} output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.

--- a/README.md
+++ b/README.md
@@ -26,14 +26,14 @@ conda install -c HEXRD python=3.8.4
 To install the latest stable release
 
 ```bash
-conda install -c hexrd -c anaconda -c conda-forge hexrdgui
+conda install -c hexrd -c conda-forge hexrdgui
 ```
 
 ## conda (prerelease)
 To install the latest changes on master, do the following.  Note that this release may be unstable.
 
 ```bash
-conda install -c hexrd/label/hexrd-prerelease -c hexrd/label/hexrdgui-prerelease -c HEXRD -c anaconda -c conda-forge hexrdgui
+conda install -c hexrd/label/hexrd-prerelease -c hexrd/label/hexrdgui-prerelease -c HEXRD -c conda-forge hexrdgui
 ```
 
 ## Binary packages
@@ -69,9 +69,9 @@ pip install -e hexrdgui
 ```bash
 # First, make sure python3.8+ is installed in your target env.
 # If it is not, run the following command:
-conda install -c anaconda python=3.8
+conda install -c conda-forge python=3.8
 # Install deps using conda package
-conda install -c HEXRD -c anaconda -c conda-forge hexrdgui
+conda install -c HEXRD -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrdgui
@@ -84,7 +84,7 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrdgui
 # See the following issue for more details: https://github.com/HEXRD/hexrdgui/issues/505
 conda install -c conda-forge python=3.8
 # Install deps using conda package
-conda install -c HEXRD -c anaconda -c conda-forge hexrdgui
+conda install -c HEXRD -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrd
 CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrdgui
@@ -94,9 +94,9 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrdgui
 ```bash
 # First, make sure python3.8+ is installed in your target env.
 # If it is not, run the following command:
-conda install -c anaconda python=3.8
+conda install -c conda-forge python=3.8
 # Install deps using conda package
-conda install -c HEXRD -c anaconda -c conda-forge hexrdgui
+conda install -c HEXRD -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
 set CONDA_BUILD=1
 pip install --no-build-isolation --no-deps -U -e hexrd

--- a/packaging/environment.yml
+++ b/packaging/environment.yml
@@ -1,6 +1,5 @@
 name: hexrdgui-package
 channels:
-  - cjh1
   - conda-forge
   - nodefaults
 dependencies:

--- a/packaging/environment.yml
+++ b/packaging/environment.yml
@@ -1,6 +1,8 @@
 name: hexrdgui-package
 channels:
   - cjh1
+  - conda-forge
+  - nodefaults
 dependencies:
   - python=3.7
   - coloredlogs

--- a/packaging/package.py
+++ b/packaging/package.py
@@ -102,8 +102,9 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     # First build the hexrdgui package
     recipe_path = str(base_path / '..' / 'conda.recipe')
     config = Config()
-    config.channel = ['cjh1', 'anaconda', 'conda-forge']
-    config.channel_urls = ['cjh1', 'anaconda', 'conda-forge']
+    config.channel = ['cjh1', 'conda-forge']
+    config.channel_urls = ['cjh1', 'conda-forge']
+    config.override_channels = True
 
     if hexrdgui_output_folder is not None:
         config.output_folder = hexrdgui_output_folder
@@ -116,6 +117,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     # (release or pre-release), and force that hexrd version to be used.
     params = [
         Conda.Commands.SEARCH,
+        '--override-channels',
         '--channel', hexrd_package_channel,
         '--json',
         'hexrd',
@@ -133,7 +135,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     # Now create a new environment to install the package into
     env_prefix = str(tmp / package_env_name)
 
-    channels = ['--channel', 'anaconda', '--channel', 'conda-forge']
+    channels = ['--channel', 'conda-forge']
 
     # For the mac we need to use our own version of Python built with the
     # latest SDK. See https://github.com/HEXRD/hexrdgui/issues/505 for
@@ -144,6 +146,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     Conda.run_command(
         Conda.Commands.CREATE,
         '--prefix', env_prefix,
+        '--override-channels',
         *channels,
         'python=3.8.4'
     )
@@ -155,10 +158,10 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     params = [
         Conda.Commands.INSTALL,
         '--prefix', env_prefix,
+        '--override-channels',
         '--channel', hexrdgui_output_folder_uri,
         '--channel', hexrd_package_channel,
         '--channel', 'cjh1',
-        '--channel', 'anaconda',
         '--channel', 'conda-forge',
         f'hexrd=={hexrd_version}',
         'hexrdgui'
@@ -171,6 +174,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
         params = [
             Conda.Commands.INSTALL,
             '--prefix', env_prefix,
+            '--override-channels',
             '--channel', 'conda-forge',
             'libgfortran=4.0.0'
         ]


### PR DESCRIPTION
This is an attempt to use the `conda-forge` channel instead of the
`defaults` and `anaconda` channels, for all packages.

This will hopefully fix the issue where we had to downgrade scikit-learn
because it would fail to install on Github Actions on Windows. It makes
more sense for us to install these packages from conda-forge since the
respective project developers actually maintain the packages on
conda-forge (whereas their packages on the anaconda/defaults channels
are maintained by anaconda).

We will first need to make sure the packaging and tests pass, and then
move on to test the packages manually.

If we run into crashing issues on Mac with openblas, as we have in the
past, we may be able to resolve it by setting the environment variable
`OPENBLAS_NUM_THREADS=1`.