### PR TITLE
Bump Python to 3.9

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -44,7 +44,7 @@ jobs:
       uses: conda-incubator/setup-miniconda@v2
       with:
         auto-update-conda: true
-        python-version: 3.8
+        python-version: 3.9
         auto-activate-base: false
 
     - name: Get version using git describe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        python-version: [3.8]
+        python-version: [3.9]
         config:
         - {
             name: "Linux",

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![platforms](https://anaconda.org/hexrd/hexrdgui/badges/platforms.svg) ![current version](https://anaconda.org/hexrd/hexrdgui/badges/version.svg) ![last updated](https://anaconda.org/hexrd/hexrdgui/badges/latest_release_relative_date.svg) ![downloads](https://anaconda.org/hexrd/hexrdgui/badges/downloads.svg)
 # Installing
 
-Requires Python 3.8+
+Requires Python 3.9+
 
 ### OSX
 
@@ -10,16 +10,7 @@ latest SDK. See the following issue for more details: https://github.com/HEXRD/h
 This can be installed using the following command:
 
 ```bash
-conda install -c conda-forge python=3.8
-```
-
-#### Big Sur (OS X 11)
-
-OS X 11 does not work with the Python from conda-forge. Please install a the version
-from the HEXRD channel
-
-```bash
-conda install -c HEXRD python=3.8.4
+conda install -c conda-forge python=3.9
 ```
 
 ## conda (release)
@@ -49,7 +40,7 @@ hexrdgui
 
 # Development
 
-Requires Python 3.8+.  First clone the Git repositories
+Requires Python 3.9+.  First clone the Git repositories
 
 ```bash
 git clone https://github.com/HEXRD/hexrd.git
@@ -68,9 +59,9 @@ pip install -e hexrdgui
 
 ### Linux
 ```bash
-# First, make sure python3.8+ is installed in your target env.
+# First, make sure python3.9+ is installed in your target env.
 # If it is not, run the following command:
-conda install -c conda-forge python=3.8
+conda install -c conda-forge python=3.9
 # Install deps using conda package
 conda install -c HEXRD -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
@@ -80,10 +71,10 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrdgui
 
 ### Mac OS
 ```bash
-# First, make sure python3.8+ is installed in your target env.
+# First, make sure python3.9+ is installed in your target env.
 # On OSX you will need to use the Python package from conda-forge
 # See the following issue for more details: https://github.com/HEXRD/hexrdgui/issues/505
-conda install -c conda-forge python=3.8
+conda install -c conda-forge python=3.9
 # Install deps using conda package
 conda install -c HEXRD -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development
@@ -93,9 +84,9 @@ CONDA_BUILD=1 pip install --no-build-isolation --no-deps -U -e hexrdgui
 
 ### Windows
 ```bash
-# First, make sure python3.8+ is installed in your target env.
+# First, make sure python3.9+ is installed in your target env.
 # If it is not, run the following command:
-conda install -c conda-forge python=3.8
+conda install -c conda-forge python=3.9
 # Install deps using conda package
 conda install -c HEXRD -c conda-forge hexrdgui
 # Now using pip to link repo's into environment for development

--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -12,7 +12,7 @@ build:
 
 requirements:
   build:
-    - python=3.8
+    - python=3.9
     - setuptools
     - setuptools_scm
 

--- a/packaging/package.py
+++ b/packaging/package.py
@@ -148,7 +148,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
         '--prefix', env_prefix,
         '--override-channels',
         *channels,
-        'python=3.8.4'
+        'python=3.9'
     )
 
     hexrdgui_output_folder_uri = Path(hexrdgui_output_folder).absolute().as_uri()

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.9'
     ],
     packages=find_packages(),
     package_data={'hexrd': ['ui/resources/**/*']},
-    python_requires='>=3.8',
+    python_requires='>=3.9',
     install_requires=install_reqs,
     entry_points={
         'gui_scripts': [


### PR DESCRIPTION
Motivated by issues with the version of Mac OS X SDK used to build
python 3.8.