### PR TITLE
Revert 962f28, as it is causing failure on startup

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -313,7 +313,7 @@ class PolarView:
         # Apply user-specified masks if they are present
         img = img.copy()
         total_mask = self.raw_mask
-        for mask in HexrdConfig().visible_masks:
+        for mask in HexrdConfig().visible_polar_masks:
             total_mask = np.logical_or(total_mask, ~mask)
         img[total_mask] = np.nan
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1343,7 +1343,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 overlay['refinements'] = default_refinements
 
     @property
-    def visible_masks(self):
+    def visible_polar_masks(self):
         masks = self.masks.items()
         visible = self.visible_masks
         return [mask for name, mask in masks if name in visible]


### PR DESCRIPTION
This reverts 962f2828ddae45f1387a5fd53018d1bf97c651b8