### PR TITLE
Import masks

### DIFF
--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -43,8 +43,6 @@ def create_polar_mask(line_data, name):
 def rebuild_polar_masks():
     HexrdConfig().polar_masks.clear()
     for name, line_data in HexrdConfig().polar_masks_line_data.items():
-        if not isinstance(line_data, list):
-            line_data = [line_data]
         create_polar_mask(line_data, name)
     for name, value in HexrdConfig().raw_masks_line_data.items():
         det, data = value[0]

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -32,3 +32,15 @@ def create_polar_mask(line_data, name):
         mask[rr, cc] = False
         final_mask = np.logical_and(final_mask, mask)
     HexrdConfig().polar_masks[name] = final_mask
+
+
+def rebuild_polar_masks():
+    HexrdConfig().polar_masks.clear()
+    for name, line_data in HexrdConfig().polar_masks_line_data.items():
+        if not isinstance(line_data, list):
+            line_data = [line_data]
+        create_polar_mask(line_data, name)
+    for name, value in HexrdConfig().raw_masks_line_data.items():
+        det, data = value[0]
+        line_data = convert_raw_to_polar(det, data)
+        create_polar_mask(line_data, name)

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -45,6 +45,7 @@ def rebuild_polar_masks():
     for name, line_data in HexrdConfig().polar_masks_line_data.items():
         create_polar_mask(line_data, name)
     for name, value in HexrdConfig().raw_masks_line_data.items():
-        det, data = value[0]
-        line_data = convert_raw_to_polar(det, data)
+        line_data = []
+        for det, data in value:
+            line_data.extend(convert_raw_to_polar(det, data))
         create_polar_mask(line_data, name)

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -9,8 +9,15 @@ from hexrd.ui.utils.conversions import pixels_to_angles
 
 
 def convert_raw_to_polar(det, line):
-    panel = create_hedm_instrument().detectors[det]
-    return [pixels_to_angles(line, panel, HexrdConfig().polar_res_eta_period)]
+    instr = create_hedm_instrument()
+    kwargs = {
+        'ij': line,
+        'panel': instr.detectors[det],
+        'eta_period': HexrdConfig().polar_res_eta_period,
+        'tvec_c': instr.tvec,
+    }
+
+    return [pixels_to_angles(**kwargs)]
 
 
 def create_polar_mask(line_data, name):

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -5,13 +5,12 @@ from skimage.draw import polygon
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.calibration.polarview import PolarView
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils.conversions import pixels_to_angles
 
 
 def convert_raw_to_polar(det, line):
     panel = create_hedm_instrument().detectors[det]
-    cart = panel.pixelToCart(line)
-    tth, gvec = panel.cart_to_angles(cart)
-    return [np.degrees(tth)]
+    return [pixels_to_angles(line, panel, HexrdConfig().polar_res_eta_period)]
 
 
 def create_polar_mask(line_data, name):

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -39,11 +39,12 @@ def _create_threshold_mask(img, comparison, value):
     return img, mask
 
 
-def convert_polar_to_raw(line):
+def convert_polar_to_raw(line_data):
     line_data = []
-    for key, panel in create_hedm_instrument().detectors.items():
-        raw = angles_to_pixels(line, panel)
-        line_data.append((key, raw))
+    for line in line_data:
+        for key, panel in create_hedm_instrument().detectors.items():
+            raw = angles_to_pixels(line, panel)
+            line_data.append((key, raw))
     return line_data
 
 
@@ -63,9 +64,5 @@ def rebuild_raw_masks():
     for name, line_data in HexrdConfig().raw_masks_line_data.items():
         create_raw_mask(name, line_data)
     for name, data in HexrdConfig().polar_masks_line_data.items():
-        if isinstance(data, list):
-            # These are Laue spots
-            continue
-        else:
-            line_data = convert_polar_to_raw(data)
-            create_raw_mask(name, line_data)
+        line_data = convert_polar_to_raw(data)
+        create_raw_mask(name, line_data)

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -49,14 +49,17 @@ def convert_polar_to_raw(line_data):
 
 
 def create_raw_mask(name, line_data):
