### PR TITLE
Ensure HDF5 files are closed after use

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -337,6 +337,6 @@ class InstrumentViewer:
             np.savez(filename, **data)
         else:
             # Default to HDF5 format
-            f = h5py.File(filename, 'w')
-            for key, value in data.items():
-                f.create_dataset(key, data=value)
+            with h5py.File(filename, 'w') as f:
+                for key, value in data.items():
+                    f.create_dataset(key, data=value)

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -131,6 +131,6 @@ class InstrumentViewer:
             np.savez(filename, **data)
         else:
             # Default to HDF5 format
-            f = h5py.File(filename, 'w')
-            for key, value in data.items():
-                f.create_dataset(key, data=value)
+            with h5py.File(filename, 'w') as f:
+                for key, value in data.items():
+                    f.create_dataset(key, data=value)

--- a/hexrd/ui/calibration/wppf_options_dialog.py
+++ b/hexrd/ui/calibration/wppf_options_dialog.py
@@ -176,17 +176,17 @@ class WppfOptionsDialog(QObject):
             filename.unlink()
 
         # Save as HDF5
-        f = h5py.File(filename, 'w')
-        for key, value in data.items():
-            f.create_dataset(key, data=value)
+        with h5py.File(filename, 'w') as f:
+            for key, value in data.items():
+                f.create_dataset(key, data=value)
 
-        # Save parameters as well
-        to_save = ('value',)
-        params_group = f.create_group('params')
-        for name, param in self.params.param_dict.items():
-            group = params_group.create_group(name)
-            for item in to_save:
-                group.create_dataset(item, data=getattr(param, item))
+            # Save parameters as well
+            to_save = ('value',)
+            params_group = f.create_group('params')
+            for name, param in self.params.param_dict.items():
+                group = params_group.create_group(name)
+                for item in to_save:
+                    group.create_dataset(item, data=getattr(param, item))
 
     def reset_object(self):
         self._wppf_object = None

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -66,13 +66,13 @@ class ImageFileManager(metaclass=Singleton):
             dset = hdf.select(self.path[1])
             ims = imageseries.open(None, 'array', data=dset)
         elif ext in self.HDF5_FILE_EXTS:
-            data = h5py.File(f, 'r')
-            dset = data['/'.join(self.path)][()]
+            with h5py.File(f, 'r') as data:
+                dset = data['/'.join(self.path)][()]
+
             if dset.ndim < 3:
                 # Handle raw two dimesional data
                 ims = imageseries.open(None, 'array', data=dset)
             else:
-                data.close()
                 ims = imageseries.open(
                     f, 'hdf5', path=self.path[0], dataname=self.path[1])
         elif ext == '.npz':

--- a/hexrd/ui/load_hdf5_dialog.py
+++ b/hexrd/ui/load_hdf5_dialog.py
@@ -30,9 +30,9 @@ class LoadHDF5Dialog:
       QMessageBox.warning(self.ui, 'HEXRD', msg)
 
   def get_HDF5_paths(self, f):
-    img = h5py.File(f, 'r')
-    self.file = img
-    img.visit(self.add_path)
+    with h5py.File(f, 'r') as img:
+        self.file = img
+        img.visit(self.add_path)
 
   def get_paths(self, f):
     ext = os.path.splitext(f)[1]


### PR DESCRIPTION
Several places where HDF5 files were not being closed were fixed. This
would cause errors to occur if the file was opened again either within
the program or in another process.