### PR TITLE
Fix calibration bug from invisible overlay

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -243,7 +243,7 @@ class CalibrationRunner:
 
         # Since python dicts are ordered, I think we can assume that the
         # ordering of the picks should still be the same.
-        for i, new_picks in enumerate(updated_picks):
+        for i, new_picks in zip(self.all_overlay_picks, updated_picks):
             self.all_overlay_picks[i] = new_picks['picks']
 
         self.overlay_picks = self.all_overlay_picks[self.current_overlay_ind]


### PR DESCRIPTION
This fixes a bug that would occur if the user chose the "Laue and Powder"
calibration and had at least one overlay that was not visible, that was
also placed above a visible overlay in the overlay manager.

The result would be that extra overlays would be submitted for calibration
that had invalid data, and would therefore produce an error, such as:
```python
Traceback (most recent call last):
  File "/Users/joel/Documents/GitHub/hexrdgui/hexrd/ui/calibration/calibration_runner.py", line 353, in run_calibration
    instr_calibrator = run_calibration(picks, instr, materials)
  File "/Users/joel/Documents/GitHub/hexrdgui/hexrd/ui/calibration/pick_based_calibration.py", line 770, in run_calibration
    x1, cox_x, infodict, mesg, ierr = leastsq(
  File "/Users/joel/opt/miniconda3/envs/hexrdgui-dev/lib/python3.9/site-packages/scipy/optimize/minpack.py", line 410, in leastsq
    shape, dtype = _check_func('leastsq', 'func', func, x0, args, n)
  File "/Users/joel/opt/miniconda3/envs/hexrdgui-dev/lib/python3.9/site-packages/scipy/optimize/minpack.py", line 24, in _check_func
    res = atleast_1d(thefunc(*((x0[:numinputs],) + args)))
  File "/Users/joel/Documents/GitHub/hexrdgui/hexrd/ui/calibration/pick_based_calibration.py", line 749, in residual
    calib.residual(
  File "/Users/joel/Documents/GitHub/hexrdgui/hexrd/ui/calibration/pick_based_calibration.py", line 669, in residual
    return self._evaluate(reduced_params, data_dict)
  File "/Users/joel/Documents/GitHub/hexrdgui/hexrd/ui/calibration/pick_based_calibration.py", line 584, in _evaluate
    assert len(pick_angs) == len(dsp_ref), "picks are wrong length"
AssertionError: picks are wrong length
```

Signed-off-by: Patrick Avery <patrick.avery@kitware.com>