### PR TITLE
Change excluded grain columns to [9, 15)

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -35,7 +35,7 @@ class FitGrainsOptionsDialog(QObject):
 
         kwargs = {
             'grains_table': grains_table,
-            'excluded_columns': [1, 2] + list(range(6, len(grains_table[0]))),
+            'excluded_columns': list(range(9, 15)),
             'parent': self.ui.grains_table_view,
         }
         self.data_model = GrainsTableModel(**kwargs)


### PR DESCRIPTION
In the fit grains options dialog, the previously excluded grain columns
would be fixed values (null values, essentially) if the user ran through
the indexing workflow to get the grains.

However, if the user loads in the grains via a `grains.out` file, these
may be non-null values, and it can be useful to see them.

Thus, show the parameters in case they are non-null.