### PR TITLE
Fix a bug with crystal slider widget range update

### DIFF
--- a/hexrd/ui/calibration_crystal_slider_widget.py
+++ b/hexrd/ui/calibration_crystal_slider_widget.py
@@ -168,7 +168,7 @@ class CalibrationCrystalSliderWidget(QObject):
         delta = range_value / 2.0
         sliders = self.slider_widgets
         for i, slider in enumerate(sliders):
-            val = data[i]
+            val = data[i] * self.CONF_VAL_TO_SLIDER_VAL
             blocker = QSignalBlocker(slider)  # noqa: F841
             slider.setRange(val - delta, val + delta)
             slider.setValue(val)


### PR DESCRIPTION
The slider widgets would behave strangely when the range was updated.

The issue was that in the range update function, the value needed to be
converted into slider units.

Fixes: #1153