### PR TITLE
Add ability to export/import WPPF parameters

### DIFF
--- a/hexrd/ui/resources/ui/wppf_options_dialog.ui
+++ b/hexrd/ui/resources/ui/wppf_options_dialog.ui
@@ -14,14 +14,18 @@
    <string>WPPF Options Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="7" column="1">
-    <widget class="QLineEdit" name="experiment_file">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
+   <item row="1" column="1" colspan="2">
+    <widget class="QComboBox" name="method">
+     <item>
+      <property name="text">
+       <string>LeBail</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Rietveld</string>
+      </property>
+     </item>
     </widget>
    </item>
    <item row="0" column="0" colspan="3">
@@ -34,17 +38,100 @@
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
-    <layout class="QVBoxLayout" name="background_method_parameters_layout"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="background_method_label">
+   <item row="2" column="0">
+    <widget class="QLabel" name="refinement_steps_label">
      <property name="text">
-      <string>Background Method:</string>
+      <string>Refinement Steps:</string>
      </property>
     </widget>
    </item>
-   <item row="15" column="0" colspan="3">
+   <item row="13" column="0" colspan="3">
+    <widget class="QTableWidget" name="table">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Value</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Minimum</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Maximum</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Vary</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QComboBox" name="background_method"/>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="method_label">
+     <property name="text">
+      <string>WPPF Method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QSpinBox" name="refinement_steps">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000000</number>
+     </property>
+     <property name="value">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="0" colspan="3">
+    <layout class="QHBoxLayout" name="plot_options_layout">
+     <item>
+      <widget class="QCheckBox" name="display_wppf_plot">
+       <property name="text">
+        <string>Display WPPF plot in polar view?</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="edit_plot_style">
+       <property name="text">
+        <string>Edit Plot Style</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="peak_shape_label">
+     <property name="text">
+      <string>Peak shape:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="3">
+    <layout class="QVBoxLayout" name="background_method_parameters_layout"/>
+   </item>
+   <item row="16" column="0" colspan="3">
     <layout class="QHBoxLayout" name="button_layout">
      <item>
       <widget class="QPushButton" name="save_plot">
@@ -117,23 +204,6 @@
      </item>
     </layout>
    </item>
-   <item row="14" column="0" colspan="3">
-    <widget class="QPushButton" name="reset_table_to_defaults">
-     <property name="text">
-      <string>Reset Table to Defaults</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QComboBox" name="peak_shape"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="refinement_steps_label">
-     <property name="text">
-      <string>Refinement Steps:</string>
-     </property>
-    </widget>
-   </item>
    <item row="7" column="2">
     <widget class="QPushButton" name="select_experiment_file_button">
      <property name="enabled">
@@ -144,108 +214,34 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="method_label">
-     <property name="text">
-      <string>WPPF Method:</string>
+   <item row="14" column="0" colspan="3">
+    <widget class="QGroupBox" name="table_settings_group">
+     <property name="title">
+      <string>Table Settings</string>
      </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="peak_shape_label">
-     <property name="text">
-      <string>Peak shape:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
-    <widget class="QCheckBox" name="use_experiment_file">
-     <property name="text">
-      <string>Use Experiment File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSpinBox" name="refinement_steps">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10000000</number>
-     </property>
-     <property name="value">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="plot_options_layout">
-     <item>
-      <widget class="QCheckBox" name="display_wppf_plot">
-       <property name="text">
-        <string>Display WPPF plot in polar view?</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="edit_plot_style">
-       <property name="text">
-        <string>Edit Plot Style</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="background_method"/>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QComboBox" name="method">
-     <item>
-      <property name="text">
-       <string>LeBail</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Rietveld</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="13" column="0" colspan="3">
-    <widget class="QTableWidget" name="table">
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Value</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Minimum</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Maximum</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Vary</string>
-      </property>
-     </column>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="export_table">
+        <property name="text">
+         <string>Export</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="import_table">
+        <property name="text">
+         <string>Import</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="reset_table_to_defaults">
+        <property name="text">
+         <string>Reset to Defaults</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="8" column="0" colspan="3">
@@ -313,6 +309,33 @@
      </item>
     </layout>
    </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="peak_shape"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="background_method_label">
+     <property name="text">
+      <string>Background Method:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QLineEdit" name="experiment_file">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QCheckBox" name="use_experiment_file">
+     <property name="text">
+      <string>Use Experiment File</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -337,7 +360,6 @@
   <tabstop>display_wppf_plot</tabstop>
   <tabstop>edit_plot_style</tabstop>
   <tabstop>table</tabstop>
-  <tabstop>reset_table_to_defaults</tabstop>
   <tabstop>save_plot</tabstop>
   <tabstop>reset_object</tabstop>
   <tabstop>preview_spectrum</tabstop>


### PR DESCRIPTION
This adds buttons to the WPPF options dialog so that the user can
export/import the WPPF parameters as an HDF5 file.

The importing performs some validation to make sure all of the
keys in the imported file match the keys that are currently in the
GUI. The keys will not match if the user has different materials
selected, and/or a different peak shape method.

![wppf](https://user-images.githubusercontent.com/9558430/134060052-6c328888-07c6-4072-a7c5-075a7c80aae2.png)

 Fixes: #1024