### PR TITLE
Add optional labels to Laue overlays

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -323,9 +323,12 @@ class ImageCanvas(FigureCanvas):
     def draw_laue_overlay(self, axis, data, style, highlight_style):
         spots = data['spots']
         ranges = data['ranges']
+        labels = data['labels']
+        label_offsets = data['label_offsets']
 
         data_style = style['data']
         ranges_style = style['ranges']
+        label_style = style['labels']
 
         highlight_indices = [i for i, x in enumerate(spots)
                              if id(x) in self.overlay_highlight_ids]
@@ -339,6 +342,20 @@ class ImageCanvas(FigureCanvas):
 
             artist = axis.scatter(x, y, **current_style)
             artists.append(artist)
+
+            if labels:
+                current_label_style = label_style
+                if i in highlight_indices:
+                    current_label_style = highlight_style['labels']
+
+                kwargs = {
+                    'x': x + label_offsets[0],
+                    'y': y + label_offsets[1],
+                    's': labels[i],
+                    **current_label_style,
+                }
+                artist = axis.text(**kwargs)
+                artists.append(artist)
 
         for i, box in enumerate(ranges):
             current_style = ranges_style

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -234,4 +234,4 @@ class OverlayManager:
 
     def edit_style(self):
         self._style_picker = OverlayStylePicker(self.active_overlay, self.ui)
-        self._style_picker.ui.exec_()
+        self._style_picker.exec_()

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+import copy
 
 import numpy as np
 
@@ -69,7 +70,7 @@ class Overlay(ABC):
             highlight_style = self.default_highlight_style
 
         self.refinements = refinements
-        self._style = style
+        self.style = style
         self.highlight_style = highlight_style
         self._visible = visible
         self._display_mode = ViewType.raw
@@ -169,8 +170,14 @@ class Overlay(ABC):
 
     @style.setter
     def style(self, v):
-        if self.style == v:
+        if hasattr(self, '_style') and self.style == v:
             return
+
+        # Ensure it has all keys
+        v = copy.deepcopy(v)
+        for key in self.default_style:
+            if key not in v:
+                v[key] = self.default_style[key]
 
         self._style = v
         self.update_needed = True

--- a/hexrd/ui/resources/ui/laue_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/laue_overlay_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>741</width>
-    <height>700</height>
+    <height>790</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,7 +19,7 @@
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>700</height>
+    <height>790</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -35,6 +35,9 @@
      <property name="text">
       <string>Max Energy:</string>
      </property>
+     <property name="buddy">
+      <cstring>max_energy</cstring>
+     </property>
     </widget>
    </item>
    <item row="0" column="0">
@@ -42,12 +45,15 @@
      <property name="text">
       <string>Min Energy:</string>
      </property>
+     <property name="buddy">
+      <cstring>min_energy</cstring>
+     </property>
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
     <layout class="QVBoxLayout" name="crystal_editor_layout"/>
    </item>
-   <item row="6" column="0" colspan="2">
+   <item row="7" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -59,44 +65,6 @@
       </size>
      </property>
     </spacer>
-   </item>
-   <item row="1" column="1">
-    <widget class="ScientificDoubleSpinBox" name="max_energy">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="maximum">
-      <double>100000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>35.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="ScientificDoubleSpinBox" name="min_energy">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="maximum">
-      <double>100000.000000000000000</double>
-     </property>
-     <property name="value">
-      <double>5.000000000000000</double>
-     </property>
-    </widget>
    </item>
    <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="ranges_group_box">
@@ -172,6 +140,9 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
+        <property name="buddy">
+         <cstring>eta_width</cstring>
+        </property>
        </widget>
       </item>
       <item row="1" column="2">
@@ -184,6 +155,9 @@
         </property>
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="buddy">
+         <cstring>tth_width</cstring>
         </property>
        </widget>
       </item>
@@ -200,6 +174,9 @@
           <property name="alignment">
            <set>Qt::AlignCenter</set>
           </property>
+          <property name="buddy">
+           <cstring>width_shape</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -214,6 +191,25 @@
      </layout>
     </widget>
    </item>
+   <item row="1" column="1">
+    <widget class="ScientificDoubleSpinBox" name="max_energy">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>100000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>35.000000000000000</double>
+     </property>
+    </widget>
+   </item>
    <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="sample_frame_group">
      <property name="title">
@@ -224,6 +220,9 @@
        <widget class="QLabel" name="sample_orientation_label">
         <property name="text">
          <string>Orientation:</string>
