### PR TITLE
Remove uses of _memo_hkls dict

### DIFF
--- a/hexrd/ui/indexing/grains_table_view.py
+++ b/hexrd/ui/indexing/grains_table_view.py
@@ -4,8 +4,6 @@ from PySide2.QtCore import QSortFilterProxyModel, Qt
 from PySide2.QtGui import QCursor
 from PySide2.QtWidgets import QMenu, QTableView
 
-from hexrd.xrdutil import _memo_hkls
-
 from hexrd.ui.async_runner import AsyncRunner
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.indexing.create_config import create_indexing_config
@@ -151,20 +149,11 @@ class GrainsTableView(QTableView):
         self.spots_viewer.ui.finished.connect(self.spots_viewer.clear_data)
 
     def run_pull_spots_on_selected_grains(self):
-        # Make sure memoized hkls are removed before and after running
-        # pull_spots(). If pull_spots() was called earlier with different
-        # exclusions, then we would get the wrong answer from pull_spots()
-        # unless we cleared these memo hkls.
-        _memo_hkls.clear()
-
         selected_grains = self.selected_grain_ids
 
         spots_output = {}
-        try:
-            for grain_id in selected_grains:
-                spots_output[grain_id] = self.run_pull_spots(grain_id)
-        finally:
-            _memo_hkls.clear()
+        for grain_id in selected_grains:
+            spots_output[grain_id] = self.run_pull_spots(grain_id)
 
         return spots_output
 

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -11,7 +11,7 @@ from hexrd.findorientations import (
     generate_eta_ome_maps, generate_orientation_fibers, run_cluster
 )
 from hexrd.fitgrains import fit_grains
-from hexrd.xrdutil import EtaOmeMaps, _memo_hkls
+from hexrd.xrdutil import EtaOmeMaps
 
 from hexrd.ui.async_worker import AsyncWorker
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -74,9 +74,6 @@ class IndexingRunner(Runner):
         self.ome_maps_viewer_dialog = None
         self.ome_maps = None
         self.grains_table = None
-
-        # Reset memo hkls in case they were set earlier with different hkls
-        _memo_hkls.clear()
 
     def run(self):
         # We will go through these steps:
@@ -341,9 +338,6 @@ class FitGrainsRunner(Runner):
         self.fit_grains_select_dialog = None
         self.fit_grains_options_dialog = None
         self.fit_grains_results = None
-
-        # Reset memo hkls in case they were set earlier with different hkls
-        _memo_hkls.clear()
 
     def run(self):
         # We will go through these steps:


### PR DESCRIPTION
Hexrd is removing it in hexrd/hexrd#351. Once that is merged, we
should remove the uses of it here. Basically, we were clearing it
to fix a memoization issue, and we no longer need to clear it
anymore since the memoization will no longer be happening...