### PR TITLE
Add ability to load crystal parameters from grains

### DIFF
--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -8,6 +8,7 @@ from hexrd import matrixutil
 
 from hexrd.ui.constants import DEFAULT_CRYSTAL_REFINEMENTS
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.select_grains_dialog import SelectGrainsDialog
 from hexrd.ui.select_items_widget import SelectItemsWidget
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import convert_angle_convention
@@ -60,6 +61,8 @@ class CalibrationCrystalEditor(QObject):
         self.slider_widget.changed.connect(self.slider_widget_changed)
         self.refinements_selector.selection_changed.connect(
             self.refinements_edited)
+
+        self.ui.load.clicked.connect(self.load)
 
     @property
     def params(self):
@@ -262,3 +265,14 @@ class CalibrationCrystalEditor(QObject):
             o_values = [x.value() for x in self.orientation_widgets]
             p_values = [x.value() for x in self.position_widgets]
             self.slider_widget.update_gui(o_values, p_values)
+
+    def load(self):
+        dialog = SelectGrainsDialog(self.ui)
+        if not dialog.exec_():
+            return
+
+        self.load_from_grain(dialog.selected_grain)
+
+    def load_from_grain(self, grain):
+        self.params = grain[3:15]
+        self.params_modified.emit()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -201,6 +201,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.logging_stderr_handler = None
         self.loading_state = False
         self.last_loaded_state_file = None
+        self.find_orientations_grains_table = None
+        self.fit_grains_grains_table = None
 
         self.setup_logging()
 

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -42,7 +42,6 @@ class FitGrainsOptionsDialog(QObject):
         view = self.ui.grains_table_view
         view.data_model = self.data_model
         view.material = self.material
-        view.grains_table = grains_table
 
         ok_button = self.ui.button_box.button(QDialogButtonBox.Ok)
         ok_button.setText('Fit Grains')

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -466,7 +466,6 @@ class FitGrainsResultsDialog(QObject):
         # Update the variables on the table view
         view.data_model = self.data_model
         view.material = self.material
-        view.grains_table = self.data
 
     def show(self):
         self.ui.show()

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>767</width>
-    <height>385</height>
+    <height>398</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -523,6 +523,13 @@
           </item>
          </layout>
         </widget>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QPushButton" name="load">
+        <property name="text">
+         <string>Load Crystal Parameters</string>
+        </property>
        </widget>
       </item>
      </layout>

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>550</width>
-    <height>565</height>
+    <height>610</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>565</height>
+    <height>610</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
@@ -7,13 +7,13 @@
     <x>0</x>
     <y>0</y>
     <width>550</width>
-    <height>680</height>
+    <height>710</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>680</height>
+    <height>710</height>
    </size>
   </property>
   <property name="windowTitle">

