### PR TITLE
Re-organize the "Run" menu items

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -199,11 +199,11 @@ class MainWindow(QObject):
             self.update_config_gui)
         self.image_mode_widget.tab_changed.connect(self.change_image_mode)
         self.image_mode_widget.mask_applied.connect(self.update_all)
-        self.ui.action_run_powder_calibration.triggered.connect(
-            self.start_powder_calibration)
-        self.ui.action_run_calibration.triggered.connect(
-            self.on_action_run_calibration_triggered)
-        self.ui.action_run_calibration.triggered.connect(
+        self.ui.action_run_fast_powder_calibration.triggered.connect(
+            self.start_fast_powder_calibration)
+        self.ui.action_run_laue_and_powder_calibration.triggered.connect(
+            self.on_action_run_laue_and_powder_calibration_triggered)
+        self.ui.action_run_laue_and_powder_calibration.triggered.connect(
             self.ui.image_tab_widget.toggle_off_toolbar)
         self.ui.action_run_indexing.triggered.connect(
             self.on_action_run_indexing_triggered)
@@ -456,7 +456,7 @@ class MainWindow(QObject):
             HexrdConfig().working_dir = os.path.dirname(selected_file)
             return self.ui.image_tab_widget.export_current_plot(selected_file)
 
-    def on_action_run_calibration_triggered(self):
+    def on_action_run_laue_and_powder_calibration_triggered(self):
         if not hasattr(self, '_calibration_runner_async_runner'):
             # Initialize this only once and keep it around, so we don't
             # run into issues connecting/disconnecting the messages.
@@ -687,14 +687,15 @@ class MainWindow(QObject):
 
         self.ui.action_export_current_plot.setEnabled(
             (is_polar or is_cartesian) and has_images)
-        self.ui.action_run_calibration.setEnabled(is_polar and has_images)
+        self.ui.action_run_laue_and_powder_calibration.setEnabled(
+            is_polar and has_images)
         self.ui.action_edit_apply_hand_drawn_mask.setEnabled(
             (is_polar or is_raw) and has_images)
         self.ui.action_run_wppf.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
         self.ui.action_edit_apply_powder_mask_to_polar.setEnabled(is_polar)
 
-    def start_powder_calibration(self):
+    def start_fast_powder_calibration(self):
         if not HexrdConfig().has_images():
             msg = ('No images available for calibration.')
             QMessageBox.warning(self.ui, 'HEXRD', msg)

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -145,13 +145,25 @@
     <property name="title">
      <string>R&amp;un</string>
     </property>
-    <addaction name="action_run_powder_calibration"/>
-    <addaction name="action_run_calibration"/>
+    <widget class="QMenu" name="menu_hedm">
+     <property name="title">
+      <string>HEDM</string>
+     </property>
+     <addaction name="action_run_indexing"/>
+     <addaction name="action_rerun_clustering"/>
+     <addaction name="action_run_fit_grains"/>
+    </widget>
+    <widget class="QMenu" name="menu_calibration">
+     <property name="title">
+      <string>Calibration</string>
+     </property>
+     <addaction name="action_run_laue_and_powder_calibration"/>
+     <addaction name="action_run_fast_powder_calibration"/>
+    </widget>
+    <addaction name="menu_calibration"/>
     <addaction name="action_run_wppf"/>
     <addaction name="separator"/>
-    <addaction name="action_run_indexing"/>
-    <addaction name="action_rerun_clustering"/>
-    <addaction name="action_run_fit_grains"/>
+    <addaction name="menu_hedm"/>
    </widget>
    <addaction name="menu_file"/>
    <addaction name="menu_edit"/>
@@ -216,7 +228,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>651</height>
+          <height>610</height>
          </rect>
         </property>
         <attribute name="label">
@@ -229,7 +241,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>651</height>
+          <height>610</height>
          </rect>
         </property>
         <attribute name="label">
@@ -414,9 +426,17 @@
     <string>&amp;Materials</string>
    </property>
   </action>
-  <action name="action_run_powder_calibration">
+  <action name="action_run_laue_and_powder_calibration">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
-    <string>&amp;Powder Calibration</string>
+    <string>Laue and Powder</string>
+   </property>
+  </action>
+  <action name="action_run_fast_powder_calibration">
+   <property name="text">
+    <string>Fast Powder</string>
    </property>
   </action>
   <action name="action_edit_euler_angle_convention">
@@ -454,14 +474,6 @@
    </property>
    <property name="text">
     <string>Current View</string>
-   </property>
-  </action>
-  <action name="action_run_calibration">
-   <property name="enabled">
-    <bool>false</bool>
-   </property>
-   <property name="text">
-    <string>Calibration</string>
    </property>
   </action>
   <action name="action_edit_reset_instrument_config">


### PR DESCRIPTION
This puts the HEDM-specific menu items under an "HEDM" menu, and the
calibration-specific menu items under a "Calibration" menu.

These changes were requested by @joelvbernier