### PR TITLE
Add support for state in HDF5

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -314,6 +314,8 @@ class PolarView:
         img = img.copy()
         total_mask = self.raw_mask
         for name in HexrdConfig().visible_masks:
+            if name not in HexrdConfig().masks:
+                continue
             mask = HexrdConfig().masks[name]
             total_mask = np.logical_or(total_mask, ~mask)
         img[total_mask] = np.nan

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -204,6 +204,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.logging_stdout_handler = None
         self.logging_stderr_handler = None
         self.loading_state = False
+        self.last_loaded_state_file = None
 
         self.setup_logging()
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -335,6 +335,10 @@ class ImageCanvas(FigureCanvas):
         pass
 
     def update_overlays(self):
+        if HexrdConfig().loading_state:
+            # Skip the request if we are loading state
+            return
+
         # iviewer is required for drawing rings
         if not self.iviewer:
             return
@@ -790,6 +794,10 @@ class ImageCanvas(FigureCanvas):
             self.auto_picked_data_artists.append(artist)
 
     def on_detector_transform_modified(self, det):
+        if HexrdConfig().loading_state:
+            # Skip the request if we are loading state
+            return
+
         if self.mode is None:
             return
 

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -94,6 +94,8 @@ class ImageModeWidget(QObject):
         HexrdConfig().mgr_threshold_mask_changed.connect(
             self.ui.raw_threshold_mask.setChecked)
 
