### PR TITLE
Add HEDM Calibration

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -9,7 +9,6 @@ from hexrd.ui.async_runner import AsyncRunner
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.overlays import default_overlay_refinements
 from hexrd.ui.utils import instr_to_internal_dict
 
 from hexrd.ui.calibration.auto import (
@@ -248,13 +247,7 @@ class PowderRunner(QObject):
 
     @property
     def active_overlay_refinements(self):
-        return [x[1] for x in self.overlay_refinements(self.active_overlay)]
-
-    def overlay_refinements(self, overlay):
-        refinements = overlay.get('refinements')
-        if refinements is None:
-            refinements = default_overlay_refinements(overlay)
-        return refinements
+        return [x[1] for x in self.active_overlay['refinements']]
 
     @property
     def refinement_flags_without_overlays(self):

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -3,6 +3,7 @@ from functools import partial
 
 import numpy as np
 
+from PySide2.QtCore import QObject, Signal
 from PySide2.QtGui import QIcon
 from PySide2.QtWidgets import QMessageBox
 
@@ -30,10 +31,14 @@ from hexrd.ui.utils import (
 from hexrd.ui.utils.conversions import cart_to_angles
 
 
-class CalibrationRunner:
+class CalibrationRunner(QObject):
+
+    finished = Signal()
+
     def __init__(self, canvas, async_runner, parent=None):
+        super().__init__(parent)
+
         self.canvas = canvas
-        self.parent = parent
         self.current_overlay_ind = -1
         self.overlay_data_index = -1
         self.all_overlay_picks = {}
@@ -371,7 +376,8 @@ class CalibrationRunner:
 
         # In case any overlays changed
         HexrdConfig().overlay_config_changed.emit()
-        HexrdConfig().calibration_complete.emit()
+        HexrdConfig().update_overlay_editor.emit()
+        self.finished.emit()
 
     def write_instrument_to_hexrd_config(self, instr):
         output_dict = instr_to_internal_dict(instr)

--- a/hexrd/ui/calibration/hedm/__init__.py
+++ b/hexrd/ui/calibration/hedm/__init__.py
@@ -1,0 +1,9 @@
+from .calibration_options_dialog import HEDMCalibrationOptionsDialog
+from .calibration_results_dialog import HEDMCalibrationResultsDialog
+from .calibration_runner import HEDMCalibrationRunner
+
+__all__ = [
+    'HEDMCalibrationOptionsDialog',
+    'HEDMCalibrationResultsDialog',
+    'HEDMCalibrationRunner',
+]

--- a/hexrd/ui/calibration/hedm/calibration_options_dialog.py
+++ b/hexrd/ui/calibration/hedm/calibration_options_dialog.py
@@ -1,0 +1,184 @@
+from PySide2.QtCore import QObject, Signal
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.reflections_table import ReflectionsTable
+from hexrd.ui.ui_loader import UiLoader
+
+
+class HEDMCalibrationOptionsDialog(QObject):
+
+    accepted = Signal()
+    rejected = Signal()
+
+    def __init__(self, num_grains_required=1, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('hedm_calibration_options_dialog.ui',
+                                   parent)
+
+        self.num_grains_required = num_grains_required
+        self.parent = parent
+
+        self.update_materials()
+        self.selected_material_changed()
+
+        self.update_gui()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.material.currentIndexChanged.connect(
+            self.selected_material_changed)
+        self.ui.choose_hkls.pressed.connect(self.choose_hkls)
+
+        HexrdConfig().overlay_config_changed.connect(self.update_num_hkls)
+
+        HexrdConfig().materials_dict_modified.connect(self.update_materials)
+
+        self.ui.accepted.connect(self.on_accepted)
+        self.ui.rejected.connect(self.on_rejected)
+
+    def update_gui(self):
+        config = HexrdConfig().indexing_config['fit_grains']
+        self.refit_pixel_scale = config['refit'][0]
+        self.refit_ome_step_scale = config['refit'][1]
+
+        indexing_config = HexrdConfig().indexing_config
+        self.selected_material = indexing_config.get('_selected_material')
+
+        calibration_config = indexing_config['_hedm_calibration']
+        self.do_refit = calibration_config['do_refit']
+        self.clobber_strain = calibration_config['clobber_strain']
+        self.clobber_centroid = calibration_config['clobber_centroid']
+        self.clobber_grain_Y = calibration_config['clobber_grain_Y']
+
+        self.update_num_hkls()
+
+    def update_config(self):
+        config = HexrdConfig().indexing_config['fit_grains']
+        config['refit'][0] = self.refit_pixel_scale
+        config['refit'][1] = self.refit_ome_step_scale
+
+        indexing_config = HexrdConfig().indexing_config
+        indexing_config['_selected_material'] = self.selected_material
+
+        calibration_config = indexing_config['_hedm_calibration']
+        calibration_config['do_refit'] = self.do_refit
+        calibration_config['clobber_strain'] = self.clobber_strain
+        calibration_config['clobber_centroid'] = self.clobber_centroid
+        calibration_config['clobber_grain_Y'] = self.clobber_grain_Y
+
+    def show(self):
+        self.ui.show()
+
+    def on_accepted(self):
+        self.update_config()
+        self.accepted.emit()
+
+    def on_rejected(self):
+        self.rejected.emit()
+
+    @property
+    def do_refit(self):
+        return self.ui.do_refit.isChecked()
+
+    @do_refit.setter
+    def do_refit(self, b):
+        self.ui.do_refit.setChecked(b)
+
+    @property
+    def refit_pixel_scale(self):
+        return self.ui.refit_pixel_scale.value()
+
+    @refit_pixel_scale.setter
+    def refit_pixel_scale(self, v):
+        self.ui.refit_pixel_scale.setValue(v)
+
+    @property
+    def refit_ome_step_scale(self):
+        return self.ui.refit_ome_step_scale.value()
+
+    @refit_ome_step_scale.setter
+    def refit_ome_step_scale(self, v):
+        self.ui.refit_ome_step_scale.setValue(v)
+
+    @property
+    def clobber_strain(self):
+        return self.ui.clobber_strain.isChecked()
+
+    @clobber_strain.setter
+    def clobber_strain(self, b):
+        self.ui.clobber_strain.setChecked(b)
+
+    @property
+    def clobber_centroid(self):
+        return self.ui.clobber_centroid.isChecked()
+
+    @clobber_centroid.setter
+    def clobber_centroid(self, b):
+        self.ui.clobber_strain.setChecked(b)
+
+    @property
+    def clobber_grain_Y(self):
+        return self.ui.clobber_grain_Y.isChecked()
+
+    @clobber_grain_Y.setter
+    def clobber_grain_Y(self, b):
+        self.ui.clobber_grain_Y.setChecked(b)
+
+    @property
+    def material_options(self):
+        w = self.ui.material
+        return [w.itemText(i) for i in range(w.count())]
+
+    @property
+    def selected_material(self):
+        return self.ui.material.currentText()
+
+    @selected_material.setter
+    def selected_material(self, name):
+        if name is None or name not in self.material_options:
+            return
+
+        self.ui.material.setCurrentText(name)
+
+    @property
+    def material(self):
+        return HexrdConfig().material(self.selected_material)
+
+    def update_materials(self):
+        prev = self.selected_material
+        material_names = list(HexrdConfig().materials)
+
+        self.ui.material.clear()
+        self.ui.material.addItems(material_names)
+
+        if prev in material_names:
+            self.ui.material.setCurrentText(prev)
+        else:
+            self.ui.material.setCurrentText(HexrdConfig().active_material_name)
+
+    def selected_material_changed(self):
+        if hasattr(self, '_reflections_table'):
+            self._reflections_table.material = self.material
+
+        # self.ui.table_view.material = self.material
+        self.update_num_hkls()
+
+    def choose_hkls(self):
+        kwargs = {
+            'material': self.material,
+            'title_prefix': 'Select hkls for HEDM calibration: ',
+            'parent': self.ui,
+        }
+        self._reflections_table = ReflectionsTable(**kwargs)
+        self._reflections_table.show()
+
+    def update_num_hkls(self):
+        if self.material is None:
+            num_hkls = 0
+        else:
+            num_hkls = len(self.material.planeData.getHKLs())
+
+        text = f'Number of hkls selected:  {num_hkls}'
+        self.ui.num_hkls_selected.setText(text)

--- a/hexrd/ui/calibration/hedm/calibration_options_dialog.py
+++ b/hexrd/ui/calibration/hedm/calibration_options_dialog.py
@@ -116,7 +116,7 @@ class HEDMCalibrationOptionsDialog(QObject):
 
     @clobber_centroid.setter
     def clobber_centroid(self, b):
-        self.ui.clobber_strain.setChecked(b)
+        self.ui.clobber_centroid.setChecked(b)
 
     @property
     def clobber_grain_Y(self):

--- a/hexrd/ui/calibration/hedm/calibration_results_dialog.py
+++ b/hexrd/ui/calibration/hedm/calibration_results_dialog.py
@@ -15,7 +15,7 @@ DEFAULT_LABEL = ''
 
 class HEDMCalibrationResultsDialog:
     def __init__(self, data, styles, labels, grain_ids, cfg, title,
-                 parent=None):
+                 ome_period, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('hedm_calibration_results_dialog.ui',
                                    parent)
@@ -30,6 +30,7 @@ class HEDMCalibrationResultsDialog:
         self.grain_ids = grain_ids
         self.cfg = cfg
         self.title = title
+        self.ome_period = ome_period
 
         self.setup_combo_boxes()
         self.setup_canvas()
@@ -139,7 +140,7 @@ class HEDMCalibrationResultsDialog:
         self.clear_artists()
 
         instr = self.cfg.instrument.hedm
-        ome_period = self.cfg.find_orientations.omega.period
+        ome_period = self.ome_period
 
         grain_ids = self.grain_ids_to_plot
         det_key = self.selected_detector_key

--- a/hexrd/ui/calibration/hedm/calibration_results_dialog.py
+++ b/hexrd/ui/calibration/hedm/calibration_results_dialog.py
@@ -1,0 +1,181 @@
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QSizePolicy
+
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.figure import Figure
+import numpy as np
+
+from hexrd.ui.navigation_toolbar import NavigationToolbar
+from hexrd.ui.ui_loader import UiLoader
+
+
+DEFAULT_STYLE = 'rx'
+DEFAULT_LABEL = ''
+
+
+class HEDMCalibrationResultsDialog:
+    def __init__(self, data, styles, labels, grain_ids, cfg, title,
+                 parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('hedm_calibration_results_dialog.ui',
+                                   parent)
+
+        if isinstance(grain_ids, np.ndarray):
+            # So we can easily use the .index() function...
+            grain_ids = grain_ids.tolist()
+
+        self.data = data
+        self.styles = styles
+        self.labels = labels
+        self.grain_ids = grain_ids
+        self.cfg = cfg
+        self.title = title
+
+        self.setup_combo_boxes()
+        self.setup_canvas()
+        self.update_canvas()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.detector.currentIndexChanged.connect(self.update_canvas)
+        self.ui.show_all_grains.toggled.connect(self.show_all_grains_toggled)
+        self.ui.grain_id.currentIndexChanged.connect(self.update_canvas)
+        self.ui.show_legend.toggled.connect(self.update_canvas)
+
+    def setup_combo_boxes(self):
+        self.ui.grain_id.clear()
+        for grain_id in self.grain_ids:
+            self.ui.grain_id.addItem(str(grain_id), grain_id)
+
+        self.ui.detector.clear()
+        for det_key in self.cfg.instrument.hedm.detectors:
+            self.ui.detector.addItem(det_key)
+
+        self.update_enable_states()
+
+    def update_enable_states(self):
+        enable_grain_id = (
+            not self.show_all_grains and
+            self.ui.grain_id.count() > 1
+        )
+        self.ui.grain_id.setEnabled(enable_grain_id)
+        self.ui.grain_id_label.setEnabled(enable_grain_id)
+
+        enable_detector = self.ui.detector.count() > 1
+        self.ui.detector.setEnabled(enable_detector)
+        self.ui.detector_label.setEnabled(enable_detector)
+
+        show_all_grains_visible = self.ui.grain_id.count() > 1
+        self.ui.show_all_grains.setVisible(show_all_grains_visible)
+
+    def setup_canvas(self):
+        self.artists = []
+
+        # Create the figure and axes to use
+        canvas = FigureCanvas(Figure())
+
+        # Get the canvas to take up the majority of the screen most of the time
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        fig = canvas.figure
+        fig.suptitle(self.title)
+        ax = fig.subplots(1, 2, sharex=True, sharey=False)
+        self.ui.canvas_layout.addWidget(canvas)
+
+        ax[0].grid(True)
+        ax[0].axis('equal')
+        ax[0].set_xlabel('detector X [mm]')
+        ax[0].set_ylabel('detector Y [mm]')
+
+        ax[1].grid(True)
+        ax[1].set_xlabel('detector X [mm]')
+        ax[1].set_ylabel(r'$\omega$ [deg]')
+
+        self.toolbar = NavigationToolbar(canvas, self.ui, coordinates=True)
+        self.ui.canvas_layout.addWidget(self.toolbar)
+
+        # Center the toolbar
+        self.ui.canvas_layout.setAlignment(self.toolbar, Qt.AlignCenter)
+
+        self.fig = fig
+        self.ax = ax
+        self.canvas = canvas
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    @property
+    def selected_detector_key(self):
+        return self.ui.detector.currentText()
+
+    @property
+    def selected_grain_id(self):
+        return self.ui.grain_id.currentData()
+
+    @property
+    def show_all_grains(self):
+        return self.ui.show_all_grains.isChecked()
+
+    @property
+    def show_legend(self):
+        return self.ui.show_legend.isChecked()
+
+    def show_all_grains_toggled(self):
+        self.update_enable_states()
+        self.update_canvas()
+
+    @property
+    def grain_ids_to_plot(self):
+        if self.show_all_grains:
+            return self.grain_ids
+
+        return [self.selected_grain_id]
+
+    def clear_artists(self):
+        while self.artists:
+            self.artists.pop(0).remove()
+
+    def update_canvas(self):
+        self.clear_artists()
+
+        instr = self.cfg.instrument.hedm
+        ome_period = self.cfg.find_orientations.omega.period
+
+        grain_ids = self.grain_ids_to_plot
+        det_key = self.selected_detector_key
+        panel = instr.detectors[det_key]
+        ax = self.ax
+
+        ax[0].set_xlim(-0.5 * panel.col_dim, 0.5 * panel.col_dim)
+        ax[0].set_ylim(-0.5 * panel.row_dim, 0.5 * panel.row_dim)
+
+        ax[1].set_xlim(-0.5 * panel.col_dim, 0.5 * panel.col_dim)
+        ax[1].set_ylim(ome_period[0], ome_period[1])
+
+        grains_to_plot = [self.grain_ids.index(x) for x in grain_ids]
+        for key, data in self.data.items():
+            style = self.styles.get(key, DEFAULT_STYLE)
+            label = self.labels.get(key, DEFAULT_LABEL)
+            self.draw_entry(grains_to_plot, data[det_key], style, label)
+
+        self.canvas.draw()
+
+    def draw_entry(self, indices, data, style, label):
+        for idx in indices:
+            x = data[idx][:, 0]
+            y1 = data[idx][:, 1]
+            y2 = np.degrees(data[idx][:, 2])
+
+            artist1, = self.ax[0].plot(x, y1, style, label=label)
+            artist2, = self.ax[1].plot(x, y2, style, label=label)
+
+            self.artists.extend([artist1, artist2])
+
+            if self.show_legend:
+                legend_kwargs = {
+                    'loc': 'lower right',
+                    'title': 'Legend',
+                }
+                artist3 = self.ax[0].legend(**legend_kwargs)
+                artist4 = self.ax[1].legend(**legend_kwargs)
+                self.artists.extend([artist3, artist4])

--- a/hexrd/ui/calibration/hedm/calibration_results_dialog.py
+++ b/hexrd/ui/calibration/hedm/calibration_results_dialog.py
@@ -44,7 +44,7 @@ class HEDMCalibrationResultsDialog:
 
     def setup_combo_boxes(self):
         self.ui.grain_id.clear()
-        for grain_id in self.grain_ids:
+        for grain_id in sorted(self.grain_ids):
             self.ui.grain_id.addItem(str(grain_id), grain_id)
 
         self.ui.detector.clear()
@@ -161,10 +161,14 @@ class HEDMCalibrationResultsDialog:
         self.canvas.draw()
 
     def draw_entry(self, indices, data, style, label):
-        for idx in indices:
+        for i, idx in enumerate(indices):
             x = data[idx][:, 0]
             y1 = data[idx][:, 1]
             y2 = np.degrees(data[idx][:, 2])
+
+            # Only add the label for the first index
+            if i != 0:
+                label = None
 
             artist1, = self.ax[0].plot(x, y1, style, label=label)
             artist2, = self.ax[1].plot(x, y2, style, label=label)

--- a/hexrd/ui/calibration/hedm/calibration_runner.py
+++ b/hexrd/ui/calibration/hedm/calibration_runner.py
@@ -1,0 +1,564 @@
+import numpy as np
+
+from PySide2.QtCore import QObject, Signal
+from PySide2.QtWidgets import QMessageBox
+
+from hexrd import constants as cnst
+from hexrd.fitting import calibration
+from hexrd.transforms import xfcapi
+
+from hexrd.ui.calibration.hedm import (
+    HEDMCalibrationOptionsDialog,
+    HEDMCalibrationResultsDialog,
+)
+from hexrd.ui.constants import OverlayType
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.indexing.create_config import (
+    create_indexing_config, OmegasNotFoundError
+)
+from hexrd.ui.overlays import overlay_name
+from hexrd.ui.select_grains_dialog import SelectGrainsDialog
+from hexrd.ui.utils import instr_to_internal_dict
+
+
+class HEDMCalibrationRunner(QObject):
+
+    finished = Signal()
+
+    def __init__(self, async_runner, parent=None):
+        super().__init__(parent)
+
+        self.async_runner = async_runner
+        self.parent = parent
+
+        self.select_grains_dialog = None
+        self.options_dialog = None
+        self.clear()
+
+    def clear(self):
+        if self.select_grains_dialog:
+            self.select_grains_dialog.ui.hide()
+            self.select_grains_dialog = None
+
+        if self.options_dialog:
+            self.options_dialog.ui.hide()
+            self.options_dialog = None
+
+        self.results = None
+        self.results_message = ''
+
+    def run(self):
+        self.clear()
+        self.pre_validate()
+
+        # Get the grains that we need
+        dialog = SelectGrainsDialog(self.num_active_overlays, self.parent)
+        dialog.show()
+        dialog.accepted.connect(self.on_grains_selected)
+        self.select_grains_dialog = dialog
+
+    def on_grains_selected(self):
+        self.grains_table = self.select_grains_dialog.selected_grains
+
+        import hexrd.ui.calibration.hedm.calibration_options_dialog
+        from importlib import reload
+        reload(hexrd.ui.calibration.hedm.calibration_options_dialog)
+        from hexrd.ui.calibration.hedm.calibration_options_dialog import (
+            HEDMCalibrationOptionsDialog,
+        )
+
+        # FIXME: bring up a dialog that sets several things we need
+        dialog = HEDMCalibrationOptionsDialog(self.parent)
+        dialog.accepted.connect(self.on_options_dialog_accepted)
+        dialog.show()
+        self.options_dialog = dialog
+
+    def on_options_dialog_accepted(self):
+        dialog = self.options_dialog
+
+        # Grab some selections from the dialog
+        self.do_refit = dialog.do_refit
+        self.clobber_strain = dialog.clobber_strain
+        self.clobber_centroid = dialog.clobber_centroid
+        self.clobber_grain_Y = dialog.clobber_grain_Y
+
+        self.clobber_refinements()
+        self.run_calibration()
+
+    def run_calibration(self):
+        # First, run pull_spots() to get the spots data
+        self.async_runner.progress_title = 'Running pull spots...'
+        self.async_runner.success_callback = self.on_pull_spots_finished
+        self.async_runner.run(self.run_pull_spots)
+
+    def on_pull_spots_finished(self, spots_data):
+        cfg = create_indexing_config()
+
+        # grab instrument
+        instr = cfg.instrument.hedm
+
+        # Save to self
+        self.instr = instr
+
+        param_flags = self.param_flags
+        grain_flags = self.grain_flags
+
+        # User selected these from the dialog
+        do_refit = self.do_refit
+        clobber_strain = self.clobber_strain
+        clobber_centroid = self.clobber_centroid
+        clobber_grain_Y = self.clobber_grain_Y
+
+        # Our grains table only contains the grains that the user
+        # selected.
+        grain_parameters = self.grains_table[:, 3:15]
+        grain_ids = self.grains_table[:, 0].astype(int)
+
+        # plane data
+        plane_data = cfg.material.plane_data
+        bmat = plane_data.latVecOps['B']
+
+        ome_period = self.ome_period
+
+        grain_parameters = grain_parameters.copy()
+        if clobber_strain:
+            for grain in grain_parameters:
+                grain[6:] = cnst.identity_6x1
+        if clobber_centroid:
+            for grain in grain_parameters:
+                grain[3:6] = cnst.zeros_3
+        if clobber_grain_Y:
+            for grain in grain_parameters:
+                grain[4] = 0.
+        ngrains = len(grain_parameters)
+
+        # The styles we will use for plotting points
+        plot_styles = {
+            'xyo_i': 'rx',
+            'xyo_det': 'k.',
+            'xyo_f': 'b+',
+        }
+
+        plot_labels = {
+            'xyo_i': 'Initial',
+            'xyo_det': 'Measured',
+            'xyo_f': 'Final',
+        }
+
+        hkls, xyo_det, idx_0 = parse_spots_data(spots_data, instr, grain_ids)
+
+        xyo_i = calibration.calibrate_instrument_from_sx(
+            instr, grain_parameters, bmat, xyo_det, hkls,
+            ome_period=np.radians(ome_period), sim_only=True
+        )
+
+        import hexrd.ui.calibration.hedm.calibration_results_dialog
+        from importlib import reload
+        reload(hexrd.ui.calibration.hedm.calibration_results_dialog)
+        from hexrd.ui.calibration.hedm.calibration_results_dialog import (
+            HEDMCalibrationResultsDialog,
+        )
+
+        data = {
+            'xyo_i': xyo_i,
+            'xyo_det': xyo_det,
+        }
+        kwargs = {
+            'data': data,
+            'styles': plot_styles,
+            'labels': plot_labels,
+            'grain_ids': grain_ids,
+            'cfg': cfg,
+            'title': 'Initial Guess. Proceed?',
+            'parent': self.parent,
+        }
+        dialog = HEDMCalibrationResultsDialog(**kwargs)
+        if not dialog.exec_():
+            return
+
+        # Run optimization
+        params, resd, xyo_f = calibration.calibrate_instrument_from_sx(
+            instr, grain_parameters, bmat, xyo_det, hkls,
+            ome_period=np.radians(ome_period),
+            param_flags=param_flags,
+            grain_flags=grain_flags
+        )
+
+        # update calibration crystal params
+        grain_parameters = params[-grain_parameters.size:].reshape(ngrains, 12)
+
+        if not do_refit:
+            data = {
+                'xyo_i': xyo_i,
+                'xyo_det': xyo_det,
+                'xyo_f': xyo_f,
+            }
+            kwargs = {
+                'data': data,
+                'styles': plot_styles,
+                'labels': plot_labels,
+                'grain_ids': grain_ids,
+                'cfg': cfg,
+                'title': 'Final results. Accept?',
+                'parent': self.parent,
+            }
+            dialog = HEDMCalibrationResultsDialog(**kwargs)
+            if not dialog.exec_():
+                return
+
+            # All done! Update the results.
+            self.results = grain_parameters
+            self.on_calibration_finished()
+            return
+
+        # load imageseries dict
+        ims_dict = cfg.image_series
+        ims = next(iter(ims_dict.values()))    # grab first member
+        delta_ome = ims.metadata['omega'][:, 1] - ims.metadata['omega'][:, 0]
+        assert np.max(np.abs(np.diff(delta_ome))) < cnst.sqrt_epsf, \
+            "something funky going one with your omegas"
+        delta_ome = delta_ome[0]   # any one member will do
+
+        # refit tolerances
+        if cfg.fit_grains.refit is not None:
+            n_pixels_tol = cfg.fit_grains.refit[0]
+            ome_tol = cfg.fit_grains.refit[1]*delta_ome
+        else:
+            n_pixels_tol = 2
+            ome_tol = 2.*delta_ome
+
+        # define difference vectors for spot fits
+        for det_key, panel in instr.detectors.items():
+            for ig in range(ngrains):
+                x_diff = abs(xyo_det[det_key][ig][:, 0] -
+                             xyo_f[det_key][ig][:, 0])
+                y_diff = abs(xyo_det[det_key][ig][:, 1] -
+                             xyo_f[det_key][ig][:, 1])
+                ome_diff = np.degrees(
+                    xfcapi.angularDifference(
+                        xyo_det[det_key][ig][:, 2],
+                        xyo_f[det_key][ig][:, 2])
+                )
+
+                # filter out reflections with centroids more than
+                # a pixel and delta omega away from predicted value
+                idx_1 = np.logical_and(
+                    x_diff <= n_pixels_tol*panel.pixel_size_col,
+                    np.logical_and(
+                        y_diff <= n_pixels_tol*panel.pixel_size_row,
+                        ome_diff <= ome_tol
+                    )
+                )
+
+                print("INFO: Will keep %d of %d input reflections "
+                      % (sum(idx_1), sum(idx_0[det_key][ig]))
+                      + "on panel %s for re-fit" % det_key)
+
+                idx_new = np.zeros_like(idx_0[det_key][ig], dtype=bool)
+                idx_new[np.where(idx_0[det_key][ig])[0][idx_1]] = True
+                idx_0[det_key][ig] = idx_new
+
+        # reparse data
+        hkls_refit, xyo_det_refit, idx_0 = parse_spots_data(
+            spots_data, instr, grain_ids, refit_idx=idx_0)
+
+        # perform refit
+        params, resd, xyo_f = calibration.calibrate_instrument_from_sx(
+            instr, grain_parameters, bmat, xyo_det_refit, hkls_refit,
+            ome_period=np.radians(ome_period),
+            param_flags=param_flags,
+            grain_flags=grain_flags
+        )
+
+        data = {
+            'xyo_i': xyo_i,
+            'xyo_det': xyo_det,
+            'xyo_f': xyo_f,
+        }
+        kwargs = {
+            'data': data,
+            'styles': plot_styles,
+            'labels': plot_labels,
+            'grain_ids': grain_ids,
+            'cfg': cfg,
+            'title': 'Final results. Accept?',
+            'parent': self.parent,
+        }
+        dialog = HEDMCalibrationResultsDialog(**kwargs)
+        if not dialog.exec_():
+            return
+
+        # update calibration crystal params
+        grain_parameters = params[-grain_parameters.size:].reshape(ngrains, 12)
+
+        self.results = grain_parameters
+        self.on_calibration_finished()
+
+    def run_pull_spots(self):
+        cfg = create_indexing_config()
+
+        instr = cfg.instrument.hedm
+        imsd = cfg.image_series
+
+        outputs = []
+        for overlay in self.active_overlays:
+            options = overlay['options']
+            kwargs = {
+                'plane_data': self.material.planeData,
+                'grain_params': overlay['options']['crystal_params'],
+                'tth_tol': np.degrees(options['tth_width']),
+                'eta_tol': np.degrees(options['eta_width']),
+                'ome_tol': np.degrees(options['ome_width']),
+                'imgser_dict': imsd,
+                'npdiv': cfg.fit_grains.npdiv,
+                'threshold': cfg.fit_grains.threshold,
+                'eta_ranges': options['eta_ranges'],
+                'ome_period': options['ome_period'],
+                'dirname': cfg.analysis_dir,
+                'filename': None,
+                'return_spot_list': False,
+                'quiet': True,
+                'check_only': False,
+                'interp': 'nearest',
+            }
+            out = instr.pull_spots(**kwargs)
+            outputs.append(out)
+
+        return outputs
+
+    def on_calibration_finished(self):
+        self.write_results_message()
+
+        # Update the instrument
+        self.update_config()
+
+    def write_results_message(self):
+        msg = ''
+
+        # First, show any updates to instrument parameters
+        instr_flags = self.instr.calibration_flags
+        if any(instr_flags):
+            cfg = create_indexing_config()
+            old_instr = cfg.instrument.hedm
+            old_values = old_instr.calibration_parameters[instr_flags]
+            new_values = self.instr.calibration_parameters[instr_flags]
+
+            msg += '*** Instrument ***\n'
+            for old, new in zip(old_values, new_values):
+                msg += f'{old: 12.8f}  => {new: 12.8f}\n'
+
+        # Next, the overlay parameters
+        for results, overlay in zip(self.results, self.active_overlays):
+            name = overlay_name(overlay)
+            refinements = self.overlay_refinements(overlay)
+            if any(refinements):
+                old_values = overlay['options']['crystal_params'][refinements]
+                new_values = results[refinements]
+
+                msg += f'*** {name} ***\n'
+                for old, new in zip(old_values, new_values):
+                    msg += f'{old: 12.8f}  => {new: 12.8f}\n'
+
+        self.results_message = msg
+
+    def update_config(self):
+        msg = 'Optimization successful!'
+        msg_box = QMessageBox(QMessageBox.Information, 'HEXRD', msg)
+        msg_box.setDetailedText(self.results_message)
+        msg_box.exec_()
+
+        # Update rotation series parameters from the results
+        for results, overlay in zip(self.results, self.active_overlays):
+            overlay['options']['crystal_params'][:] = results
+
+        # Update modified instrument parameters
+        output_dict = instr_to_internal_dict(self.instr)
+
+        # Save the previous iconfig to restore the statuses
+        prev_iconfig = HexrdConfig().config['instrument']
+
+        # Update the config
+        HexrdConfig().config['instrument'] = output_dict
+
+        # This adds in any missing keys. In particular, it is going to
+        # add in any "None" detector distortions
+        HexrdConfig().set_detector_defaults_if_missing()
+
+        # Add status values
+        HexrdConfig().add_status(output_dict)
+
+        # Set the previous statuses to be the current statuses
+        HexrdConfig().set_statuses_from_prev_iconfig(prev_iconfig)
+
+        # Tell GUI that the overlays need to be re-computed
+        HexrdConfig().flag_overlay_updates_for_material(self.material.name)
+
+        # update the materials panel
+        if self.material is HexrdConfig().active_material:
+            HexrdConfig().active_material_modified.emit()
+
+        # Update the overlay editor in case it is visible
+        HexrdConfig().update_overlay_editor.emit()
+
+        # redraw updated overlays
+        HexrdConfig().overlay_config_changed.emit()
+
+        # Done!
+        self.finished.emit()
+
+    @property
+    def param_flags(self):
+        return HexrdConfig().get_statuses_instrument_format()
+
+    @property
+    def grain_flags(self):
+        return np.array(self.active_overlay_refinements).flatten()
+
+    @property
+    def all_flags(self):
+        return np.concatenate((self.param_flags, self.grain_flags))
+
+    @property
+    def overlays(self):
+        return HexrdConfig().overlays
+
+    @property
+    def visible_overlays(self):
+        return [x for x in self.overlays if x['visible']]
+
+    @property
+    def visible_rotation_series_overlays(self):
+        overlays = self.visible_overlays
+        needed_type = OverlayType.rotation_series
+        return [x for x in overlays if x['type'] == needed_type]
+
+    @property
+    def active_overlays(self):
+        return self.visible_rotation_series_overlays
+
+    @property
+    def num_active_overlays(self):
+        return len(self.active_overlays)
+
+    @property
+    def first_active_overlay(self):
+        overlays = self.active_overlays
+        return overlays[0] if overlays else None
+
+    @property
+    def ome_period(self):
+        # These should be the same for all overlays, and it is pre-validated
+        return np.degrees(self.first_active_overlay['options']['ome_period'])
+
+    @property
+    def material(self):
+        overlay = self.first_active_overlay
+        return HexrdConfig().material(overlay['material']) if overlay else None
+
+    @property
+    def active_overlay_refinements(self):
+        return [self.overlay_refinements(x) for x in self.active_overlays]
+
+    def overlay_refinements(self, overlay):
+        return [x[1] for x in overlay['refinements']]
+
+    def clobber_refinements(self):
+        any_clobbering = (
+            self.clobber_strain or
+            self.clobber_centroid or
+            self.clobber_grain_Y
+        )
+        if not any_clobbering:
+            return
+
+        for overlay in self.active_overlays:
+            refinements = overlay['refinements']
+            if self.clobber_strain:
+                for i in range(6, len(refinements)):
+                    refinements[i] = (refinements[i][0], False)
+            if self.clobber_centroid:
+                for i in range(3, 6):
+                    refinements[i] = (refinements[i][0], False)
+            if self.clobber_grain_Y:
+                refinements[4] = (refinements[4][0], False)
+
+        HexrdConfig().update_overlay_editor.emit()
+
+    def pre_validate(self):
+        # Validation to perform before we do anything else
+        if not self.active_overlays:
+            msg = 'There must be at least one visible rotation series overlay'
+            raise Exception(msg)
+
+        ome_periods = []
+        for overlay in self.active_overlays:
+            options = overlay['options']
+            if any(options.get(x) is None for x in ('eta_width', 'tth_width')):
+                msg = (
+                    'All visible rotation series overlays must have widths '
+                    'enabled'
+                )
+                raise Exception(msg)
+
+            ome_periods.append(options['ome_period'])
+
+        for i in range(1, len(ome_periods)):
+            if not np.allclose(ome_periods[0], ome_periods[i]):
+                msg = (
+                    'All visible rotation series overlays must have '
+                    'identical omega periods'
+                )
+                raise Exception(msg)
+
+        materials = [overlay['material'] for overlay in self.active_overlays]
+        if not all(x == materials[0] for x in materials):
+            msg = (
+                'All visible rotation series overlays must have the same '
+                'material'
+            )
+            raise Exception(msg)
+
+        if not np.any(self.all_flags):
+            msg = 'There are no refinable parameters'
+            raise Exception(msg)
+
+        # Ensure we have omega metadata
+        try:
+            create_indexing_config()
+        except OmegasNotFoundError:
+            msg = (
+                'No omega metadata found. Be sure to import the image '
+                'series using the "Simple Image Series" import tool.'
+            )
+            raise Exception(msg)
+
+
+def parse_spots_data(spots_data, instr, grain_ids, refit_idx=None):
+    hkls = {}
+    xyo_det = {}
+    idx_0 = {}
+    for det_key, panel in instr.detectors.items():
+        hkls[det_key] = []
+        xyo_det[det_key] = []
+        idx_0[det_key] = []
+
+        for ig, grain_id in enumerate(grain_ids):
+            data = spots_data[grain_id][1][det_key]
+            # Convert to numpy array to make operations easier
+            data = np.array(data, dtype=object)
+            valid_reflections = data[:, 0] >= 0
+            not_saturated = data[:, 4] < panel.saturation_level
+
+            if refit_idx is None:
+                idx = np.logical_and(valid_reflections, not_saturated)
+                idx_0[det_key].append(idx)
+            else:
+                idx = refit_idx[det_key][ig]
+                idx_0[det_key].append(idx)
+
+            hkls[det_key].append(np.vstack(data[idx, 2]))
+            meas_omes = np.vstack(data[idx, 6])[:, 2].reshape(sum(idx), 1)
+            xyo_det[det_key].append(np.hstack([np.vstack(data[idx, 7]),
+                                               meas_omes]))
+
+    return hkls, xyo_det, idx_0

--- a/hexrd/ui/calibration/hedm/calibration_runner.py
+++ b/hexrd/ui/calibration/hedm/calibration_runner.py
@@ -168,6 +168,7 @@ class HEDMCalibrationRunner(QObject):
             'grain_ids': grain_ids,
             'cfg': cfg,
             'title': 'Initial Guess. Proceed?',
+            'ome_period': ome_period,
             'parent': self.parent,
         }
         dialog = HEDMCalibrationResultsDialog(**kwargs)
@@ -198,6 +199,7 @@ class HEDMCalibrationRunner(QObject):
                 'grain_ids': grain_ids,
                 'cfg': cfg,
                 'title': 'Final results. Accept?',
+                'ome_period': ome_period,
                 'parent': self.parent,
             }
             dialog = HEDMCalibrationResultsDialog(**kwargs)
@@ -280,6 +282,7 @@ class HEDMCalibrationRunner(QObject):
             'grain_ids': grain_ids,
             'cfg': cfg,
             'title': 'Final results. Accept?',
+            'ome_period': ome_period,
             'parent': self.parent,
         }
         dialog = HEDMCalibrationResultsDialog(**kwargs)

--- a/hexrd/ui/calibration/hedm/calibration_runner.py
+++ b/hexrd/ui/calibration/hedm/calibration_runner.py
@@ -483,6 +483,12 @@ class HEDMCalibrationRunner(QObject):
 
         HexrdConfig().update_overlay_editor.emit()
 
+    def synchronize_material(self):
+        # This material is used for creating the indexing config.
+        # Make sure it matches the material we are using.
+        cfg = HexrdConfig().indexing_config
+        cfg['_selected_material'] = self.material.name
+
     def synchronize_omega_period(self):
         # This omega period is deprecated, but still used in some places.
         # Make sure it is synchronized with our overlays' omega period.
@@ -526,6 +532,9 @@ class HEDMCalibrationRunner(QObject):
         if not np.any(self.all_flags):
             msg = 'There are no refinable parameters'
             raise Exception(msg)
+
+        # Make sure the material is updated in the indexing config
+        self.synchronize_material()
 
         # Ensure we have omega metadata
         try:

--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -267,7 +267,7 @@ class CalibrationCrystalEditor(QObject):
             self.slider_widget.update_gui(o_values, p_values)
 
     def load(self):
-        dialog = SelectGrainsDialog(self.ui)
+        dialog = SelectGrainsDialog(1, self.ui)
         if not dialog.exec_():
             return
 

--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -3,8 +3,9 @@ import numpy as np
 from numpy.linalg import LinAlgError
 
 from PySide2.QtCore import QObject, QSignalBlocker, Signal
+from PySide2.QtWidgets import QFileDialog
 
-from hexrd import matrixutil
+from hexrd import instrument, matrixutil
 
 from hexrd.ui.constants import DEFAULT_CRYSTAL_REFINEMENTS
 from hexrd.ui.hexrd_config import HexrdConfig
@@ -63,6 +64,7 @@ class CalibrationCrystalEditor(QObject):
             self.refinements_edited)
 
         self.ui.load.clicked.connect(self.load)
