### PR TITLE
Add backward-compatible method for material name

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -403,7 +403,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         self.overlays = []
         for overlay_dict in v:
-            if overlay_dict['material_name'] not in material_names:
+            material_name = overlays.compatibility.material_name(overlay_dict)
+            if material_name not in material_names:
                 # Skip over ones that do not have a matching material
                 continue
 

--- a/hexrd/ui/overlays/compatibility.py
+++ b/hexrd/ui/overlays/compatibility.py
@@ -1,6 +1,16 @@
 CURRENT_DICT_VERSION = 2
 
 
+def material_name(overlay_dict):
+    version = overlay_dict.get('_version', 1)
+    if version == 1:
+        key = 'material'
+    else:
+        key = 'material_name'
+
+    return overlay_dict.get(key)
+
+
 def to_dict(overlay):
     d = overlay.to_dict()
     # Keep track of a version so we can convert between formats properly


### PR DESCRIPTION
This prevents errors when reading older settings.
