### PR TITLE
added proper extent to polarview class and use it in the imshow

### DIFF
--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -1,827 +1,827 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>image_mode_widget</class>
-  <widget class="QWidget" name="image_mode_widget">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>596</width>
-        <height>187</height>
-      </rect>
-    </property>
-    <layout class="QGridLayout" name="gridLayout_4">
-      <property name="leftMargin">
-        <number>0</number>
-      </property>
-      <property name="topMargin">
-        <number>0</number>
-      </property>
-      <property name="rightMargin">
-        <number>0</number>
-      </property>
-      <property name="bottomMargin">
-        <number>0</number>
-      </property>
-      <property name="spacing">
-        <number>0</number>
-      </property>
-      <item row="0" column="0" rowspan="2">
-        <widget class="QTabWidget" name="tab_widget">
-          <property name="styleSheet">
-            <string notr="true"/>
-          </property>
-          <property name="tabPosition">
-            <enum>QTabWidget::North</enum>
-          </property>
-          <property name="tabShape">
-            <enum>QTabWidget::Rounded</enum>
-          </property>
-          <property name="currentIndex">
-            <number>2</number>
-          </property>
-          <property name="iconSize">
-            <size>
-              <width>16</width>
-              <height>16</height>
-            </size>
-          </property>
-          <property name="elideMode">
-            <enum>Qt::ElideNone</enum>
-          </property>
-          <property name="documentMode">
+ <class>image_mode_widget</class>
+ <widget class="QWidget" name="image_mode_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>596</width>
+    <height>187</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <property name="spacing">
+    <number>0</number>
+   </property>
+   <item row="0" column="0" rowspan="2">
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
+     <property name="tabPosition">
+      <enum>QTabWidget::North</enum>
+     </property>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="currentIndex">
+      <number>2</number>
+     </property>
+     <property name="iconSize">
+      <size>
+       <width>16</width>
+       <height>16</height>
+      </size>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabBarAutoHide">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="raw_tab">
+      <attribute name="title">
+       <string>Raw</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QCheckBox" name="raw_tabbed_view">
+           <property name="text">
+            <string>Tabbed View</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="raw_show_saturation">
+           <property name="text">
+            <string>Show Saturation</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0" colspan="2">
+          <widget class="QCheckBox" name="raw_threshold_mask">
+           <property name="text">
+            <string>Set Threshold Mask</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QComboBox" name="raw_threshold_comparison">
+           <property name="enabled">
             <bool>false</bool>
-          </property>
-          <property name="tabBarAutoHide">
+           </property>
+           <item>
+            <property name="text">
+             <string>less than</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>greater than</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>eqaul to</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="ScientificDoubleSpinBox" name="raw_threshold_value">
+           <property name="enabled">
             <bool>false</bool>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="cartesian_tab">
+      <attribute name="title">
+       <string>Cartesian</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="styleSheet">
+          <string notr="true">QGroupBox{padding-top:15px; margin-top:-20px}</string>
+         </property>
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <property name="spacing">
+           <number>0</number>
           </property>
-          <widget class="QWidget" name="raw_tab">
-            <attribute name="title">
-              <string>Raw</string>
-            </attribute>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-              <item>
-                <layout class="QVBoxLayout" name="verticalLayout_3">
-                  <item>
-                    <widget class="QCheckBox" name="raw_tabbed_view">
-                      <property name="text">
-                        <string>Tabbed View</string>
-                      </property>
-                    </widget>
-                  </item>
-                  <item>
-                    <widget class="QCheckBox" name="raw_show_saturation">
-                      <property name="text">
-                        <string>Show Saturation</string>
-                      </property>
-                    </widget>
-                  </item>
-                </layout>
-              </item>
-              <item>
-                <layout class="QFormLayout" name="formLayout">
-                  <item row="0" column="0" colspan="2">
-                    <widget class="QCheckBox" name="raw_threshold_mask">
-                      <property name="text">
-                        <string>Set Threshold Mask</string>
-                      </property>
-                    </widget>
-                  </item>
-                  <item row="1" column="0">
-                    <widget class="QComboBox" name="raw_threshold_comparison">
-                      <property name="enabled">
-                        <bool>false</bool>
-                      </property>
-                      <item>
-                        <property name="text">
-                          <string>less than</string>
-                        </property>
-                      </item>
-                      <item>
-                        <property name="text">
-                          <string>greater than</string>
-                        </property>
-                      </item>
-                      <item>
-                        <property name="text">
-                          <string>eqaul to</string>
-                        </property>
-                      </item>
-                    </widget>
-                  </item>
-                  <item row="1" column="1">
-                    <widget class="ScientificDoubleSpinBox" name="raw_threshold_value">
-                      <property name="enabled">
-                        <bool>false</bool>
-                      </property>
-                      <property name="keyboardTracking">
-                        <bool>false</bool>
-                      </property>
-                      <property name="decimals">
-                        <number>8</number>
-                      </property>
-                      <property name="minimum">
-                        <double>-100000.000000000000000</double>
-                      </property>
-                      <property name="maximum">
-                        <double>100000.000000000000000</double>
-                      </property>
-                    </widget>
-                  </item>
-                </layout>
-              </item>
-            </layout>
-          </widget>
-          <widget class="QWidget" name="cartesian_tab">
-            <attribute name="title">
-              <string>Cartesian</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout">
-              <property name="leftMargin">
-                <number>0</number>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QGridLayout" name="gridLayout_5">
+            <item row="1" column="1">
+             <widget class="ScientificDoubleSpinBox" name="cartesian_virtual_plane_distance">
+              <property name="toolTip">
+               <string>The distance from the source to the virtual plane.</string>
               </property>
-              <property name="topMargin">
-                <number>0</number>
+              <property name="keyboardTracking">
+               <bool>false</bool>
               </property>
-              <property name="rightMargin">
-                <number>0</number>
+              <property name="decimals">
+               <number>8</number>
               </property>
-              <property name="bottomMargin">
-                <number>0</number>
+              <property name="maximum">
+               <double>1000000.000000000000000</double>
               </property>
-              <property name="spacing">
-                <number>0</number>
+              <property name="value">
+               <double>1000.000000000000000</double>
               </property>