+        self.ui.save.clicked.connect(self.save)
 
     @property
     def params(self):
@@ -276,3 +278,20 @@ class CalibrationCrystalEditor(QObject):
     def load_from_grain(self, grain):
         self.params = grain[3:15]
         self.params_modified.emit()
+
+    def save(self):
+        selected_file, selected_filter = QFileDialog.getSaveFileName(
+            self.ui, 'Save Crystal Parameters', HexrdConfig().working_dir,
+            'Grains.out files (*.out)')
+
+        if not selected_file:
+            return
+
+        self.write_params(selected_file)
+
+    def write_params(self, filepath):
+        gw = instrument.GrainDataWriter(filepath)
+        try:
+            gw.dump_grain(0, 1, 0, self.params)
+        finally:
+            gw.close()

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -155,7 +155,7 @@ DEFAULT_ROTATION_SERIES_OPTIONS = {
     'ome_ranges': [[-np.pi, np.pi]],
     'ome_period': [-np.pi, np.pi],
     'aggregated': True,
-    'ome_width': 5.0,
+    'ome_width': np.radians(5.0),
     'tth_width': None,
     'eta_width': None,
 }

--- a/hexrd/ui/grains_viewer_dialog.py
+++ b/hexrd/ui/grains_viewer_dialog.py
@@ -1,0 +1,54 @@
+from PySide2.QtWidgets import QDialog, QVBoxLayout
+
+from hexrd.ui.indexing.grains_table_model import GrainsTableModel
+from hexrd.ui.ui_loader import UiLoader
+
+
+class GrainsViewerWidget:
+
+    def __init__(self, grains_table, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('grains_viewer_widget.ui', parent)
+
+        self.grains_table = grains_table
+
+        # pull_spots is not allowed with this grains table view
+        self.ui.table_view.pull_spots_allowed = False
+
+    @property
+    def grains_table(self):
+        return self.ui.table_view.grains_table
+
+    @grains_table.setter
+    def grains_table(self, v):
+        # We make a new GrainsTableModel each time for now to save
+        # dev time, since the model wasn't designed to be mutable.
+        # FIXME: in the future, make GrainsTableModel grains mutable,
+        # and then just set the grains table on it, rather than
+        # creating a new one every time.
+        view = self.ui.table_view
+        if v is None:
+            view.data_model = None
+            return
+
+        kwargs = {
+            'grains_table': v,
+            'excluded_columns': list(range(9, 15)),
+            'parent': view,
+        }
+        view.data_model = GrainsTableModel(**kwargs)
+
+
+class GrainsViewerDialog(QDialog):
+    def __init__(self, grains_table, parent=None):
+        super().__init__(parent)
+        self.widget = GrainsViewerWidget(grains_table, self)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.widget.ui)
+        self.setLayout(layout)
+
+        self.setWindowTitle('Grains Table Viewer')
+        self.resize(800, 200)
+
+        UiLoader().install_dialog_enter_key_filters(self)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -147,9 +147,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when a new polar mask has been created"""
     polar_masks_changed = Signal()
 
-    """Emitted when point picked calibration is complete"""
-    calibration_complete = Signal()
-
     """Emitted when reflections tables for a given material should update
 
     The string argument is the material name.
