### PR TITLE
Add materials list editor

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -120,6 +120,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when the materials panel should update"""
     active_material_modified = Signal()
 
+    """Emitted when the materials dict is modified in any way"""
+    materials_dict_modified = Signal()
+
     """Emitted when a material is renamed"""
     material_renamed = Signal()
 
@@ -231,6 +234,20 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.active_material = mat
 
         self.update_visible_material_energies()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        materials_dict_modified_signals = [
+            self.material_renamed,
+            self.materials_added,
+            self.materials_removed,
+            self.materials_rearranged,
+            self.materials_set,
+        ]
+
+        for signal in materials_dict_modified_signals:
+            signal.connect(self.materials_dict_modified.emit)
 
     def save_settings(self):
         settings = QSettings()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -123,8 +123,17 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when a material is renamed"""
     material_renamed = Signal()
 
-    """Emitted when a material is removed"""
-    material_removed = Signal()
+    """Emitted when materials were added"""
+    materials_added = Signal()
+
+    """Emitted when materials were removed"""
+    materials_removed = Signal()
+
+    """Emitted when materials keys were re-arranged"""
+    materials_rearranged = Signal()
+
+    """Emitted when materials have been set"""
+    materials_set = Signal()
 
     """Emitted to update the tth width in the powder overlay editor"""
     material_tth_width_modified = Signal(str)
@@ -563,14 +572,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     def import_material(self, f):
         beam_energy = valWUnit('beam', 'energy', self.beam_energy, 'keV')
-        base_name = os.path.splitext(os.path.basename(f))[0]
+        name = os.path.splitext(os.path.basename(f))[0]
 
         # Make sure we have a unique name
-        ind = 1
-        name = base_name
-        while name in self.materials:
-            name = base_name + f'_{ind}'
-            ind += 1
+        name = utils.unique_name(self.materials, name)
 
         material = Material(name, f, kev=beam_energy)
         self.add_material(name, material)
@@ -976,33 +981,79 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.reset_tth_max_all_materials()
 
     def add_material(self, name, material):
-        if name in self.materials:
-            raise Exception(name + ' is already in materials list!')
-        self.config['materials']['materials'][name] = material
-        self.reset_tth_max(name)
+        self.add_materials([name], [material])
+
+    def add_materials(self, names, materials):
+        if any(x in self.materials for x in names):
+            mats = list(self.materials.keys())
+            msg = f'Some names {names} are already in materials list {mats}!'
+            raise Exception(msg)
+
+        if len(names) != len(materials):
+            msg = f'{len(names)=} does not match {len(materials)=}!'
+            raise Exception(msg)
+
+        for name, mat in zip(names, materials):
+            self.config['materials']['materials'][name] = mat
+            self.reset_tth_max(name)
+
+        self.materials_added.emit()
+
+    def copy_materials(self, from_names, to_names):
+        mats = self.materials
+        cannot_copy = (
+            any(x in from_names for x in to_names) or
+            any(x in mats for x in to_names) or
+            any(x not in mats for x in from_names) or
+            len(from_names) != len(to_names)
+        )
+        if cannot_copy:
+            mat_names = list(mats.keys())
+            msg = f'Cannot copy {from_names=} to {to_names=} for {mat_names=}'
+            raise Exception(msg)
+
+        for from_name, to_name in zip(from_names, to_names):
+            self.add_material(to_name, copy.deepcopy(mats[from_name]))
+
+    def rearrange_materials(self, new_order):
+        if sorted(new_order) != sorted(self.materials):
+            old = list(self.materials.keys())
+            msg = f'Cannot re-arrange material names from {old} to {new_order}'
+            raise Exception(msg)
+
+        mats = self.materials
+        new_materials = {k: mats[k] for k in new_order}
+        self.config['materials']['materials'] = new_materials
+
+        # This should not require any overlay updates
+        self.materials_rearranged.emit()
 
     def rename_material(self, old_name, new_name):
-        if old_name != new_name:
-            self.config['materials']['materials'][new_name] = (
-                self.config['materials']['materials'][old_name])
-            self.config['materials']['materials'][new_name].name = new_name
+        if old_name == new_name:
+            return
 