-    for line in line_data:
-        det, data = line
+    for det in HexrdConfig().detector_names:
+        det_lines = [l for l in line_data if det == l[0]]
         img = HexrdConfig().image(det, 0)
-        rr, cc = polygon(data[:, 1], data[:, 0], shape=img.shape)
-        if len(rr) >= 1:
-            mask = np.ones(img.shape, dtype=bool)
-            mask[rr, cc] = False
-            HexrdConfig().raw_masks[name] = (det, mask)
+        final_mask = np.ones(img.shape, dtype=bool)
+        for _, data in det_lines:
+            rr, cc = polygon(data[:, 1], data[:, 0], shape=img.shape)
+            if len(rr) >= 1:
+                mask = np.ones(img.shape, dtype=bool)
+                mask[rr, cc] = False
+                final_mask = np.logical_and(final_mask, mask)
+        HexrdConfig().raw_masks.setdefault(name, []).append((det, final_mask))
 
 
 def rebuild_raw_masks():

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -40,12 +40,12 @@ def _create_threshold_mask(img, comparison, value):
 
 
 def convert_polar_to_raw(line_data):
-    line_data = []
+    raw_line_data = []
     for line in line_data:
         for key, panel in create_hedm_instrument().detectors.items():
             raw = angles_to_pixels(line, panel)
-            line_data.append((key, raw))
-    return line_data
+            raw_line_data.append((key, raw))
+    return raw_line_data
 
 
 def create_raw_mask(name, line_data):

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -52,7 +52,7 @@ def convert_polar_to_raw(line_data):
 
 def create_raw_mask(name, line_data):
     for det in HexrdConfig().detector_names:
-        det_lines = [l for l in line_data if det == l[0]]
+        det_lines = [line for line in line_data if det == line[0]]
         img = HexrdConfig().image(det, 0)
         final_mask = np.ones(img.shape, dtype=bool)
         for _, data in det_lines:

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -6,6 +6,7 @@ from skimage.draw import polygon
 from hexrd.ui import constants
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils.conversions import angles_to_pixels
 
 
 def apply_threshold_mask(imageseries):
@@ -41,8 +42,7 @@ def _create_threshold_mask(img, comparison, value):
 def convert_polar_to_raw(line):
     line_data = []
     for key, panel in create_hedm_instrument().detectors.items():
-        cart = panel.angles_to_cart(np.radians(line))
-        raw = panel.cartToPixel(cart)
+        raw = angles_to_pixels(line, panel)
         line_data.append((key, raw))
     return line_data
 

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -56,3 +56,16 @@ def create_raw_mask(name, line_data):
             mask = np.ones(img.shape, dtype=bool)
             mask[rr, cc] = False
             HexrdConfig().raw_masks[name] = (det, mask)
+
+
+def rebuild_raw_masks():
+    HexrdConfig().raw_masks.clear()
+    for name, line_data in HexrdConfig().raw_masks_line_data.items():
+        create_raw_mask(name, line_data)
+    for name, data in HexrdConfig().polar_masks_line_data.items():
+        if isinstance(data, list):
+            # These are Laue spots
+            continue
+        else:
+            line_data = convert_polar_to_raw(data)
+            create_raw_mask(name, line_data)

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -44,6 +44,8 @@ def convert_polar_to_raw(line_data):
     for line in line_data:
         for key, panel in create_hedm_instrument().detectors.items():
             raw = angles_to_pixels(line, panel)
+            if all([np.isnan(x) for x in raw.flatten()]):
+                continue
             raw_line_data.append((key, raw))
     return raw_line_data
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -132,10 +132,11 @@ class ImageCanvas(FigureCanvas):
                 img = images_dict[name]
 
                 # Apply any masks
-                for mask_name, (det, mask) in HexrdConfig().raw_masks.items():
-                    if (mask_name in HexrdConfig().visible_masks and
-                            det == name):
-                        img[~mask] = 0
+                for mask_name, data in HexrdConfig().raw_masks.items():
+                    for det, mask in data:
+                        if (mask_name in HexrdConfig().visible_masks and
+                                det == name):
+                            img[~mask] = 0
 
                 axis = self.figure.add_subplot(rows, cols, i + 1)
                 axis.set_title(name)
