### PR TITLE
Fix bug where extra NaNs are added to laue picks

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -499,7 +499,7 @@ class CalibrationRunner:
         elif self.active_overlay_type == OverlayType.laue:
             while self.current_data_path is not None:
                 # Use NaN's to indicate a skip for laue
-                self.current_data_list.append((np.nan, np.nan))
+                self.current_data_list
                 self.overlay_data_index += 1
 
     def increment_overlay_data_index(self):


### PR DESCRIPTION
Rather than appending NaNs in that loop, it's better to call current_data_list,
which will append the NaNs for us automatically, and it avoids adding the extra
set of NaNs to the end...