### PR TITLE
Change reflections table behavior for Limit Active

### DIFF
--- a/hexrd/ui/utils/__init__.py
+++ b/hexrd/ui/utils/__init__.py
@@ -250,6 +250,16 @@ def exclusions_off(plane_data):
         plane_data.exclusions = prev
 
 
+@contextmanager
+def tth_max_off(plane_data):
+    prev = plane_data.tThMax
+    plane_data.tThMax = None
+    try:
+        yield
+    finally:
+        plane_data.tThMax = prev
+
+
 def has_nan(x):
     # Utility function to check if there are any NaNs in x
     return np.isnan(np.min(x))


### PR DESCRIPTION
This changes the reflections table behavior for the "Limit Active"
section so that the inactive hkls are still shown in the table, but
are grayed out and unselectable.

https://user-images.githubusercontent.com/9558430/138163750-5df3b46d-3899-4c13-a78b-5aa260de67ee.mp4

The previous behaviour was that they would not be visible at all.

Fixes: #1072