### PR TITLE
Add auto point picking as calibration option

### DIFF
--- a/hexrd/ui/calibration/auto/instrument_calibrator.py
+++ b/hexrd/ui/calibration/auto/instrument_calibrator.py
@@ -135,7 +135,7 @@ class InstrumentCalibrator(object):
         iter_count = 0
         while delta_r > conv_tol \
             and step_successful \
-                and iter_count <= max_iter:
+                and iter_count < max_iter:
 
             # extract data
             master_data_dict_list = self.extract_points(

--- a/hexrd/ui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrd/ui/calibration/auto/powder_calibration_dialog.py
@@ -82,4 +82,4 @@ class PowderCalibrationDialog:
         self.ui.optimization_parameters_group.setVisible(b)
 
         # Resize later so that the dialog is the correct size
-        QTimer.singleShot(0, lambda: self.ui.resize(self.ui.sizeHint()));
+        QTimer.singleShot(0, lambda: self.ui.resize(self.ui.sizeHint()))

--- a/hexrd/ui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrd/ui/calibration/auto/powder_calibration_dialog.py
@@ -1,3 +1,4 @@
+from PySide2.QtCore import QTimer
 from PySide2.QtWidgets import QMessageBox
 
 import numpy as np
@@ -76,3 +77,9 @@ class PowderCalibrationDialog:
         HexrdConfig().material_tth_width_modified.emit(self.material.name)
         HexrdConfig().flag_overlay_updates_for_material(self.material.name)
         HexrdConfig().overlay_config_changed.emit()
+
+    def show_optimization_parameters(self, b=True):
+        self.ui.optimization_parameters_group.setVisible(b)
+
+        # Resize later so that the dialog is the correct size
+        QTimer.singleShot(0, lambda: self.ui.resize(self.ui.sizeHint()));

--- a/hexrd/ui/calibration/picks_tree_view_dialog.py
+++ b/hexrd/ui/calibration/picks_tree_view_dialog.py
@@ -9,6 +9,7 @@ from PySide2.QtWidgets import QFileDialog, QMessageBox
 
 from hexrd.instrument import unwrap_dict_to_h5, unwrap_h5_to_dict
 
+from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.tree_views.picks_tree_view import PicksTreeView
@@ -18,11 +19,13 @@ from hexrd.ui.utils.conversions import angles_to_cart, cart_to_angles
 
 class PicksTreeViewDialog:
 
-    def __init__(self, dictionary, canvas=None, parent=None):
+    def __init__(self, dictionary, coords_type=ViewType.polar, canvas=None,
+                 parent=None):
         self.ui = UiLoader().load_file('picks_tree_view_dialog.ui', parent)
 
         self.dictionary = dictionary
-        self.tree_view = PicksTreeView(dictionary, canvas, self.ui)
+        self.tree_view = PicksTreeView(dictionary, coords_type, canvas,
+                                       self.ui)
         self.ui.tree_view_layout.addWidget(self.tree_view)
 
         self.setup_connections()
@@ -138,6 +141,14 @@ class PicksTreeViewDialog:
     @property
     def dict_with_cart_coords(self):
         return picks_angles_to_cartesian(self.dictionary)
+
+    @property
+    def coords_type(self):
+        return self.tree_view.coords_type
+
+    @coords_type.setter
+    def coords_type(self, v):
+        self.tree_view.coords_type = v
 
 
 def convert_picks(picks, conversion_function, **kwargs):

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -284,11 +284,12 @@ class LinePickerDialog(QObject):
 
     @property
     def disabled(self):
-        return self.zoom_canvas.disabled
+        return self.zoom_canvas.disabled if self.zoom_canvas else True
 
     @disabled.setter
     def disabled(self, v):
-        self.zoom_canvas.disabled = v
+        if self.zoom_canvas:
+            self.zoom_canvas.disabled = v
         self.show_artists(not v)
 
 class LineBuilder(QObject):

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -1,5 +1,3 @@
-import copy
-
 from PySide2.QtCore import Qt, QObject, Signal
 
 from itertools import cycle
@@ -291,6 +289,7 @@ class LinePickerDialog(QObject):
         if self.zoom_canvas:
             self.zoom_canvas.disabled = v
         self.show_artists(not v)
+
 
 class LineBuilder(QObject):
 

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -16,7 +16,7 @@ from hexrd.ui.zoom_canvas import ZoomCanvas
 class LinePickerDialog(QObject):
 
     # Emitted when a point was picked
-    point_picked = Signal()
+    point_picked = Signal(float, float)
 
     # Emitted when a line is added
     line_added = Signal()
@@ -36,7 +36,8 @@ class LinePickerDialog(QObject):
     # Emitted when "Picks Table" was clicked
     view_picks = Signal()
 
-    def __init__(self, canvas, parent, single_line_mode=False):
+    def __init__(self, canvas, parent, single_line_mode=False,
+                 single_pick_mode=False):
         super().__init__(parent)
 
         self.canvas = canvas
@@ -44,8 +45,13 @@ class LinePickerDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('line_picker_dialog.ui', parent)
 
+        if single_pick_mode:
+            # Override single line mode
+            single_line_mode = True
+
         self.single_line_mode = single_line_mode
-        self.ui.start_new_line_label.setVisible(not self.single_line_mode)
+        self.single_pick_mode = single_pick_mode
+        self.update_visible_states()
 
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
@@ -83,6 +89,9 @@ class LinePickerDialog(QObject):
         self.zoom_canvas.point_picked.connect(self.zoom_point_picked)
         self.ui.view_picks.clicked.connect(self.view_picks.emit)
 
+        if self.single_pick_mode:
+            self.point_picked.connect(self.ui.accept)
+
     def update_enable_states(self):
         linebuilder = self.linebuilder
         enable_back_button = (
@@ -90,6 +99,17 @@ class LinePickerDialog(QObject):
             all(z for z in [linebuilder.xs, linebuilder.ys])
         )
         self.ui.back_button.setEnabled(enable_back_button)
+
+    def update_visible_states(self):
+        single_line = self.single_line_mode
+        single_pick = self.single_pick_mode
+
+        self.ui.start_new_line_label.setVisible(not single_line)
+
+        self.ui.finish_label.setVisible(not single_pick)
+        self.ui.back_button.setVisible(not single_pick)
+        self.ui.view_picks.setVisible(not single_pick)
+        self.ui.button_box.setVisible(not single_pick)
 
     def move_dialog_to_left(self):
         # This moves the dialog to the left border of the parent
@@ -182,8 +202,6 @@ class LinePickerDialog(QObject):
         for line in self.lines:
             line.set_visible(show)
 
-        self.zoom_canvas.show_main_artists(show)
-
     def line_finished(self):
         # If the linebuilder is already gone, just return
         if self.linebuilder is None:
@@ -192,7 +210,14 @@ class LinePickerDialog(QObject):
         self.add_line()
 
     def button_pressed(self, event):
+        if self.disabled:
+            return
+
         if event.button == 3:
+            if self.single_pick_mode:
+                # Ignore right-click in single pick mode
+                return
+
             # Advance the line to the next one
             self.next_line()
             return
@@ -257,11 +282,19 @@ class LinePickerDialog(QObject):
     def current_hkl_label(self, text):
         self.ui.current_hkl_label.setText(text)
 
+    @property
+    def disabled(self):
+        return self.zoom_canvas.disabled
+
+    @disabled.setter
+    def disabled(self, v):
+        self.zoom_canvas.disabled = v
+        self.show_artists(not v)
 
 class LineBuilder(QObject):
 
     # Emits when a point was picked
-    point_picked = Signal()
+    point_picked = Signal(float, float)
 
     def __init__(self, line):
         super().__init__()
@@ -282,7 +315,7 @@ class LineBuilder(QObject):
         ys = self.ys + [y]
         self.line.set_data(xs, ys)
         self.line_modified()
-        self.point_picked.emit()
+        self.point_picked.emit(x, y)
 
     def remove_last_point(self):
         xs = self.xs[:-1]

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -9,6 +9,7 @@ from PySide2.QtWidgets import (
     QMessageBox, QVBoxLayout
 )
 
+from hexrd.ui.async_runner import AsyncRunner
 from hexrd.ui.calibration_config_widget import CalibrationConfigWidget
 from hexrd.ui.calibration_slider_widget import CalibrationSliderWidget
 
@@ -483,8 +484,14 @@ class MainWindow(QObject):
             return self.ui.image_tab_widget.export_current_plot(selected_file)
 
     def on_action_run_calibration_triggered(self):
+        if not hasattr(self, '_calibration_runner_async_runner'):
+            # Initialize this only once and keep it around, so we don't
+            # run into issues connecting/disconnecting the messages.
+            self._calibration_runner_async_runner = AsyncRunner(self.ui)
+
+        async_runner = self._calibration_runner_async_runner
         canvas = self.ui.image_tab_widget.image_canvases[0]
-        runner = CalibrationRunner(canvas)
+        runner = CalibrationRunner(canvas, async_runner)
         self._calibration_runner = runner
 
         try:

--- a/hexrd/ui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrd/ui/resources/ui/powder_calibration_dialog.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>571</width>
-    <height>319</height>
+    <width>672</width>
+    <height>372</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="3" column="0" colspan="3">
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="optimization_parameters_group">
      <property name="title">
       <string>Optimization Parameters:</string>
      </property>
@@ -68,7 +68,7 @@
     </widget>
    </item>
    <item row="0" column="1" rowspan="2" colspan="2">
-    <widget class="QGroupBox" name="groupBox_2">
+    <widget class="QGroupBox" name="peak_fitting_group">
      <property name="title">
       <string>Peak Fitting:</string>
      </property>

--- a/hexrd/ui/tree_views/base_dict_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_dict_tree_item_model.py
@@ -27,7 +27,7 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
 
         self.config = dictionary
 
-    def setData(self, index, value, role):
+    def setData(self, index, value, role=Qt.EditRole):
         item = self.get_item(index)
 
         # If they are identical, don't do anything
@@ -141,7 +141,9 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
 
         # Set the data for these items
         for i, item in enumerate(items, position):
-            parent_item.child(i).data_list = item.data_list
+            # Over-write the added tree items with the provided items
+            parent_item.child_items[i] = item
+            item.parent_item = parent_item
 
         data_list = [item.data_list[1:] for item in parent_item.child_items]
         self.set_config_val(parent_path, data_list)

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -51,6 +51,7 @@ class ZoomCanvas(FigureCanvas):
         self.box_overlay_line, = ax.plot([], [], 'm-', animated=True)
         self.crosshairs = None
         self.vhlines = None
+        self.disabled = False
 
         # user-specified ROI in degrees (from interactors)
         self.tth_tol = 0.5
@@ -103,6 +104,9 @@ class ZoomCanvas(FigureCanvas):
             self.crosshairs = None
 
     def button_pressed(self, event):
+        if self.disabled:
+            return
+
         if event.button != 1:
             # Don't do anything if it isn't a left click
             return
@@ -110,6 +114,9 @@ class ZoomCanvas(FigureCanvas):
         self.point_picked.emit(event)
 
     def mouse_moved(self, event):
+        if self.disabled:
+            return
+
         # Clear the crosshairs when the mouse is moving over the canvas
         self.clear_crosshairs()
         self.update_vhlines(event)
@@ -132,6 +139,9 @@ class ZoomCanvas(FigureCanvas):
         hline.set_ydata(event.ydata)
 
     def main_canvas_mouse_moved(self, event):
+        if self.disabled:
+            return
+
         if event.inaxes is None:
             # Do nothing...
             return
@@ -187,6 +197,9 @@ class ZoomCanvas(FigureCanvas):
         self.main_artists_visible = show
 
     def on_main_canvas_draw_event(self, event):
+        if self.disabled:
+            return
+
         invalid = (
             self.xdata is None or
             self.ydata is None or
@@ -246,6 +259,9 @@ class ZoomCanvas(FigureCanvas):
         self.axes[2].autoscale_view()
 
     def render(self):
+        if self.disabled:
+            return
+
         self.clear_crosshairs()
 
         point = (self.xdata, self.ydata)
@@ -344,6 +360,15 @@ class ZoomCanvas(FigureCanvas):
     @property
     def rsimg(self):
         return self.main_canvas.iviewer.img
+
+    @property
+    def disabled(self):
+        return self._disabled
+
+    @disabled.setter
+    def disabled(self, b):
+        self._disabled = b
+        self.show_main_artists(not b)
 
 
 class MainCanvasCursor(Cursor):


### PR DESCRIPTION
When performing a calibration, if a powder overlay is about to be
used, a window now appears asking the user if they wish to auto pick
points, or hand pick points.

![image](https://user-images.githubusercontent.com/9558430/134738924-857184d6-8c75-412f-a1b1-736122712e70.png)

If the user chooses to hand pick points, it proceeds with the line
picker dialog as it did before.

If the user chooses to auto pick the points, a dialog appears that
gets the user to select options for the auto picking. When the user
clicks "Ok", auto picking is performed, and if successful, a dialog
will appear showing the user the picks, and allowing the user to
modify the picks.

![image](https://user-images.githubusercontent.com/9558430/134738951-6c2b37e3-ea1a-4d60-85c9-0b15753fbdad.png)

![image](https://user-images.githubusercontent.com/9558430/134738991-f5775e63-0b03-46c0-bd23-658a6246aeec.png)

The user can add, delete, and re-pick by hand points that were picked.
