### PR TITLE
Ensure rotation series omegas are synced properly

### DIFF
--- a/hexrd/ui/overlays/rotation_series_overlay.py
+++ b/hexrd/ui/overlays/rotation_series_overlay.py
@@ -50,6 +50,9 @@ class RotationSeriesOverlay(Overlay):
         self._sync_ome_period = sync_ome_period
         self._sync_ome_ranges = sync_ome_ranges
 
+        # In case we need to sync up the omegas
+        self.sync_omegas()
+
     @property
     def child_attributes_to_save(self):
         # These names must be identical here, as attributes, and as


### PR DESCRIPTION
This fixes a bug where, when a new rotation series overlay is created
after an image series has already been loaded, the omega period and
ranges would not be synced properly.

It was because they need to be synced on overlay initialization.

Fixes: #1204