### PR TITLE
Add snip viewer dialog

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -19,6 +19,7 @@ from hexrd.ui.calibration.polar_plot import polar_viewer
 from hexrd.ui.calibration.raw_iviewer import raw_iviewer
 from hexrd.ui.constants import OverlayType, ViewType
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.snip_viewer_dialog import SnipViewerDialog
 from hexrd.ui import utils
 from hexrd.ui.utils.conversions import cart_to_angles, cart_to_pixels
 import hexrd.ui.constants
@@ -914,22 +915,9 @@ class ImageCanvas(FigureCanvas):
 
         if self.iviewer.img is None:
             print('No image! Cannot generate snip1d!')
+            return
 
         extent = self.iviewer._extent
-
-        # Create the figure and axes to use
-        fig, ax = plt.subplots()
-        fig.canvas.manager.set_window_title('SNIP Background')
-        ax.set_xlabel(r'2$\theta$ (deg)')
-        ax.set_ylabel(r'$\eta$ (deg)')
-
-        algorithm = HexrdConfig().polar_snip1d_algorithm
-        titles = ['Fast SNIP 1D', 'SNIP 1D', 'SNIP 2D']
-        if algorithm < len(titles):
-            title = titles[algorithm]
-        else:
-            title = f'Algorithm {algorithm}'
-        ax.set_title(title)
 
         if self.iviewer.snip_background is not None:
             background = self.iviewer.snip_background
@@ -943,16 +931,8 @@ class ImageCanvas(FigureCanvas):
 
             background = utils.run_snip1d(img)
 
-        im = ax.imshow(background)
-
-        im.set_extent(extent)
-        ax.relim()
-        ax.autoscale_view()
-        ax.axis('auto')
-        fig.tight_layout()
-
-        fig.canvas.draw_idle()
-        fig.show()
+        self._snip_viewer_dialog = SnipViewerDialog(background, extent)
+        self._snip_viewer_dialog.show()
 
 
 def transform_from_plain_cartesian_func(mode):

--- a/hexrd/ui/resources/ui/snip_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/snip_viewer_dialog.ui
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>snip_viewer_dialog</class>
+ <widget class="QDialog" name="snip_viewer_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>650</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>SNIP Background</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="export_data">
+     <property name="text">
+      <string>Export</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/snip_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/snip_viewer_dialog.ui
@@ -26,15 +26,18 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <widget class="QPushButton" name="export_data">
      <property name="text">
       <string>Export</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="color_map_editor_layout"/>
    </item>
   </layout>
  </widget>

--- a/hexrd/ui/snip_viewer_dialog.py
+++ b/hexrd/ui/snip_viewer_dialog.py
@@ -1,0 +1,105 @@
+from pathlib import Path
+
+import h5py
+from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.figure import Figure
+import numpy as np
+
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QFileDialog, QSizePolicy
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.navigation_toolbar import NavigationToolbar
+from hexrd.ui.ui_loader import UiLoader
+
+
+class SnipViewerDialog:
+    def __init__(self, data, extent, parent=None):
+        self.ui = UiLoader().load_file('snip_viewer_dialog.ui', parent)
+
+        self.data = data
+        self.extent = extent
+
+        self.setup_canvas()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.export_data.clicked.connect(self.export)
+
+    def setup_canvas(self):
+        canvas = FigureCanvas(Figure(tight_layout=True))
+        figure = canvas.figure
+        ax = figure.add_subplot()
+
+        # Get the canvas to take up the majority of the screen most of the time
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        ax.set_xlabel(r'2$\theta$ (deg)')
+        ax.set_ylabel(r'$\eta$ (deg)')
+
+        algorithm = HexrdConfig().polar_snip1d_algorithm
+        titles = ['Fast SNIP 1D', 'SNIP 1D', 'SNIP 2D']
+        if algorithm < len(titles):
+            title = titles[algorithm]
+        else:
+            title = f'Algorithm {algorithm}'
+        ax.set_title(title)
+
+        im = ax.imshow(self.data)
+
+        ax.relim()
+        ax.autoscale_view()
+        ax.axis('auto')
+        figure.tight_layout()
+
+        self.ui.canvas_layout.addWidget(canvas)
+
+        self.toolbar = NavigationToolbar(canvas, self.ui, coordinates=True)
+        self.ui.canvas_layout.addWidget(self.toolbar)
+
+        # Center the toolbar
+        self.ui.canvas_layout.setAlignment(self.toolbar, Qt.AlignCenter)
+
+        self.figure = figure
+        self.ax = ax
+        self.canvas = canvas
+        self.im = im
+
+        figure.canvas.draw_idle()
+
+    def show(self):
+        self.ui.show()
+
+    def export(self):
+        selected_file, selected_filter = QFileDialog.getSaveFileName(
+            self.ui, 'Save Snip Background', HexrdConfig().working_dir,
+            'HDF5 files (*.h5 *.hdf5);; NPZ files (*.npz)')
+
+        if not selected_file:
+            return
+
+        HexrdConfig().working_dir = str(Path(selected_file).parent)
+        self.write_data(selected_file)
+
+    def write_data(self, filename):
+        filename = Path(filename)
+
+        # Prepare the data to write out
+        data = {
+            'snip_background': self.data,
+            'extent': self.extent,
+        }
+
+        # Delete the file if it already exists
+        if filename.exists():
+            filename.unlink()
+
+        # Check the file extension
+        if filename.suffix.lower() == '.npz':
+            # If it looks like npz, save as npz
+            np.savez(filename, **data)
+        else:
+            # Default to HDF5 format
+            with h5py.File(filename, 'w') as f:
+                for key, value in data.items():
+                    f.create_dataset(key, data=value)


### PR DESCRIPTION
The dialog allows us to customize the snip viewer more easily. This adds both an export button and a color map editor to that dialog.

![image](https://user-images.githubusercontent.com/9558430/151888192-43bec04a-37ea-483a-baf2-bf887be3cc3f.png)

Fixes: #1029