### PR TITLE
Display overlay names and allow editing

### DIFF
--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -55,10 +55,13 @@ class Overlay(ABC):
         pass
 
     # Concrete methods
-    def __init__(self, material_name, refinements=None, style=None,
+    def __init__(self, material_name, name=None, refinements=None, style=None,
                  highlight_style=None, visible=True):
 
         self._material_name = material_name
+
+        if name is None:
+            name = self._generate_unique_name()
 
         if refinements is None:
             refinements = self.default_refinements
@@ -69,6 +72,7 @@ class Overlay(ABC):
         if highlight_style is None:
             highlight_style = self.default_highlight_style
 
+        self.name = name
         self.refinements = refinements
         self.style = style
         self.highlight_style = highlight_style
@@ -101,6 +105,7 @@ class Overlay(ABC):
         # arguments to the __init__ method.
         return [
             'material_name',
+            'name',
             'refinements',
             'style',
             'highlight_style',
@@ -108,30 +113,25 @@ class Overlay(ABC):
         ]
 
     @property
-    def non_unique_name(self):
+    def _non_unique_name(self):
         return f'{self.material_name} {self.type.value}'
 
-    @property
-    def unique_name(self):
+    def _generate_unique_name(self):
         from hexrd.ui.hexrd_config import HexrdConfig
 
-        name = self.non_unique_name
+        name = self._non_unique_name
         index = 1
         for overlay in HexrdConfig().overlays:
             if overlay is self:
                 break
 
-            if overlay.non_unique_name == name:
+            if overlay._non_unique_name == name:
                 index += 1
 
         if index > 1:
             name = f'{name} {index}'
 
         return name
-
-    @property
-    def name(self):
-        return self.unique_name
 
     @staticmethod
     def from_name(name):

--- a/hexrd/ui/resources/ui/overlay_manager.ui
+++ b/hexrd/ui/resources/ui/overlay_manager.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>494</width>
-    <height>200</height>
+    <width>672</width>
+    <height>245</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -63,9 +63,6 @@
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select row to edit&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::NoEditTriggers</set>
-     </property>
      <property name="dragDropOverwriteMode">
       <bool>false</bool>
      </property>
@@ -97,6 +94,11 @@
      <row/>
      <row/>
      <row/>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
      <column>
       <property name="text">
        <string>Material</string>


### PR DESCRIPTION
This displays overlay names in the overlay manager, and the user is
allowed to edit the names there. These names are now saved and loaded in
the overlay serialization.

The overlay names are also used in a few other places, including the
calibration workflow and the refinements editor.

![image](https://user-images.githubusercontent.com/9558430/156647459-fb39916a-a8dc-4434-bc41-5c1cfca3e1df.png)