-              <item row="0" column="0">
-                <widget class="QGroupBox" name="groupBox">
-                  <property name="styleSheet">
-                    <string notr="true">QGroupBox{padding-top:15px; margin-top:-20px}</string>
-                  </property>
-                  <property name="title">
-                    <string/>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout_2">
-                    <property name="spacing">
-                      <number>0</number>
-                    </property>
-                    <property name="leftMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="topMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                      <number>0</number>
-                    </property>
-                    <item>
-                      <layout class="QGridLayout" name="gridLayout_5">
-                        <item row="1" column="1">
-                          <widget class="ScientificDoubleSpinBox" name="cartesian_virtual_plane_distance">
-                            <property name="toolTip">
-                              <string>The distance from the source to the virtual plane.</string>
-                            </property>
-                            <property name="keyboardTracking">
-                              <bool>false</bool>
-                            </property>
-                            <property name="decimals">
-                              <number>8</number>
-                            </property>
-                            <property name="maximum">
-                              <double>1000000.000000000000000</double>
-                            </property>
-                            <property name="value">
-                              <double>1000.000000000000000</double>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="0" column="1">
-                          <widget class="ScientificDoubleSpinBox" name="cartesian_pixel_size">
-                            <property name="keyboardTracking">
-                              <bool>false</bool>
-                            </property>
-                            <property name="decimals">
-                              <number>8</number>
-                            </property>
-                            <property name="minimum">
-                              <double>0.000100000000000</double>
-                            </property>
-                            <property name="maximum">
-                              <double>1000000.000000000000000</double>
-                            </property>
-                            <property name="singleStep">
-                              <double>0.010000000000000</double>
-                            </property>
-                            <property name="value">
-                              <double>0.500000000000000</double>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="1" column="3">
-                          <widget class="ScientificDoubleSpinBox" name="cartesian_plane_normal_rotate_y">
-                            <property name="keyboardTracking">
-                              <bool>false</bool>
-                            </property>
-                            <property name="suffix">
-                              <string>°</string>
-                            </property>
-                            <property name="decimals">
-                              <number>8</number>
-                            </property>
-                            <property name="minimum">
-                              <double>-360.000000000000000</double>
-                            </property>
-                            <property name="maximum">
-                              <double>360.000000000000000</double>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="0" column="0">
-                          <widget class="QLabel" name="label">
-                            <property name="text">
-                              <string>Pixel Size:</string>
-                            </property>
-                            <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="0" column="3">
-                          <widget class="ScientificDoubleSpinBox" name="cartesian_plane_normal_rotate_x">
-                            <property name="keyboardTracking">
-                              <bool>false</bool>
-                            </property>
-                            <property name="suffix">
-                              <string>°</string>
-                            </property>
-                            <property name="decimals">
-                              <number>8</number>
-                            </property>
-                            <property name="minimum">
-                              <double>-360.000000000000000</double>
-                            </property>
-                            <property name="maximum">
-                              <double>360.000000000000000</double>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="0" column="2">
-                          <widget class="QLabel" name="label_7">
-                            <property name="text">
-                              <string>Rotate x:</string>
-                            </property>
-                            <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="1" column="2">
-                          <widget class="QLabel" name="label_8">
-                            <property name="text">
-                              <string>Rotate y:</string>
-                            </property>
-                            <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                            </property>
-                          </widget>
-                        </item>
-                        <item row="1" column="0">
-                          <widget class="QLabel" name="label_9">
-                            <property name="toolTip">
-                              <string>The distance from the source to the virtual plane.</string>
-                            </property>
-                            <property name="text">
-                              <string>Distance:</string>
-                            </property>
-                            <property name="alignment">
-                              <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                            </property>
-                          </widget>
-                        </item>
-                      </layout>
-                    </item>
-                    <item>
-                      <spacer name="verticalSpacer">
-                        <property name="orientation">
-                          <enum>Qt::Vertical</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>20</width>
-                            <height>36</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-            </layout>
-          </widget>
-          <widget class="QWidget" name="polar_tab">
-            <attribute name="title">
-              <string>Polar</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout_2">
-              <property name="leftMargin">
-                <number>0</number>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="ScientificDoubleSpinBox" name="cartesian_pixel_size">
+              <property name="keyboardTracking">
+               <bool>false</bool>
               </property>
-              <property name="topMargin">
-                <number>0</number>
+              <property name="decimals">
+               <number>8</number>
               </property>
-              <property name="rightMargin">
-                <number>0</number>
+              <property name="minimum">
+               <double>0.000100000000000</double>
               </property>
-              <property name="bottomMargin">
-                <number>0</number>
+              <property name="maximum">
+               <double>1000000.000000000000000</double>
               </property>
-              <property name="spacing">
-                <number>0</number>
+              <property name="singleStep">
+               <double>0.010000000000000</double>
               </property>