@@ -155,10 +156,11 @@ class ImageCanvas(FigureCanvas):
                 img = images_dict[name]
 
                 # Apply any masks
-                for mask_name, (det, mask) in HexrdConfig().raw_masks.items():
-                    if (mask_name in HexrdConfig().visible_masks and
-                            det == name):
-                        img[~mask] = 0
+                for mask_name, data in HexrdConfig().raw_masks.items():
+                    for det, mask in data:
+                        if (mask_name in HexrdConfig().visible_masks and
+                                det == name):
+                            img[~mask] = 0
                 self.axes_images[i].set_data(img)
 
         # This will call self.draw_idle()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -21,8 +21,8 @@ from hexrd.ui.indexing.fit_grains_results_dialog import FitGrainsResultsDialog
 from hexrd.ui.calibration.calibration_runner import CalibrationRunner
 from hexrd.ui.calibration.auto.powder_runner import PowderRunner
 from hexrd.ui.calibration.wppf_runner import WppfRunner
-from hexrd.ui.create_polar_mask import convert_raw_to_polar, create_polar_mask
-from hexrd.ui.create_raw_mask import convert_polar_to_raw, create_raw_mask
+from hexrd.ui.create_polar_mask import create_polar_mask, rebuild_polar_masks
+from hexrd.ui.create_raw_mask import rebuild_raw_masks
 from hexrd.ui.utils import unique_name
 from hexrd.ui.constants import (
     OverlayType, ViewType, WORKFLOW_HEDM, WORKFLOW_LLNL)
@@ -734,29 +734,10 @@ class MainWindow(QObject):
         if self.image_mode == ViewType.cartesian:
             self.ui.image_tab_widget.show_cartesian()
         elif self.image_mode == ViewType.polar:
-            # Rebuild polar masks
-            HexrdConfig().polar_masks.clear()
-            for name, line_data in HexrdConfig().polar_masks_line_data.items():
-                if not isinstance(line_data, list):
-                    line_data = [line_data]
-                create_polar_mask(line_data, name)
-            for name, value in HexrdConfig().raw_masks_line_data.items():
-                det, data = value[0]
-                line_data = convert_raw_to_polar(det, data)
-                create_polar_mask(line_data, name)
+            rebuild_polar_masks()
             self.ui.image_tab_widget.show_polar()
         else:
-            # Rebuild raw masks
-            HexrdConfig().raw_masks.clear()
-            for name, line_data in HexrdConfig().raw_masks_line_data.items():
-                create_raw_mask(name, line_data)
-            for name, data in HexrdConfig().polar_masks_line_data.items():
-                if isinstance(data, list):
-                    # These are Laue spots
-                    continue
-                else:
-                    line_data = convert_polar_to_raw(data)
-                    create_raw_mask(name, line_data)
+            rebuild_raw_masks()
             self.ui.image_tab_widget.load_images()
 
         # Only ask if have haven't asked before

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -573,9 +573,10 @@ class MainWindow(QObject):
             self.run_apply_polar_mask)
 
     def run_apply_polar_mask(self, line_data):
+        raw_lines = HexrdConfig().raw_masks_line_data
+        polar_lines = HexrdConfig().polar_masks_line_data
         for line in line_data:
-            name = unique_name(HexrdConfig().polar_masks_line_data,
-                               'polar_mask_0')
+            name = unique_name({**raw_lines, **polar_lines}, 'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = [line.copy()]
             HexrdConfig().visible_masks.append(name)
             create_polar_mask([line.copy()], name)
@@ -606,7 +607,10 @@ class MainWindow(QObject):
             msg = 'No Laue overlay ranges found'
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             return
-        name = unique_name(HexrdConfig().polar_masks_line_data, 'laue_mask')
+
+        raw_lines = HexrdConfig().raw_masks_line_data
+        polar_lines = HexrdConfig().polar_masks_line_data
+        name = unique_name({**raw_lines, **polar_lines}, 'laue_mask')
         create_polar_mask(data, name)
         HexrdConfig().polar_masks_line_data[name] = data
         HexrdConfig().visible_masks.append(name)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -576,7 +576,7 @@ class MainWindow(QObject):
         for line in line_data:
             name = unique_name(HexrdConfig().polar_masks_line_data,
                                'polar_mask_0')
-            HexrdConfig().polar_masks_line_data[name] = line.copy()
+            HexrdConfig().polar_masks_line_data[name] = [line.copy()]
             HexrdConfig().visible_masks.append(name)
             create_polar_mask([line.copy()], name)
         HexrdConfig().polar_masks_changed.emit()

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -82,6 +82,7 @@ class MaskManagerDialog(QObject):
         self.ui.masks_table.customContextMenuRequested.connect(
             self.context_menu_event)
         self.ui.export_masks.clicked.connect(self.export_visible_masks)
+        self.ui.import_masks.clicked.connect(self.import_masks)
         HexrdConfig().mode_threshold_mask_changed.connect(
             self.update_masks_list)
         HexrdConfig().detectors_changed.connect(self.clear_masks)
@@ -242,3 +243,12 @@ class MaskManagerDialog(QObject):
         HexrdConfig().visible_masks.clear()
         self.masks.clear()
         self.setup_table()
+
+    def import_masks(self):
+        selected_file, _ = QFileDialog.getOpenFileName(
+            self.ui, 'Save Mask', HexrdConfig().working_dir,
+            'NPZ files (*.npz)')
+
+        if selected_file:
+            HexrdConfig().working_dir = os.path.dirname(selected_file)
+            # Load data

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -190,10 +190,10 @@ class MaskManagerDialog(QObject):
             self.masks[new_name] = self.masks.pop(self.old_name)
             if self.old_name in HexrdConfig().polar_masks_line_data.keys():
                 value = HexrdConfig().polar_masks_line_data.pop(self.old_name)
-                HexrdConfig().polar_masks[new_name] = value
+                HexrdConfig().polar_masks_line_data[new_name] = value
             elif self.old_name in HexrdConfig().raw_masks_line_data.keys():
                 value = HexrdConfig().raw_masks_line_data.pop(self.old_name)
-                HexrdConfig().raw_masks[new_name] = value
+                HexrdConfig().raw_masks_line_data[new_name] = value
 
             if self.old_name in HexrdConfig().polar_masks.keys():
                 value = HexrdConfig().polar_masks.pop(self.old_name)

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -61,7 +61,7 @@ class MaskManagerDialog(QObject):
                 return
             for name, data in HexrdConfig().polar_masks_line_data.items():
                 vals = self.masks.values()
-                if any(np.array_equal(val, m) for val, (_, m) in zip(data, vals)):
+                if any(np.array_equal(v, m) for v, (_, m) in zip(data, vals)):
                     continue
                 self.masks[name] = (mask_type, data)
         elif mask_type == 'raw':

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -259,29 +259,31 @@ class MaskManagerDialog(QObject):
             self.ui, 'Save Mask', HexrdConfig().working_dir,
             'HDF5 files (*.h5 *.hdf5)')
 
-        if selected_file:
-            HexrdConfig().working_dir = os.path.dirname(selected_file)
-            # Unwrap the h5 file to a dict
-            masks_dict = {}
-            with h5py.File(selected_file, 'r') as f:
-                unwrap_h5_to_dict(f, masks_dict)
+        if not selected_file:
+            return
 
-            raw_line_data = HexrdConfig().raw_masks_line_data
-            mask_data = masks_dict['masks']
-            for det, data in mask_data.items():
-                if det not in HexrdConfig().detector_names:
-                    msg = (
-                        f'Detectors must match.\n'
-                        f'Current detectors: {HexrdConfig().detector_names}.\n'
-                        f'Detectors found in masks: {list(mask_data.keys())}')
-                    QMessageBox.warning(self.ui, 'HEXRD', msg)
-                    return
-                for name, mask in data.items():
-                    raw_line_data.setdefault(name, []).append((det, mask))
+        HexrdConfig().working_dir = os.path.dirname(selected_file)
+        # Unwrap the h5 file to a dict
+        masks_dict = {}
+        with h5py.File(selected_file, 'r') as f:
+            unwrap_h5_to_dict(f, masks_dict)
 