@@ -164,6 +161,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     """Indicate that the state was loaded..."""
     state_loaded = Signal()
+
+    """Indicate that the overlay editor should update its GUI"""
+    update_overlay_editor = Signal()
 
     def __init__(self):
         # Should this have a parent?

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -12,6 +12,7 @@ import yaml
 
 import hexrd.imageseries.save
 from hexrd.config.loader import NumPyIncludeLoader
+from hexrd.findorientations import _process_omegas
 from hexrd.instrument import HEDMInstrument
 from hexrd.material import load_materials_hdf5, save_materials_hdf5, Material
 from hexrd.rotations import RotMatEuler
@@ -515,17 +516,34 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return len(self.imageseries_dict) != 0
 
     @property
-    def has_omega_ranges(self):
-        return self.current_imageseries_omega_range is not None
+    def omega_imageseries_dict(self):
+        if self.is_aggregated:
+            imsd = self.unagg_images
+        else:
+            imsd = self.imageseries_dict
 
-    @property
-    def current_imageseries_omega_range(self):
-        # Just assume all of the imageseries have the same omega ranges.
-        # Grab the first one.
-        first_ims = next(iter(self.imageseries_dict.values()))
-        if not utils.is_omega_imageseries(first_ims):
+        if not imsd:
             return None
 