-              <item row="0" column="0">
-                <widget class="QGroupBox" name="groupBox_2">
-                  <property name="styleSheet">
-                    <string notr="true">QGroupBox{padding-top:15px; margin-top:-20px}</string>
-                  </property>
-                  <property name="title">
-                    <string/>
-                  </property>
-                  <layout class="QVBoxLayout" name="verticalLayout">
-                    <property name="spacing">
-                      <number>0</number>
-                    </property>
-                    <property name="leftMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="topMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="rightMargin">
-                      <number>0</number>
-                    </property>
-                    <property name="bottomMargin">
-                      <number>0</number>
-                    </property>
-                    <item>
-                      <layout class="QHBoxLayout" name="horizontalLayout">
-                        <property name="spacing">
-                          <number>0</number>
-                        </property>
-                        <item>
-                          <layout class="QGridLayout" name="gridLayout_3">
-                            <property name="spacing">
-                              <number>0</number>
-                            </property>
-                            <item row="2" column="7">
-                              <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="minimum">
-                                  <double>-100000.000000000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>100000.000000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>180.000000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="0" column="6">
-                              <widget class="QLabel" name="label_2">
-                                <property name="text">
-                                  <string>η:</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="0">
-                              <widget class="QCheckBox" name="polar_apply_snip1d">
-                                <property name="text">
-                                  <string>Apply SNIP?</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="4">
-                              <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="minimum">
-                                  <double>-100000.000000000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>100000.000000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>-180.000000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="0">
-                              <widget class="QLabel" name="label_13">
-                                <property name="text">
-                                  <string>η Range:</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="4">
-                              <widget class="ScientificDoubleSpinBox" name="polar_snip1d_width">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="maximum">
-                                  <double>100000.000000000000000</double>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.100000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>0.200000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="4">
-                              <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="minimum">
-                                  <double>0.000000000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>180.000000000000000</double>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.010000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>1.000000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="6">
-                              <widget class="QLabel" name="label_5">
-                                <property name="text">
-                                  <string>max</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="0" column="7">
-                              <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="minimum">
-                                  <double>0.000100000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>100000.000000000000000</double>
-                                </property>
-                                <property name="singleStep">
-                                  <double>5.000000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>0.200000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="7">
-                              <widget class="QSpinBox" name="polar_snip1d_numiter">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="minimum">
-                                  <number>1</number>
-                                </property>
-                                <property name="maximum">
-                                  <number>10000</number>
-                                </property>
-                                <property name="value">
-                                  <number>2</number>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="5">
-                              <spacer name="horizontalSpacer_2">
-                                <property name="orientation">
-                                  <enum>Qt::Horizontal</enum>
-                                </property>
-                                <property name="sizeHint" stdset="0">
-                                  <size>
-                                    <width>40</width>
-                                    <height>20</height>
-                                  </size>
-                                </property>
-                              </spacer>
-                            </item>
-                            <item row="1" column="3">
-                              <widget class="QLabel" name="label_12">
-                                <property name="text">
-                                  <string>min</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="3">
-                              <widget class="QLabel" name="label_10">
-                                <property name="enabled">
-                                  <bool>true</bool>
-                                </property>
-                                <property name="text">
-                                  <string>w:</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="0" column="0">
-                              <widget class="QLabel" name="label_3">
-                                <property name="text">
-                                  <string>Pixel Size:</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="0" column="3">
-                              <widget class="QLabel" name="label_6">
-                                <property name="text">
-                                  <string>2θ:</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="0">
-                              <widget class="QLabel" name="label_4">
-                                <property name="text">
-                                  <string>2θ Range:</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="4" column="0">
-                              <widget class="QComboBox" name="polar_snip1d_algorithm">
-                                <item>
-                                  <property name="text">
-                                    <string>Fast SNIP 1D</string>
-                                  </property>
-                                </item>
-                                <item>
-                                  <property name="text">
-                                    <string>SNIP 1D</string>
-                                  </property>
-                                </item>
-                                <item>
-                                  <property name="text">
-                                    <string>SNIP 2D</string>
-                                  </property>
-                                </item>
-                              </widget>
-                            </item>
-                            <item row="3" column="6">
-                              <widget class="QLabel" name="label_11">
-                                <property name="enabled">
-                                  <bool>true</bool>
-                                </property>
-                                <property name="text">
-                                  <string>n iter:</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="1" column="7">
-                              <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="minimum">
-                                  <double>0.000000000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>180.000000000000000</double>
-                                </property>
-                                <property name="singleStep">
-                                  <double>1.000000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>20.000000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="0" column="4">
-                              <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_tth">
-                                <property name="alignment">
-                                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                                </property>
-                                <property name="keyboardTracking">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="suffix">
-                                  <string>°</string>
-                                </property>
-                                <property name="decimals">
-                                  <number>8</number>
-                                </property>
-                                <property name="minimum">
-                                  <double>0.000100000000000</double>
-                                </property>
-                                <property name="maximum">
-                                  <double>100000.000000000000000</double>
-                                </property>
-                                <property name="singleStep">
-                                  <double>0.005000000000000</double>
-                                </property>
-                                <property name="value">
-                                  <double>0.050000000000000</double>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="3" column="2">
-                              <spacer name="horizontalSpacer">
-                                <property name="orientation">
-                                  <enum>Qt::Horizontal</enum>
-                                </property>
-                                <property name="sizeHint" stdset="0">
-                                  <size>
-                                    <width>40</width>
-                                    <height>20</height>
-                                  </size>
-                                </property>
-                              </spacer>
-                            </item>
-                            <item row="4" column="3" colspan="2">
-                              <widget class="QPushButton" name="polar_show_snip1d">
-                                <property name="text">
-                                  <string>Show SNIP</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="3">
-                              <widget class="QLabel" name="label_14">
-                                <property name="text">
-                                  <string>min</string>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="2" column="6">
-                              <widget class="QLabel" name="label_15">
-                                <property name="text">
-                                  <string>max</string>
-                                </property>
-                                <property name="alignment">
-                                  <set>Qt::AlignCenter</set>
-                                </property>
-                              </widget>
-                            </item>
-                            <item row="4" column="7">
-                              <widget class="QCheckBox" name="polar_apply_erosion">
-                                <property name="enabled">
-                                  <bool>false</bool>
-                                </property>
-                                <property name="toolTip">
-                                  <string>Apply binary erosion to eliminate edge artifacts.</string>
-                                </property>
-                                <property name="text">
-                                  <string>Apply erosion?</string>
-                                </property>
-                              </widget>
-                            </item>
-                          </layout>
-                        </item>
-                      </layout>
-                    </item>
-                    <item>
-                      <spacer name="verticalSpacer_2">
-                        <property name="orientation">
-                          <enum>Qt::Vertical</enum>
-                        </property>
-                        <property name="sizeHint" stdset="0">
-                          <size>
-                            <width>20</width>
-                            <height>2</height>
-                          </size>
-                        </property>
-                      </spacer>
-                    </item>
-                  </layout>
-                </widget>
-              </item>
-            </layout>
-          </widget>
+              <property name="value">
+               <double>0.500000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <widget class="ScientificDoubleSpinBox" name="cartesian_plane_normal_rotate_y">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-360.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>360.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QLabel" name="label">
+              <property name="text">
+               <string>Pixel Size:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="ScientificDoubleSpinBox" name="cartesian_plane_normal_rotate_x">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-360.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>360.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="label_7">
+              <property name="text">
+               <string>Rotate x:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="2">
+             <widget class="QLabel" name="label_8">
+              <property name="text">
+               <string>Rotate y:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="0">
+             <widget class="QLabel" name="label_9">
+              <property name="toolTip">
+               <string>The distance from the source to the virtual plane.</string>
+              </property>
+              <property name="text">
+               <string>Distance:</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>36</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
         </widget>