-            if self.image_mode == ViewType.raw:
-                rebuild_raw_masks()
-            elif self.image_mode == ViewType.polar:
-                rebuild_polar_masks()
+        raw_line_data = HexrdConfig().raw_masks_line_data
+        mask_data = masks_dict['masks']
+        for det, data in mask_data.items():
+            if det not in HexrdConfig().detector_names:
+                msg = (
+                    f'Detectors must match.\n'
+                    f'Current detectors: {HexrdConfig().detector_names}.\n'
+                    f'Detectors found in masks: {list(mask_data.keys())}')
+                QMessageBox.warning(self.ui, 'HEXRD', msg)
+                return
+            for name, mask in data.items():
+                raw_line_data.setdefault(name, []).append((det, mask))
 
-            self.update_masks_list('raw')
+        if self.image_mode == ViewType.raw:
+            rebuild_raw_masks()
+        elif self.image_mode == ViewType.polar:
+            rebuild_polar_masks()
+
+        self.update_masks_list('raw')

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -193,7 +193,7 @@ class MaskRegionsDialog(QObject):
         if self.image_mode == ViewType.raw:
             self.raw_masks_line_data.append((self.det, data_coords))
         elif self.image_mode == ViewType.polar:
-            self.polar_masks_line_data.append(data_coords)
+            self.polar_masks_line_data.append([data_coords])
 
     def create_masks(self):
         for data in self.raw_masks_line_data:
@@ -206,7 +206,7 @@ class MaskRegionsDialog(QObject):
             name = unique_name(HexrdConfig().polar_masks_line_data,
                                'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = data_coords
-            create_polar_mask([data_coords], name)
+            create_polar_mask(data_coords, name)
             HexrdConfig().visible_masks.append(name)
 
         if self.raw_masks_line_data:

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -196,15 +196,16 @@ class MaskRegionsDialog(QObject):
             self.polar_masks_line_data.append([data_coords])
 
     def create_masks(self):
+        raw_lines = HexrdConfig().raw_masks_line_data
+        polar_lines = HexrdConfig().polar_masks_line_data
         for data in self.raw_masks_line_data:
-            name = unique_name(HexrdConfig().raw_masks_line_data, 'raw_mask_0')
+            name = unique_name({**raw_lines, **polar_lines}, 'raw_mask_0')
             HexrdConfig().raw_masks_line_data[name] = [data]
             create_raw_mask(name, [data])
             HexrdConfig().visible_masks.append(name)
 
         for data_coords in self.polar_masks_line_data:
-            name = unique_name(HexrdConfig().polar_masks_line_data,
-                               'polar_mask_0')
+            name = unique_name({**raw_lines, **polar_lines}, 'polar_mask_0')
             HexrdConfig().polar_masks_line_data[name] = data_coords
             create_polar_mask(data_coords, name)
             HexrdConfig().visible_masks.append(name)

--- a/hexrd/ui/resources/ui/mask_manager_dialog.ui
+++ b/hexrd/ui/resources/ui/mask_manager_dialog.ui
@@ -57,6 +57,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QPushButton" name="import_masks">
+       <property name="text">
+        <string>Import Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -8,7 +8,7 @@ def cart_to_pixels(xys, panel):
 
 
 def pixels_to_cart(ij, panel):
-    return panel.pixelToCart(ij)[:, [1, 0]]
+    return panel.pixelToCart(ij[:, [1, 0]])
 
 
 def cart_to_angles(xys, panel, eta_period, tvec_c=None, apply_distortion=True):


### PR DESCRIPTION
This branch adds a new feature that allows users to import masks previously exported from the GUI. The export has been updated to save the raw masking coordinates as well as the mask name and its associated detector. This information is used on import to re-populate the mask manager and apply the masks to the correct detectors in the raw view.

![import_masks](https://user-images.githubusercontent.com/51238406/134192589-37987c43-edc5-4011-a64f-b8d1ba469f98.gif)

Fixes #995