### PR TITLE
Add extra argument for Qt 5.13 compatibility

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -279,7 +279,7 @@ class FitGrainsOptionsDialog(QObject):
         for row in range(num_rows):
             if selection_model.isRowSelected(row, QModelIndex()):
                 selected_rows.append(row)
-            elif selection_model.rowIntersectsSelection(row):
+            elif selection_model.rowIntersectsSelection(row, QModelIndex()):
                 # Partial row is selected - return empty list
                 del selected_rows[:]
                 break


### PR DESCRIPTION
In Qt 5.15, the second argument to `rowIntersectsSelection()` has a default
value of `QModelIndex()`. Earlier than Qt 5.15, however, does not
have a default value. Let's add it in for compatibility. Windows is
using Qt 5.13, for instance, and needs this change.