### PR TITLE
Only load the "CeO2" material by default

### DIFF
--- a/hexrd/ui/resources/ui/material_list_editor.ui
+++ b/hexrd/ui/resources/ui/material_list_editor.ui
@@ -26,10 +26,17 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="1" column="0">
-    <widget class="QPushButton" name="import_material">
+   <item row="2" column="0">
+    <widget class="QPushButton" name="import_from_defaults">
      <property name="text">
-      <string>Import Material</string>
+      <string>Import from Defaults</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QPushButton" name="import_from_cif">
+     <property name="text">
+      <string>Import from CIF</string>
      </property>
     </widget>
    </item>
@@ -38,6 +45,10 @@
    </item>
   </layout>
  </widget>
+ <tabstops>
+  <tabstop>import_from_cif</tabstop>
+  <tabstop>import_from_defaults</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This modifies hexrdgui to only load the "CeO2" material by default,
which improves start-up time because some computations that are ran
when the materials are created take up some time.

The other default materials are available in the material list editor
via a "Import from Defaults" button. If the user clicks this button,
they may select other default materials to import.

If the program exits cleanly, the names of the default materials that
were loaded get saved, so that when hexrdgui is restarted, these default
materials will also be loaded again. Additionally, if any overlays were
saved that are using default material names, these default materials will
also be loaded on start-up.

Fixes: #1197