+        if any(not utils.is_omega_imageseries(ims) for ims in imsd.values()):
+            # This is not an omega imageseries dict...
+            return None
+
+        return imsd
+
+    @property
+    def has_omegas(self):
+        return self.omega_imageseries_dict is not None
+
+    @property
+    def omega_ranges(self):
+        # Just assume all of the imageseries have the same omega ranges.
+        # Grab the first one.
+        imsd = self.omega_imageseries_dict
+        if not imsd:
+            return None
+
+        first_ims = next(iter(imsd.values()))
         return first_ims.omega[self.current_imageseries_idx]
 
     @property
@@ -1442,7 +1460,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 overlay['refinements'] = default_refinements
 
             if overlay['type'] == constants.OverlayType.rotation_series:
-                if not self.has_omega_ranges:
+                if self.is_aggregated or not self.has_omegas:
                     # Force aggregation
                     overlay.get('options', {})['aggregated'] = True
                     overlay['update_needed'] = True
@@ -1806,6 +1824,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def unagg_images(self):
         return self.unaggregated_images
 
+    @property
+    def is_aggregated(self):
+        # Having unaggregated images implies the image series is aggregated
+        return self.unagg_images is not None
+
     def reset_unagg_imgs(self, new_imgs=False):
         if self.unagg_images is not None:
             if not new_imgs:
@@ -1976,3 +1999,36 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @config_image.setter
     def config_image(self, image):
         self.config['image'] = image
+
+    def process_overlay_updates(self):
+        # Perform any overlay processing needed from loading new images
+        rotation_series_overlays = [
+            overlay for overlay in self.overlays
+            if overlay['type'] == constants.OverlayType.rotation_series]
+
+        if rotation_series_overlays:
+            ims_dict = self.omega_imageseries_dict
+            if ims_dict is None:
+                ome_period = None
+                ome_ranges = None
+            else:
+                ome_period, ome_ranges = _process_omegas(ims_dict)
+
+            for overlay in rotation_series_overlays:
+                internal = overlay.get('internal', {})
+                sync_ome_period = internal.get('sync_ome_period', True)
+                sync_ome_ranges = internal.get('sync_ome_ranges', True)
+
+                if sync_ome_period and ome_period is not None:
+                    options = overlay.setdefault('options', {})
+                    options['ome_period'] = np.radians(ome_period)
+                    overlay['update_needed'] = True
+
+                if sync_ome_ranges and ome_ranges is not None:
+                    options = overlay.setdefault('options', {})
+                    options['ome_ranges'] = np.radians(ome_ranges)
+                    overlay['update_needed'] = True
+
+        if any(o['update_needed'] for o in self.overlays):
+            self.overlay_config_changed.emit()
+            self.update_overlay_editor.emit()

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -331,8 +331,9 @@ class ImageCanvas(FigureCanvas):
             artists.append(artist)
 
     def draw_rotation_series_overlay(self, axis, data, style):
-        ome_range = HexrdConfig().current_imageseries_omega_range
-        aggregated = data['aggregated'] or ome_range is None
+        is_aggregated = HexrdConfig().is_aggregated
+        ome_range = HexrdConfig().omega_ranges
+        aggregated = data['aggregated'] or is_aggregated or ome_range is None
         if not aggregated:
             ome_width = data['omega_width']
             ome_mean = np.mean(ome_range)

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -208,6 +208,8 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
         if self.transformed_images:
             HexrdConfig().deep_rerender_needed.emit()
 
