### PR TITLE
Specify ome_period in indexing results spots

### DIFF
--- a/hexrd/ui/indexing/indexing_results_dialog.py
+++ b/hexrd/ui/indexing/indexing_results_dialog.py
@@ -302,6 +302,7 @@ class IndexingResultsDialog(QObject):
         kwargs = {
             'plane_data': plane_data,
             'grain_param_list': [crystal_params],
+            'ome_period': self.ome_maps.omeEdges[0] + np.radians([0, 360]),
         }
         sim_data = instr.simulate_rotation_series(**kwargs)
 


### PR DESCRIPTION
It was previously being set to the default, which was [-π, π]. Now,
it is being set based upon the first omega edge value in the eta
omega maps. This appears to generate results correctly.

![example](https://user-images.githubusercontent.com/9558430/163505355-f3a66421-7a1f-4c39-8504-856319cf8d65.png)

Fixes: #1190