### PR TITLE
Add sample frame orientation to laue editor

### DIFF
--- a/hexrd/ui/overlays/laue_diffraction.py
+++ b/hexrd/ui/overlays/laue_diffraction.py
@@ -35,10 +35,11 @@ class LaueSpotOverlay:
 
         self._min_energy = min_energy
         self._max_energy = max_energy
+
         if sample_rmat is None:
-            self._sample_rmat = constants.identity_3x3
-        else:
-            self.sample_rmat = sample_rmat
+            sample_rmat = constants.identity_3x3
+
+        self.sample_rmat = sample_rmat
 
         self.tth_width = tth_width
         self.eta_width = eta_width

--- a/hexrd/ui/resources/ui/calibration_crystal_slider_widget.ui
+++ b/hexrd/ui/resources/ui/calibration_crystal_slider_widget.ui
@@ -66,6 +66,9 @@
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify the sensitivity of the sliders by setting the ranges that the sliders cover.&lt;/p&gt;&lt;p&gt;When the ranges are modified, the current slider values will be centered, and the min and max will be set to &amp;quot;current_value - range / 2&amp;quot; and &amp;quot;current_value + range / 2&amp;quot;, respectively.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
        </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>550</width>
-    <height>610</height>
+    <width>741</width>
+    <height>700</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>610</height>
+    <height>700</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -30,22 +30,6 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="5" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <layout class="QVBoxLayout" name="crystal_editor_layout"/>
-   </item>
    <item row="1" column="0">
     <widget class="QLabel" name="max_energy_label">
      <property name="text">
@@ -59,6 +43,22 @@
       <string>Min Energy:</string>
      </property>
     </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="crystal_editor_layout"/>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
    <item row="1" column="1">
     <widget class="ScientificDoubleSpinBox" name="max_energy">
@@ -214,20 +214,68 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="ScientificDoubleSpinBox" name="min_energy">
-     <property name="keyboardTracking">
-      <bool>false</bool>
+   <item row="5" column="0" colspan="2">
+    <widget class="QGroupBox" name="sample_frame_group">
+     <property name="title">
+      <string>Sample Frame</string>
      </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="maximum">
-      <double>100000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>5.000000000000000</double>
-     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <widget class="QLabel" name="sample_orientation_label">
+        <property name="text">
+         <string>Orientation:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ScientificDoubleSpinBox" name="sample_orientation_0">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ScientificDoubleSpinBox" name="sample_orientation_1">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ScientificDoubleSpinBox" name="sample_orientation_2">
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -246,6 +294,9 @@
   <tabstop>width_shape</tabstop>
   <tabstop>tth_width</tabstop>
   <tabstop>eta_width</tabstop>
+  <tabstop>sample_orientation_0</tabstop>
+  <tabstop>sample_orientation_1</tabstop>
+  <tabstop>sample_orientation_2</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -62,6 +62,9 @@
    </item>
    <item row="1" column="1">
     <widget class="ScientificDoubleSpinBox" name="max_energy">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
      <property name="keyboardTracking">
       <bool>false</bool>
      </property>
@@ -73,6 +76,25 @@
      </property>
      <property name="value">
       <double>35.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="ScientificDoubleSpinBox" name="min_energy">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>100000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>5.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -93,6 +115,9 @@
        <widget class="ScientificDoubleSpinBox" name="eta_width">
         <property name="enabled">
          <bool>false</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -115,6 +140,9 @@
        <widget class="ScientificDoubleSpinBox" name="tth_width">
         <property name="enabled">
          <bool>false</bool>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
         <property name="keyboardTracking">
          <bool>false</bool>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -76,6 +76,9 @@
    </item>
    <item row="2" column="4">
     <widget class="ScientificDoubleSpinBox" name="offset_2">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
      <property name="keyboardTracking">
       <bool>false</bool>
      </property>
@@ -92,6 +95,9 @@
    </item>
    <item row="2" column="3">
     <widget class="ScientificDoubleSpinBox" name="offset_1">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
      <property name="keyboardTracking">
       <bool>false</bool>
      </property>
@@ -108,6 +114,9 @@
    </item>
    <item row="2" column="2">
     <widget class="ScientificDoubleSpinBox" name="offset_0">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
      <property name="keyboardTracking">
       <bool>false</bool>
      </property>

--- a/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/rotation_series_overlay_editor.ui
@@ -78,6 +78,9 @@
             <property name="enabled">
              <bool>false</bool>
             </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <property name="keyboardTracking">
              <bool>false</bool>
             </property>
@@ -112,6 +115,9 @@
            <widget class="ScientificDoubleSpinBox" name="tth_width">
             <property name="enabled">
              <bool>false</bool>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
             </property>
             <property name="keyboardTracking">
              <bool>false</bool>
@@ -171,6 +177,9 @@
           </item>
           <item>
            <widget class="ScientificDoubleSpinBox" name="omega_period_0">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <property name="keyboardTracking">
              <bool>false</bool>
             </property>
@@ -187,6 +196,9 @@
           </item>
           <item>
            <widget class="ScientificDoubleSpinBox" name="omega_period_1">
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
             <property name="keyboardTracking">
              <bool>false</bool>
             </property>
@@ -224,6 +236,9 @@
          </property>
          <property name="toolTip">
           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The omega width is used primarily in two areas:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;1. As the omega tolerance for HEDM calibration&lt;/p&gt;&lt;p&gt;2. If the displayed image series is unaggregated, and this overlay is also unaggregated, the omega width is used to compute which spots to display on the currently displayed frame.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
          </property>
          <property name="suffix">
           <string>°</string>


### PR DESCRIPTION
@joelvbernier I'm currently putting this at the bottom of the Laue overlay editor like so:

![Screenshot from 2022-01-24 07-20-30](https://user-images.githubusercontent.com/9558430/150790166-32dc700d-3214-44c7-b20f-1018370dd3ba.png)

For some options that may be uncommon, maybe we should consider placing them in an "Advanced" tab? That way, they would be hidden by default, but still available if needed. We can also leave it where it is in the image if you think that's fine...

Fixes: #1134