### PR TITLE
Mask powder rings

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -179,6 +179,8 @@ class MainWindow(QObject):
             self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_edit_apply_laue_mask_to_polar.triggered.connect(
             self.on_action_edit_apply_laue_mask_to_polar_triggered)
+        self.ui.action_edit_apply_powder_mask_to_polar.triggered.connect(
+            self.action_edit_apply_powder_mask_to_polar)
         self.ui.action_edit_apply_polygon_mask.triggered.connect(
             self.on_action_edit_apply_polygon_mask_triggered)
         self.ui.action_edit_apply_polygon_mask.triggered.connect(
@@ -664,6 +666,7 @@ class MainWindow(QObject):
                                                         has_images)
         self.ui.action_run_wppf.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
+        self.ui.action_edit_apply_powder_mask_to_polar.setEnabled(is_polar)
 
     def start_powder_calibration(self):
         if not HexrdConfig().has_images():

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -113,6 +113,7 @@
      <addaction name="action_edit_apply_polar_mask"/>
      <addaction name="action_edit_apply_laue_mask_to_polar"/>
      <addaction name="action_edit_apply_polygon_mask"/>
+     <addaction name="action_edit_apply_powder_mask_to_polar"/>
      <addaction name="action_open_mask_manager"/>
     </widget>
     <widget class="QMenu" name="menu_intensity_corrections">
@@ -610,6 +611,14 @@
    </property>
    <property name="text">
     <string>Re-run Clustering</string>
+   </property>
+  </action>
+  <action name="action_edit_apply_powder_mask_to_polar">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Apply Powder Rings Mask to Polar</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This branch is a quick first pass at supporting masking of powder rings. Testing on the tardis example looks good, but testing on the hydra example is showing some weird behavior on detector `ge2` in the raw view for reasons I have not yet figured out

![polar_powder_masking](https://user-images.githubusercontent.com/51238406/134732987-e6f2f2a8-27f3-4a7e-b9c5-cd2b8f879cd2.png)
![raw_powder_masking](https://user-images.githubusercontent.com/51238406/134732988-b9240c00-26f0-43ee-8f31-59254da800db.png)
![ge_powder_polar](https://user-images.githubusercontent.com/51238406/134732662-8ce255e8-0f16-4012-838f-d72051fe9959.png)
![ge_powder_raw](https://user-images.githubusercontent.com/51238406/134732664-ae090780-5efa-4337-a6a7-f7d64f56cdfd.png)