-      </item>
-    </layout>
-  </widget>
-  <customwidgets>
-    <customwidget>
-      <class>ScientificDoubleSpinBox</class>
-      <extends>QDoubleSpinBox</extends>
-      <header>scientificspinbox.h</header>
-    </customwidget>
-  </customwidgets>
-  <tabstops>
-    <tabstop>tab_widget</tabstop>
-    <tabstop>raw_tabbed_view</tabstop>
-    <tabstop>raw_show_saturation</tabstop>
-    <tabstop>raw_threshold_mask</tabstop>
-    <tabstop>raw_threshold_comparison</tabstop>
-    <tabstop>raw_threshold_value</tabstop>
-    <tabstop>cartesian_pixel_size</tabstop>
-    <tabstop>cartesian_virtual_plane_distance</tabstop>
-    <tabstop>cartesian_plane_normal_rotate_x</tabstop>
-    <tabstop>cartesian_plane_normal_rotate_y</tabstop>
-    <tabstop>polar_pixel_size_tth</tabstop>
-    <tabstop>polar_pixel_size_eta</tabstop>
-    <tabstop>polar_res_tth_min</tabstop>
-    <tabstop>polar_res_tth_max</tabstop>
-    <tabstop>polar_res_eta_min</tabstop>
-    <tabstop>polar_res_eta_max</tabstop>
-    <tabstop>polar_apply_snip1d</tabstop>
-    <tabstop>polar_snip1d_width</tabstop>
-    <tabstop>polar_snip1d_numiter</tabstop>
-    <tabstop>polar_snip1d_algorithm</tabstop>
-    <tabstop>polar_show_snip1d</tabstop>
-    <tabstop>polar_apply_erosion</tabstop>
-  </tabstops>
-  <resources/>
-  <connections/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="polar_tab">
+      <attribute name="title">
+       <string>Polar</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QGroupBox" name="groupBox_2">
+         <property name="styleSheet">
+          <string notr="true">QGroupBox{padding-top:15px; margin-top:-20px}</string>
+         </property>
+         <property name="title">
+          <string/>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout">
+            <property name="spacing">
+             <number>0</number>
+            </property>
+            <item>
+             <layout class="QGridLayout" name="gridLayout_3">
+              <property name="spacing">
+               <number>0</number>
+              </property>
+              <item row="2" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-100000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>η:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0">
+               <widget class="QCheckBox" name="polar_apply_snip1d">
+                <property name="text">
+                 <string>Apply SNIP?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-100000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>-180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>η Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_snip1d_width">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="6">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000100000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>5.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="7">
+               <widget class="QSpinBox" name="polar_snip1d_numiter">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>10000</number>
+                </property>
+                <property name="value">
+                 <number>2</number>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="5">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="1" column="3">
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="3">
+               <widget class="QLabel" name="label_10">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>w:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Pixel Size:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="label_6">
+                <property name="text">
+                 <string>2θ:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>2θ Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QComboBox" name="polar_snip1d_algorithm">
+                <item>
+                 <property name="text">
+                  <string>Fast SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 2D</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="3" column="6">
+               <widget class="QLabel" name="label_11">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>n iter:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>1.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>20.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_tth">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000100000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.005000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.050000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="2">
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="4" column="3" colspan="2">
+               <widget class="QPushButton" name="polar_show_snip1d">
+                <property name="text">
+                 <string>Show SNIP</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="6">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="7">
+               <widget class="QCheckBox" name="polar_apply_erosion">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Apply binary erosion to eliminate edge artifacts.</string>
+                </property>
+                <property name="text">
+                 <string>Apply erosion?</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>2</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>tab_widget</tabstop>
+  <tabstop>raw_tabbed_view</tabstop>
+  <tabstop>raw_show_saturation</tabstop>
+  <tabstop>raw_threshold_mask</tabstop>
+  <tabstop>raw_threshold_comparison</tabstop>
+  <tabstop>raw_threshold_value</tabstop>
+  <tabstop>cartesian_pixel_size</tabstop>
+  <tabstop>cartesian_virtual_plane_distance</tabstop>
+  <tabstop>cartesian_plane_normal_rotate_x</tabstop>
+  <tabstop>cartesian_plane_normal_rotate_y</tabstop>
+  <tabstop>polar_pixel_size_tth</tabstop>
+  <tabstop>polar_pixel_size_eta</tabstop>
+  <tabstop>polar_res_tth_min</tabstop>
+  <tabstop>polar_res_tth_max</tabstop>
+  <tabstop>polar_res_eta_min</tabstop>
+  <tabstop>polar_res_eta_max</tabstop>
+  <tabstop>polar_apply_snip1d</tabstop>
+  <tabstop>polar_snip1d_width</tabstop>
+  <tabstop>polar_snip1d_numiter</tabstop>
+  <tabstop>polar_snip1d_algorithm</tabstop>
+  <tabstop>polar_show_snip1d</tabstop>
+  <tabstop>polar_apply_erosion</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
 </ui>

--- a/hexrd/ui/resources/ui/image_stack_dialog.ui
+++ b/hexrd/ui/resources/ui/image_stack_dialog.ui
@@ -1,508 +1,508 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>ImageStackDialog</class>
-  <widget class="QDialog" name="ImageStackDialog">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>476</width>
-        <height>636</height>
-      </rect>
-    </property>
-    <property name="sizePolicy">
-      <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-      </sizepolicy>
-    </property>
-    <property name="windowTitle">
-      <string>Image Stack Import</string>
-    </property>
-    <layout class="QGridLayout" name="gridLayout_4">
-      <item row="4" column="0">
-        <widget class="QDialogButtonBox" name="buttonBox">
-          <property name="orientation">
-            <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="standardButtons">
-            <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-          </property>
-        </widget>
-      </item>
-      <item row="1" column="0">
-        <widget class="QGroupBox" name="files_group">
-          <property name="title">
-            <string>Files</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_3">
-            <item row="0" column="2" colspan="2">
-              <widget class="QPushButton" name="select_files">
-                <property name="text">
-                  <string>Select Files</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="0">
-              <widget class="QLabel" name="matching_files_label">
-                <property name="text">
-                  <string>Matching Files Found:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="0">
-              <widget class="QRadioButton" name="files_by_selection">
-                <property name="text">
-                  <string>Manual Selection</string>
-                </property>
-                <property name="checked">
-                  <bool>true</bool>
-                </property>
-                <attribute name="buttonGroup">
-                  <string notr="true">file_options</string>
-                </attribute>
-              </widget>
-            </item>
-            <item row="1" column="2">
-              <widget class="QPushButton" name="search">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Search</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="1">
-              <widget class="QRadioButton" name="files_by_search">
-                <property name="text">
-                  <string>Search</string>
-                </property>
-                <attribute name="buttonGroup">
-                  <string notr="true">file_options</string>
-                </attribute>
-              </widget>
-            </item>
-            <item row="1" column="3" alignment="Qt::AlignHCenter">
-              <widget class="QCheckBox" name="apply_to_all">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Apply to All</string>
-                </property>
-                <property name="checked">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0" colspan="2">
-              <widget class="QLineEdit" name="search_text">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                  <string/>
-                </property>
-                <property name="placeholderText">
-                  <string>Search Pattern</string>
-                </property>
-                <property name="clearButtonEnabled">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="2" alignment="Qt::AlignHCenter">
-              <widget class="QLabel" name="file_count">
-                <property name="text">
-                  <string>0</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="3">
-              <widget class="QPushButton" name="clear_file_selections">
-                <property name="text">
-                  <string>Clear Selections</string>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+ <class>ImageStackDialog</class>
+ <widget class="QDialog" name="ImageStackDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>476</width>
+    <height>636</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Image Stack Import</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_4">
+   <item row="4" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QGroupBox" name="files_group">
+     <property name="title">
+      <string>Files</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="2" colspan="2">
+       <widget class="QPushButton" name="select_files">
+        <property name="text">
+         <string>Select Files</string>
+        </property>
+       </widget>
       </item>
       <item row="2" column="0">
