### PR TITLE
Clip Laue labels that are outside the plot

### DIFF
--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -352,6 +352,7 @@ class ImageCanvas(FigureCanvas):
                     'x': x + label_offsets[0],
                     'y': y + label_offsets[1],
                     's': labels[i],
+                    'clip_on': True,
                     **current_label_style,
                 }
                 artist = axis.text(**kwargs)


### PR DESCRIPTION
Here's an example of them being clipped:

![example](https://user-images.githubusercontent.com/9558430/157950392-98262dc1-d3ea-43df-b91c-78d31758abb2.gif)