-            # Rename any overlays as well
-            for overlay in self.overlays:
-                if overlay['material'] == old_name:
-                    overlay['material'] = new_name
+        ordering = list(self.materials.keys())
+        ordering[ordering.index(old_name)] = new_name
 
-            if self.active_material_name == old_name:
-                # Change the active material before removing the old one
-                # Set the dict directly to bypass the updates that occur
-                # if we did self.active_material = new_name
-                self.config['materials']['active_material'] = new_name
+        # First, rename the material
+        self.materials[new_name] = self.materials[old_name]
+        self.materials[new_name].name = new_name
 
-            # Avoid calling self.remove_material() to avoid pruning
-            # overlays and such.
-            del self.config['materials']['materials'][old_name]
+        # Now re-create the dict to keep the ordering
+        new_dict = {k: self.materials[k] for k in ordering}
+        self.config['materials']['materials'] = new_dict
 
-            self.material_renamed.emit()
+        # Rename any overlays as well
+        for overlay in self.overlays:
+            if overlay['material'] == old_name:
+                overlay['material'] = new_name
+
+        if self.active_material_name == old_name:
+            # Set the dict directly to bypass the updates that occur
+            # if we did self.active_material = new_name
+            self.config['materials']['active_material'] = new_name
+
+        self.material_renamed.emit()
 
     def modify_material(self, name, material):
         if name not in self.materials:
@@ -1013,18 +1064,26 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.overlay_config_changed.emit()
 
     def remove_material(self, name):
-        if name not in self.materials:
-            raise Exception(name + ' is not in materials list!')
-        del self.config['materials']['materials'][name]
+        self.remove_materials([name])
+
+    def remove_materials(self, names):
+        if any(x not in self.materials for x in names):
+            mats = list(self.materials.keys())
+            msg = f'Some of {names=} are not in materials list {mats=}'
+            raise Exception(msg)
+
+        for name in names:
+            del self.config['materials']['materials'][name]
+
         self.prune_overlays()
 
-        if name == self.active_material_name:
-            if self.materials.keys():
-                self.active_material = list(self.materials.keys())[0]
+        if self.active_material_name in names:
+            if self.materials:
+                self.active_material = next(iter(self.materials))
             else:
                 self.active_material = None
 
-        self.material_removed.emit()
+        self.materials_removed.emit()
 
     def _materials(self):
         return self.config['materials'].get('materials', {})
@@ -1037,6 +1096,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.prune_overlays()
         self.flag_overlay_updates_for_all_materials()
         self.overlay_config_changed.emit()
+
+        self.materials_set.emit()
 
     materials = property(_materials, _set_materials)
 

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -31,7 +31,7 @@ class FitGrainsOptionsDialog(QObject):
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
 
