### PR TITLE
Catch IndexError on mouse move

### DIFF
--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -281,8 +281,17 @@ class ImageTabWidget(QTabWidget):
         if event.inaxes.get_images():
             # Image was created with imshow()
             artist = event.inaxes.get_images()[0]
+
             i, j = utils.coords2index(artist, info['x_data'], info['y_data'])
-            intensity = artist.get_array().data[i, j]
+            try:
+                intensity = artist.get_array().data[i, j]
+            except IndexError:
+                # Most likely, this means we are slightly out of bounds,
+                # and the index is too big. Just clear the status bar in
+                # this case.
+                # FIXME: can we avoid this somehow?
+                self.clear_mouse_position.emit()
+                return
         else:
             # This is probably just a plot. Do not calculate intensity.
             intensity = None


### PR DESCRIPTION
This error would happen occasionally in the cartesian and polar views
when the mouse is moved close to an edge of the canvas. It appears that
it was happening because the x_data for the event was slightly over the
max, which led to an out-of-bounds index being computed. This would
then result in an IndexError.

This error is relatively harmless, but it may worry users, so catch it
to prevent it from appearing.

I believe this error has been happening more commonly for me after #1138 was merged.