+        </property>
+        <property name="buddy">
+         <cstring>sample_orientation_0</cstring>
         </property>
        </widget>
       </item>
@@ -278,6 +277,105 @@
      </layout>
     </widget>
    </item>
+   <item row="0" column="1">
+    <widget class="ScientificDoubleSpinBox" name="min_energy">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>100000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>5.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
+    <widget class="QGroupBox" name="labelsGroup">
+     <property name="title">
+      <string>Labels</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="3">
+       <widget class="ScientificDoubleSpinBox" name="label_offset_x">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="label_type"/>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_offset_x_label">
+        <property name="text">
+         <string>Offset X:</string>
+        </property>
+        <property name="buddy">
+         <cstring>label_offset_x</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_type_label">
+        <property name="text">
+         <string>Type:</string>
+        </property>
+        <property name="buddy">
+         <cstring>label_type</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="label_offset_y_label">
+        <property name="text">
+         <string>Offset Y:</string>
+        </property>
+        <property name="buddy">
+         <cstring>label_offset_y</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="ScientificDoubleSpinBox" name="label_offset_y">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-10000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -297,6 +395,9 @@
   <tabstop>sample_orientation_0</tabstop>
   <tabstop>sample_orientation_1</tabstop>
   <tabstop>sample_orientation_2</tabstop>
+  <tabstop>label_type</tabstop>
+  <tabstop>label_offset_x</tabstop>
+  <tabstop>label_offset_y</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/overlay_style_picker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>632</width>
-    <height>246</height>
+    <height>336</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -23,13 +23,6 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="5" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" colspan="4">
     <widget class="QLabel" name="material_name">
      <property name="text">
@@ -37,6 +30,13 @@
      </property>
      <property name="alignment">
       <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
@@ -51,12 +51,18 @@
         <property name="text">
          <string>Line Style:</string>
         </property>
+        <property name="buddy">
+         <cstring>data_style</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="0">
        <widget class="QLabel" name="data_color_label">
         <property name="text">
          <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>data_color</cstring>
         </property>
        </widget>
       </item>
@@ -77,6 +83,9 @@
        <widget class="QLabel" name="data_size_label">
         <property name="text">
          <string>Line Width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>data_size</cstring>
         </property>
        </widget>
       </item>
@@ -126,12 +135,18 @@
         <property name="text">
          <string>Color:</string>
         </property>
+        <property name="buddy">
+         <cstring>range_color</cstring>
+        </property>
        </widget>
       </item>
       <item row="0" column="4">
        <widget class="QLabel" name="range_style_label">
         <property name="text">
          <string>Line Style:</string>
+        </property>
+        <property name="buddy">
+         <cstring>range_style</cstring>
         </property>
        </widget>
       </item>
@@ -146,6 +161,9 @@
        <widget class="QLabel" name="range_size_label">
         <property name="text">
          <string>Line Width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>range_size</cstring>
         </property>
        </widget>
       </item>
@@ -174,6 +192,68 @@
      </layout>
     </widget>
    </item>
+   <item row="5" column="0" colspan="4">
+    <widget class="QGroupBox" name="label_group">
+     <property name="title">
+      <string>Label Style</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="2">
+       <widget class="QLabel" name="label_size_label">
+        <property name="text">
+         <string>Size:</string>
+        </property>
+        <property name="buddy">
+         <cstring>label_size</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>label_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QComboBox" name="label_weight"/>
+      </item>
+      <item row="0" column="3">
+       <widget class="ScientificDoubleSpinBox" name="label_size">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>10.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="label_weight_label">
+        <property name="text">
+         <string>Weight:</string>
+        </property>
+        <property name="buddy">
+         <cstring>label_weight</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="label_color">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -190,6 +270,9 @@
   <tabstop>range_color</tabstop>
   <tabstop>range_style</tabstop>
   <tabstop>range_size</tabstop>
+  <tabstop>label_color</tabstop>
+  <tabstop>label_size</tabstop>
+  <tabstop>label_weight</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This adds a "Labels" section to the Laue overlay editor where the user
may choose to label the Laue overlays by either hkls or energy. The user
is able to control the label offsets in both x and y directions (which
also accept negative values).

The user is also able to modify the label style via the overlay style
editor dialog.

![image](https://user-images.githubusercontent.com/9558430/156589674-86eba0a5-0e40-4335-84b4-76dfd22cfc8c.png)

Fixes: hexrd/hexrd#411