### PR TITLE
In fiber picking, append empty array for no spots

### DIFF
--- a/hexrd/ui/indexing/fiber_pick_utils.py
+++ b/hexrd/ui/indexing/fiber_pick_utils.py
@@ -152,6 +152,6 @@ def _angles_from_orientation(instr, eta_ome_maps, orientation):
                 np.degrees(np.atleast_2d(angs[this_idx, 1:]))
             )
         else:
-            simulated_angles.append(None)
+            simulated_angles.append(np.empty((0,)))
 
     return simulated_angles


### PR DESCRIPTION
If no spots were found, append `np.empty((0,))` instead of `None` so
that we can just check the size of the array elsewhere, and not have
to check for `None` also.