### PR TITLE
added round to bins computation

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -105,11 +105,11 @@ class PolarView:
 
     @property
     def ntth(self):
-        return int(np.degrees(self.tth_range) / self.tth_pixel_size)
+        return int(round(np.degrees(self.tth_range) / self.tth_pixel_size))
 
     @property
     def neta(self):
-        return int(np.degrees(self.eta_range) / self.eta_pixel_size)
+        return int(round(np.degrees(self.eta_range) / self.eta_pixel_size))
 
     @property
     def shape(self):


### PR DESCRIPTION
This is change is to reduce the maximum difference between the requested and computed maximum angle for 2θ and η to 0.5 the corresponding pixel size instead of 1.  We made this [change in hexrd](https://github.com/HEXRD/hexrd/pull/367) as well.