### PR TITLE
Ensure HexrdConfig().has_images returns a bool

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -546,7 +546,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @property
     def has_images(self):
         # There are images, and they are not dummy images
-        return self.imageseries_dict and not self.has_dummy_images
+        return bool(self.imageseries_dict and not self.has_dummy_images)
 
     @property
     def omega_imageseries_dict(self):


### PR DESCRIPTION
It appears that in some cases, it was returning a dict, and when we used it as
the argument for QWidget.setEnabled(), Qt would complain that the function only
accepts booleans, but was provided with a dict.

Ensure that it returns a bool so that this error is avoided.