### PR TITLE
Add hand-picked indexing method

### DIFF
--- a/hexrd/ui/indexing/fiber_pick_utils.py
+++ b/hexrd/ui/indexing/fiber_pick_utils.py
@@ -1,0 +1,157 @@
+import numpy as np
+
+from hexrd import constants as cnst
+from hexrd.rotations import discreteFiber
+from hexrd.transforms import xfcapi
+
+
+def _pick_to_fiber(pick_coords, eta_ome_maps, map_index, step=0.5,
+                   beam_vec=None, chi=0., as_expmap=True):
+    """
+    Returns the orientations for the specified fiber parameters.
+
+    Parameters
+    ----------
+    pick_coords : array_like
+        The (2, ) list/vector containing the pick coordinates as (eta, omega)
+        in DEGREES.  This corresponds to the (column, row) or (x, y) dimensions
+        on the map.
+    eta_ome_maps : hexrd.xrdutil.utils.EtaOmeMaps
+        The eta-omega maps.
+    map_index : int
+        The index of the current map.
+    step : scalar, optional
+        The step size along the fiber in DEGREES.  The default is 0.5.
+    chi : scalar, optional
+        The chi angle from the associated instrument (specifically,
+        `instr.chi`).  The default is 0.
+    beam_vec : array_like, optional
+        The beam vector of the associated instrument (specifically,
+        `instr.beam_vector`).  The default is None (giving [0, 0, -1]).
+    as_expmap : bool, optional
+        Flag for converting the output from qauternions to exponential map.
+        The default is True.
+
+    Returns
+    -------
+    qfib : numpy.ndarray
+        The array containing the fiber points as quaternions or exponential
+        map parameters, according to the `as_expmap` kwarg.
+
+    """
+    pick_coords = np.atleast_1d(pick_coords).flatten()
+
+    if beam_vec is None:
+        beam_vec = cnst.beam_vec
+
+    ndiv = int(np.round(360./float(step)))
+
+    # grab the planeData instance from the maps
+    # !!! this should have a copy of planeData that has hkls consistent with
+    #     the map data.
+    pd = eta_ome_maps.planeData
+    bmat = pd.latVecOps['B']
+
+    # the crystal direction (plane normal)
+    crys_dir = pd.hkls[:, map_index].reshape(3, 1)
+
+    # the sample direction
+    tth = pd.getTTh()[map_index]  # !!! in radians
+    angs = np.atleast_2d(np.hstack([tth, np.radians(pick_coords)]))
+    samp_dir = xfcapi.anglesToGVec(
+        angs, bHat_l=beam_vec, chi=chi
+    ).reshape(3, 1)
+
+    # make the fiber
+    qfib = discreteFiber(
+        crys_dir, samp_dir,
+        B=bmat, ndiv=ndiv,
+        invert=False,
+        csym=pd.getQSym(), ssym=None
+    )[0]
+
+    if as_expmap:
+        phis = 2.*np.arccos(qfib[0, :])
+        ns = xfcapi.unitRowVector(qfib[1:, :].T)
+        expmaps = phis*ns.T
+        return expmaps.T  # (3, ndiv)
+    else:
+        return qfib.T  # (4, ndiv)
+
+
+def _angles_from_orientation(instr, eta_ome_maps, orientation):
+    """
+    Return the (eta, omega) angles for a specified orientation consistent with
+    input EtaOmeMaps.
+
+    Parameters
+    ----------
+    instr : hexrd.instrument.HEDMInstrument
+        The instrument instance used to generate the EtaOmeMaps.
+    eta_ome_maps : hexrd.xrdutil.utils.EtaOmeMaps
+        The eta-omega maps.
+    orientation : array_like
+        Either a (3, ) or (4, ) element vector specifying an orientation.
+
+    Raises
+    ------
+    RuntimeError
+        If orientation has more than 4 elements.
+
+    Returns
+    -------
+    simulated_angles : list
+        A list with length = len(eta_ome_maps.dataStore) containing the angular
+        coordinates of all valid reflections for each map.  If no valid points
+        exist for a particular map, the entry contains `None`.  Otherwise,
+        the entry is a (2, p) array of the (eta, omega) coordinates in DEGREES
+        for the p valid reflections.
+
+    """
+    plane_data = eta_ome_maps.planeData
+
+    # angle ranges from maps
+    eta_range = (eta_ome_maps.etaEdges[0], eta_ome_maps.etaEdges[-1])
+    ome_range = (eta_ome_maps.omeEdges[0], eta_ome_maps.omeEdges[-1])
+    ome_period = eta_ome_maps.omeEdges[0] + np.r_[0., 2*np.pi]
+
+    # need the hklids
+    hklids = [i['hklID'] for i in plane_data.hklDataList]
+
+    expmap = np.atleast_1d(orientation).flatten()
+    if len(expmap) == 4:
+        # have a quat; convert here
+        phi = 2.*np.arccos(expmap[0])
+        n = xfcapi.unitRowVector(expmap[1:])
+        expmap = phi*n
+    elif len(expmap) > 4:
+        raise RuntimeError(
+            "orientation must be a single exponential map or quaternion"
+        )
+
+    grain_param_list = [np.hstack([expmap, cnst.zeros_3, cnst.identity_6x1]), ]
+    sim_dict = instr.simulate_rotation_series(
+        plane_data, grain_param_list,
+        eta_ranges=[eta_range, ], ome_ranges=[ome_range, ],
+        ome_period=ome_period, wavelength=None
+    )
+
+    rids = []
+    angs = []
+    for sim in sim_dict.values():
+        rids.append(sim[0][0])
+        angs.append(sim[2][0])
+    rids = np.hstack(rids)
+    angs = np.vstack(angs)
+
+    simulated_angles = []
+    for rid in hklids:
+        this_idx = rids == rid
+        if np.any(this_idx):
+            simulated_angles.append(
+                np.degrees(np.atleast_2d(angs[this_idx, 1:]))
+            )
+        else:
+            simulated_angles.append(None)
+
+    return simulated_angles

