### PR TITLE
Save/load refinement statuses in the state file

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -387,6 +387,35 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # Thus, set the overlays later.
             QTimer.singleShot(0, set_overlays)
 
+    @property
+    def _instrument_status_dict(self):
+        config = self.internal_instrument_config
+
+        def recurse(cur, result):
+            for k, v in cur.items():
+                if 'status' in v:
+                    result[k] = v['status']
+                else:
+                    result[k] = {}
+                    recurse(v, result[k])
+
+        result = {}
+        recurse(config, result)
+        return result
+
+    @_instrument_status_dict.setter
+    def _instrument_status_dict(self, v):
+        config = self.internal_instrument_config
+
+        def recurse(cur, config):
+            for k, v in cur.items():
+                if 'status' in config[k]:
+                    config[k]['status'] = v
+                else:
+                    recurse(v, config[k])
+
+        recurse(v, config)
+
     def save_settings(self):
         settings = QSettings()
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -937,18 +937,24 @@ class MainWindow(QObject):
             self.ui, 'Load State', HexrdConfig().working_dir,
             'HDF5 files (*.h5 *.hdf5)')
 
-        if selected_file:
-            path = Path(selected_file)
-            HexrdConfig().working_dir = str(path.parent)
+        if not selected_file:
+            return
 
-            # The image series will take care of closing the file
-            h5_file = h5py.File(selected_file, "r")
-            try:
-                state.load(h5_file)
-            except Exception:
-                # If an exception occurred, assume we should close the file...
-                h5_file.close()
-                raise
+        path = Path(selected_file)
+        HexrdConfig().working_dir = str(path.parent)
+
+        # The image series will take care of closing the file
+        h5_file = h5py.File(selected_file, "r")
+        try:
+            state.load(h5_file)
+        except Exception:
+            # If an exception occurred, assume we should close the file...
+            h5_file.close()
+            raise
+
+        # Since statuses are added after the instrument config is loaded,
+        # the statuses in the GUI might not be up to date. Ensure it is.
+        self.update_config_gui()
 
     def add_view_dock_widget_actions(self):
         # Add actions to show/hide all of the dock widgets

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -145,9 +145,13 @@ def save(h5_file):
     ]
 
     state = HexrdConfig().state_to_persist()
+
     for entry in skip_list:
         if entry in state:
             del state[entry]
+
+    # Add in the statuses since we skip the instrument config
+    state['__instrument_status_dict'] = HexrdConfig()._instrument_status_dict
 
     # Save the state
     _save_config(h5_file, state)
@@ -190,6 +194,11 @@ def load(h5_file):
 
         # Load the instrument config...
         HexrdConfig().load_instrument_config(h5_file)
+
+        key = '__instrument_status_dict'
+        if key in state:
+            # Load the instrument statuses as well
+            HexrdConfig()._instrument_status_dict = state[key]
 
         # Get any connected parts to load state...
         HexrdConfig().load_state.emit(h5_file)


### PR DESCRIPTION
These were previously not being saved/loaded because we are saving the
instrument config differently from how we do so with QSettings. In state
files, we are using hexrd's HEDMInstrument to write out the instrument
config, but this does not include refinement statuses.

This PR adds a property to HexrdConfig() to create/set a dict of
refinement statuses, and this dict is used to save/load the
refinement statuses from the state file.

Fixes: #1217