### PR TITLE
Use current view data for B&C editor histogram and auto button

### DIFF
--- a/hexrd/ui/brightness_contrast_editor.py
+++ b/hexrd/ui/brightness_contrast_editor.py
@@ -97,8 +97,8 @@ class BrightnessContrastEditor(QObject):
             return (0, 1)
 
         data = self.data_list
-        mins = [x.min() for x in data]
-        maxes = [x.max() for x in data]
+        mins = [np.nanmin(x) for x in data]
+        maxes = [np.nanmax(x) for x in data]
         return (min(mins), max(maxes))
 
     def reset_data_range(self):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -45,6 +45,13 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when new plane data is generated for the active material"""
     new_plane_data = Signal()
 
+    """Emitted when an image view has finished loading
+
+    The dict contains the images. This is used, for instance, to update
+    the brightness and contrast histogram with the new image data.
+    """
+    image_view_loaded = Signal(dict)
+
     """Emitted when overlay configuration has changed"""
     overlay_config_changed = Signal()
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -114,6 +114,13 @@ class ImageCanvas(FigureCanvas):
 
         images_dict = HexrdConfig().images_dict
 
+        def apply_masks(img, name):
+            visible_masks = HexrdConfig().visible_masks
+            for mask_name, data in HexrdConfig().masks.items():
+                for det, mask in data:
+                    if mask_name in visible_masks and det == name:
+                        img[~mask] = 0
+
         if (self.mode != ViewType.raw or
                 len(image_names) != len(self.axes_images)):
             # Either we weren't in image mode before, we have a different
@@ -134,11 +141,7 @@ class ImageCanvas(FigureCanvas):
                 img = images_dict[name]
 
                 # Apply any masks
-                for mask_name, data in HexrdConfig().masks.items():
-                    for det, mask in data:
-                        if (mask_name in HexrdConfig().visible_masks and
-                                det == name):
-                            img[~mask] = 0
+                apply_masks(img, name)
 
                 axis = self.figure.add_subplot(rows, cols, i + 1)
                 axis.set_title(name)
@@ -158,11 +161,7 @@ class ImageCanvas(FigureCanvas):
                 img = images_dict[name]
 
                 # Apply any masks
-                for mask_name, data in HexrdConfig().masks.items():
-                    for det, mask in data:
-                        if (mask_name in HexrdConfig().visible_masks and
-                                det == name):
-                            img[~mask] = 0
+                apply_masks(img, name)
                 self.axes_images[i].set_data(img)
 
         # This will call self.draw_idle()

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -173,6 +173,8 @@ class ImageCanvas(FigureCanvas):
         self.update_auto_picked_data()
         self.update_overlays()
 
+        HexrdConfig().image_view_loaded.emit(images_dict)
+
         msg = 'Image view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
 
@@ -605,6 +607,8 @@ class ImageCanvas(FigureCanvas):
         self.update_overlays()
         self.draw_detector_borders()
 
+        HexrdConfig().image_view_loaded.emit({'img': img})
+
         msg = 'Cartesian view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
 
@@ -710,6 +714,8 @@ class ImageCanvas(FigureCanvas):
         self.update_auto_picked_data()
         self.update_overlays()
         self.draw_detector_borders()
+
+        HexrdConfig().image_view_loaded.emit({'img': img})
 
         msg = 'Polar view loaded!'
         HexrdConfig().emit_update_status_bar(msg)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -274,6 +274,7 @@ class MainWindow(QObject):
             self.enforce_view_mode)
 
         HexrdConfig().instrument_config_loaded.connect(self.update_config_gui)
+        HexrdConfig().image_view_loaded.connect(self.on_image_view_loaded)
 
     def set_icon(self, icon):
         self.ui.setWindowIcon(icon)
@@ -988,3 +989,8 @@ class MainWindow(QObject):
 
     def on_action_image_stack_triggered(self):
         self.image_stack_dialog.show()
+
+    def on_image_view_loaded(self, images):
+        # Update the data, but don't reset the bounds
+        # This will update the histogram in the B&C editor
+        self.color_map_editor.data = images

--- a/hexrd/ui/snip_viewer_dialog.py
+++ b/hexrd/ui/snip_viewer_dialog.py
@@ -35,9 +35,7 @@ class SnipViewerDialog:
     def setup_color_map(self):
         self.color_map_editor = ColorMapEditor(self, self.ui)
         self.ui.color_map_editor_layout.addWidget(self.color_map_editor.ui)
-
-        no_nans_data = np.nan_to_num(self.data)
-        self.color_map_editor.update_bounds(no_nans_data)
+        self.color_map_editor.update_bounds(self.data)
 
     def setup_canvas(self):
         canvas = FigureCanvas(Figure(tight_layout=True))


### PR DESCRIPTION
This makes the "Auto" button significantly more useful for the Cartesian and Polar views because they are now
using their displayed data, rather than the raw data.

https://user-images.githubusercontent.com/9558430/151904139-16ad1794-5e4f-4811-9fec-d10fb0651c8f.mp4

This includes a few other minor fixes.

Fixes: #1003