+        HexrdConfig().state_loaded.connect(self.update_gui_from_config)
+
     def currentChanged(self, index):
         modes = {
             0: ViewType.raw,
@@ -178,6 +180,11 @@ class ImageModeWidget(QObject):
         self.ui.polar_apply_erosion.setEnabled(apply_snip1d)
 
     def auto_generate_cartesian_params(self):
+        if HexrdConfig().loading_state:
+            # Don't modify the parameters if a state file is being
+            # loaded. We want to keep whatever is in the state file...
+            return
+
         # This will automatically generate and set values for the
         # Cartesian pixel size and virtual plane distance based upon
         # values in the instrument config.
@@ -199,6 +206,11 @@ class ImageModeWidget(QObject):
         self.update_gui_from_config()
 
     def auto_generate_polar_params(self):
+        if HexrdConfig().loading_state:
+            # Don't modify the parameters if a state file is being
+            # loaded. We want to keep whatever is in the state file...
+            return
+
         # This will automatically generate and set values for the polar
         # pixel values based upon the config.
         # This function does not invoke a re-render.

--- a/hexrd/ui/load_panel.py
+++ b/hexrd/ui/load_panel.py
@@ -36,9 +36,7 @@ class LoadPanel(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('load_panel.ui', parent)
 
-        self.ims = HexrdConfig().imageseries_dict
-        self.parent_dir = HexrdConfig().images_dir
-        self.state = HexrdConfig().load_panel_state
+        self.update_config_variables()
 
         self.files = []
         self.omega_min = []
@@ -101,6 +99,8 @@ class LoadPanel(QObject):
         self.ui.file_options.cellChanged.connect(self.enable_aggregations)
         self.ui.update_img_data.clicked.connect(self.update_image_data)
 
+        HexrdConfig().state_loaded.connect(self.state_loaded)
+
     def setup_processing_options(self):
         self.state = HexrdConfig().load_panel_state
         self.num_dets = len(HexrdConfig().detector_names)
@@ -111,6 +111,15 @@ class LoadPanel(QObject):
             'dark', [UI_DARK_INDEX_NONE for x in range(self.num_dets)])
         self.state.setdefault(
             'dark_files', [None for x in range(self.num_dets)])
+
+    def state_loaded(self):
+        self.update_config_variables()
+        self.setup_gui()
+
+    def update_config_variables(self):
+        self.ims = HexrdConfig().imageseries_dict
+        self.parent_dir = HexrdConfig().images_dir
+        self.state = HexrdConfig().load_panel_state
 
     # Handle GUI changes
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -282,6 +282,8 @@ class MainWindow(QObject):
         self.import_data_widget.enforce_raw_mode.connect(
             self.enforce_view_mode)
 
+        HexrdConfig().instrument_config_loaded.connect(self.update_config_gui)
+
     def set_icon(self, icon):
         self.ui.setWindowIcon(icon)
 
@@ -322,7 +324,6 @@ class MainWindow(QObject):
             HexrdConfig().working_dir = str(path.parent)
 
             HexrdConfig().load_instrument_config(str(path))
-            self.update_config_gui()
 
     def _save_config(self, extension, filter):
         selected_file, selected_filter = QFileDialog.getSaveFileName(
@@ -678,7 +679,6 @@ class MainWindow(QObject):
         HexrdConfig().visible_masks.append(name)
         self.new_mask_added.emit(self.image_mode)
         HexrdConfig().polar_masks_changed.emit()
-
 
     def on_action_edit_apply_polygon_mask_triggered(self):
         mrd = MaskRegionsDialog(self.ui)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -913,8 +913,14 @@ class MainWindow(QObject):
             path = Path(selected_file)
             HexrdConfig().working_dir = str(path.parent)
 
-            with h5py.File(selected_file, "r") as h5_file:
+            # The image series will take care of closing the file
+            h5_file = h5py.File(selected_file, "r")
+            try:
                 state.load(h5_file)
+            except Exception:
+                # If an exception occurred, assume we should close the file...
+                h5_file.close()
+                raise
 
     def add_view_dock_widget_actions(self):
         # Add actions to show/hide all of the dock widgets

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import h5py
 
 import numpy as np
 
@@ -52,6 +53,7 @@ from hexrd.ui.image_mode_widget import ImageModeWidget
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.workflow_selection_dialog import WorkflowSelectionDialog
 from hexrd.ui.rerun_clustering_dialog import RerunClusteringDialog
+from hexrd.ui import state
 
 
 class MainWindow(QObject):
@@ -171,6 +173,10 @@ class MainWindow(QObject):
             self.on_action_save_imageseries_triggered)
         self.ui.action_save_materials.triggered.connect(
             self.on_action_save_materials_triggered)
+        self.ui.action_save_state.triggered.connect(
+            self.on_action_save_state_triggered)
+        self.ui.action_open_state.triggered.connect(
+            self.on_action_load_state_triggered)
         self.ui.action_export_current_plot.triggered.connect(
             self.on_action_export_current_plot_triggered)
         self.ui.action_edit_euler_angle_convention.triggered.connect(
@@ -885,6 +891,30 @@ class MainWindow(QObject):
 
     def on_action_open_mask_manager_triggered(self):
         self.mask_manager_dialog.show()
+
+    def on_action_save_state_triggered(self):
+
+        selected_file, _ = QFileDialog.getSaveFileName(
+            self.ui, 'Save Current State', HexrdConfig().working_dir,
+            'HDF5 files (*.h5 *.hdf5)')
+
+        if selected_file:
+            with h5py.File(selected_file, "w") as h5_file:
+                state.save(h5_file)
+
+            HexrdConfig().working_dir = os.path.dirname(selected_file)
+
+    def on_action_load_state_triggered(self):
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            self.ui, 'Load State', HexrdConfig().working_dir,
+            'HDF5 files (*.h5 *.hdf5)')
+
+        if selected_file:
+            path = Path(selected_file)
+            HexrdConfig().working_dir = str(path.parent)
+
+            with h5py.File(selected_file, "r") as h5_file:
+                state.load(h5_file)
 
     def add_view_dock_widget_actions(self):
         # Add actions to show/hide all of the dock widgets

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -24,7 +24,7 @@ class MaskManagerDialog(QObject):
     update_masks = Signal()
 
     def __init__(self, parent=None):
-        super(MaskManagerDialog, self).__init__(parent)
+        super().__init__(parent)
         self.parent = parent
 
         loader = UiLoader()
@@ -217,6 +217,7 @@ class MaskManagerDialog(QObject):
         self.write_all_masks(h5py_group['masks'])
 
     def load_state(self, h5py_group):
+        self.clear_masks()
         if 'masks' in h5py_group:
             self.load_masks(h5py_group['masks'])
 
@@ -251,6 +252,7 @@ class MaskManagerDialog(QObject):
     def clear_masks(self):
         HexrdConfig().masks.clear()
         HexrdConfig().visible_masks.clear()
+        HexrdConfig().raw_mask_coords.clear()
         self.masks.clear()
         self.setup_table()
 

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -10,6 +10,7 @@ from PySide2.QtWidgets import (
 from PySide2.QtGui import QCursor
 
 from hexrd.instrument import unwrap_dict_to_h5, unwrap_h5_to_dict
+from hexrd.utils.compatibility import h5py_read_string
 
 from hexrd.ui.utils import block_signals, unique_name
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -259,7 +260,8 @@ class MaskManagerDialog(QObject):
         raw_line_data = HexrdConfig().raw_mask_coords
         for key, data in h5py_group.items():
             if key == '_visible':
-                HexrdConfig().visible_masks = list(data)
+                # Convert strings into actual python strings
+                HexrdConfig().visible_masks = list(h5py_read_string(data))
             else:
                 if key not in HexrdConfig().detector_names:
                     msg = (
@@ -270,6 +272,8 @@ class MaskManagerDialog(QObject):
                     return
                 for name, masks in data.items():
                     for mask in masks.values():
+                        # Load the numpy array from the hdf5 file
+                        mask = mask[()]
                         raw_line_data.setdefault(name, []).append((key, mask))
 
         if self.image_mode == ViewType.raw:

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -80,6 +80,9 @@ class MaskManagerDialog(QObject):
             self.update_masks_list)
         HexrdConfig().detectors_changed.connect(self.clear_masks)
 
+        HexrdConfig().save_state.connect(self.save_state)
+        HexrdConfig().load_state.connect(self.load_state)
+
     def setup_table(self, status=True):
         with block_signals(self.ui.masks_table):
             self.ui.masks_table.setRowCount(0)
@@ -206,6 +209,16 @@ class MaskManagerDialog(QObject):
                     parent = d.setdefault(det, {})
                     parent.setdefault(selection, {})[str(i)] = mask
                 self.export_masks_to_file(d)
+
+    def save_state(self, h5py_group):
+        if 'masks' not in h5py_group:
+            h5py_group.create_group('masks')
+
+        self.write_all_masks(h5py_group['masks'])
+
+    def load_state(self, h5py_group):
+        if 'masks' in h5py_group:
+            self.load_masks(h5py_group['masks'])
 
     def write_all_masks(self, h5py_group=None):
         d = {'_visible': HexrdConfig().visible_masks}

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -44,6 +44,8 @@ class OverlayManager:
         HexrdConfig().material_renamed.connect(self.update_table)
         HexrdConfig().materials_removed.connect(self.update_table)
 
+        HexrdConfig().state_loaded.connect(self.update_table)
+
     def show(self):
         self.update_table()
         self.ui.show()

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -58,6 +58,7 @@
      <addaction name="action_open_aps_imageseries"/>
      <addaction name="separator"/>
      <addaction name="action_open_grain_fitting_results"/>
+     <addaction name="action_open_state"/>
     </widget>
     <widget class="QMenu" name="menu_save">
      <property name="title">
@@ -73,6 +74,7 @@
      <addaction name="action_save_imageseries"/>
      <addaction name="menu_save_config"/>
      <addaction name="action_save_materials"/>
+     <addaction name="action_save_state"/>
     </widget>
     <widget class="QMenu" name="menu_export">
      <property name="title">
@@ -622,6 +624,16 @@
    </property>
    <property name="text">
     <string>Apply Powder Rings Mask to Polar</string>
+   </property>
+  </action>
+  <action name="action_save_state">
+   <property name="text">
+    <string>State</string>
+   </property>
+  </action>
+  <action name="action_open_state">
+   <property name="text">
+    <string>State</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -53,12 +53,12 @@
       <string>&amp;Open</string>
      </property>
      <addaction name="action_open_images"/>
+     <addaction name="action_open_state"/>
      <addaction name="action_open_config_file"/>
      <addaction name="action_open_materials"/>
      <addaction name="action_open_aps_imageseries"/>
      <addaction name="separator"/>
      <addaction name="action_open_grain_fitting_results"/>
-     <addaction name="action_open_state"/>
     </widget>
     <widget class="QMenu" name="menu_save">
      <property name="title">
@@ -72,9 +72,9 @@
       <addaction name="action_save_config_yaml"/>
      </widget>
      <addaction name="action_save_imageseries"/>
+     <addaction name="action_save_state"/>
      <addaction name="menu_save_config"/>
      <addaction name="action_save_materials"/>
-     <addaction name="action_save_state"/>
     </widget>
     <widget class="QMenu" name="menu_export">
      <property name="title">
@@ -209,7 +209,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>620</height>
+          <height>574</height>
          </rect>
         </property>
         <attribute name="label">
@@ -222,7 +222,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>620</height>
+          <height>574</height>
          </rect>
         </property>
         <attribute name="label">
@@ -235,7 +235,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>620</height>
+          <height>574</height>
          </rect>
         </property>
         <attribute name="label">

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -191,3 +191,6 @@ def load(h5_file):
 
     # Indicate that the state was loaded...
     HexrdConfig().state_loaded.emit()
+
+    # Perform a deep rerender to make sure everything is updated...
+    HexrdConfig().deep_rerender_needed.emit()

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -1,0 +1,142 @@
+import hexrd.ui
+from hexrd.ui.hexrd_config import HexrdConfig
+import yaml
+from pathlib import Path
+import h5py
+import numpy as np
+
+CONFIG_PREFIX = "config"
+CONFIG_YAML_PATH = str(Path(CONFIG_PREFIX) / "yaml")
+
+
+class H5StateLoader(yaml.SafeLoader):
+    """
+    A yaml.Loader implementation that allows !include <numpy_file_path>. This
+    allows the loading of npy files into the YAML document from a HDF5 file. We
+    also whitelist a new python types.
+    """
+
+    def __init__(self, *pargs, h5_file=None, **kwargs):
+        super().__init__(*pargs, **kwargs)
+        self.h5_file = h5_file
+
+    def include(self, node):
+        path = self.construct_scalar(node)
+
+        return self.h5_file[path][()]
+
+    def hexrd_ui_constants_overlaytype(self, node):
+        value = self.construct_sequence(node)
+
+        return hexrd.ui.constants.OverlayType(value[0])
+
+    def python_tuple(self, node):
+        value = self.construct_sequence(node)
+
+        return tuple(value)
+
+
+H5StateLoader.add_constructor(u'!include', H5StateLoader.include)
+H5StateLoader.add_constructor(
+    u'tag:yaml.org,2002:python/object/apply:hexrd.ui.constants.OverlayType',
+    H5StateLoader.hexrd_ui_constants_overlaytype)
+H5StateLoader.add_constructor(
+    u'tag:yaml.org,2002:python/tuple', H5StateLoader.python_tuple)
+
+
+def _dict_path_by_id(d, value, path=()):
+    if id(d) == value:
+        return path
+    elif isinstance(d, dict):
+        for k, v in d.items():
+            p = _dict_path_by_id(v, value, path + (k, ))
+            if p is not None:
+                return p
+    elif isinstance(d, list):
+        for i, v in enumerate(d):
+            p = _dict_path_by_id(v, value, path + (str(i),))
+            if p is not None:
+                return p
+
+    return None
+
+
+class H5StateDumper(yaml.Dumper):
+    """
+    A yaml.Dumper implementation that will dump numpy types to a HDF5 file.
+    The path generate from the values path in the YAML document is used as the
+    path in the HDF5 file. For example:
+
+    "foo":
+        "bar": ndarray
+
+    The ndarray would be saved in foo/bar.
+
+    """
+    def __init__(self, stream, h5_file=None, prefix=None, **kwargs):
+        super().__init__(stream, **kwargs)
+
+        self.h5_file = h5_file
+        self.prefix = prefix
+
+    def numpy_representer(self, data):
+        path = _dict_path_by_id(self._dct, id(data))
+        if path is None:
+            raise ValueError("Unable to determine array path.")
+
+        path = Path(*path)
+        if self.prefix:
+            path = Path(self.prefix) / path
+        path = str(path)
+
+        self.h5_file.create_dataset(path, data.shape, data.dtype, data=data)
+
+        return self.represent_scalar('!include', path)
+
+    # We need intercept the dict so we can lookup the paths to numpy types
+    def represent(self, data):
+        self._dct = data
+        return super().represent(data)
+
+
+H5StateDumper.add_representer(np.ndarray, H5StateDumper.numpy_representer)
+H5StateDumper.add_representer(np.float64, H5StateDumper.numpy_representer)
+
+
+def _save_config(h5_file, config):
+    def _create_dumper(*arg, **kwargs):
+        return H5StateDumper(*arg, **kwargs, h5_file=h5_file,
+                             prefix=CONFIG_PREFIX)
+
+    # Dump the YAML, this will write the numpy types to the H5 file
+    config_yaml = yaml.dump(config, Dumper=_create_dumper)
+
+    # Add the YAML as a string dataset
+    h5_file.create_dataset(CONFIG_YAML_PATH, data=config_yaml,
+                           dtype=h5py.string_dtype())
+
+
+def _load_config(h5_file):
+    def _create_loader(*pargs, **kwargs):
+        return H5StateLoader(*pargs, **kwargs, h5_file=h5_file)
+
+    # First load extract the YAML string from the H5 file.
+    config_yaml = h5_file[CONFIG_YAML_PATH][()]
+
+    # Load it, which will cause the numpy type to be loaded as well.
+    return yaml.load(config_yaml, Loader=_create_loader)
+
+
+def save(h5_file):
+    """
+    Save the state of the application in a HDF5 file
+    """
+    _save_config(h5_file, HexrdConfig().state_to_persist())
+
+
+def load(h5_file):
+    """
+    Load application state from a HDF5 file
+    """
+    state = _load_config(h5_file)
+    HexrdConfig().load_from_state(state)

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -196,22 +196,29 @@ def load(h5_file):
         HexrdConfig().workflow_changed.emit()
 
         # Finally, load the imageseries...
-        imsd = HexrdConfig().imageseries_dict
-        imsd.clear()
-
-        root = 'images'
-        for det, ims in list(h5_file[root].items()):
-            imsd[det] = imageseries.open(h5_file, 'hdf5', path=f'{root}/{det}')
-
-        HexrdConfig().reset_unagg_imgs(new_imgs=True)
-
-        ImageLoadManager().update_status = HexrdConfig().live_update
-        ImageLoadManager().finish_processing_ims()
+        load_imageseries_dict(h5_file)
     finally:
         HexrdConfig().loading_state = False
+
+    # Record the location of the state file in case we save over it
+    HexrdConfig().last_loaded_state_file = h5_file.filename
 
     # Indicate that the state was loaded...
     HexrdConfig().state_loaded.emit()
 
     # Perform a deep rerender to make sure everything is updated...
     HexrdConfig().deep_rerender_needed.emit()
+
+
+def load_imageseries_dict(h5_file):
+    imsd = HexrdConfig().imageseries_dict
+    imsd.clear()
+
+    root = 'images'
+    for det, ims in list(h5_file[root].items()):
+        imsd[det] = imageseries.open(h5_file, 'hdf5', path=f'{root}/{det}')
+
+    HexrdConfig().reset_unagg_imgs(new_imgs=True)
+
+    ImageLoadManager().update_status = HexrdConfig().live_update
+    ImageLoadManager().finish_processing_ims()


### PR DESCRIPTION
We convert the configuration to YAML and then use a custom loader/dumper to allow us to include numpy types in the HDF5 file in separate datasets. The high level YAML configuration is saved as a string dataset. We use the SafeLoader for loading so we have whitelisted a few safe python types.

This PR currently only persist the state held in `HexrdConfig`

Depends on: hexrd/hexrd#310.