### PR TITLE
Fix HexrdConfig().has_images

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -82,8 +82,9 @@ class ColorMapEditor:
         self.update_norm()
 
     def update_bc_enable_state(self):
+        has_images = HexrdConfig().has_images
         has_data = self.data is not None
-        self.ui.bc_editor_button.setEnabled(has_data)
+        self.ui.bc_editor_button.setEnabled(has_data and has_images)
 
     def bc_editor_button_pressed(self):
         if self.bc_editor:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -528,8 +528,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def imageseries(self, name):
         return self.imageseries_dict.get(name)
 
+    @property
+    def has_dummy_images(self):
+        if not self.imageseries_dict:
+            return False
+
+        first_ims = next(iter(self.imageseries_dict.values()))
+        return getattr(first_ims, 'is_dummy', False)
+
+    @property
     def has_images(self):
-        return len(self.imageseries_dict) != 0
+        # There are images, and they are not dummy images
+        return self.imageseries_dict and not self.has_dummy_images
 
     @property
     def omega_imageseries_dict(self):

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -36,6 +36,11 @@ class ImageFileManager(metaclass=Singleton):
             shape = (rows, cols)
             data = np.ones(shape, dtype=np.uint8)
             ims = imageseries.open(None, 'array', data=data)
+
+            # Set a flag on these image series indicating that they are
+            # dummies.
+            ims.is_dummy = True
+
             HexrdConfig().imageseries_dict[det] = ims
 
     def load_images(self, detectors, file_names, options=None):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -431,7 +431,7 @@ class MainWindow(QObject):
             HexrdConfig().load_materials(selected_file)
 
     def on_action_save_imageseries_triggered(self):
-        if not HexrdConfig().has_images():
+        if not HexrdConfig().has_images:
             msg = ('No ImageSeries available for saving.')
             QMessageBox.warning(self.ui, 'HEXRD', msg)
             return
@@ -708,7 +708,7 @@ class MainWindow(QObject):
         is_polar = self.image_mode == ViewType.polar
         is_raw = self.image_mode == ViewType.raw
 
-        has_images = HexrdConfig().has_images()
+        has_images = HexrdConfig().has_images
 
         self.ui.action_export_current_plot.setEnabled(
             (is_polar or is_cartesian) and has_images)
@@ -721,7 +721,7 @@ class MainWindow(QObject):
         self.ui.action_edit_apply_powder_mask_to_polar.setEnabled(is_polar)
 
     def start_fast_powder_calibration(self):
-        if not HexrdConfig().has_images():
+        if not HexrdConfig().has_images:
             msg = ('No images available for calibration.')
             QMessageBox.warning(self.ui, 'HEXRD', msg)
             return
@@ -780,7 +780,7 @@ class MainWindow(QObject):
 
     def update_all(self, clear_canvases=False):
         # If there are no images loaded, skip the request
-        if not HexrdConfig().has_images():
+        if not HexrdConfig().imageseries_dict:
             return
 
         if HexrdConfig().loading_state:


### PR DESCRIPTION
This should only return `True` when there are images loaded that are
not dummy images. It was previously returning `True` when there were
dummy images loaded.

This also fixes the brightness and contrast editor to be disabled when
there are dummy images (because otherwise, it will produce a not
very clear error if you try to use it).