-        <widget class="QGroupBox" name="frames_group">
-          <property name="title">
-            <string>Frames</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_6">
-            <item row="1" column="2">
-              <widget class="QLabel" name="max_total_frames_label">
-                <property name="text">
-                  <string>Max Total Frames</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="0">
-              <widget class="QLabel" name="empty_frames_label">
-                <property name="text">
-                  <string>Empty Frames</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
-              <widget class="QLabel" name="max_file_frames_label">
-                <property name="text">
-                  <string>Max File Frames</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="3">
-              <widget class="QSpinBox" name="max_total_frames">
-                <property name="maximum">
-                  <number>1000000</number>
-                </property>
-                <property name="value">
-                  <number>0</number>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="3">
-              <widget class="QLabel" name="total_frames">
-                <property name="text">
-                  <string>0</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="1">
-              <widget class="QSpinBox" name="empty_frames">
-                <property name="maximum">
-                  <number>1000000</number>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="2">
-              <widget class="QLabel" name="frames_label">
-                <property name="enabled">
-                  <bool>true</bool>
-                </property>
-                <property name="text">
-                  <string>Total Frames</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <widget class="QSpinBox" name="max_file_frames">
-                <property name="frame">
-                  <bool>true</bool>
-                </property>
-                <property name="keyboardTracking">
-                  <bool>false</bool>
-                </property>
-                <property name="maximum">
-                  <number>1000000</number>
-                </property>
-                <property name="value">
-                  <number>0</number>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_5">
-                  <property name="leftMargin">
-                    <number>0</number>
-                  </property>
-                </layout>
-              </widget>
-            </item>
-            <item row="2" column="0" colspan="2">
-              <widget class="QCheckBox" name="reverse_frames">
-                <property name="text">
-                  <string>Reverse Frame Order</string>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
-      </item>
-      <item row="3" column="0">
-        <widget class="QGroupBox" name="omega_group">
-          <property name="sizePolicy">
-            <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-            </sizepolicy>
-          </property>
-          <property name="title">
-            <string>Omega</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout">
-            <item row="1" column="0" colspan="2">
-              <widget class="QCheckBox" name="omega_from_file">
-                <property name="text">
-                  <string>Load from File</string>
-                </property>
-                <property name="checked">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="3" column="5">
-              <widget class="QPushButton" name="add_wedge">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Add Wedge</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="2">
-              <widget class="QPushButton" name="load_omega_file">
-                <property name="text">
-                  <string>Select File</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="3" colspan="3">
-              <widget class="QLineEdit" name="omega_file">
-                <property name="text">
-                  <string>(No File Selected)</string>
-                </property>
-                <property name="readOnly">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="3" column="0">
-              <widget class="QPushButton" name="clear_wedges">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Clear</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="0">
-              <widget class="QRadioButton" name="add_omega">
-                <property name="text">
-                  <string>Add Omega Data</string>
-                </property>
-                <property name="checked">
-                  <bool>true</bool>
-                </property>
-                <attribute name="buttonGroup">
-                  <string notr="true">omega_options</string>
-                </attribute>
-              </widget>
-            </item>
-            <item row="2" column="0" colspan="6">
-              <widget class="QTableWidget" name="omega_wedges">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="sizePolicy">
-                  <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                    <horstretch>0</horstretch>
-                    <verstretch>0</verstretch>
-                  </sizepolicy>
-                </property>
-                <property name="sizeAdjustPolicy">
-                  <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-                </property>
-                <property name="alternatingRowColors">
-                  <bool>true</bool>
-                </property>
-                <attribute name="horizontalHeaderDefaultSectionSize">
-                  <number>139</number>
-                </attribute>
-                <attribute name="horizontalHeaderStretchLastSection">
-                  <bool>true</bool>
-                </attribute>
-                <attribute name="verticalHeaderVisible">
-                  <bool>false</bool>
-                </attribute>
-                <attribute name="verticalHeaderStretchLastSection">
-                  <bool>false</bool>
-                </attribute>
-                <column>
-                  <property name="text">
-                    <string>Start</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Stop</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Steps</string>
-                  </property>
-                </column>
-              </widget>
-            </item>
-            <item row="0" column="2">
-              <widget class="QRadioButton" name="no_omega">
-                <property name="text">
-                  <string>No Omega Data</string>
-                </property>
-                <attribute name="buttonGroup">
-                  <string notr="true">omega_options</string>
-                </attribute>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+       <widget class="QLabel" name="matching_files_label">
+        <property name="text">
+         <string>Matching Files Found:</string>
+        </property>
+       </widget>
       </item>
       <item row="0" column="0">
-        <widget class="QGroupBox" name="detector_group">
-          <property name="title">
-            <string>Detector</string>
-          </property>
-          <layout class="QGridLayout" name="gridLayout_2">
-            <item row="0" column="0">
-              <widget class="QRadioButton" name="all_detectors">
-                <property name="text">
-                  <string>All Detectors</string>
-                </property>
-                <property name="checked">
-                  <bool>true</bool>
-                </property>
-                <attribute name="buttonGroup">
-                  <string notr="true">detector_options</string>
-                </attribute>
-              </widget>
-            </item>
-            <item row="0" column="1" colspan="3">
-              <widget class="QLineEdit" name="detector_search">
-                <property name="placeholderText">
-                  <string>Search Pattern</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="4">
-              <widget class="QPushButton" name="search_directories">
-                <property name="text">
-                  <string>Search</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0" colspan="2">
-              <widget class="QRadioButton" name="single_detector">
-                <property name="text">
-                  <string>Single Detector</string>
-                </property>
-                <attribute name="buttonGroup">
-                  <string notr="true">detector_options</string>
-                </attribute>
-              </widget>
-            </item>
-            <item row="1" column="2">
-              <widget class="QComboBox" name="detectors">
-                <property name="enabled">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="3" colspan="2">
-              <widget class="QPushButton" name="select_directory">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Select Directory</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="0" colspan="5">
-              <widget class="QLineEdit" name="current_directory">
-                <property name="enabled">
-                  <bool>true</bool>
-                </property>
-                <property name="contextMenuPolicy">
-                  <enum>Qt::DefaultContextMenu</enum>
-                </property>
-                <property name="text">
-                  <string>(No Directory Selected)</string>
-                </property>
-                <property name="readOnly">
-                  <bool>true</bool>
-                </property>
-                <property name="clearButtonEnabled">
-                  <bool>false</bool>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+       <widget class="QRadioButton" name="files_by_selection">
+        <property name="text">
+         <string>Manual Selection</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">file_options</string>
+        </attribute>
+       </widget>
       </item>
