### PR TITLE
Block enter key press accept/reject for dialogs

### DIFF
--- a/hexrd/ui/__init__.py
+++ b/hexrd/ui/__init__.py
@@ -1,24 +1,34 @@
 from PySide2.QtCore import QEvent, QObject, Qt
-from PySide2.QtWidgets import QDialog
+from PySide2.QtWidgets import QDialog, QPushButton
 
 
 class EnterKeyFilter(QObject):
     """An event filter to ignore <Enter> keys in QDialog instances.
 
-    QButtonBox will **always** assign a default button to the <Enter> key,
-    even if each button has its default and autoDefault properties explicitly
-    set False. So to prevent a QDialog with QButtonBox from responding
-    to the <Enter> key, install this filter on the QDialog instance.
+    QDialogButtonBox will **always** assign a default button to the <Enter>
+    key, even if each button has its default and autoDefault properties
+    explicitly set False. So to prevent a QDialog with QDialogButtonBox from
+    responding to the <Enter> key, install this filter on the QDialog instance.
 
-    Note that this filter **only** filters QDialog objects.
+    We must install the event filter on both the QDialog and on QPushButton
+    children of QDialogButtonBoxes, because sometimes the QPushButton will
+    receive the key press event, and sometimes the QDialog will receive it.
+    When QDialog receives the key press event, it "clicks" the QPushButton,
+    rather than forwarding the event to the QPushButton.
+
+    Note that this filter **only** filters QDialog and QPushButton objects.
     """
     def eventFilter(self, obj, event):
-        if event.type() == QEvent.KeyPress and \
-                event.key() == Qt.Key_Return and \
-                isinstance(obj, QDialog):
+        block = (
+            event.type() == QEvent.KeyPress and
+            event.key() in (Qt.Key_Return, Qt.Key_Enter) and
+            isinstance(obj, (QDialog, QPushButton))
+        )
+
+        if block:
             return True
-        # (else) standard event processing
-        return QObject.eventFilter(self, obj, event)
+
+        return super().eventFilter(obj, event)
 
 
 enter_key_filter = EnterKeyFilter()

--- a/hexrd/ui/brightness_contrast_editor.py
+++ b/hexrd/ui/brightness_contrast_editor.py
@@ -385,6 +385,8 @@ class BrightnessContrastEditor(QObject):
         button_box.rejected.connect(dialog.reject)
         layout.addWidget(button_box)
 
+        UiLoader().install_dialog_enter_key_filters(dialog)
+
         if not dialog.exec_():
             # User canceled
             return

--- a/hexrd/ui/periodic_table_dialog.py
+++ b/hexrd/ui/periodic_table_dialog.py
@@ -4,6 +4,8 @@ from PySide2.QtWidgets import (
 
 from silx.gui.widgets.PeriodicTable import PeriodicTable
 
+from hexrd.ui.ui_loader import UiLoader
+
 
 class PeriodicTableDialog(QDialog):
 
@@ -21,6 +23,8 @@ class PeriodicTableDialog(QDialog):
         buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         self.button_box = QDialogButtonBox(buttons, self)
         self.layout().addWidget(self.button_box)
+
+        UiLoader().install_dialog_enter_key_filters(self)
 
         if atoms_selected:
             self.periodic_table.setSelection(atoms_selected)

--- a/hexrd/ui/select_items_dialog.py
+++ b/hexrd/ui/select_items_dialog.py
@@ -1,6 +1,7 @@
 from PySide2.QtWidgets import QDialog, QDialogButtonBox, QVBoxLayout
 
 from hexrd.ui.select_items_widget import SelectItemsWidget
+from hexrd.ui.ui_loader import UiLoader
 
 
 class SelectItemsDialog(QDialog):
@@ -15,6 +16,8 @@ class SelectItemsDialog(QDialog):
         buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
         self.button_box = QDialogButtonBox(buttons, self)
         self.layout().addWidget(self.button_box)
+
+        UiLoader().install_dialog_enter_key_filters(self)
 
         self.setup_connections()
 

--- a/hexrd/ui/ui_loader.py
+++ b/hexrd/ui/ui_loader.py
@@ -1,6 +1,6 @@
 from PySide2.QtCore import QBuffer, QByteArray
 from PySide2.QtUiTools import QUiLoader
-from PySide2.QtWidgets import QDialog
+from PySide2.QtWidgets import QDialog, QDialogButtonBox, QPushButton
 
 from hexrd.ui import enter_key_filter, resource_loader
 
@@ -44,8 +44,32 @@ class UiLoader(QUiLoader, metaclass=QSingleton):
     def process_ui(self, ui):
         """Perform any additional processing on loaded UI objects
 
-        Currently: it installs an enter key filter for QDialogs to prevent
+        Currently, it installs an enter key filter for QDialogs to prevent
         the enter key from closing them.
         """
         if isinstance(ui, QDialog):
-            ui.installEventFilter(enter_key_filter)
+            self.install_dialog_enter_key_filters(ui)
+
+    def install_dialog_enter_key_filters(self, dialog):
+        """Block enter key press accept/reject for dialogs
+
+        This function installs enter key filters on a QDialog and all
+        QPushButton children that follow this parent/child scheme:
+
+        QDialog -> QDialogButtonBox -> QPushButton
+
+        The enter key filter blocks all enter/return key presses from
+        automatically accepting or rejecting the dialog, to prevent
+        the user from accidentally closing the dialog by pressing enter.
+
+        The event filter must be installed both on the QDialog and the
+        QPushButtons because it is currently unpredictable (to me,
+        at least) which one will receive the key press event, and if the
+        QDialog receives the key press event, it DOES NOT forward the
+        event to the QPushButton, but rather "clicks" the QPushButton.
+        """
+        dialog.installEventFilter(enter_key_filter)
+
+        for box in dialog.findChildren(QDialogButtonBox):
+            for button in box.findChildren(QPushButton):
+                button.installEventFilter(enter_key_filter)

--- a/hexrd/ui/xray_energy_selection_dialog.py
+++ b/hexrd/ui/xray_energy_selection_dialog.py
@@ -13,6 +13,7 @@ from hexrd.utils.decorators import memoize
 
 from hexrd.ui.resource_loader import load_resource
 from hexrd.ui.tree_views.dict_tree_view import DictTreeViewDialog
+from hexrd.ui.ui_loader import UiLoader
 
 
 class XRayEnergySelectionDialog(DictTreeViewDialog):
@@ -44,6 +45,8 @@ class XRayEnergySelectionDialog(DictTreeViewDialog):
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
         self.layout().addWidget(button_box)
+
+        UiLoader().install_dialog_enter_key_filters(self)
 
     def load_xray_dict(self):
         self.xray_dict = _load_xray_dict()


### PR DESCRIPTION
Previously, enter key presses would be blocked if the QDialog
received them. However, sometimes, the QPushButtons in the
QDialogButtonBox in the QDialog would receive the key press event
instead, thus bypassing our event filter. This would result in
the dialog being accepted/rejected accidentally, upon accidental
enter key press, and thus the issue we tried to prevent would not
always be fixed.

Now, the key event filter is installed on both the QDialogs and
on QPushButtons that follow this parent/child scheme:

QDialog -> QDialogButtonBox -> QPushButton

The event filter must be installed both on the QDialog and the
QPushButtons because it is currently unpredictable (to me,
at least) which one will receive the key press event, and if the
QDialog receives the key press event, it DOES NOT forward the
event to the QPushButton, but rather "clicks" the QPushButton.

This appears to fix all cases that I found.

Fixes: #1004