### PR TITLE
Save last hkl index for generating fibers

### DIFF
--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -65,6 +65,7 @@ class OmeMapsViewerDialog(QObject):
         self.hand_picked_fibers = np.empty((0, 3))
         self.latest_picked_eta = None
         self.latest_picked_ome = None
+        self.latest_picked_hkl_index = None
 
         self.setup_widget_paths()
 
@@ -863,6 +864,7 @@ class OmeMapsViewerDialog(QObject):
         # Reset the latest picks to None
         self.latest_picked_eta = None
         self.latest_picked_ome = None
+        self.latest_picked_hkl_index = None
 
         self.generated_fibers = np.empty((0,))
         self.ui.current_fiber_slider.setValue(0)
@@ -881,6 +883,7 @@ class OmeMapsViewerDialog(QObject):
 
         self.latest_picked_eta = event.xdata
         self.latest_picked_ome = event.ydata
+        self.latest_picked_hkl_index = self.current_hkl_index
 
         self.recreate_generated_fibers()
 
@@ -890,12 +893,17 @@ class OmeMapsViewerDialog(QObject):
             # No picked coords. Just return.
             return
 
+        hkl_index = self.latest_picked_hkl_index
+        if hkl_index is None or hkl_index >= len(self.data.dataStore):
+            # Invalid hkl index. Return.
+            return
+
         instr = create_hedm_instrument()
 
         kwargs = {
             'pick_coords': pick_coords,
             'eta_ome_maps': self.data,
-            'map_index': self.current_hkl_index,
+            'map_index': hkl_index,
             'step': self.fiber_step,
             'beam_vec': instr.beam_vector,
             'chi': instr.chi,


### PR DESCRIPTION
This fixes a bug where, if the user generated fibers based upon a
clicked position, and then they switched to a different hkl index,
and then they modified the fiber step, the newly generated fibers
would be incorrect.

This is because when the user modifies the fiber step, it regenerates
the fibers using the new step. The hand picked coordinates used to
generate the fibers was previously saved and would be used to generate
the fibers with the new steps. However, the hkl index used to generate
the fibers was not saved, and thus the fibers would be generated
with an incorrect hkl index.

Save and use the last hkl index to avoid this issue.