-    </layout>
-  </widget>
-  <tabstops>
-    <tabstop>all_detectors</tabstop>
-    <tabstop>detector_search</tabstop>
-    <tabstop>search_directories</tabstop>
-    <tabstop>single_detector</tabstop>
-    <tabstop>detectors</tabstop>
-    <tabstop>select_directory</tabstop>
-    <tabstop>current_directory</tabstop>
-    <tabstop>files_by_selection</tabstop>
-    <tabstop>files_by_search</tabstop>
-    <tabstop>select_files</tabstop>
-    <tabstop>search_text</tabstop>
-    <tabstop>search</tabstop>
-    <tabstop>apply_to_all</tabstop>
-    <tabstop>clear_file_selections</tabstop>
-    <tabstop>empty_frames</tabstop>
-    <tabstop>max_file_frames</tabstop>
-    <tabstop>max_total_frames</tabstop>
-    <tabstop>omega_from_file</tabstop>
-    <tabstop>load_omega_file</tabstop>
-    <tabstop>omega_file</tabstop>
-    <tabstop>omega_wedges</tabstop>
-    <tabstop>clear_wedges</tabstop>
-    <tabstop>add_wedge</tabstop>
-  </tabstops>
-  <resources/>
-  <connections>
-    <connection>
-      <sender>buttonBox</sender>
-      <signal>accepted()</signal>
-      <receiver>ImageStackDialog</receiver>
-      <slot>accept()</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>217</x>
-          <y>415</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>154</x>
-          <y>218</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>buttonBox</sender>
-      <signal>rejected()</signal>
-      <receiver>ImageStackDialog</receiver>
-      <slot>reject()</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>217</x>
-          <y>415</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>154</x>
-          <y>218</y>
-        </hint>
-      </hints>
-    </connection>
-  </connections>
-  <buttongroups>
-    <buttongroup name="detector_options"/>
-    <buttongroup name="omega_options"/>
-    <buttongroup name="file_options">
-      <property name="exclusive">
-        <bool>true</bool>
-      </property>
-    </buttongroup>
-  </buttongroups>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="search">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Search</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QRadioButton" name="files_by_search">
+        <property name="text">
+         <string>Search</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">file_options</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="1" column="3" alignment="Qt::AlignHCenter">
+       <widget class="QCheckBox" name="apply_to_all">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Apply to All</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QLineEdit" name="search_text">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="toolTip">
+         <string/>
+        </property>
+        <property name="placeholderText">
+         <string>Search Pattern</string>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" alignment="Qt::AlignHCenter">
+       <widget class="QLabel" name="file_count">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QPushButton" name="clear_file_selections">
+        <property name="text">
+         <string>Clear Selections</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QGroupBox" name="frames_group">
+     <property name="title">
+      <string>Frames</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="1" column="2">
+       <widget class="QLabel" name="max_total_frames_label">
+        <property name="text">
+         <string>Max Total Frames</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="empty_frames_label">
+        <property name="text">
+         <string>Empty Frames</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="max_file_frames_label">
+        <property name="text">
+         <string>Max File Frames</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3">
+       <widget class="QSpinBox" name="max_total_frames">
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QLabel" name="total_frames">
+        <property name="text">
+         <string>0</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="empty_frames">
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="frames_label">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="text">
+         <string>Total Frames</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSpinBox" name="max_file_frames">
+        <property name="frame">
+         <bool>true</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+        <property name="value">
+         <number>0</number>
+        </property>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+        </layout>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="reverse_frames">
+        <property name="text">
+         <string>Reverse Frame Order</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="omega_group">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="title">
+      <string>Omega</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="omega_from_file">
+        <property name="text">
+         <string>Load from File</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="5">
+       <widget class="QPushButton" name="add_wedge">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Add Wedge</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QPushButton" name="load_omega_file">
+        <property name="text">
+         <string>Select File</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="3">
+       <widget class="QLineEdit" name="omega_file">
+        <property name="text">
+         <string>(No File Selected)</string>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QPushButton" name="clear_wedges">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Clear</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="add_omega">
+        <property name="text">
+         <string>Add Omega Data</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">omega_options</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="6">
+       <widget class="QTableWidget" name="omega_wedges">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>139</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <attribute name="verticalHeaderVisible">
+         <bool>false</bool>
+        </attribute>
+        <attribute name="verticalHeaderStretchLastSection">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Start</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Stop</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Steps</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QRadioButton" name="no_omega">
+        <property name="text">
+         <string>No Omega Data</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">omega_options</string>
+        </attribute>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QGroupBox" name="detector_group">
+     <property name="title">
+      <string>Detector</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0">
+       <widget class="QRadioButton" name="all_detectors">
+        <property name="text">
+         <string>All Detectors</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">detector_options</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="0" column="1" colspan="3">
+       <widget class="QLineEdit" name="detector_search">
+        <property name="placeholderText">
+         <string>Search Pattern</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QPushButton" name="search_directories">
+        <property name="text">
+         <string>Search</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QRadioButton" name="single_detector">
+        <property name="text">
+         <string>Single Detector</string>
+        </property>
+        <attribute name="buttonGroup">
+         <string notr="true">detector_options</string>
+        </attribute>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QComboBox" name="detectors">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="3" colspan="2">
+       <widget class="QPushButton" name="select_directory">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Select Directory</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="5">
+       <widget class="QLineEdit" name="current_directory">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="contextMenuPolicy">
+         <enum>Qt::DefaultContextMenu</enum>
+        </property>
+        <property name="text">
+         <string>(No Directory Selected)</string>
+        </property>
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+        <property name="clearButtonEnabled">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>all_detectors</tabstop>
+  <tabstop>detector_search</tabstop>
+  <tabstop>search_directories</tabstop>
+  <tabstop>single_detector</tabstop>
+  <tabstop>detectors</tabstop>
+  <tabstop>select_directory</tabstop>
+  <tabstop>current_directory</tabstop>
+  <tabstop>files_by_selection</tabstop>
+  <tabstop>files_by_search</tabstop>
+  <tabstop>select_files</tabstop>
+  <tabstop>search_text</tabstop>
+  <tabstop>search</tabstop>
+  <tabstop>apply_to_all</tabstop>
+  <tabstop>clear_file_selections</tabstop>
+  <tabstop>empty_frames</tabstop>
+  <tabstop>max_file_frames</tabstop>
+  <tabstop>max_total_frames</tabstop>
+  <tabstop>omega_from_file</tabstop>
+  <tabstop>load_omega_file</tabstop>
+  <tabstop>omega_file</tabstop>
+  <tabstop>omega_wedges</tabstop>
+  <tabstop>clear_wedges</tabstop>
+  <tabstop>add_wedge</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>ImageStackDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>415</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>154</x>
+     <y>218</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>ImageStackDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>415</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>154</x>
+     <y>218</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="detector_options"/>
+  <buttongroup name="omega_options"/>
+  <buttongroup name="file_options">
+   <property name="exclusive">
+    <bool>true</bool>
+   </property>
+  </buttongroup>
+ </buttongroups>
 </ui>