--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -150,6 +150,7 @@ class OmeMapsSelectDialog(QObject):
         # Set the new config options on the internal config
         indexing_config = HexrdConfig().indexing_config
         maps_config = indexing_config['find_orientations']['orientation_maps']
+        maps_config['_select_method'] = self.method_name
         maps_config['file'] = self.file_name
         maps_config['threshold'] = self.threshold
         maps_config['bin_frames'] = self.bin_frames
@@ -161,6 +162,8 @@ class OmeMapsSelectDialog(QObject):
 
         indexing_config = HexrdConfig().indexing_config
         maps_config = indexing_config['find_orientations']['orientation_maps']
+
+        self.method_name = maps_config.get('_select_method', 'load')
 
         file_name = maps_config['file'] if maps_config['file'] else ''
 

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -135,6 +135,15 @@ class IndexingRunner(Runner):
         self.ome_maps_viewer_dialog = dialog
 
     def ome_maps_viewed(self):
+        # If we did the hand-picked method, go ahead and skip now to
+        # generating the grains table and running fit grains
+        dialog = self.ome_maps_viewer_dialog
+        if dialog.quaternions_hand_picked:
+            self.qbar = dialog.hand_picked_quaternions
+            self.generate_grains_table()
+            self.start_fit_grains_runner()
+            return
+
         # The dialog should have automatically updated our internal config
         # Let's go ahead and run the indexing!
 
@@ -298,7 +307,9 @@ class IndexingRunner(Runner):
             print('No grains found')
             return
 
-        msg = f'{num_grains} grains found'
+        plural = 's' if num_grains != 1 else ''
+
+        msg = f'{num_grains} grain{plural} found'
         self.update_progress_text(msg)
         print(msg)
 

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -404,7 +404,7 @@
       <item row="1" column="0">
        <widget class="QTabWidget" name="quaternion_method_tab_widget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>2</number>
         </property>
         <widget class="QWidget" name="seed_search_tab">
          <attribute name="title">
@@ -929,6 +929,13 @@
             </layout>
            </widget>
           </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Fiber Step:</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0" colspan="2">
            <widget class="QGroupBox" name="current_fiber_group">
             <property name="sizePolicy">
@@ -1051,6 +1058,9 @@
                <property name="enabled">
                 <bool>false</bool>
                </property>
+               <property name="maximum">
+                <number>719</number>
+               </property>
                <property name="orientation">
                 <enum>Qt::Horizontal</enum>
                </property>
@@ -1076,6 +1086,31 @@
               </widget>
              </item>
             </layout>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="ScientificDoubleSpinBox" name="hand_picked_fiber_step">
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string>°</string>
+            </property>
+            <property name="decimals">
+             <number>8</number>
+            </property>
+            <property name="minimum">
+             <double>0.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+            <property name="value">
+             <double>0.500000000000000</double>
+            </property>
            </widget>
           </item>
          </layout>

