### PR TITLE
Use tvec_s instead of tvec_c for coord conversions

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -839,7 +839,7 @@ def auto_picks_to_picks(auto_picks, overlay):
         kwargs = {
             'panel': instr.detectors[det],
             'eta_period': HexrdConfig().polar_res_eta_period,
-            'tvec_c': instr.tvec,
+            'tvec_s': instr.tvec,
         }
         for i, line in enumerate(det_picks):
             det_picks[i] = cart_to_angles(line, **kwargs).tolist()

--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -14,7 +14,7 @@ def convert_raw_to_polar(det, line):
         'ij': line,
         'panel': instr.detectors[det],
         'eta_period': HexrdConfig().polar_res_eta_period,
-        'tvec_c': instr.tvec,
+        'tvec_s': instr.tvec,
     }
 
     return [pixels_to_angles(**kwargs)]

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -920,7 +920,7 @@ def transform_from_plain_cartesian_func(mode):
             'xys': xys,
             'panel': panel,
             'eta_period': HexrdConfig().polar_res_eta_period,
-            'tvec_c': iviewer.instr.tvec,
+            'tvec_s': iviewer.instr.tvec,
         }
         return cart_to_angles(**kwargs)
 

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -11,8 +11,10 @@ def pixels_to_cart(ij, panel):
     return panel.pixelToCart(ij[:, [1, 0]])
 
 
-def cart_to_angles(xys, panel, eta_period, tvec_c=None, apply_distortion=True):
+def cart_to_angles(xys, panel, eta_period, tvec_s=None, tvec_c=None,
+                   apply_distortion=True):
     kwargs = {
+        'tvec_s': tvec_s,
         'tvec_c': tvec_c,
         'apply_distortion': apply_distortion,
     }
@@ -32,6 +34,12 @@ def angles_to_pixels(angles, panel):
     return cart_to_pixels(xys, panel)
 
 
-def pixels_to_angles(ij, panel, eta_period, tvec_c=None):
+def pixels_to_angles(ij, panel, eta_period, tvec_s=None, tvec_c=None):
     xys = pixels_to_cart(ij, panel)
-    return cart_to_angles(xys, panel, eta_period, tvec_c)
+
+    kwargs = {
+        'eta_period': eta_period,
+        'tvec_s': tvec_s,
+        'tvec_c': tvec_c,
+    }
+    return cart_to_angles(xys, panel, **kwargs)


### PR DESCRIPTION
The instrument tvec is actually tvec_s, and we need to use tvec_s
for coordinate conversions instead of tvec_c.