### PR TITLE
Fixes for hand picked indexing

### DIFF
--- a/hexrd/ui/indexing/fiber_pick_utils.py
+++ b/hexrd/ui/indexing/fiber_pick_utils.py
@@ -109,6 +109,8 @@ def _angles_from_orientation(instr, eta_ome_maps, orientation):
 
     """
     plane_data = eta_ome_maps.planeData
+    excl_indices = np.where(~plane_data.exclusions)[0]
+    hklDataList_reduced = np.array(plane_data.hklDataList)[excl_indices]
 
     # angle ranges from maps
     eta_range = (eta_ome_maps.etaEdges[0], eta_ome_maps.etaEdges[-1])
@@ -116,7 +118,7 @@ def _angles_from_orientation(instr, eta_ome_maps, orientation):
     ome_period = eta_ome_maps.omeEdges[0] + np.r_[0., 2*np.pi]
 
     # need the hklids
-    hklids = [i['hklID'] for i in plane_data.hklDataList]
+    hklids = [i['hklID'] for i in hklDataList_reduced]
 
     expmap = np.atleast_1d(orientation).flatten()
     if len(expmap) == 4:

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -1089,7 +1089,7 @@ class OmeMapsViewerDialog(QObject):
         artists = []
         for i in self.selected_fibers_rows:
             spots = self.spots_for_hand_picked_quaternion(i)
-            if spots is None:
+            if spots is None or spots.size == 0:
                 continue
 
             kwargs = {

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -775,6 +775,7 @@ class OmeMapsViewerDialog(QObject):
 
         self.ui.current_fiber_slider.setRange(
             0, self.num_hand_picked_fibers - 1)
+        self.ui.current_fiber_angle.setSingleStep(self.fiber_step)
 
     def update_config(self):
         # Update all of the config with their settings from the widgets


### PR DESCRIPTION
If the spots are empty, and we try to draw them, we end up with an error.

Skip over them.

This also adds a few other fixes for the hand-picked indexing method.