### PR TITLE
Do not set buffers until images have been rotated back

### DIFF
--- a/hexrd/ui/import_data_panel.py
+++ b/hexrd/ui/import_data_panel.py
@@ -433,7 +433,6 @@ class ImportDataPanel(QObject):
         self.cmap.block_updates(True)
         self.check_for_unsaved_changes()
 
-        files = []
         detectors = self.detector_defaults['default_config'].setdefault(
             'detectors', {})
         not_set = [d for d in detectors if d not in self.completed_detectors]
@@ -453,7 +452,6 @@ class ImportDataPanel(QObject):
             rang, raxs = angleAxisOfRotMat(rmat_updated)
             # update tilt property on panel
             panel.tilt = rang * raxs.flatten()
-            files.append([self.edited_images[det]['img']])
 
         temp = tempfile.NamedTemporaryFile(delete=False, suffix='.hexrd')
         try:
@@ -467,8 +465,10 @@ class ImportDataPanel(QObject):
         if self.instrument == 'PXRDIP':
             HexrdConfig().load_panel_state['trans'] = (
                 [UI_TRANS_INDEX_ROTATE_90] * len(self.detectors))
+        det_names = HexrdConfig().detector_names
+        files = [[self.edited_images[det]['img']] for det in det_names]
         ImageLoadManager().read_data(files, parent=self.ui)
-        for det in HexrdConfig().detector_names:
+        for det in det_names:
             panel = instr.detectors[det]
             panel.panel_buffer = self.edited_images[det]['panel_buffer']
 


### PR DESCRIPTION
This branch fixes two bugs found using the LLNL import panel:

- Panel buffer size not matching image size: Some instruments require rotating the images one direction while processing and then rotating back when loading the cropped images. Wait to update the panel buffer until all images have been rotated back.
- Wrong image assigned to detector after reload: The order of the detector keys was assumed not to change after reload but this is not a guarantee (and was usually wrong). Use the *actual* order to determine which image belongs to which detector.