### PR TITLE
Reusable mask import export

### DIFF
--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -278,15 +278,16 @@ class MaskManagerDialog(QObject):
         masks_dict = {}
         with h5py.File(selected_file, 'r') as f:
             unwrap_h5_to_dict(f, masks_dict)
+        self.load_masks(masks_dict['masks'])
 
+    def load_masks(self, h5py_group):
         raw_line_data = HexrdConfig().raw_masks_line_data
-        mask_data = masks_dict['masks']
-        for det, data in mask_data.items():
+        for det, data in h5py_group.items():
             if det not in HexrdConfig().detector_names:
                 msg = (
                     f'Detectors must match.\n'
                     f'Current detectors: {HexrdConfig().detector_names}.\n'
-                    f'Detectors found in masks: {list(mask_data.keys())}')
+                    f'Detectors found in masks: {list(h5py_group.keys())}')
                 QMessageBox.warning(self.ui, 'HEXRD', msg)
                 return
             for name, masks in data.items():


### PR DESCRIPTION
This breaks up the import and export functions in the mask manager so that they can be reused elsewhere, like when exporting/importing the state.

The `export_masks` function can now accept a h5py group and will update that group if it is provided. If one is not provided the user is prompted to select or create a file instead. The `import_masks` function is now only called when import is selected in the mask manager dialog. The actual parsing of the h5py group is performed in `load_masks` which is now called from `import_masks` and could be connected to a signal when a state is loaded.