### PR TITLE
Update enable states immediately in select grains

### DIFF
--- a/hexrd/ui/select_grains_dialog.py
+++ b/hexrd/ui/select_grains_dialog.py
@@ -44,6 +44,7 @@ class SelectGrainsDialog(QObject):
         finally:
             self.ignore_errors = False
 
+        self.update_enable_states()
         self.setup_connections()
 
     def setup_connections(self):


### PR DESCRIPTION
This fixes an issue where the "OK" button would be disabled sometimes
when the SelectGrainsDialog was first initialized, even though there
was a valid selection.