-        self.setup_material_options()
+        self.update_materials()
 
         kwargs = {
             'grains_table': grains_table,
@@ -82,6 +82,8 @@ class FitGrainsOptionsDialog(QObject):
         self.tolerances_model.data_modified.connect(
             self.tolerance_data_modified)
 
+        HexrdConfig().materials_dict_modified.connect(self.update_materials)
+
     def all_widgets(self):
         """Only includes widgets directly related to config parameters"""
         widgets = [
@@ -100,10 +102,17 @@ class FitGrainsOptionsDialog(QObject):
     def show(self):
         self.ui.show()
 
-    def setup_material_options(self):
+    def update_materials(self):
+        prev = self.selected_material
+        material_names = list(HexrdConfig().materials)
+
         self.ui.material.clear()
-        self.ui.material.addItems(list(HexrdConfig().materials.keys()))
-        self.ui.material.setCurrentText(HexrdConfig().active_material_name)
+        self.ui.material.addItems(material_names)
+
+        if prev in material_names:
+            self.ui.material.setCurrentText(prev)
+        else:
+            self.ui.material.setCurrentText(HexrdConfig().active_material_name)
 
     def on_accepted(self):
         # Save the selected options on the config
@@ -314,7 +323,11 @@ class FitGrainsOptionsDialog(QObject):
         self._table.show()
 
     def update_num_hkls(self):
-        num_hkls = len(self.material.planeData.getHKLs())
+        if self.material is None:
+            num_hkls = 0
+        else:
+            num_hkls = len(self.material.planeData.getHKLs())
+
         text = f'Number of hkls selected:  {num_hkls}'
         self.ui.num_hkls_selected.setText(text)
 

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -29,6 +29,7 @@ class OmeMapsSelectDialog(QObject):
         self.setup_connections()
 
     def setup_connections(self):
+        HexrdConfig().materials_dict_modified.connect(self.update_materials)
         self.ui.select_file_button.pressed.connect(self.select_file)
         self.ui.method.currentIndexChanged.connect(self.update_method_tab)
         self.ui.material.currentIndexChanged.connect(
@@ -47,9 +48,19 @@ class OmeMapsSelectDialog(QObject):
         for i, data in enumerate(item_data):
             self.ui.method.setItemData(i, data)
 
+        self.update_materials()
+
+    def update_materials(self):
+        prev = self.selected_material
+        material_names = list(HexrdConfig().materials)
+
         self.ui.material.clear()
-        self.ui.material.addItems(list(HexrdConfig().materials.keys()))
-        self.ui.material.setCurrentText(HexrdConfig().active_material_name)
+        self.ui.material.addItems(material_names)
+
+        if prev in material_names:
+            self.ui.material.setCurrentText(prev)
+        else:
+            self.ui.material.setCurrentText(HexrdConfig().active_material_name)
 
     def show(self):
         self.ui.show()
@@ -192,6 +203,10 @@ class OmeMapsSelectDialog(QObject):
         self._table.show()
 
     def update_num_hkls(self):
-        num_hkls = len(self.material.planeData.getHKLs())
+        if self.material is None:
+            num_hkls = 0
+        else:
+            num_hkls = len(self.material.planeData.getHKLs())
+
         text = f'Number of hkls selected:  {num_hkls}'
         self.ui.num_hkls_selected.setText(text)

--- a/hexrd/ui/list_editor.py
+++ b/hexrd/ui/list_editor.py
@@ -32,7 +32,7 @@ class ListEditor(QObject):
         # Make sure there are no duplicates in the items
         items = list(dict.fromkeys(items))
 
-        self.items = items
+        self._items = items
         self._prev_selected_items = []
 
         self.update_table()
@@ -56,6 +56,21 @@ class ListEditor(QObject):
     @property
     def selected_rows(self):
         return sorted([x.row() for x in self.selection_model.selectedRows()])
+
+    @property
+    def items(self):
+        return self._items
+
+    @items.setter
+    def items(self, items):
+        if self._items == items:
+            return
+
+        # Make sure there are no duplicates in the items
+        items = list(dict.fromkeys(items))
+
+        self._items = items
+        self.update_table()
 
     @property
     def selected_items(self):

--- a/hexrd/ui/list_editor.py
+++ b/hexrd/ui/list_editor.py
@@ -1,0 +1,232 @@
+from PySide2.QtCore import QItemSelectionModel, QObject, Signal
+from PySide2.QtWidgets import QDialog, QTableWidgetItem, QVBoxLayout
+
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals, unique_name
+
+
+class ListEditor(QObject):
+    """A string list editor that doesn't allow duplicates"""
+
+    # Indicates the items were re-arranged
+    items_rearranged = Signal()
+
+    # Indicates that some items were deleted
+    # Provides a list of names that were deleted.
+    items_deleted = Signal(list)
+
+    # Indicates that an item was renamed.
+    # Provides an old item name and it's new name.
+    item_renamed = Signal(str, str)
+
+    # Indicates that some items were copied.
+    # Provides a list of items that were copied, and a list of new
+    # names they correspond to, in order.
+    items_copied = Signal(list, list)
+
+    def __init__(self, items, parent=None):
+        super().__init__(parent)
+
+        self.ui = UiLoader().load_file('list_editor.ui', parent)
+
+        # Make sure there are no duplicates in the items
+        items = list(dict.fromkeys(items))
+
+        self.items = items
+        self._prev_selected_items = []
+
+        self.update_table()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.selection_model.selectionChanged.connect(self.selection_changed)
+
+        self.ui.up.clicked.connect(self.up)
+        self.ui.down.clicked.connect(self.down)
+        self.ui.delete_.clicked.connect(self.delete)
+        self.ui.copy.clicked.connect(self.copy)
+
+        self.ui.table.itemChanged.connect(self.item_edited)
+
+    @property
+    def selection_model(self):
+        return self.ui.table.selectionModel()
+
+    @property
+    def selected_rows(self):
+        return sorted([x.row() for x in self.selection_model.selectedRows()])
+
+    @property
+    def selected_items(self):
+        return [self.items[x] for x in self.selected_rows]
+
+    @property
+    def num_items(self):
+        return len(self.items)
+
+    def select_row(self, i):
+        model_index = self.selection_model.model().index(i, 0)
+        command = QItemSelectionModel.Select | QItemSelectionModel.Rows
+        self.selection_model.select(model_index, command)
+
+    def selection_changed(self):
+        self.update_enable_states()
+
+    def update_enable_states(self):
+        selected_rows = self.selected_rows
+        num_selected = len(selected_rows)
+
+        top_selected = 0 in selected_rows
+        bottom_selected = self.num_items - 1 in selected_rows
+        one_selected = num_selected == 1
+        any_selected = num_selected > 0
+        all_selected = num_selected == self.num_items
+
+        self.ui.up.setEnabled(one_selected and not top_selected)
+        self.ui.down.setEnabled(one_selected and not bottom_selected)
+        self.ui.copy.setEnabled(any_selected)
+        self.ui.delete_.setEnabled(any_selected and not all_selected)
+
+    def update_prev_selected_items(self):
+        self._prev_selected_items = self.selected_items
+
+    def up(self):
+        i = self.selected_rows[0]
+        self.swap(i, i - 1)
+
+    def down(self):
+        i = self.selected_rows[0]
+        self.swap(i, i + 1)
+
+    def delete(self):
+        self.update_prev_selected_items()
+        selected_rows = self.selected_rows
+
+        deleted = []
+        for i in selected_rows:
+            deleted.append(self.items.pop(i - len(deleted)))
+
+        new_selection = min(selected_rows[-1] - len(deleted) + 1,
+                            self.num_items - 1)
+
+        self.update_table()
+        self.select_row(new_selection)
+
+        self.items_deleted.emit(deleted)
+
+    def copy(self):
+        self.update_prev_selected_items()
+
+        old_items = [self.items[x] for x in self.selected_rows]
+
+        new_items = []
+        for name in old_items:
+            new_name = unique_name(self.items + new_items, name)
+            new_items.append(new_name)
+
+        self.items += new_items
+        self.update_table()
+
+        self.items_copied.emit(old_items, new_items)
+
+    def item_edited(self, item):
+        row = item.row()
+
+        old_name = self.items[row]
+        new_name = item.text()
+
+        if new_name in self.items:
+            # Make sure it is not a duplicate. If it is, then revert it.
+            new_name = old_name
+
+        self.items[row] = new_name
+        self.update_prev_selected_items()
+        self.update_table()
+
+        if new_name != old_name:
+            self.item_renamed.emit(old_name, new_name)
+
+    def swap(self, i, j):
+        self.update_prev_selected_items()
+        items = self.items
+        items[i], items[j] = items[j], items[i]
+        self.update_table()
+
+        self.items_rearranged.emit()
+
+    def update_table(self):
+        table = self.ui.table
+
+        with block_signals(table):
+            table.clearContents()
+
+            table.setRowCount(self.num_items)
+            for i, item in enumerate(self.items):
+                table.setItem(i, 0, QTableWidgetItem(item))
+
+            for item in self._prev_selected_items:
+                if item in self.items:
+                    self.select_row(self.items.index(item))
+
+
+class ListEditorDialog(QDialog):
+    def __init__(self, items, parent=None):
+        super().__init__(parent)
+
+        layout = QVBoxLayout(self)
+        self.setLayout(layout)
+
+        self.editor = ListEditor(items, self)
+        layout.addWidget(self.editor.ui)
+
+        self.setWindowTitle('List Editor')
+
+        UiLoader().install_dialog_enter_key_filters(self)
+
+    @property
+    def items(self):
+        return self.editor.items
+
+
+if __name__ == '__main__':
+    import sys
+
+    from PySide2.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    items = [
+        'a',
+        'b',
+        'c',
+        'd',
+        'e',
+    ]
+    dialog = ListEditorDialog(items)
+
+    def dialog_finished():
+        print(f'Final items: {dialog.items}')
+
+    def items_rearranged():
+        print(f'Items re-arranged: {dialog.items}')
+
+    def items_deleted(items):
+        print(f'Items deleted: {items=}')
+
+    def items_copied(old_names, new_names):
+        print(f'Items copied: {old_names=} => {new_names=}')
+
+    def item_renamed(old_name, new_name):
+        print(f'Item renamed: {old_name} => {new_name}')
+
+    editor = dialog.editor
+    editor.items_rearranged.connect(items_rearranged)
+    editor.items_deleted.connect(items_deleted)
+    editor.items_copied.connect(items_copied)
+    editor.item_renamed.connect(item_renamed)
+
+    dialog.finished.connect(dialog_finished)
+    dialog.finished.connect(app.quit)
+    dialog.show()
+    app.exec_()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -23,7 +23,7 @@ from hexrd.ui.calibration.auto.powder_runner import PowderRunner
 from hexrd.ui.calibration.wppf_runner import WppfRunner
 from hexrd.ui.create_polar_mask import convert_raw_to_polar, create_polar_mask
 from hexrd.ui.create_raw_mask import convert_polar_to_raw, create_raw_mask
-from hexrd.ui.utils import create_unique_name
+from hexrd.ui.utils import unique_name
 from hexrd.ui.constants import (
     OverlayType, ViewType, WORKFLOW_HEDM, WORKFLOW_LLNL)
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -574,8 +574,8 @@ class MainWindow(QObject):
 
     def run_apply_polar_mask(self, line_data):
         for line in line_data:
-            name = create_unique_name(
-                HexrdConfig().polar_masks_line_data, 'polar_mask_0')
+            name = unique_name(HexrdConfig().polar_masks_line_data,
+                               'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = line.copy()
             HexrdConfig().visible_masks.append(name)
             create_polar_mask([line.copy()], name)
@@ -606,8 +606,7 @@ class MainWindow(QObject):
             msg = 'No Laue overlay ranges found'
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             return
-        name = create_unique_name(
-            HexrdConfig().polar_masks_line_data, 'laue_mask')
+        name = unique_name(HexrdConfig().polar_masks_line_data, 'laue_mask')
         create_polar_mask(data, name)
         HexrdConfig().polar_masks_line_data[name] = data
         HexrdConfig().visible_masks.append(name)

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -6,7 +6,7 @@ from PySide2.QtWidgets import (
     QCheckBox, QFileDialog, QMenu, QPushButton, QTableWidgetItem)
 from PySide2.QtGui import QCursor
 
-from hexrd.ui.utils import block_signals, create_unique_name
+from hexrd.ui.utils import block_signals, unique_name
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.constants import ViewType
@@ -70,7 +70,7 @@ class MaskManagerDialog(QObject):
                     continue
                 self.masks[name] = (det, val)
         elif not self.threshold:
-            name = create_unique_name(self.masks, 'threshold')
+            name = unique_name(self.masks, 'threshold')
             self.masks[name] = ('threshold', HexrdConfig().threshold_mask)
             HexrdConfig().visible_masks.append(name)
             self.threshold = True

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -2,7 +2,7 @@ from PySide2.QtCore import QObject, Signal
 
 from hexrd.ui.create_polar_mask import create_polar_mask
 from hexrd.ui.create_raw_mask import create_raw_mask
-from hexrd.ui.utils import create_unique_name
+from hexrd.ui.utils import unique_name
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
@@ -197,15 +197,14 @@ class MaskRegionsDialog(QObject):
 
     def create_masks(self):
         for data in self.raw_masks_line_data:
-            name = create_unique_name(
-                HexrdConfig().raw_masks_line_data, 'raw_mask_0')
+            name = unique_name(HexrdConfig().raw_masks_line_data, 'raw_mask_0')
             HexrdConfig().raw_masks_line_data[name] = [data]
             create_raw_mask(name, [data])
             HexrdConfig().visible_masks.append(name)
 
         for data_coords in self.polar_masks_line_data:
-            name = create_unique_name(
-                HexrdConfig().polar_masks_line_data, 'polar_mask_0')
+            name = unique_name(HexrdConfig().polar_masks_line_data,
+                               'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = data_coords
             create_polar_mask([data_coords], name)
             HexrdConfig().visible_masks.append(name)

--- a/hexrd/ui/material_list_editor.py
+++ b/hexrd/ui/material_list_editor.py
@@ -29,15 +29,7 @@ class MaterialListEditor:
 
         self.ui.import_material.clicked.connect(self.import_material)
 
-        update_editor_signals = [
-            HexrdConfig().material_renamed,
-            HexrdConfig().materials_removed,
-            HexrdConfig().materials_rearranged,
-            HexrdConfig().materials_set,
-        ]
-
-        for signal in update_editor_signals:
-            signal.connect(self.update_editor_items)
+        HexrdConfig().materials_dict_modified.connect(self.update_editor_items)
 
     def update_editor_items(self):
         self.editor.items = self.materials_names

--- a/hexrd/ui/material_list_editor.py
+++ b/hexrd/ui/material_list_editor.py
@@ -1,0 +1,95 @@
+from pathlib import Path
+
+from PySide2.QtWidgets import QFileDialog
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.list_editor import ListEditor
+from hexrd.ui.ui_loader import UiLoader
+
+
+class MaterialListEditor:
+    """A list editor for materials"""
+
+    def __init__(self, parent=None):
+        self.ui = UiLoader().load_file('material_list_editor.ui', parent)
+
+        self.editor = ListEditor(self.materials_names, parent)
+        self.ui.list_editor_layout.addWidget(self.editor.ui)
+        self.update_editor_items()
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        editor = self.editor
+
+        editor.items_rearranged.connect(self.items_rearranged)
+        editor.items_deleted.connect(self.items_deleted)
+        editor.items_copied.connect(self.items_copied)
+        editor.item_renamed.connect(self.item_renamed)
+
+        self.ui.import_material.clicked.connect(self.import_material)
+
+        update_editor_signals = [
+            HexrdConfig().material_renamed,
+            HexrdConfig().materials_removed,
+            HexrdConfig().materials_rearranged,
+            HexrdConfig().materials_set,
+        ]
+
+        for signal in update_editor_signals:
+            signal.connect(self.update_editor_items)
+
+    def update_editor_items(self):
+        self.editor.items = self.materials_names
+
+    @property
+    def items(self):
+        return self.editor.items
+
+    @property
+    def materials(self):
+        return HexrdConfig().materials
+
+    @property
+    def materials_names(self):
+        return list(self.materials)
+
+    def items_rearranged(self):
+        HexrdConfig().rearrange_materials(self.items)
+
+    def items_deleted(self, deleted):
+        HexrdConfig().remove_materials(deleted)
+
+    def items_copied(self, old_names, new_names):
+        HexrdConfig().copy_materials(old_names, new_names)
+
+    def item_renamed(self, old_name, new_name):
+        HexrdConfig().rename_material(old_name, new_name)
+
+    def import_material(self):
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            self.ui, 'Import Material', HexrdConfig().working_dir,
+            'CIF files (*.cif)')
+
+        if not selected_file:
+            return
+
+        HexrdConfig().working_dir = str(Path(selected_file).parent)
+        new_name = HexrdConfig().import_material(selected_file)
+        HexrdConfig().active_material = new_name
+
+        self.update_editor_items()
+
+
+if __name__ == '__main__':
+    import sys
+
+    from PySide2.QtWidgets import QApplication
+
+    app = QApplication(sys.argv)
+
+    dialog = MaterialListEditor()
+
+    dialog.ui.finished.connect(app.quit)
+    dialog.ui.show()
+    app.exec_()

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -1,15 +1,13 @@
 import math
-import os
 
 from PySide2.QtCore import QObject, QSignalBlocker, Qt
 from PySide2.QtGui import QFocusEvent, QKeyEvent
-from PySide2.QtWidgets import QComboBox, QFileDialog, QMenu, QMessageBox
-
-from hexrd.material import Material
+from PySide2.QtWidgets import QComboBox
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.material_editor_widget import MaterialEditorWidget
+from hexrd.ui.material_list_editor import MaterialListEditor
 from hexrd.ui.material_properties_editor import MaterialPropertiesEditor
 from hexrd.ui.material_structure_editor import MaterialStructureEditor
 from hexrd.ui.overlay_manager import OverlayManager
@@ -42,30 +40,12 @@ class MaterialsPanel(QObject):
         # Turn off autocomplete for the QComboBox
         self.ui.materials_combo.setCompleter(None)
 
-        self.add_tool_button_actions()
-
         self.setup_connections()
 
         self.update_gui_from_config()
 
-    def add_tool_button_actions(self):
-        b = self.ui.materials_tool_button
-
-        m = QMenu(b)
-        self.tool_button_menu = m
-
-        self.add_material_action = m.addAction('Add material')
-        self.import_material_action = m.addAction('Import material')
-        self.delete_material_action = m.addAction('Delete material')
-
-        b.setMenu(m)
-
     def setup_connections(self):
         self.ui.materials_combo.installEventFilter(self)
-        self.add_material_action.triggered.connect(self.add_material)
-        self.import_material_action.triggered.connect(self.import_material)
-        self.delete_material_action.triggered.connect(
-            self.remove_current_material)
         self.ui.materials_combo.currentIndexChanged.connect(
             self.set_active_material)
         self.ui.materials_combo.currentIndexChanged.connect(
@@ -99,9 +79,22 @@ class MaterialsPanel(QObject):
             self.active_material_changed)
         HexrdConfig().active_material_modified.connect(
             self.active_material_modified)
+        HexrdConfig().materials_rearranged.connect(
+            self.update_gui_from_config)
+        HexrdConfig().materials_added.connect(self.update_gui_from_config)
+        HexrdConfig().material_renamed.connect(self.update_gui_from_config)
+        HexrdConfig().materials_removed.connect(self.update_gui_from_config)
+        HexrdConfig().materials_set.connect(self.update_gui_from_config)
 
         self.material_structure_editor.material_modified.connect(
             self.material_structure_edited)
+
+        self.ui.materials_tool_button.clicked.connect(self.tool_button_clicked)
+
+    def tool_button_clicked(self):
+        if not hasattr(self, '_material_list_editor'):
+            self._material_list_editor = MaterialListEditor(self.ui)
+        self._material_list_editor.ui.show()
 
     def update_enable_states(self):
         limit_active = self.ui.limit_active.isChecked()
@@ -235,42 +228,6 @@ class MaterialsPanel(QObject):
 
     def current_material(self):
         return self.ui.materials_combo.currentText()
-
-    def add_material(self):
-        # Create a default material
-        new_mat = Material()
-
-        # Get a unique name
-        base_name = 'new_material'
-        names = list(HexrdConfig().materials.keys())
-        for i in range(1, 100000):
-            new_name = f'{base_name}_{i}'
-            if new_name not in names:
-                new_mat.name = new_name
-                break
-
-        HexrdConfig().add_material(new_name, new_mat)
-        HexrdConfig().active_material = new_name
-
-    def import_material(self):
-        selected_file, selected_filter = QFileDialog.getOpenFileName(
-            self.ui, 'Import Material', HexrdConfig().working_dir,
-            'CIF files (*.cif)')
-
-        if selected_file:
-            HexrdConfig().working_dir = os.path.dirname(selected_file)
-            new_name = HexrdConfig().import_material(selected_file)
-            HexrdConfig().active_material = new_name
-
-    def remove_current_material(self):
-        # Don't allow the user to remove all of the materials
-        if len(HexrdConfig().materials.keys()) == 1:
-            msg = 'Cannot remove all materials. Add another first.'
-            QMessageBox.warning(self.ui, 'HEXRD', msg)
-            return
-
-        name = self.current_material()
-        HexrdConfig().remove_material(name)
 
     def modify_material_name(self):
         combo = self.ui.materials_combo

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -79,12 +79,8 @@ class MaterialsPanel(QObject):
             self.active_material_changed)
         HexrdConfig().active_material_modified.connect(
             self.active_material_modified)
-        HexrdConfig().materials_rearranged.connect(
+        HexrdConfig().materials_dict_modified.connect(
             self.update_gui_from_config)
-        HexrdConfig().materials_added.connect(self.update_gui_from_config)
-        HexrdConfig().material_renamed.connect(self.update_gui_from_config)
-        HexrdConfig().materials_removed.connect(self.update_gui_from_config)
-        HexrdConfig().materials_set.connect(self.update_gui_from_config)
 
         self.material_structure_editor.material_modified.connect(
             self.material_structure_edited)

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -42,7 +42,7 @@ class OverlayManager:
         self.ui.edit_style_button.pressed.connect(self.edit_style)
         HexrdConfig().calibration_complete.connect(self.update_overlay_editor)
         HexrdConfig().material_renamed.connect(self.update_table)
-        HexrdConfig().material_removed.connect(self.update_table)
+        HexrdConfig().materials_removed.connect(self.update_table)
 
     def show(self):
         self.update_table()

--- a/hexrd/ui/resources/ui/list_editor.ui
+++ b/hexrd/ui/resources/ui/list_editor.ui
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>list_editor</class>
+ <widget class="QWidget" name="list_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>268</width>
+    <height>204</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="0" column="2">
+    <layout class="QVBoxLayout" name="button_layout">
+     <item>
+      <widget class="QPushButton" name="up">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>up</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="down">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>down</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="delete_">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>delete</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="copy">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>copy</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="vertical_spacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <widget class="QTableWidget" name="table">
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>false</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="showGrid">
+      <bool>false</bool>
+     </property>
+     <property name="gridStyle">
+      <enum>Qt::SolidLine</enum>
+     </property>
+     <property name="columnCount">
+      <number>1</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderDefaultSectionSize">
+      <number>25</number>
+     </attribute>
+     <column/>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/material_list_editor.ui
+++ b/hexrd/ui/resources/ui/material_list_editor.ui
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>material_list_editor</class>
+ <widget class="QDialog" name="material_list_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>400</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Material List Editor</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="import_material">
+     <property name="text">
+      <string>Import Material</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="list_editor_layout"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/ui_loader.py
+++ b/hexrd/ui/ui_loader.py
@@ -22,10 +22,15 @@ class UiLoader(QUiLoader, metaclass=QSingleton):
         from hexrd.ui.image_tab_widget import ImageTabWidget
         from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
 
-        self.registerCustomWidget(GrainsTableView)
-        self.registerCustomWidget(ImageCanvas)
-        self.registerCustomWidget(ImageTabWidget)
-        self.registerCustomWidget(ScientificDoubleSpinBox)
+        register_list = [
+            GrainsTableView,
+            ImageCanvas,
+            ImageTabWidget,
+            ScientificDoubleSpinBox,
+        ]
+
+        for item in register_list:
+            self.registerCustomWidget(item)
 
     def load_file(self, file_name, parent=None):
         """Load a UI file and return the widget

--- a/hexrd/ui/utils.py
+++ b/hexrd/ui/utils.py
@@ -184,11 +184,17 @@ class EventBlocker(QObject):
             return super().eventFilter(obj, event)
 
 
-def create_unique_name(dic, name, value=0):
-    while name in dic.keys():
-        prefix, *rest = name.rpartition('_')
-        name = f'{prefix}_{value}'
+def unique_name(items, name, start=1, delimiter='_'):
+    value = start
+    while name in items:
+        prefix, delim, suffix = name.rpartition(delimiter)
+        if not delim or not is_int(suffix):
+            # We don't have a "<name><delim><num>" system yet. Start one.
+            name += f'{delimiter}{value}'
+        else:
+            name = f'{prefix}{delim}{value}'
         value += 1
+
     return name
 
 


### PR DESCRIPTION
This adds a "Materials List Editor" dialog that is used to edit the list
of materials.

The user can change the ordering of the materials, copy, delete, rename,
and import materials.

This "takes over" the functionality of the tool button in the materials
panel. That button no longer displays menu items (which included adding a
material, importing a material, and deleting a material). But now, when
the user clicks on the tool button, the materials list editor appears.

https://user-images.githubusercontent.com/9558430/131402667-2d428fdf-8c7f-4840-b81f-c0444b472d14.mp4

Fixes: #982