--- a/hexrd/ui/resources/ui/simple_image_series_dialog.ui
+++ b/hexrd/ui/resources/ui/simple_image_series_dialog.ui
@@ -1,464 +1,464 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
-  <class>SimpleImageSeriesDialog</class>
-  <widget class="QDialog" name="SimpleImageSeriesDialog">
-    <property name="geometry">
-      <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>598</width>
-        <height>675</height>
-      </rect>
-    </property>
-    <property name="windowTitle">
-      <string>Simple Image Series Import</string>
-    </property>
-    <layout class="QVBoxLayout" name="verticalLayout_2">
+ <class>SimpleImageSeriesDialog</class>
+ <widget class="QDialog" name="SimpleImageSeriesDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>598</width>
+    <height>675</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Simple Image Series Import</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <widget class="QGroupBox" name="file_reader_group">
+     <property name="title">
+      <string>File Reader</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <property name="spacing">
+       <number>0</number>
+      </property>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="aggregation">
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Maximum</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Median</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Average</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QPushButton" name="image_files">
+        <property name="text">
+         <string>Select Image Files</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="QPushButton" name="select_dark">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Select Dark File</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="0">
+       <widget class="QCheckBox" name="aps_imageseries">
+        <property name="text">
+         <string>Use APS ImageSeries</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="dark_label">
+        <property name="text">
+         <string>Dark Mode:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="files_label">
+        <property name="text">
+         <string>Image Files:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="transform_label">
+        <property name="text">
+         <string>Image Transform:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QComboBox" name="dark_mode">
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Median</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Empty Frames</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Average</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Maximum</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>File</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="4" column="2" rowspan="2">
+       <widget class="QPushButton" name="read">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Read Files</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="aggregation_label">
+        <property name="text">
+         <string>Aggregation:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QComboBox" name="transform">
+        <item>
+         <property name="text">
+          <string>None</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Mirror about Vertical</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Mirror about Horizontal</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Transpose</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Rotate 90°</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Rotate 180°</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Rotate 270°</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QPushButton" name="image_folder">
+        <property name="text">
+         <string>Change Image Folder</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="1">
+       <widget class="QCheckBox" name="reverse_frames">
+        <property name="text">
+         <string>Reverse Frame Order</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="multiframe_group">
+     <property name="title">
+      <string>Multiframe Options</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
       <item>
-        <widget class="QGroupBox" name="file_reader_group">
-          <property name="title">
-            <string>File Reader</string>
+       <layout class="QHBoxLayout" name="multiframe_layout">
+        <item>
+         <widget class="QLabel" name="detector_label">
+          <property name="text">
+           <string>Detector:</string>
           </property>
-          <layout class="QGridLayout" name="gridLayout">
-            <property name="leftMargin">
-              <number>0</number>
-            </property>
-            <property name="topMargin">
-              <number>0</number>
-            </property>
-            <property name="rightMargin">
-              <number>0</number>
-            </property>
-            <property name="bottomMargin">
-              <number>0</number>
-            </property>
-            <property name="spacing">
-              <number>0</number>
-            </property>
-            <item row="0" column="1">
-              <widget class="QComboBox" name="aggregation">
-                <item>
-                  <property name="text">
-                    <string>None</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Maximum</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Median</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Average</string>
-                  </property>
-                </item>
-              </widget>
-            </item>
-            <item row="3" column="2">
-              <widget class="QPushButton" name="image_files">
-                <property name="text">
-                  <string>Select Image Files</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="2">
-              <widget class="QPushButton" name="select_dark">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Select Dark File</string>
-                </property>
-              </widget>
-            </item>
-            <item row="5" column="0">
-              <widget class="QCheckBox" name="aps_imageseries">
-                <property name="text">
-                  <string>Use APS ImageSeries</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="0">
-              <widget class="QLabel" name="dark_label">
-                <property name="text">
-                  <string>Dark Mode:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="3" column="0">
-              <widget class="QLabel" name="files_label">
-                <property name="text">
-                  <string>Image Files:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
-              <widget class="QLabel" name="transform_label">
-                <property name="text">
-                  <string>Image Transform:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="2" column="1">
-              <widget class="QComboBox" name="dark_mode">
-                <property name="currentIndex">
-                  <number>0</number>
-                </property>
-                <item>
-                  <property name="text">
-                    <string>None</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Median</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Empty Frames</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Average</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Maximum</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>File</string>
-                  </property>
-                </item>
-              </widget>
-            </item>
-            <item row="4" column="2" rowspan="2">
-              <widget class="QPushButton" name="read">
-                <property name="enabled">
-                  <bool>false</bool>
-                </property>
-                <property name="text">
-                  <string>Read Files</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="0">
-              <widget class="QLabel" name="aggregation_label">
-                <property name="text">
-                  <string>Aggregation:</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <widget class="QComboBox" name="transform">
-                <item>
-                  <property name="text">
-                    <string>None</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Mirror about Vertical</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Mirror about Horizontal</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Transpose</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Rotate 90°</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Rotate 180°</string>
-                  </property>
-                </item>
-                <item>
-                  <property name="text">
-                    <string>Rotate 270°</string>
-                  </property>
-                </item>
-              </widget>
-            </item>
-            <item row="3" column="1">
-              <widget class="QPushButton" name="image_folder">
-                <property name="text">
-                  <string>Change Image Folder</string>
-                </property>
-              </widget>
-            </item>
-            <item row="5" column="1">
-              <widget class="QCheckBox" name="reverse_frames">
-                <property name="text">
-                  <string>Reverse Frame Order</string>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
-      </item>
-      <item>
-        <widget class="QGroupBox" name="multiframe_group">
-          <property name="title">
-            <string>Multiframe Options</string>
+         </widget>
+        </item>
+        <item>
+         <widget class="QComboBox" name="detector">
+          <property name="enabled">
+           <bool>true</bool>
           </property>
