### PR TITLE
Display chi in degrees

### DIFF
--- a/hexrd/ui/cal_tree_view.py
+++ b/hexrd/ui/cal_tree_view.py
@@ -84,6 +84,10 @@ class CalTreeItemModel(BaseTreeItemModel):
 
         if item.child_count() == 0:
             parent = item.parent_item.data(KEY_COL)
+            chi_path = ['oscillation_stage', 'chi', 'value']
+            if path == chi_path:
+                # Convert to radians before saving
+                value = np.radians(value).item()
             if (parent == 'tilt' and
                     HexrdConfig().rotation_matrix_euler() is not None and
                     len(path) > 1 and path[-2] == 'value'):
@@ -143,9 +147,15 @@ class CalTreeItemModel(BaseTreeItemModel):
 
         for key in keys:
             if key == 'value':
+                name = cur_tree_item.data(KEY_COL)
                 data = cur_config[key]
-                if (cur_tree_item.data(KEY_COL) == 'tilt' and
-                        HexrdConfig().rotation_matrix_euler() is not None):
+                path = self.path_to_value(cur_tree_item, VALUE_COL)
+
+                chi_path = ['oscillation_stage', 'chi', 'value']
+                if path == chi_path:
+                    data = np.degrees(data).item()
+                elif (name == 'tilt' and
+                      HexrdConfig().rotation_matrix_euler() is not None):
                     data = [np.degrees(rad).item() for rad in cur_config[key]]
                 self.set_value(key, data, cur_tree_item)
                 continue

--- a/hexrd/ui/calibration_config_widget.py
+++ b/hexrd/ui/calibration_config_widget.py
@@ -192,11 +192,16 @@ class CalibrationConfigWidget(QObject):
                     # We give these special treatment
                     continue
 
-                gui_var = getattr(self.ui, var)
                 config_val = self.cfg.get_instrument_config_val(path)
+                chi_path = ['oscillation_stage', 'chi', 'value']
+                if path == chi_path:
+                    # Display chi in degrees
+                    config_val = np.degrees(config_val).item()
+
                 path[path.index('value')] = 'status'
                 status_val = self.cfg.get_instrument_config_val(path)
 
+                gui_var = getattr(self.ui, var)
                 self._set_gui_value(gui_var, config_val, status_val)
         finally:
             self.unblock_all_signals(previously_blocked)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1056,6 +1056,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                         if path[2:-1] == tilt_path:
                             # This will be in degrees. Convert to radians.
                             value = np.radians(value).item()
+                else:
+                    chi_path = ['oscillation_stage', 'chi', 'value']
+                    if path == chi_path:
+                        # This will be in degrees. Convert to radians.
+                        value = np.radians(value).item()
 
                 self.set_instrument_config_val(path, value)
                 return


### PR DESCRIPTION
Previously, it was being displayed in radians, even though the form
view indicated it was in degrees.

This is applied to both the tree view and the form view.

Fixes: #1117