### PR TITLE
Mask manager

### DIFF
--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -100,14 +100,13 @@ class MaskManagerDialog(QObject):
             cb.setChecked(status)
             cb.setStyleSheet('margin-left:50%; margin-right:50%;')
             self.ui.masks_table.setCellWidget(i, 1, cb)
-            self.ui.masks_table.cellWidget(i, 1).toggled.connect(
+            cb.toggled.connect(
                 lambda checked, key=key: self.toggle_visibility(checked, key))
 
             # Add push button to remove mask
             pb = QPushButton('Remove Mask')
             self.ui.masks_table.setCellWidget(i, 2, pb)
-            self.ui.masks_table.cellWidget(i, 2).released.connect(
-                lambda i=i, key=key: self.remove_mask(i, key))
+            pb.clicked.connect(lambda i=i, key=key: self.remove_mask(i, key))
 
             # Connect manager to raw image mode tab settings
             # for threshold mask
@@ -120,7 +119,7 @@ class MaskManagerDialog(QObject):
     def setup_threshold_connections(self, checkbox, row, name):
         HexrdConfig().mode_threshold_mask_changed.connect(checkbox.setChecked)
         checkbox.toggled.connect(self.threshold_toggled)
-        self.ui.masks_table.cellWidget(row, 2).released.connect(
+        self.ui.masks_table.cellWidget(row, 2).clicked.connect(
             lambda row=row, name=name: self.remove_mask(row, name))
 
 

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -84,6 +84,7 @@ class MaskManagerDialog(QObject):
         self.ui.export_masks.clicked.connect(self.export_visible_masks)
         HexrdConfig().mode_threshold_mask_changed.connect(
             self.update_masks_list)
+        HexrdConfig().detectors_changed.connect(self.clear_masks)
 
     def setup_table(self, status=True):
         self.ui.masks_table.blockSignals(True)
@@ -233,3 +234,10 @@ class MaskManagerDialog(QObject):
             mtype, data = self.masks[mask]
             d[mask] = data
         self.export_masks(d)
+
+    def clear_masks(self):
+        HexrdConfig().polar_masks.clear()
+        HexrdConfig().raw_masks.clear()
+        HexrdConfig().visible_masks.clear()
+        self.masks.clear()
+        self.setup_table()

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -113,13 +113,16 @@ class MaskManagerDialog(QObject):
             # for threshold mask
             mtype, data = self.masks[key]
             if mtype == 'threshold':
-                self.setup_threshold_connections(cb, pb)
+                self.setup_threshold_connections(cb, i, key)
 
         self.ui.masks_table.blockSignals(False)
 
     def setup_threshold_connections(self, checkbox, row, name):
         HexrdConfig().mode_threshold_mask_changed.connect(checkbox.setChecked)
         checkbox.toggled.connect(self.threshold_toggled)
+        self.ui.masks_table.cellWidget(row, 2).released.connect(
+            lambda row=row, name=name: self.remove_mask(row, name))
+
 
     def image_mode_changed(self, mode):
         self.image_mode = mode

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -209,13 +209,14 @@ class MaskManagerDialog(QObject):
 
     def context_menu_event(self, event):
         index = self.ui.masks_table.indexAt(event)
-        menu = QMenu(self.ui.masks_table)
-        export = menu.addAction('Export Mask')
-        action = menu.exec_(QCursor.pos())
-        if action == export:
-            selection = self.ui.masks_table.item(index.row(), 0).text()
-            mtype, data = self.masks[selection]
-            self.export_masks({selection: data})
+        if index.row() >= 0:
+            menu = QMenu(self.ui.masks_table)
+            export = menu.addAction('Export Mask')
+            action = menu.exec_(QCursor.pos())
+            if action == export:
+                selection = self.ui.masks_table.item(index.row(), 0).text()
+                _, data = self.masks[selection]
+                self.export_masks({selection: data})
 
     def export_masks(self, data):
         selected_file, selected_filter = QFileDialog.getSaveFileName(

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -86,6 +86,7 @@ class MaskManagerDialog(QObject):
             self.update_masks_list)
 
     def setup_table(self, status=True):
+        self.ui.masks_table.blockSignals(True)
         self.ui.masks_table.setRowCount(0)
         for i, key in enumerate(self.masks.keys()):
             # Add label
@@ -113,7 +114,9 @@ class MaskManagerDialog(QObject):
             if mtype == 'threshold':
                 self.setup_threshold_connections(cb, pb)
 
-    def setup_threshold_connections(self, checkbox, pushbutton):
+        self.ui.masks_table.blockSignals(False)
+
+    def setup_threshold_connections(self, checkbox, row, name):
         HexrdConfig().mode_threshold_mask_changed.connect(checkbox.setChecked)
         checkbox.toggled.connect(self.threshold_toggled)
 
@@ -155,6 +158,7 @@ class MaskManagerDialog(QObject):
             self.reset_threshold()
 
         self.ui.masks_table.removeRow(row)
+        self.setup_table()
 
         if self.image_mode == ViewType.polar:
             HexrdConfig().polar_masks_changed.emit()
@@ -197,6 +201,7 @@ class MaskManagerDialog(QObject):
                 HexrdConfig().visible_masks.remove(self.old_name)
 
         self.old_name = None
+        self.setup_table()
 
     def context_menu_event(self, event):
         index = self.ui.masks_table.indexAt(event)

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -38,10 +38,10 @@ class MaskManagerDialog(QObject):
         polar_data = HexrdConfig().polar_masks_line_data
         raw_data = HexrdConfig().raw_masks_line_data
 
-        for _, (key, val) in enumerate(polar_data.items()):
+        for key, val in polar_data.items():
             if not any(np.array_equal(m, val) for m in self.masks.values()):
                 self.masks[key] = ('polar', val)
-        for _, (key, val) in enumerate(raw_data.items()):
+        for key, val in raw_data.items():
             if not any(np.array_equal(m, val) for m in self.masks.values()):
                 self.masks[key] = val
         if HexrdConfig().threshold_mask_status:

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -101,12 +101,12 @@ class MaskManagerDialog(QObject):
                 cb.setStyleSheet('margin-left:50%; margin-right:50%;')
                 self.ui.masks_table.setCellWidget(i, 1, cb)
                 cb.toggled.connect(
-                    lambda checked, key=key: self.toggle_visibility(checked, key))
+                    lambda c, k=key: self.toggle_visibility(c, k))
 
                 # Add push button to remove mask
                 pb = QPushButton('Remove Mask')
                 self.ui.masks_table.setCellWidget(i, 2, pb)
-                pb.clicked.connect(lambda i=i, key=key: self.remove_mask(i, key))
+                pb.clicked.connect(lambda i=i, k=key: self.remove_mask(i, k))
 
                 # Connect manager to raw image mode tab settings
                 # for threshold mask

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -38,10 +38,10 @@ class MaskManagerDialog(QObject):
         polar_data = HexrdConfig().polar_masks_line_data
         raw_data = HexrdConfig().raw_masks_line_data
 
-        for i, (key, val) in enumerate(polar_data.items()):
+        for _, (key, val) in enumerate(polar_data.items()):
             if not any(np.array_equal(m, val) for m in self.masks.values()):
                 self.masks[key] = ('polar', val)
-        for i, (key, val) in enumerate(raw_data.items()):
+        for _, (key, val) in enumerate(raw_data.items()):
             if not any(np.array_equal(m, val) for m in self.masks.values()):
                 self.masks[key] = val
         if HexrdConfig().threshold_mask_status:
@@ -57,7 +57,7 @@ class MaskManagerDialog(QObject):
             for name, data in HexrdConfig().polar_masks_line_data.items():
                 vals = self.masks.values()
                 for val in data:
-                    if any(np.array_equal(val, m) for t, m in vals):
+                    if any(np.array_equal(val, m) for _, m in vals):
                         continue
                     self.masks[name] = (mask_type, val)
         elif mask_type == 'raw':
@@ -66,7 +66,7 @@ class MaskManagerDialog(QObject):
             for name, value in HexrdConfig().raw_masks_line_data.items():
                 det, val = value[0]
                 vals = self.masks.values()
-                if any(np.array_equal(val, m) for t, m in vals):
+                if any(np.array_equal(val, m) for _, m in vals):
                     continue
                 self.masks[name] = (det, val)
         elif not self.threshold:
@@ -111,7 +111,7 @@ class MaskManagerDialog(QObject):
 
             # Connect manager to raw image mode tab settings
             # for threshold mask
-            mtype, data = self.masks[key]
+            mtype, _ = self.masks[key]
             if mtype == 'threshold':
                 self.setup_threshold_connections(cb, i, key)
 
@@ -175,7 +175,7 @@ class MaskManagerDialog(QObject):
 
         self.old_name = self.ui.masks_table.item(row, 0).text()
 
-    def update_mask_name(self, row, column):
+    def update_mask_name(self, row):
         if not hasattr(self, 'old_name') or self.old_name is None:
             return
 
@@ -219,13 +219,13 @@ class MaskManagerDialog(QObject):
                 self.export_masks({selection: data})
 
     def export_masks(self, data):
-        selected_file, selected_filter = QFileDialog.getSaveFileName(
+        selected_file, _ = QFileDialog.getSaveFileName(
             self.ui, 'Save Mask', HexrdConfig().working_dir,
             'NPZ files (*.npz);; NPY files (*.npy)')
 
         if selected_file:
             HexrdConfig().working_dir = os.path.dirname(selected_file)
-            path, ext = os.path.splitext(selected_file)
+            _, ext = os.path.splitext(selected_file)
 
             if ext.lower() == '.npz':
                 np.savez(selected_file, **data)
@@ -235,7 +235,7 @@ class MaskManagerDialog(QObject):
     def export_visible_masks(self):
         d = {}
         for mask in HexrdConfig().visible_masks:
-            mtype, data = self.masks[mask]
+            _, data = self.masks[mask]
             d[mask] = data
         self.export_masks(d)
 

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -262,4 +262,5 @@ class MaskRegionsDialog(QObject):
                     axes.patches.clear()
 
         self.disconnect()
-        self.canvas.draw_idle()
+        if self.canvas is not None:
+            self.canvas.draw_idle()

--- a/hexrd/ui/resources/ui/mask_manager_dialog.ui
+++ b/hexrd/ui/resources/ui/mask_manager_dialog.ui
@@ -19,6 +19,15 @@
      <property name="contextMenuPolicy">
       <enum>Qt::CustomContextMenu</enum>
      </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::DoubleClicked</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
      </attribute>

--- a/hexrd/ui/resources/ui/mask_manager_dialog.ui
+++ b/hexrd/ui/resources/ui/mask_manager_dialog.ui
@@ -25,8 +25,11 @@
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
      <property name="sortingEnabled">
-      <bool>true</bool>
+      <bool>false</bool>
      </property>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>


### PR DESCRIPTION
This branch fixes issues and bugs in the mask manager:

- Originally it was assumed that selecting a cell widget would also set the `currentRow` on the table, and that value is what was used to determine which mask had been selected. This is not guaranteed though and while it seemed to work on Linux machines it failed to work properly on Mac machines and the wrong mask was being affected. The name of the mask associated with the selected widget is now emitted with the signal so that the correct mask is always selected.
- Any existing masks are now removed when the configuration or detectors change. This was not the case before and this would create issues when trying to load a new configuration.
- Previously the user was able to use the context menu to request to export a mask that didn't exist and this would produce errors. The context menu is now only created when the user selects a valid row.

Fixes: #1012 
Fixes: #1013 