-          <layout class="QVBoxLayout" name="verticalLayout">
-            <item>
-              <layout class="QHBoxLayout" name="multiframe_layout">
-                <item>
-                  <widget class="QLabel" name="detector_label">
-                    <property name="text">
-                      <string>Detector:</string>
-                    </property>
-                  </widget>
-                </item>
-                <item>
-                  <widget class="QComboBox" name="detector">
-                    <property name="enabled">
-                      <bool>true</bool>
-                    </property>
-                    <property name="currentText">
-                      <string>detector_1</string>
-                    </property>
-                    <property name="sizeAdjustPolicy">
-                      <enum>QComboBox::AdjustToContents</enum>
-                    </property>
-                    <item>
-                      <property name="text">
-                        <string>detector_1</string>
-                      </property>
-                    </item>
-                  </widget>
-                </item>
-                <item>
-                  <spacer name="multiframe_det_spacer">
-                    <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>40</width>
-                        <height>20</height>
-                      </size>
-                    </property>
-                  </spacer>
-                </item>
-                <item>
-                  <widget class="QCheckBox" name="all_detectors">
-                    <property name="text">
-                      <string>Apply Selections to All Detectors</string>
-                    </property>
-                    <property name="checked">
-                      <bool>true</bool>
-                    </property>
-                  </widget>
-                </item>
-                <item>
-                  <spacer name="multiframe_select_spacer">
-                    <property name="orientation">
-                      <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                      <size>
-                        <width>40</width>
-                        <height>20</height>
-                      </size>
-                    </property>
-                  </spacer>
-                </item>
-              </layout>
-            </item>
-            <item>
-              <widget class="QTableWidget" name="file_options">
-                <property name="contextMenuPolicy">
-                  <enum>Qt::CustomContextMenu</enum>
-                </property>
-                <property name="sizeAdjustPolicy">
-                  <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
-                </property>
-                <property name="alternatingRowColors">
-                  <bool>true</bool>
-                </property>
-                <property name="selectionMode">
-                  <enum>QAbstractItemView::SingleSelection</enum>
-                </property>
-                <property name="selectionBehavior">
-                  <enum>QAbstractItemView::SelectItems</enum>
-                </property>
-                <property name="showGrid">
-                  <bool>false</bool>
-                </property>
-                <attribute name="horizontalHeaderDefaultSectionSize">
-                  <number>100</number>
-                </attribute>
-                <attribute name="horizontalHeaderStretchLastSection">
-                  <bool>true</bool>
-                </attribute>
-                <column>
-                  <property name="text">
-                    <string>Image File</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Empty Frames</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Total Frames</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Omega Start</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Omega Stop</string>
-                  </property>
-                </column>
-                <column>
-                  <property name="text">
-                    <string>Steps</string>
-                  </property>
-                </column>
-              </widget>
-            </item>
-          </layout>
-        </widget>
-      </item>
-      <item>
-        <layout class="QHBoxLayout" name="update_image_layout">
-          <item>
-            <spacer name="update_image_spacer">
-              <property name="orientation">
-                <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-                <size>
-                  <width>624</width>
-                  <height>20</height>
-                </size>
-              </property>
-            </spacer>
-          </item>
-          <item>
-            <widget class="QPushButton" name="update_image_data">
-              <property name="enabled">
-                <bool>false</bool>
-              </property>
-              <property name="text">
-                <string>Update Image Data</string>
-              </property>
-            </widget>
-          </item>
-        </layout>
-      </item>
-      <item>
-        <widget class="QGroupBox" name="information_group">
-          <property name="title">
-            <string>Information</string>
+          <property name="currentText">
+           <string>detector_1</string>
           </property>
-          <layout class="QFormLayout" name="formLayout">
-            <item row="0" column="0">
-              <widget class="QLabel" name="image_directory_label">
-                <property name="text">
-                  <string>Image Directory</string>
-                </property>
-              </widget>
-            </item>
-            <item row="0" column="1">
-              <widget class="QLineEdit" name="img_directory">
-                <property name="readOnly">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="0">
-              <widget class="QLabel" name="dark_file_label">
-                <property name="text">
-                  <string>Dark File</string>
-                </property>
-              </widget>
-            </item>
-            <item row="1" column="1">
-              <widget class="QLineEdit" name="dark_file">
-                <property name="readOnly">
-                  <bool>true</bool>
-                </property>
-              </widget>
-            </item>
-          </layout>
-        </widget>
+          <property name="sizeAdjustPolicy">
+           <enum>QComboBox::AdjustToContents</enum>
+          </property>
+          <item>
+           <property name="text">
+            <string>detector_1</string>
+           </property>
+          </item>
+         </widget>
+        </item>
+        <item>
+         <spacer name="multiframe_det_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="all_detectors">
+          <property name="text">
+           <string>Apply Selections to All Detectors</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <spacer name="multiframe_select_spacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+       </layout>
       </item>
       <item>
-        <layout class="QHBoxLayout" name="cancel_layout">
-          <item>
-            <widget class="QDialogButtonBox" name="button_box">
-              <property name="standardButtons">
-                <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-              </property>
-              <property name="centerButtons">
-                <bool>false</bool>
-              </property>
-            </widget>
-          </item>
-        </layout>
+       <widget class="QTableWidget" name="file_options">
+        <property name="contextMenuPolicy">
+         <enum>Qt::CustomContextMenu</enum>
+        </property>
+        <property name="sizeAdjustPolicy">
+         <enum>QAbstractScrollArea::AdjustToContentsOnFirstShow</enum>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="selectionMode">
+         <enum>QAbstractItemView::SingleSelection</enum>
+        </property>
+        <property name="selectionBehavior">
+         <enum>QAbstractItemView::SelectItems</enum>
+        </property>
+        <property name="showGrid">
+         <bool>false</bool>
+        </property>
+        <attribute name="horizontalHeaderDefaultSectionSize">
+         <number>100</number>
+        </attribute>
+        <attribute name="horizontalHeaderStretchLastSection">
+         <bool>true</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Image File</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Empty Frames</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Total Frames</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Omega Start</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Omega Stop</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Steps</string>
+         </property>
+        </column>
+       </widget>
       </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="update_image_layout">
+     <item>
+      <spacer name="update_image_spacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>624</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="update_image_data">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Update Image Data</string>
+       </property>
+      </widget>
+     </item>
     </layout>
-  </widget>
-  <resources/>
-  <connections>
-    <connection>
-      <sender>button_box</sender>
-      <signal>accepted()</signal>
-      <receiver>SimpleImageSeriesDialog</receiver>
-      <slot>accept()</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>322</x>
-          <y>652</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>322</x>
-          <y>337</y>
-        </hint>
-      </hints>
-    </connection>
-    <connection>
-      <sender>button_box</sender>
-      <signal>rejected()</signal>
-      <receiver>SimpleImageSeriesDialog</receiver>
-      <slot>reject()</slot>
-      <hints>
-        <hint type="sourcelabel">
-          <x>322</x>
-          <y>652</y>
-        </hint>
-        <hint type="destinationlabel">
-          <x>322</x>
-          <y>337</y>
-        </hint>
-      </hints>
-    </connection>
-  </connections>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="information_group">
+     <property name="title">
+      <string>Information</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="image_directory_label">
+        <property name="text">
+         <string>Image Directory</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="img_directory">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="dark_file_label">
+        <property name="text">
+         <string>Dark File</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="dark_file">
+        <property name="readOnly">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="cancel_layout">
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+       <property name="centerButtons">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>SimpleImageSeriesDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>322</x>
+     <y>652</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>337</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>SimpleImageSeriesDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>322</x>
+     <y>652</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>322</x>
+     <y>337</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
I noticed that there was a discrepancy between the peak positions in plotted polar image and the row-wise (read: azimuthal) sum that depended on the 2&theta; pixel size.  Further examination showed that the cause was the extents; in the existing class the axis extents are static, fixed to the interactor values.  This is not correct, since the max values may differ from the user-requested value by up to a pixel due to truncation.  The true angular grid vectors in the polarview generator are effectively calculated as
```
nbins = int((max_val - min_val)/bin_size)
bin_edges = bin_size*np.arange(nbins + 1) - min_val
```
so that if the range is not evenly divisible but the bin_size, the _true_ max with be less than the requested.

I added an `extent` property on the `PolarView` class, and use it in the image render.  Tested and looks good!