+        HexrdConfig().process_overlay_updates()
+
     def get_dark_aggr_op(self, ims, idx):
         """
         Returns a tuple of the form (function, frames), where func is the

--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -88,9 +88,12 @@ class ImageSeriesToolbar(QWidget):
         self.update_omega_label_text()
 
     def update_omega_label_text(self):
-        ome_range = HexrdConfig().current_imageseries_omega_range
-        self.omega_label.setVisible(ome_range is not None)
-        if ome_range is None:
+        is_aggregated = HexrdConfig().is_aggregated
+        ome_range = HexrdConfig().omega_ranges
+
+        enable = not is_aggregated and ome_range is not None
+        self.omega_label.setVisible(enable)
+        if not enable:
             return
 
         ome_min, ome_max = ome_range

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -124,7 +124,9 @@ class ImageTabWidget(QTabWidget):
         HexrdConfig().current_imageseries_idx = pos
         self.update_needed.emit()
 
-        if not HexrdConfig().has_omega_ranges:
+        is_aggregated = HexrdConfig().is_aggregated
+        has_omegas = HexrdConfig().has_omegas
+        if is_aggregated or not has_omegas:
             return
 
         # For rotation series, changing the image series index may require

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -9,7 +9,6 @@ from hexrd.config.instrument import Instrument as InstrumentConfig
 
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.utils import is_omega_imageseries
 
 
 def create_indexing_config():
@@ -48,14 +47,8 @@ def create_indexing_config():
     # Set this so the config won't over-write our tThWidth
     config.set('material:tth_width', np.degrees(material.planeData.tThWidth))
 
-    # Use unaggregated images if possible
-    ims_dict = HexrdConfig().unagg_images
+    ims_dict = HexrdConfig().omega_imageseries_dict
     if ims_dict is None:
-        # This probably means the image series was never aggregated.
-        # Try using the imageseries dict.
-        ims_dict = HexrdConfig().imageseries_dict
-
-    if any(not is_omega_imageseries(ims) for ims in ims_dict.values()):
         # Add an early error that is easier to understand...
         raise OmegasNotFoundError('Omegas not found!')
 

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -57,7 +57,7 @@ def create_indexing_config():
 
     if any(not is_omega_imageseries(ims) for ims in ims_dict.values()):
         # Add an early error that is easier to understand...
-        raise Exception('Omegas not found!')
+        raise OmegasNotFoundError('Omegas not found!')
 
     config.image_series = ims_dict
 
@@ -78,3 +78,7 @@ def validate_config(config):
 
         # Make sure future configs use the new working dir as well...
         HexrdConfig().indexing_config['working_dir'] = os.getcwd()
+
+
+class OmegasNotFoundError(Exception):
+    pass

--- a/hexrd/ui/indexing/indexing_tree_view_dialog.py
+++ b/hexrd/ui/indexing/indexing_tree_view_dialog.py
@@ -19,6 +19,12 @@ class IndexingTreeViewDialog(DictTreeViewDialog):
             ('seed_search', 'method'): self.seed_search_defaults,
         }
         self.tree_view.combo_keys = combo_keys
+
+        # Don't allow the user to see/modify the omega period.
+        # This is deprecated, and we only set it programmatically where
+        # needed.
+        self.tree_view.blacklisted_paths = [('omega', 'period')]
+
         self.expand_rows()
 
     @lazy_property

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -490,10 +490,6 @@ class MainWindow(QObject):
 
         async_runner = getattr(self, cached_async_runner_name)
 
-        import hexrd.ui.calibration.hedm.calibration_runner
-        from importlib import reload
-        reload(hexrd.ui.calibration.hedm.calibration_runner)
-        from hexrd.ui.calibration.hedm.calibration_runner import HEDMCalibrationRunner
         runner = HEDMCalibrationRunner(async_runner, self.ui)
         runner.finished.connect(self.on_hedm_calibration_finished)
         try:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -257,8 +257,6 @@ class MainWindow(QObject):
         self.image_mode_widget.tab_changed.connect(
             self.mask_manager_dialog.image_mode_changed)
 
-        HexrdConfig().calibration_complete.connect(self.calibration_finished)
-
         self.ui.action_apply_pixel_solid_angle_correction.toggled.connect(
             HexrdConfig().set_apply_pixel_solid_angle_correction)
         self.ui.action_apply_lorentz_polarization_correction.toggled.connect(
@@ -466,11 +464,12 @@ class MainWindow(QObject):
         canvas = self.ui.image_tab_widget.image_canvases[0]
         runner = CalibrationRunner(canvas, async_runner)
         self._calibration_runner = runner
+        runner.finished.connect(self.calibration_finished)
 
         try:
             runner.run()
         except Exception as e:
-            QMessageBox.warning(self.ui, 'HEXRD', str(e))
+            QMessageBox.critical(self.ui, 'HEXRD', str(e))
             raise
 
     def calibration_finished(self):

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -40,7 +40,7 @@ class OverlayManager:
         self.ui.add_button.pressed.connect(self.add)
         self.ui.remove_button.pressed.connect(self.remove)
         self.ui.edit_style_button.pressed.connect(self.edit_style)
-        HexrdConfig().calibration_complete.connect(self.update_overlay_editor)
+        HexrdConfig().update_overlay_editor.connect(self.update_overlay_editor)
         HexrdConfig().material_renamed.connect(self.update_table)
         HexrdConfig().materials_removed.connect(self.update_table)
 

--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -153,4 +153,21 @@ def overlay_from_name(name):
 
 
 def overlay_name(overlay):
-    return f'{overlay["material"]} {overlay["type"].value}'
+    from hexrd.ui.hexrd_config import HexrdConfig
+
+    material = overlay['material']
+    type = overlay['type']
+
+    duplicate_index = 1
+    for o in HexrdConfig().overlays:
+        if o is overlay:
+            break
+
+        if o['material'] == material and o['type'] == type:
+            duplicate_index += 1
+
+    name = f'{material} {type.value}'
+    if duplicate_index > 1:
+        name += f' {duplicate_index}'
+
+    return name

--- a/hexrd/ui/overlays/__init__.py
+++ b/hexrd/ui/overlays/__init__.py
@@ -150,3 +150,7 @@ def overlay_from_name(name):
         )
         if matches:
             return overlay
+
+
+def overlay_name(overlay):
+    return f'{overlay["material"]} {overlay["type"].value}'

--- a/hexrd/ui/overlays/rotation_series.py
+++ b/hexrd/ui/overlays/rotation_series.py
@@ -13,7 +13,7 @@ class RotationSeriesSpotOverlay:
                  ome_period=None,
                  eta_period=np.r_[-180., 180.],
                  aggregated=True,
-                 ome_width=5.0,
+                 ome_width=np.radians(5.0),
                  tth_width=None,
                  eta_width=None):
 
@@ -150,7 +150,7 @@ class RotationSeriesSpotOverlay:
                 'data': data,
                 'aggregated': self.aggregated,
                 'omegas': np.degrees(omegas),
-                'omega_width': self.ome_width,
+                'omega_width': np.degrees(self.ome_width),
                 'ranges': ranges,
             }
 

--- a/hexrd/ui/reorder_pairs_widget.py
+++ b/hexrd/ui/reorder_pairs_widget.py
@@ -1,0 +1,127 @@
+import copy
+
+from PySide2.QtCore import QObject, Qt, Signal
+from PySide2.QtWidgets import QComboBox, QHBoxLayout, QSizePolicy, QWidget
+
+from hexrd.ui.ui_loader import UiLoader
+
+
+class ReorderPairsWidget(QObject):
+
+    items_reordered = Signal()
+
+    def __init__(self, items, titles, parent=None):
+        # The items should be a list of tuples of length two, like
+        # (first, second).
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('reorder_pairs_widget.ui', parent)
+
+        self.combo_boxes = []
+
+        self.titles = titles
+        self.parent = parent
+        self.items = items
+
+    @property
+    def items(self):
+        return self._items
+
+    @items.setter
+    def items(self, v):
+        self._items = copy.deepcopy(v)
+        self.update_table()
+        self.ui.table.resizeColumnsToContents()
+
+    @property
+    def titles(self):
+        table = self.ui.table
+        num_cols = table.columnCount()
+        return [table.horizontalHeaderItem(i) for i in range(num_cols)]
+
+    @titles.setter
+    def titles(self, v):
+        self.ui.table.setHorizontalHeaderLabels(v)
+
+    def create_table_widget(self, w):
+        # These are required to center the widget...
+        tw = QWidget(self.ui.table)
+        layout = QHBoxLayout(tw)
+        layout.addWidget(w)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setContentsMargins(0, 0, 0, 0)
+        return tw
+
+    def create_combo_box(self, i, j):
+        value = self.items[i][j]
+        options = [x[j] for x in self.items]
+
+        cb = QComboBox(self.ui.table)
+        size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        cb.setSizePolicy(size_policy)
+        cb.addItems(options)
+        cb.setCurrentIndex(options.index(value))
+
+        def callback():
+            self.item_edited(i, j, cb.currentText())
+
+        cb.currentIndexChanged.connect(callback)
+        self.combo_boxes.append(cb)
+        return self.create_table_widget(cb)
+
+    def clear_table(self):
+        self.combo_boxes.clear()
+        self.ui.table.clearContents()
+
+    def update_table(self):
+        self.clear_table()
+        self.ui.table.setRowCount(len(self.items))
+        for i, pair in enumerate(self.items):
+            for j in range(len(pair)):
+                w = self.create_combo_box(i, j)
+                self.ui.table.setCellWidget(i, j, w)
+
+    def item_edited(self, i, j, new_value):
+        # Find the old index of the new value and do a swap
+        old_index = [x[j] for x in self.items].index(new_value)
+
+        old_row = list(self.items[old_index])
+        new_row = list(self.items[i])
+
+        # Swap the j between them
+        old_row[j], new_row[j] = new_row[j], old_row[j]
+
+        self.items[old_index] = tuple(old_row)
+        self.items[i] = tuple(new_row)
+
+        self.update_table()
+        self.items_reordered.emit()
+
+
+if __name__ == '__main__':
+    # Make an example to test out
+    from PySide2.QtWidgets import QApplication, QDialog, QVBoxLayout
+
+    app = QApplication()
+
+    titles = ['Items', 'Indices']
+
+    items = [
+        ('Item1', '1'),
+        ('Item2', '2'),
+        ('Item3', '3'),
+        ('Item4', '4'),
+    ]
+
+    dialog = QDialog()
+    layout = QVBoxLayout()
+    dialog.setLayout(layout)
+    widget = ReorderPairsWidget(items, titles)
+    layout.addWidget(widget.ui)
+
+    def items_reordered():
+        print(f'Items reordered: {widget.items}')
+
+    widget.items_reordered.connect(items_reordered)
+    dialog.exec_()

--- a/hexrd/ui/resources/indexing/default_indexing_config.yml
+++ b/hexrd/ui/resources/indexing/default_indexing_config.yml
@@ -140,3 +140,11 @@ fit_grains:
 #       panel: ff2_1_1  # must match detector key
 
 # instrument: dexelas_id3a_20200130_comp.yml
+
+
+# Some custom ones we have added for the GUI
+_hedm_calibration:
+  do_refit: false
+  clobber_strain: false
+  clobber_centroid: false
+  clobber_grain_Y: false

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -39,7 +39,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Calibration Crystal</string>
+      <string>Crystal Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
       <item row="0" column="0" colspan="2">

--- a/hexrd/ui/resources/ui/calibration_crystal_editor.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_editor.ui
@@ -42,7 +42,7 @@
       <string>Crystal Parameters</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0" colspan="2">
+      <item row="0" column="0" colspan="3">
        <widget class="QTabWidget" name="tab_widget">
         <property name="enabled">
          <bool>true</bool>
@@ -525,12 +525,23 @@
         </widget>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
-       <widget class="QPushButton" name="load">
-        <property name="text">
-         <string>Load Crystal Parameters</string>
-        </property>
-       </widget>
+      <item row="1" column="0" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QPushButton" name="load">
+          <property name="text">
+           <string>Load</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="save">
+          <property name="text">
+           <string>Save</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
      </layout>
     </widget>
@@ -561,6 +572,8 @@
   <tabstop>stretch_matrix_6</tabstop>
   <tabstop>stretch_matrix_7</tabstop>
   <tabstop>stretch_matrix_8</tabstop>
+  <tabstop>load</tabstop>
+  <tabstop>save</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/grains_viewer_widget.ui
+++ b/hexrd/ui/resources/ui/grains_viewer_widget.ui
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>grains_viewer_widget</class>
+ <widget class="QWidget" name="grains_viewer_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>635</width>
+    <height>372</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select Grains</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="GrainsTableView" name="table_view">
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>GrainsTableView</class>
+   <extends>QTableView</extends>
+   <header>grains_table_view.py</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>table_view</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/hedm_calibration_options_dialog.ui
+++ b/hexrd/ui/resources/ui/hedm_calibration_options_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>479</width>
-    <height>464</height>
+    <height>558</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,18 +15,80 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
+    <layout class="QVBoxLayout" name="overlay_grain_pairing_widget_layout"/>
+   </item>
+   <item>
+    <widget class="QPushButton" name="view_grains_table">
+     <property name="text">
+      <string>View Grains Table</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>10</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
     <layout class="QGridLayout" name="grid_layout">
-     <item row="1" column="2">
-      <widget class="QComboBox" name="material"/>
+     <item row="4" column="1" colspan="2">
+      <widget class="QGroupBox" name="clobbering_group">
+       <property name="title">
+        <string>Clobbering</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="clobber_strain">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the stretch matrix to identity.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Clobber strain?</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="clobber_centroid">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain position to the origin: (0, 0, 0).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Clobber centroid?</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="clobber_grain_Y">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain Y to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Clobber grain Y?</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
      </item>
-     <item row="2" column="1">
+     <item row="1" column="1">
       <widget class="QLabel" name="num_hkls_selected">
        <property name="text">
         <string>Number of hkls selected:</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1" colspan="2">
+     <item row="5" column="1" colspan="2">
       <widget class="QGroupBox" name="refitting_group">
        <property name="title">
         <string>Refitting</string>
@@ -100,57 +162,11 @@
        </layout>
       </widget>
      </item>
-     <item row="2" column="2">
+     <item row="1" column="2">
       <widget class="QPushButton" name="choose_hkls">
        <property name="text">
         <string>Choose HKLs</string>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QLabel" name="material_label">
-       <property name="text">
-        <string>Selected Material:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1" colspan="2">
-      <widget class="QGroupBox" name="clobbering_group">
-       <property name="title">
-        <string>Clobbering</string>
-       </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QCheckBox" name="clobber_strain">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the stretch matrix to identity.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Clobber strain?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="clobber_centroid">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain position to the origin: (0, 0, 0).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Clobber centroid?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="clobber_grain_Y">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain Y to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Clobber grain Y?</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </widget>
      </item>
     </layout>
@@ -191,7 +207,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>material</tabstop>
   <tabstop>choose_hkls</tabstop>
  </tabstops>
  <resources/>

--- a/hexrd/ui/resources/ui/hedm_calibration_options_dialog.ui
+++ b/hexrd/ui/resources/ui/hedm_calibration_options_dialog.ui
@@ -1,0 +1,296 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>hedm_calibration_options_dialog</class>
+ <widget class="QDialog" name="hedm_calibration_options_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>479</width>
+    <height>464</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>HEDM Calibration Options</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QGridLayout" name="grid_layout">
+     <item row="1" column="2">
+      <widget class="QComboBox" name="material"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLabel" name="num_hkls_selected">
+       <property name="text">
+        <string>Number of hkls selected:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="1" colspan="2">
+      <widget class="QGroupBox" name="refitting_group">
+       <property name="title">
+        <string>Refitting</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="0">
+         <widget class="QLabel" name="refit_pixel_scale_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Refit pixel scale</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QCheckBox" name="do_refit">
+          <property name="text">
+           <string>Do refit?</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="refit_ome_step_scale_label">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Refit ome step scale</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="ScientificDoubleSpinBox" name="refit_pixel_scale">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="decimals">
+           <number>8</number>
+          </property>
+          <property name="maximum">
+           <double>1000000.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>2.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="ScientificDoubleSpinBox" name="refit_ome_step_scale">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="decimals">
+           <number>8</number>
+          </property>
+          <property name="maximum">
+           <double>1000000.000000000000000</double>
+          </property>
+          <property name="value">
+           <double>1.000000000000000</double>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QPushButton" name="choose_hkls">
+       <property name="text">
+        <string>Choose HKLs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="material_label">
+       <property name="text">
+        <string>Selected Material:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1" colspan="2">
+      <widget class="QGroupBox" name="clobbering_group">
+       <property name="title">
+        <string>Clobbering</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_2">
+        <item>
+         <widget class="QCheckBox" name="clobber_strain">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the stretch matrix to identity.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Clobber strain?</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="clobber_centroid">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain position to the origin: (0, 0, 0).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Clobber centroid?</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="clobber_grain_Y">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain Y to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Clobber grain Y?</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <spacer name="vertical_spacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>17</width>
+       <height>18</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>material</tabstop>
+  <tabstop>choose_hkls</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>hedm_calibration_options_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>hedm_calibration_options_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>do_refit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>refit_pixel_scale_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>354</x>
+     <y>218</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>123</x>
+     <y>253</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>do_refit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>refit_pixel_scale</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>354</x>
+     <y>218</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>253</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>do_refit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>refit_ome_step_scale_label</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>354</x>
+     <y>218</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>123</x>
+     <y>290</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>do_refit</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>refit_ome_step_scale</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>354</x>
+     <y>218</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>354</x>
+     <y>290</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/hedm_calibration_results_dialog.ui
+++ b/hexrd/ui/resources/ui/hedm_calibration_results_dialog.ui
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>hedm_calibration_results_dialog</class>
+ <widget class="QDialog" name="hedm_calibration_results_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>1281</width>
+    <height>900</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>600</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>HEDM Calibration Results</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="6">
+    <widget class="QComboBox" name="grain_id">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="styleSheet">
+      <string notr="true">combobox-popup: 0;</string>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="QCheckBox" name="show_all_grains">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="text">
+      <string>Show all grains</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="QComboBox" name="detector">
+     <property name="styleSheet">
+      <string notr="true">combobox-popup: 0;</string>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="QLabel" name="grain_id_label">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Grain ID:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="detector_label">
+     <property name="text">
+      <string>Detector:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="7">
+    <spacer name="horizontal_spacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0" colspan="9">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+   <item row="1" column="8">
+    <widget class="QCheckBox" name="show_legend">
+     <property name="text">
+      <string>Show legend</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="9">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>detector</tabstop>
+  <tabstop>show_all_grains</tabstop>
+  <tabstop>grain_id</tabstop>
+  <tabstop>show_legend</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>hedm_calibration_results_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>636</x>
+     <y>874</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>640</x>
+     <y>449</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>hedm_calibration_results_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>636</x>
+     <y>874</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>640</x>
+     <y>449</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -159,6 +159,7 @@
      </property>
      <addaction name="action_run_laue_and_powder_calibration"/>
      <addaction name="action_run_fast_powder_calibration"/>
+     <addaction name="action_run_hedm_calibration"/>
     </widget>
     <addaction name="menu_calibration"/>
     <addaction name="action_run_wppf"/>
@@ -645,6 +646,11 @@
   <action name="action_image_stack">
    <property name="text">
     <string>Image Stack</string>
+   </property>
+  </action>
+  <action name="action_run_hedm_calibration">
+   <property name="text">
+    <string>HEDM</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/reorder_pairs_widget.ui
+++ b/hexrd/ui/resources/ui/reorder_pairs_widget.ui
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>reorder_pairs_widget</class>
+ <widget class="QWidget" name="reorder_pairs_widget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>548</width>
+    <height>265</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Reorder Pairs</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QVBoxLayout" name="vertical_layout">
+   <item>
+    <widget class="QTableWidget" name="table">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::NoSelection</enum>
+     </property>
+     <property name="columnCount">
+      <number>2</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column/>
+     <column/>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
@@ -175,7 +175,10 @@
        <item row="1" column="2">
         <widget class="ScientificDoubleSpinBox" name="omega_width">
          <property name="enabled">
-          <bool>false</bool>
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The omega width is used primarily in two areas:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;1. As the omega tolerance for HEDM calibration&lt;/p&gt;&lt;p&gt;2. If the displayed image series is unaggregated, and this overlay is also unaggregated, the omega width is used to compute which spots to display on the currently displayed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="suffix">
           <string>°</string>
@@ -191,7 +194,10 @@
        <item row="1" column="1">
         <widget class="QLabel" name="omega_width_label">
          <property name="enabled">
-          <bool>false</bool>
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The omega width is used primarily in two areas:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;1. As the omega tolerance for HEDM calibration&lt;/p&gt;&lt;p&gt;2. If the displayed image series is unaggregated, and this overlay is also unaggregated, the omega width is used to compute which spots to display on the currently displayed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
          </property>
          <property name="text">
           <string>Omega Width:</string>

--- a/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>550</width>
-    <height>710</height>
+    <width>507</width>
+    <height>770</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>710</height>
+    <height>770</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -24,6 +24,26 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="11" column="1" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QPushButton" name="reflections_table">
+     <property name="text">
+      <string>Reflections Table</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="1" colspan="4">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
@@ -34,49 +54,10 @@
        <string>General</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_3">
-       <item row="0" column="2">
-        <widget class="ScientificDoubleSpinBox" name="omega_period_1">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="suffix">
-          <string>°</string>
-         </property>
-         <property name="minimum">
-          <double>-360.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="ScientificDoubleSpinBox" name="omega_period_0">
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="suffix">
-          <string>°</string>
-         </property>
-         <property name="minimum">
-          <double>-360.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-        </widget>
+       <item row="5" column="0" colspan="3">
+        <layout class="QVBoxLayout" name="crystal_editor_layout"/>
        </item>
        <item row="0" column="0">
-        <widget class="QLabel" name="omega_period_label">
-         <property name="text">
-          <string>Omega Period:</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
         <widget class="QCheckBox" name="aggregated">
          <property name="text">
           <string>Aggregated</string>
@@ -172,7 +153,71 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="2">
+       <item row="1" column="0" colspan="3">
+        <widget class="QGroupBox" name="groupBox">
+         <property name="title">
+          <string>Omega Period</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QCheckBox" name="sync_ome_period">
+            <property name="text">
+             <string>Use from Image Series</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="ScientificDoubleSpinBox" name="omega_period_0">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="minimum">
+             <double>-360.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="ScientificDoubleSpinBox" name="omega_period_1">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="minimum">
+             <double>-360.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="omega_width_label">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The omega width is used primarily in two areas:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;1. As the omega tolerance for HEDM calibration&lt;/p&gt;&lt;p&gt;2. If the displayed image series is unaggregated, and this overlay is also unaggregated, the omega width is used to compute which spots to display on the currently displayed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>Omega Width:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
         <widget class="ScientificDoubleSpinBox" name="omega_width">
          <property name="enabled">
           <bool>true</bool>
@@ -191,57 +236,56 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="omega_width_label">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="toolTip">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The omega width is used primarily in two areas:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;1. As the omega tolerance for HEDM calibration&lt;/p&gt;&lt;p&gt;2. If the displayed image series is unaggregated, and this overlay is also unaggregated, the omega width is used to compute which spots to display on the currently displayed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="text">
-          <string>Omega Width:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="3">
-        <layout class="QVBoxLayout" name="crystal_editor_layout"/>
-       </item>
       </layout>
      </widget>
      <widget class="QWidget" name="eta_omega_ranges">
       <attribute name="title">
        <string>η/ω ranges</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <layout class="QVBoxLayout" name="eta_ranges_layout"/>
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="0" rowspan="3">
+        <widget class="QGroupBox" name="eta_range_group">
+         <property name="title">
+          <string>η</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout">
+          <item>
+           <widget class="QPushButton" name="mask_eta_by_wedge">
+            <property name="text">
+             <string>Mask by Wedge</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="eta_ranges_layout"/>
+          </item>
+         </layout>
+        </widget>
        </item>
-       <item>
-        <layout class="QVBoxLayout" name="omega_ranges_layout"/>
+       <item row="0" column="1" rowspan="3">
+        <widget class="QGroupBox" name="omega_range_group">
+         <property name="title">
+          <string>ω</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QCheckBox" name="sync_ome_ranges">
+            <property name="text">
+             <string>Use from Image Series</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <layout class="QVBoxLayout" name="omega_ranges_layout"/>
+          </item>
+         </layout>
+        </widget>
        </item>
       </layout>
      </widget>
-    </widget>
-   </item>
-   <item row="11" column="1" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QPushButton" name="reflections_table">
-     <property name="text">
-      <string>Reflections Table</string>
-     </property>
     </widget>
    </item>
   </layout>
@@ -256,13 +300,16 @@
  <tabstops>
   <tabstop>reflections_table</tabstop>
   <tabstop>tab_widget</tabstop>
-  <tabstop>omega_period_0</tabstop>
-  <tabstop>omega_period_1</tabstop>
   <tabstop>aggregated</tabstop>
   <tabstop>omega_width</tabstop>
+  <tabstop>sync_ome_period</tabstop>
+  <tabstop>omega_period_0</tabstop>
+  <tabstop>omega_period_1</tabstop>
   <tabstop>enable_widths</tabstop>
   <tabstop>tth_width</tabstop>
   <tabstop>eta_width</tabstop>
+  <tabstop>mask_eta_by_wedge</tabstop>
+  <tabstop>sync_ome_ranges</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
@@ -110,7 +110,7 @@
              <double>360.000000000000000</double>
             </property>
             <property name="value">
-             <double>5.000000000000000</double>
+             <double>3.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -145,7 +145,7 @@
              <double>360.000000000000000</double>
             </property>
             <property name="value">
-             <double>5.000000000000000</double>
+             <double>0.250000000000000</double>
             </property>
            </widget>
           </item>

--- a/hexrd/ui/resources/ui/select_grains_dialog.ui
+++ b/hexrd/ui/resources/ui/select_grains_dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>grains_select_dialog</class>
- <widget class="QDialog" name="grains_select_dialog">
+ <class>select_grains_dialog</class>
+ <widget class="QDialog" name="select_grains_dialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -98,7 +98,7 @@
   <connection>
    <sender>button_box</sender>
    <signal>accepted()</signal>
-   <receiver>grains_select_dialog</receiver>
+   <receiver>select_grains_dialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -114,7 +114,7 @@
   <connection>
    <sender>button_box</sender>
    <signal>rejected()</signal>
-   <receiver>grains_select_dialog</receiver>
+   <receiver>select_grains_dialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/hexrd/ui/rotation_series_overlay_editor.py
+++ b/hexrd/ui/rotation_series_overlay_editor.py
@@ -189,11 +189,11 @@ class RotationSeriesOverlayEditor:
 
     @property
     def ome_width(self):
-        return self.ui.omega_width.value()
+        return np.radians(self.ui.omega_width.value())
 
     @ome_width.setter
     def ome_width(self, v):
-        self.ui.omega_width.setValue(v)
+        self.ui.omega_width.setValue(np.degrees(v))
 
     @property
     def eta_ranges(self):

--- a/hexrd/ui/rotation_series_overlay_editor.py
+++ b/hexrd/ui/rotation_series_overlay_editor.py
@@ -90,8 +90,6 @@ class RotationSeriesOverlayEditor:
 
     def update_enable_states(self):
         self.ui.aggregated.setEnabled(HexrdConfig().has_omega_ranges)
-        self.ui.omega_width_label.setDisabled(self.aggregated)
-        self.ui.omega_width.setDisabled(self.aggregated)
 
         enable_widths = self.enable_widths
         names = [


### PR DESCRIPTION
The user can perform HEDM calibration from a single grain that is
either loaded from a `grains.out` file or generated through the 
HEDM workflow in hexrdgui. There must be exactly one visible rotation
series overlay associated with the single grain.

This runs `pull_spots()` using the tolerances specified in the overlay
settings. It then displays two 2D charts (one x-y and one omega-x) of
initial and measured points, and after calibration, it displays two 
2D charts of intial, measured, and final points. If the user accepts,
it modifies the refinable parameters and updates the instrument.

This is mostly working, but I need to make sure some settings are 
consistent, especially omega tolerances and the omega period.

Multi grain HEDM calibration should be working soon.

https://user-images.githubusercontent.com/9558430/145917099-978f95f1-2360-4024-b9e1-d96ce8451906.mp4