### PR TITLE
Add context menu items to refinements view

### DIFF
--- a/hexrd/ui/refinements_editor.py
+++ b/hexrd/ui/refinements_editor.py
@@ -24,6 +24,8 @@ class RefinementsEditor:
             'Refinable': '_refinable',
         }
         self.tree_view = MultiColumnDictTreeView(self.dict, columns, parent)
+        self.tree_view.check_selection_index = 2
+
         self.ui.tree_view_layout.addWidget(self.tree_view)
 
         self.iconfig_values_modified = False


### PR DESCRIPTION
This adds the "Collapse All", "Expand All", "Check All", and
"Uncheck All" context menu items to the refinements view. It seems that
they are working properly.

Fixes: #1118