### PR TITLE
Do not load overlays that have missing materials

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -399,8 +399,14 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @overlays_dictified.setter
     def overlays_dictified(self, v):
+        material_names = list(self.materials.keys())
+
         self.overlays = []
         for overlay_dict in v:
+            if overlay_dict['material_name'] not in material_names:
+                # Skip over ones that do not have a matching material
+                continue
+
             self.overlays.append(overlays.from_dict(overlay_dict))
 
     def emit_update_status_bar(self, msg):

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 
+from PySide2.QtCore import QTimer
+
 import h5py
 import numpy as np
 import yaml
@@ -200,11 +202,16 @@ def load(h5_file):
     # Record the location of the state file in case we save over it
     HexrdConfig().last_loaded_state_file = h5_file.filename
 
-    # Indicate that the state was loaded...
-    HexrdConfig().state_loaded.emit()
+    def finalize():
+        # Indicate that the state was loaded...
+        HexrdConfig().state_loaded.emit()
 
-    # Perform a deep rerender to make sure everything is updated...
-    HexrdConfig().deep_rerender_needed.emit()
+        # Perform a deep rerender to make sure everything is updated...
+        HexrdConfig().deep_rerender_needed.emit()
+
+    # Allow some events to be processed, including loading the overlays,
+    # before finalizing.
+    QTimer.singleShot(0, finalize)
 
 
 def load_imageseries_dict(h5_file):


### PR DESCRIPTION
This prevents errors from occurring on load.