### PR TITLE
A few overlay fixes

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1175,6 +1175,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         for name, mat in zip(names, materials):
             self.config['materials']['materials'][name] = mat
+            # Force the material name to match
+            mat.name = name
             self.reset_tth_max(name)
 
         self.materials_added.emit()

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -44,6 +44,7 @@ class OverlayManager:
         self.ui.remove_button.pressed.connect(self.remove)
         self.ui.edit_style_button.pressed.connect(self.edit_style)
         HexrdConfig().update_overlay_editor.connect(self.update_overlay_editor)
+        HexrdConfig().materials_added.connect(self.update_table)
         HexrdConfig().material_renamed.connect(self.update_table)
         HexrdConfig().materials_removed.connect(self.update_table)
 

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -204,6 +204,7 @@ class OverlayManager:
             HexrdConfig().change_overlay_type(i, OverlayType(w.currentData()))
 
         HexrdConfig().overlay_config_changed.emit()
+        self.update_table()
         self.update_overlay_editor()
 
     def update_config_visibilities(self):

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -1,6 +1,7 @@
 from PySide2.QtCore import Qt, QItemSelectionModel, QSignalBlocker
 from PySide2.QtWidgets import (
-    QCheckBox, QComboBox, QHBoxLayout, QSizePolicy, QTableWidgetItem, QWidget
+    QCheckBox, QComboBox, QHBoxLayout, QHeaderView, QSizePolicy,
+    QTableWidgetItem, QWidget
 )
 
 from hexrd.ui.constants import OverlayType
@@ -151,6 +152,14 @@ class OverlayManager:
             self.select_row(select_row)
 
         self.ui.table.resizeColumnsToContents()
+
+        # The last section isn't always stretching automatically, even
+        # though we have setStretchLastSection(True) set.
+        # Force it to stretch manually.
+        last_column = max(v for v in COLUMNS.values())
+        self.ui.table.horizontalHeader().setSectionResizeMode(
+            last_column, QHeaderView.Stretch)
+
         # Just in case the selection actually changed...
         self.selection_changed()
 

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -248,7 +248,11 @@ class Overlay(ABC):
                 )
                 raise Exception(msg)
 
-            self._data = self.generate_overlay()
+            # We are identifying this dict by its id() in the image_canvas.
+            # Because of this, make sure we use the same dict so that we
+            # do not change ids.
+            self._data.clear()
+            self._data |= self.generate_overlay()
             self.update_needed = False
         return self._data
 


### PR DESCRIPTION
This contains a few fixes:

1. Update overlay manager table on type change
2. Update overlay manager table on type change (fixes: #1182)
3. Force last section to stretch in overlay manager
4. Force material name to match upon adding (fixes: #1183)
5. Update overlay manager table when materials added

More details can be read in their commit messages.

Fixes: #1182
Fixes: #1183