### PR TITLE
Ensure the _imported_default_materials value is list

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -407,6 +407,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @_imported_default_materials.setter
     def _imported_default_materials(self, v):
+
+        # A list with a single item will come back from QSettings as a str,
+        # so make sure we convert it to a list.
+        if isinstance(v, str):
+            v = [v]
+
         for x in v:
             self.load_default_material(x)
 


### PR DESCRIPTION
A list with a single value will come back from QSettings as a str we need to check for this a convert to a list.