--- a/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_viewer_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1900</width>
-    <height>1108</height>
+    <height>1149</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -886,6 +886,200 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="hand_picked_tab">
+         <attribute name="title">
+          <string>Hand Picked</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_14">
+          <item row="2" column="0" colspan="2">
+           <widget class="QGroupBox" name="picked_fibers_group">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Picked Fibers</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_16">
+             <item row="0" column="0">
+              <widget class="QTableWidget" name="picked_fibers_table">
+               <property name="selectionBehavior">
+                <enum>QAbstractItemView::SelectRows</enum>
+               </property>
+               <attribute name="horizontalHeaderVisible">
+                <bool>false</bool>
+               </attribute>
+               <attribute name="horizontalHeaderStretchLastSection">
+                <bool>true</bool>
+               </attribute>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QPushButton" name="picked_fibers_delete_selected">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Delete Selected</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="QGroupBox" name="current_fiber_group">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="title">
+             <string>Current Fiber</string>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_15">
+             <item row="5" column="0" colspan="3">
+              <layout class="QHBoxLayout" name="selected_fiber_orientation_layout">
+               <item>
+                <widget class="ScientificDoubleSpinBox" name="selected_fiber_orientation_0">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="decimals">
+                  <number>6</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-10.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>10.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="ScientificDoubleSpinBox" name="selected_fiber_orientation_1">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="decimals">
+                  <number>6</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-10.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>10.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="ScientificDoubleSpinBox" name="selected_fiber_orientation_2">
+                 <property name="enabled">
+                  <bool>false</bool>
+                 </property>
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="readOnly">
+                  <bool>true</bool>
+                 </property>
+                 <property name="buttonSymbols">
+                  <enum>QAbstractSpinBox::NoButtons</enum>
+                 </property>
+                 <property name="keyboardTracking">
+                  <bool>false</bool>
+                 </property>
+                 <property name="decimals">
+                  <number>6</number>
+                 </property>
+                 <property name="minimum">
+                  <double>-10.000000000000000</double>
+                 </property>
+                 <property name="maximum">
+                  <double>10.000000000000000</double>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="6" column="0" colspan="3">
+              <widget class="QPushButton" name="add_fiber_button">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="text">
+                <string>Add Fiber</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0" colspan="2">
+              <widget class="QLabel" name="current_fiber_label">
+               <property name="text">
+                <string>Right-click the canvas to generate fibers for a position</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="0">
+              <widget class="QSlider" name="current_fiber_slider">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="1">
+              <widget class="ScientificDoubleSpinBox" name="current_fiber_angle">
+               <property name="enabled">
+                <bool>false</bool>
+               </property>
+               <property name="keyboardTracking">
+                <bool>false</bool>
+               </property>
+               <property name="suffix">
+                <string>°</string>
+               </property>
+               <property name="decimals">
+                <number>8</number>
+               </property>
+               <property name="maximum">
+                <double>360.000000000000000</double>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </widget>
       </item>
       <item row="0" column="0">
@@ -898,6 +1092,11 @@
         <item>
          <property name="text">
           <string>Grid Search</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Hand Picked</string>
          </property>
         </item>
        </widget>
@@ -915,9 +1114,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>apply_filtering</tabstop>
-  <tabstop>filtering_apply_gaussian_laplace</tabstop>
-  <tabstop>filtering_fwhm</tabstop>
   <tabstop>quaternion_method</tabstop>
   <tabstop>quaternion_method_tab_widget</tabstop>
   <tabstop>seed_search_method</tabstop>
@@ -935,6 +1131,16 @@
   <tabstop>bl_threshold</tabstop>
   <tabstop>bl_overlap</tabstop>
   <tabstop>fiber_step</tabstop>
+  <tabstop>quaternion_grid_file</tabstop>
+  <tabstop>select_quaternion_grid_file</tabstop>
+  <tabstop>current_fiber_slider</tabstop>
+  <tabstop>current_fiber_angle</tabstop>
+  <tabstop>selected_fiber_orientation_0</tabstop>
+  <tabstop>selected_fiber_orientation_1</tabstop>
+  <tabstop>selected_fiber_orientation_2</tabstop>
+  <tabstop>add_fiber_button</tabstop>
+  <tabstop>picked_fibers_table</tabstop>
+  <tabstop>picked_fibers_delete_selected</tabstop>
   <tabstop>omega_tolerance</tabstop>
   <tabstop>eta_tolerance</tabstop>
   <tabstop>eta_mask</tabstop>
@@ -943,7 +1149,12 @@
   <tabstop>clustering_algorithm</tabstop>
   <tabstop>write_scored_orientations</tabstop>
   <tabstop>select_working_dir</tabstop>
+  <tabstop>apply_filtering</tabstop>
+  <tabstop>filtering_apply_gaussian_laplace</tabstop>
+  <tabstop>filtering_fwhm</tabstop>
+  <tabstop>active_hkl</tabstop>
   <tabstop>label_spots</tabstop>
+  <tabstop>export_button</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This allows the user to hand pick the grains by first selecting the 
hand-picked quaternion method in the eta omega maps viewer, then
right-clicking on a spot. This will create a list of fibers from 0
to 360 degrees that intersect with the spot. A slider can then be
moved to determine the angle at which the fiber intersects with other
spots as well. This fiber can then be added to the list of quaternions.

If the user utilizes this method, the workflow then proceeds directly
to fit grains.

https://user-images.githubusercontent.com/9558430/165319223-cb4af179-ed8a-4fdc-887b-affef27d4108.mp4