### PR TITLE
added dexela function key

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1644,6 +1644,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             return 0
         elif func_name == 'GE_41RT':
             return 6
+        elif func_name == 'Dexela_2923':
+            return 8
 
         raise Exception('Unknown distortion function: ' + func_name)
 

--- a/hexrd/ui/resources/calibration/yaml_to_gui.yml
+++ b/hexrd/ui/resources/calibration/yaml_to_gui.yml
@@ -14,7 +14,10 @@ detectors:
         'cal_det_param_2',
         'cal_det_param_3',
         'cal_det_param_4',
-        'cal_det_param_5'
+        'cal_det_param_5',
+        'cal_det_param_6',
+        'cal_det_param_7',
+        'cal_det_param_8',
       ]
     pixels:
       columns: 'cal_det_columns'

--- a/hexrd/ui/resources/ui/calibration_config_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_config_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>678</width>
-    <height>726</height>
+    <height>801</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -514,6 +514,31 @@
          <property name="spacing">
           <number>0</number>
          </property>
+         <item row="3" column="1">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_3">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label_9">
            <property name="text">
@@ -521,6 +546,34 @@
            </property>
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="3">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_2">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
            </property>
           </widget>
          </item>
@@ -539,10 +592,15 @@
              <string>GE_41RT</string>
             </property>
            </item>
+           <item>
+            <property name="text">
+             <string>Dexela_2923</string>
+            </property>
+           </item>
           </widget>
          </item>
-         <item row="2" column="3">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_param_2">
+         <item row="2" column="2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_1">
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -554,6 +612,31 @@
            </property>
            <property name="prefix">
             <string/>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_4">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
            </property>
            <property name="decimals">
             <number>8</number>
@@ -597,84 +680,6 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="2">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_param_1">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="1">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_param_3">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="3" column="2">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_param_4">
-           <property name="enabled">
-            <bool>false</bool>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
          <item row="3" column="3">
           <widget class="ScientificDoubleSpinBox" name="cal_det_param_5">
            <property name="enabled">
@@ -700,7 +705,82 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0" rowspan="2">
+         <item row="4" column="1">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_6">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_7">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="3">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_param_8">
+           <property name="enabled">
+            <bool>false</bool>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" rowspan="3">
           <widget class="QLabel" name="distortion_parameters_label">
            <property name="enabled">
             <bool>false</bool>
@@ -744,7 +824,27 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="2" column="2">
+         <item row="1" column="1">
+          <widget class="QLabel" name="label_17">
+           <property name="text">
+            <string>Sizes:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLabel" name="label_12">
+           <property name="text">
+            <string>Dimensions:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
           <widget class="ScientificDoubleSpinBox" name="cal_det_size_0">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -769,27 +869,7 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="1">
-          <widget class="QLabel" name="label_17">
-           <property name="text">
-            <string>Sizes:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="QLabel" name="label_12">
-           <property name="text">
-            <string>Dimensions:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="3">
+         <item row="1" column="3">
           <widget class="ScientificDoubleSpinBox" name="cal_det_size_1">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -814,8 +894,8 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="2">
-          <widget class="QSpinBox" name="cal_det_rows">
+         <item row="0" column="3">
+          <widget class="QSpinBox" name="cal_det_columns">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -833,8 +913,8 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="3">
-          <widget class="QSpinBox" name="cal_det_columns">
+         <item row="0" column="2">
+          <widget class="QSpinBox" name="cal_det_rows">
            <property name="alignment">
             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
@@ -1069,6 +1149,9 @@
   <tabstop>cal_det_param_3</tabstop>
   <tabstop>cal_det_param_4</tabstop>
   <tabstop>cal_det_param_5</tabstop>
+  <tabstop>cal_det_param_6</tabstop>
+  <tabstop>cal_det_param_7</tabstop>
+  <tabstop>cal_det_param_8</tabstop>
   <tabstop>cal_det_rows</tabstop>
   <tabstop>cal_det_columns</tabstop>
   <tabstop>cal_det_size_0</tabstop>


### PR DESCRIPTION
The GUI was missing a key for the `Dexela_2923` distortion function, which was added to `hexrd` some time back...  The distortion package is a registry, so perhaps we should ask it for all available functions at runtime?