### PR TITLE
Fix TARDIS IP template for LLNL workflow

### DIFF
--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -41,6 +41,10 @@ class InteractiveTemplate:
         verts = self.panels['default'].cartToPixel(data)
         verts[:, [0, 1]] = verts[:, [1, 0]]
         self.shape = patches.Polygon(verts, fill=False, lw=1, color='cyan')
+        if np.any(np.isnan(verts)):
+            # This template contains more than one polygon and the last point
+            # should not be connected to the first. See Tardis IP for example.
+            self.shape.set_closed(False)
         self.shape_styles.append({'line': '-', 'width': 1, 'color': 'cyan'})
         self.center = self.get_midpoint()
         self.update_position(instr, det)

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -11,6 +11,7 @@ from skimage.draw import polygon
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui import resource_loader
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils import has_nan
 
 
 class InteractiveTemplate:
@@ -41,7 +42,7 @@ class InteractiveTemplate:
         verts = self.panels['default'].cartToPixel(data)
         verts[:, [0, 1]] = verts[:, [1, 0]]
         self.shape = patches.Polygon(verts, fill=False, lw=1, color='cyan')
-        if np.any(np.isnan(verts)):
+        if has_nan(verts):
             # This template contains more than one polygon and the last point
             # should not be connected to the first. See Tardis IP for example.
             self.shape.set_closed(False)


### PR DESCRIPTION
Do not set polygon patches to "closed" if there are multiple polygons being drawn within one patch. This prevents a bug with the `TARDIS` instrument where a line was being drawn between the inner and outer polygon in an attempt to "close" the shape.