### PR TITLE
Increase width of progress dialog for tqdm

### DIFF
--- a/hexrd/ui/resources/ui/progress_dialog.ui
+++ b/hexrd/ui/resources/ui/progress_dialog.ui
@@ -6,13 +6,13 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>80</height>
+    <width>500</width>
+    <height>88</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
-    <width>300</width>
+    <width>500</width>
     <height>0</height>
    </size>
   </property>


### PR DESCRIPTION
This allows the tqdm progress bar to fit better inside it.

If we continue to run into issues with tqdm, we can either make the
progress dialog even larger, or reduce the size of the tqdm progress
bars.