### PR TITLE
Add missing code paths for rotation series

### DIFF
--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -120,6 +120,7 @@ def path_to_hkl(overlay, detector_name, hkl):
     data_key_map = {
         OverlayType.powder: 'rings',
         OverlayType.laue: 'spots',
+        OverlayType.rotation_series: 'data',
     }
 
     overlay_type = overlay['type']

--- a/hexrd/ui/refinements_editor.py
+++ b/hexrd/ui/refinements_editor.py
@@ -257,9 +257,14 @@ def refinement_values(overlay):
 
         return ret
 
+    def rotation_series_values():
+        # Currently the same as laue
+        return laue_values()
+
     func_dict = {
         OverlayType.powder: powder_values,
         OverlayType.laue: laue_values,
+        OverlayType.rotation_series: rotation_series_values,
     }
 
     return func_dict[overlay['type']]()
@@ -287,9 +292,14 @@ def set_refinement_values(overlay, values):
 
         return False
 
+    def set_rotation_series():
+        # Currently the same as laue
+        return set_laue()
+
     func_dict = {
         OverlayType.powder: set_powder,
         OverlayType.laue: set_laue,
+        OverlayType.rotation_series: set_rotation_series,
     }
 
     return func_dict[overlay['type']]()


### PR DESCRIPTION
This adds the rotation_series code paths for a couple of places. Namely,
setting/getting the refinable values in the refinements editor, and
getting the path to data for certain hkls.