### PR TITLE
Remove the APS Imageseries option

### DIFF
--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -55,17 +55,6 @@ class ImageFileManager(metaclass=Singleton):
         if self.remember:
             HexrdConfig().hdf5_path = self.path
 
-    def load_aps_imageseries(self, detectors, directory_names):
-        HexrdConfig().imageseries_dict.clear()
-        for name, d in zip(detectors, directory_names):
-            try:
-                ims = self.open_directory(d)
-                HexrdConfig().imageseries_dict[name] = ims
-            except (Exception, IOError) as error:
-                msg = ('ERROR - Could not read file: \n' + str(error))
-                QMessageBox.warning(None, 'HEXRD', msg)
-                return
-
     def open_file(self, f, options=None):
         # f could be either a file or numpy array
         ext = os.path.splitext(f)[1] if isinstance(f, str) else None

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -238,8 +238,6 @@ class MainWindow(QObject):
 
         self.ui.action_open_images.triggered.connect(
             self.open_image_files)
-        self.ui.action_open_aps_imageseries.triggered.connect(
-            self.open_aps_imageseries)
         HexrdConfig().update_status_bar.connect(
             self.ui.status_bar.showMessage)
         HexrdConfig().detectors_changed.connect(
@@ -416,25 +414,6 @@ class MainWindow(QObject):
         self.update_hedm_enable_states()
         self.color_map_editor.reset_range()
         self.image_mode_widget.reset_masking()
-
-    def open_aps_imageseries(self):
-        # Get the most recent images dir
-        images_dir = HexrdConfig().images_dir
-        detector_names = HexrdConfig().detector_names
-        selected_dirs = []
-        for name in detector_names:
-            caption = 'Select directory for detector: ' + name
-            d = QFileDialog.getExistingDirectory(self.ui, caption,
-                                                 dir=images_dir)
-            if not d:
-                return
-
-            selected_dirs.append(d)
-            images_dir = os.path.dirname(d)
-
-        ImageFileManager().load_aps_imageseries(detector_names, selected_dirs)
-        self.update_all()
-        self.new_images_loaded.emit()
 
     def on_action_open_materials_triggered(self):
         selected_file, selected_filter = QFileDialog.getOpenFileName(

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -56,7 +56,6 @@
      <addaction name="action_open_state"/>
      <addaction name="action_open_config_file"/>
      <addaction name="action_open_materials"/>
-     <addaction name="action_open_aps_imageseries"/>
      <addaction name="separator"/>
      <addaction name="action_open_grain_fitting_results"/>
     </widget>
@@ -423,11 +422,6 @@
   <action name="action_edit_euler_angle_convention">
    <property name="text">
     <string>Euler Angle &amp;Convention</string>
-   </property>
-  </action>
-  <action name="action_open_aps_imageseries">
-   <property name="text">
-    <string>&amp;APS ImageSeries</string>
    </property>
   </action>
   <action name="actionQuit">

--- a/hexrd/ui/resources/ui/simple_image_series_dialog.ui
+++ b/hexrd/ui/resources/ui/simple_image_series_dialog.ui
@@ -76,13 +76,6 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0">
-       <widget class="QCheckBox" name="aps_imageseries">
-        <property name="text">
-         <string>Use APS ImageSeries</string>
-        </property>
-       </widget>
-      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="dark_label">
         <property name="text">

--- a/hexrd/ui/simple_image_series_dialog.py
+++ b/hexrd/ui/simple_image_series_dialog.py
@@ -233,15 +233,9 @@ class SimpleImageSeriesDialog(QObject):
 
     def select_images(self):
         # This takes one or more images for a single detector.
-        if self.ui.aps_imageseries.isChecked():
-            files = QDir(self.parent_dir).entryInfoList(QDir.Files)
-            selected_files = []
-            for file in files:
-                selected_files.append(file.absoluteFilePath())
-        else:
-            caption = HexrdConfig().images_dirtion = 'Select image file(s)'
-            selected_files, selected_filter = QFileDialog.getOpenFileNames(
-                self.ui, caption, dir=self.parent_dir)
+        caption = HexrdConfig().images_dirtion = 'Select image file(s)'
+        selected_files, _ = QFileDialog.getOpenFileNames(
+            self.ui, caption, dir=self.parent_dir)
 
         if selected_files:
             self.update_allowed = False


### PR DESCRIPTION
This was originally intended for users to be able to select all of the images in a chosen directory to be loaded in as an imageseries. This option is now handled in both the image stack dialog and the simple imageseries dialog and is no longer needed.