--- a/hexrd/ui/resources/ui/select_grains_dialog.ui
+++ b/hexrd/ui/resources/ui/select_grains_dialog.ui
@@ -1,0 +1,131 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>grains_select_dialog</class>
+ <widget class="QDialog" name="grains_select_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>635</width>
+    <height>372</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select Grains</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QLabel" name="method_label">
+     <property name="text">
+      <string>From:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="method"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTabWidget" name="tab_widget">
+     <property name="currentIndex">
+      <number>0</number>
+     </property>
+     <widget class="QWidget" name="find_orientations_output_tab">
+      <attribute name="title">
+       <string>Find Orientations Output</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout"/>
+     </widget>
+     <widget class="QWidget" name="fit_grains_output_tab">
+      <attribute name="title">
+       <string>Fit Grains Output</string>
+      </attribute>
+      <layout class="QHBoxLayout" name="horizontalLayout_2"/>
+     </widget>
+     <widget class="QWidget" name="file_tab">
+      <attribute name="title">
+       <string>File</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="0">
+        <widget class="QLineEdit" name="file_name">
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QPushButton" name="select_file_button">
+         <property name="text">
+          <string>Select File</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="GrainsTableView" name="table_view"/>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>GrainsTableView</class>
+   <extends>QTableView</extends>
+   <header>grains_table_view.py</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>method</tabstop>
+  <tabstop>tab_widget</tabstop>
+  <tabstop>table_view</tabstop>
+  <tabstop>file_name</tabstop>
+  <tabstop>select_file_button</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>grains_select_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>grains_select_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/select_grains_dialog.py
+++ b/hexrd/ui/select_grains_dialog.py
@@ -1,0 +1,236 @@
+import os
+
+import numpy as np
+
+from PySide2.QtCore import Signal, QItemSelectionModel, QObject, Qt
+from PySide2.QtWidgets import QDialogButtonBox, QFileDialog, QMessageBox
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.indexing.grains_table_model import GrainsTableModel
+from hexrd.ui.ui_loader import UiLoader
+
+
+class SelectGrainsDialog(QObject):
+
+    accepted = Signal()
+    rejected = Signal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.ignore_errors = False
+
+        loader = UiLoader()
+        self.ui = loader.load_file('select_grains_dialog.ui', parent)
+
+        # Hide the tab bar. It gets selected by changes to the combo box.
+        self.ui.tab_widget.tabBar().hide()
+
+        # pull_spots is not allowed with this grains table view
+        self.ui.table_view.pull_spots_allowed = False
+
+        self.setup_methods()
+        self.update_gui()
+
+        self.ignore_errors = True
+        try:
+            self.update_grains_table()
+        finally:
+            self.ignore_errors = False
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.select_file_button.pressed.connect(self.select_file)
+        self.ui.file_name.editingFinished.connect(self.file_name_changed)
+        self.ui.method.currentIndexChanged.connect(self.method_index_changed)
+        self.ui.accepted.connect(self.on_accepted)
+        self.ui.rejected.connect(self.on_rejected)
+        self.ui.table_view.selection_changed.connect(self.update_enable_states)
+
+    @property
+    def find_orientations_grains_table(self):
+        return HexrdConfig().find_orientations_grains_table
+
+    @property
+    def fit_grains_grains_table(self):
+        return HexrdConfig().fit_grains_grains_table
+
+    def setup_methods(self):
+        fo_grains_table = self.find_orientations_grains_table
+        fg_grains_table = self.fit_grains_grains_table
+        methods_and_enable = {
+            'fit_grains_output': fg_grains_table is not None,
+            'find_orientations_output': fo_grains_table is not None,
+            'file': True,
+        }
+
+        methods = list(methods_and_enable.keys())
+        self.ui.method.addItems([name_to_label(x) for x in methods])
+
+        # FIXME: it'd be nice to eventually put this QComboBox
+        # item disabling in a utility function.
+        model = self.ui.method.model()
+        for i, method in enumerate(methods):
+            enabled = methods_and_enable[method]
+            if enabled:
+                # Already enabled...
+                continue
+
+            item = model.item(i)
+            item.setFlags(item.flags() & ~Qt.ItemIsEnabled)
+
+        # Set the combo box to the first enabled entry
+        for i, method in enumerate(methods):
+            enabled = methods_and_enable[method]
+            if enabled:
+                self.ui.method.setCurrentIndex(i)
+                break
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    def on_accepted(self):
+        self.update_config()
+        self.accepted.emit()
+
+    def on_rejected(self):
+        self.rejected.emit()
+
+    def select_file(self):
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            self.ui, 'grains.out', HexrdConfig().working_dir,
+            'Grains.out files (*.out)')
+
+        if selected_file:
+            HexrdConfig().working_dir = os.path.dirname(selected_file)
+            self.file_name = selected_file
+
+    @property
+    def file_name(self):
+        return self.ui.file_name.text()
+
+    @file_name.setter
+    def file_name(self, v):
+        self.ui.file_name.setText(v)
+        self.file_name_changed()
+
+    def file_name_changed(self):
+        file_name = self.file_name
+        if not file_name:
+            self.grains_table = None
+            return
+
+        # Try to load the file
+        try:
+            self.grains_table = np.loadtxt(file_name, ndmin=2)
+        except Exception as e:
+            if not self.ignore_errors:
+                msg = f'Failed to load "{file_name}". Error was:\n\n{e}'
+                QMessageBox.critical(self.ui, 'HEXRD', msg)
+            self.grains_table = None
+
+    def load_fo_grains_table(self):
+        self.grains_table = self.find_orientations_grains_table
+
+    def load_fg_grains_table(self):
+        self.grains_table = self.fit_grains_grains_table
+
+    @property
+    def grains_table(self):
+        return self.ui.table_view.grains_table
+
+    @grains_table.setter
+    def grains_table(self, v):
+        # We make a new GrainsTableModel each time for now to save
+        # dev time, since the model wasn't designed to be mutable.
+        # FIXME: in the future, make GrainsTableModel grains mutable,
+        # and then just set the grains table on it, rather than
+        # creating a new one every time.
+        view = self.ui.table_view
+        if v is None:
+            view.data_model = None
+            self.update_enable_states()
+            return
+
+        kwargs = {
+            'grains_table': v,
+            'excluded_columns': list(range(9, 15)),
+            'parent': view,
+        }
+        view.data_model = GrainsTableModel(**kwargs)
+
+        # If there is only one row, select it automatically
+        if len(v) == 1:
+            selection_model = view.selectionModel()
+            model_index = selection_model.model().index(0, 0)
+            command = QItemSelectionModel.Select | QItemSelectionModel.Rows
+            selection_model.select(model_index, command)
+
+    def update_grains_table(self):
+        functions = {
+            'find_orientations_output': self.load_fo_grains_table,
+            'fit_grains_output': self.load_fg_grains_table,
+            'file': self.file_name_changed,
+        }
+        if self.method_name not in functions:
+            raise NotImplementedError(self.method_name)
+
+        functions[self.method_name]()
+
+    @property
+    def selected_grain(self):
+        grains = self.ui.table_view.selected_grains
+        if grains is None or len(grains) == 0:
+            return
+
+        # Should only be one
+        if len(grains) > 1:
+            raise Exception('Only one grain may be selected')
+
+        return grains[0]
+
+    def update_gui(self):
+        indexing_config = HexrdConfig().indexing_config
+        key = '_loaded_crystal_params_file'
+        self.file_name = indexing_config.get(key, '')
+
+        self.update_method_tab()
+        self.update_enable_states()
+
+    def update_config(self):
+        indexing_config = HexrdConfig().indexing_config
+        indexing_config['_loaded_crystal_params_file'] = self.file_name
+
+    def update_enable_states(self):
+        button_box = self.ui.button_box
+        ok_button = button_box.button(QDialogButtonBox.Ok)
+        if ok_button:
+            ok_button.setEnabled(self.selected_grain is not None)
+
+    @property
+    def method_name(self):
+        return label_to_name(self.ui.method.currentText())
+
+    @method_name.setter
+    def method_name(self, v):
+        self.ui.method.setCurrentText(name_to_label(v))
+
+    def method_index_changed(self):
+        self.update_method_tab()
+        self.update_grains_table()
+
+    def update_method_tab(self):
+        # Take advantage of the naming scheme...
+        method_tab = getattr(self.ui, self.method_name + '_tab')
+        self.ui.tab_widget.setCurrentWidget(method_tab)
+
+        visible = self.method_name == 'file'
+        self.ui.tab_widget.setVisible(visible)
+
+
+def name_to_label(s):
+    return ' '.join(x.capitalize() for x in s.split('_'))
+
+
+def label_to_name(s):
+    return '_'.join(x.lower() for x in s.split())


### PR DESCRIPTION
In the calibration crystal editor (found in both the Laue overlay
editor and the Rotation Series overlay editor), there is now a
"Load Crystal Parameters" button at the bottom, that allows the user
to load crystal parameters from grains. It gives the user the choice
to display grains from the fit grains output, find orientations output,
or from a file. The user may select a grain in the table and click
"OK", and the crystal parameters will be populated with the parameters
from the selected grain.


https://user-images.githubusercontent.com/9558430/140572926-9ff04070-919b-43a0-8b48-a852371c902b.mp4

