### PR TITLE
Store calibration picks in overlays

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -234,7 +234,6 @@ class CalibrationRunner(QObject):
         # Set the new picks on the overlay
         updated_picks = tree_format_to_picks(results)
         overlay.calibration_picks = updated_picks[0]['picks']
-
         self.use_current_pick_points()
 
     def on_view_picks_clicked(self):
@@ -342,6 +341,10 @@ class CalibrationRunner(QObject):
             json.dump(flags, wf, cls=NumpyEncoder)
 
     def finish(self):
+        # Ensure the line picker is disabled and gone
+        self.disable_line_picker()
+        self.line_picker = None
+
         # Ask the user if they want to review the picks
         msg = 'Point picking complete. Review picks?'
         response = QMessageBox.question(self.canvas, 'HEXRD', msg)

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -19,8 +19,8 @@ from hexrd.ui.calibration.pick_based_calibration import (
     run_calibration,
 )
 from hexrd.ui.calibration.picks_tree_view_dialog import (
-    generate_picks_results, PicksTreeViewDialog, picks_cartesian_to_angles,
-    overlays_to_tree_format, tree_format_to_picks,
+    generate_picks_results, overlays_to_tree_format, PicksTreeViewDialog,
+    picks_cartesian_to_angles, tree_format_to_picks,
 )
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.constants import OverlayType, ViewType

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -215,9 +215,6 @@ class CalibrationRunner(QObject):
                                prev_visibilities):
         # Update all of the picks with the modified data
         updated_picks = tree_format_to_picks(dialog.dictionary)
-
-        # Since python dicts are ordered, I think we can assume that the
-        # ordering of the picks should still be the same.
         for i, new_picks in enumerate(updated_picks):
             self.active_overlays[i].calibration_picks = new_picks['picks']
 

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -234,7 +234,10 @@ class CalibrationRunner(QObject):
         # Set the new picks on the overlay
         updated_picks = tree_format_to_picks(results)
         overlay.calibration_picks = updated_picks[0]['picks']
-        self.use_current_pick_points()
+        self.reset_overlay_picks()
+
+        dialog = self.view_picks_table()
+        dialog.ui.finished.connect(self.finish_line)
 
     def on_view_picks_clicked(self):
         # Save the overlay picks so that they will be displayed in the table

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -19,8 +19,8 @@ from hexrd.ui.calibration.pick_based_calibration import (
     run_calibration,
 )
 from hexrd.ui.calibration.picks_tree_view_dialog import (
-    generate_picks_results, PicksTreeViewDialog, overlays_to_tree_format,
-    tree_format_to_picks,
+    generate_picks_results, PicksTreeViewDialog, picks_cartesian_to_angles,
+    overlays_to_tree_format, tree_format_to_picks,
 )
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.constants import OverlayType, ViewType
@@ -228,8 +228,11 @@ class CalibrationRunner(QObject):
             self.pick_this_line()
             return
 
-        ndarrays_to_lists(sorted_picks)
         results = {overlay.name: sorted_picks}
+
+        # Convert to angles, and to lists
+        results = picks_cartesian_to_angles(results)
+        ndarrays_to_lists(results)
 
         # Set the new picks on the overlay
         updated_picks = tree_format_to_picks(results)

--- a/hexrd/ui/calibration/picks_tree_view_dialog.py
+++ b/hexrd/ui/calibration/picks_tree_view_dialog.py
@@ -17,6 +17,7 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.tree_views.picks_tree_view import PicksTreeView
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils.conversions import angles_to_cart, cart_to_angles
+from hexrd.ui.utils.dicts import ensure_all_keys_match, ndarrays_to_lists
 
 
 class PicksTreeViewDialog:
@@ -94,14 +95,7 @@ class PicksTreeViewDialog:
 
         # Our tree view is expecting lists rather than numpy arrays.
         # Go ahead and perform the conversion...
-        def ndarray_to_lists(d):
-            for k, v in d.items():
-                if isinstance(v, dict):
-                    ndarray_to_lists(v)
-                elif isinstance(v, np.ndarray):
-                    d[k] = v.tolist()
-
-        ndarray_to_lists(self.dictionary)
+        ndarrays_to_lists(self.dictionary)
         self.tree_view.model().config = self.dictionary
         self.tree_view.rebuild_tree()
         self.tree_view.expand_rows()
@@ -110,34 +104,15 @@ class PicksTreeViewDialog:
         # This will validate and sort the keys to match that of the
         # internal dict we already have.
         # All of the dict keys must match exactly.
-        def recurse(this, other, ret, path):
-            this_keys = sorted(this.keys())
-            other_keys = sorted(other.keys())
-            if this_keys != other_keys:
-                this_keys_str = ', '.join(f'"{x}"' for x in this_keys)
-                other_keys_str = ', '.join(f'"{x}"' for x in other_keys)
-                msg = (
-                    f'Current keys {this_keys_str} failed to match import '
-                    f'data keys {other_keys_str}'
-                )
-                if path:
-                    path_str = ' -> '.join(path)
-                    msg += f' for path "{path_str}"'
+        try:
+            ret = ensure_all_keys_match(self.dictionary, data)
+        except KeyError as e:
+            msg = e.args[0]
+            msg += f'\nin file "{filename}"\n'
+            msg += '\nPlease be sure the same settings are being used.'
 
-                msg += f' in file "{filename}"'
-                msg += '\n\nPlease be sure the same settings are being used.'
-                QMessageBox.critical(self.ui, 'HEXRD', msg)
-                raise Exception(msg)
-
-            for k, v in this.items():
-                if isinstance(v, dict):
-                    ret[k] = {}
-                    recurse(v, other[k], ret[k], path + [k])
-                else:
-                    ret[k] = other[k]
-
-        ret = {}
-        recurse(self.dictionary, data, ret, [])
+            QMessageBox.critical(self.ui, 'HEXRD', msg)
+            raise KeyError(msg)
 
         # Update the validated data
         data.clear()

--- a/hexrd/ui/calibration/picks_tree_view_dialog.py
+++ b/hexrd/ui/calibration/picks_tree_view_dialog.py
@@ -28,6 +28,9 @@ class PicksTreeViewDialog:
                                        self.ui)
         self.ui.tree_view_layout.addWidget(self.tree_view)
 
+        # Default to a hidden button box
+        self.button_box_visible = False
+
         self.setup_connections()
 
     def setup_connections(self):
@@ -149,6 +152,14 @@ class PicksTreeViewDialog:
     @coords_type.setter
     def coords_type(self, v):
         self.tree_view.coords_type = v
+
+    @property
+    def button_box_visible(self):
+        return self.ui.button_box.isVisible()
+
+    @button_box_visible.setter
+    def button_box_visible(self, b):
+        self.ui.button_box.setVisible(b)
 
 
 def convert_picks(picks, conversion_function, **kwargs):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1225,6 +1225,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         # Set the tth_max to match that of the polar resolution config.
         self.reset_tth_max(name)
+        self.update_material_energy(materials[name])
 
     def add_material(self, name, material):
         self.add_materials([name], [material])

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -420,6 +420,7 @@ class MainWindow(QObject):
         self.update_hedm_enable_states()
         self.color_map_editor.reset_range()
         self.image_mode_widget.reset_masking()
+        self.update_image_mode_enable_states()
 
     def on_action_open_materials_triggered(self):
         selected_file, selected_filter = QFileDialog.getOpenFileName(

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -857,16 +857,12 @@ class MainWindow(QObject):
 
         canvas = self.ui.image_tab_widget.image_canvases[0]
 
-        # Find overlays that contain picks
-        overlays = [o for o in HexrdConfig().overlays if o.has_picks_data]
+        overlays = HexrdConfig().overlays
 
-        if not overlays:
-            msg = 'None of the overlays appear to contain picks data'
-            print(msg)
-            QMessageBox.critical(self.ui, 'HEXRD', msg)
-            return
+        # Pad all of the overlays to make sure their data is updated
+        for overlay in overlays:
+            overlay.pad_picks_data()
 
-        # Doesn't allow you to write back to the overlays (need to add that)
         kwargs = {
             'dictionary': overlays_to_tree_format(overlays),
             'coords_type': ViewType.polar,

--- a/hexrd/ui/overlays/laue_overlay.py
+++ b/hexrd/ui/overlays/laue_overlay.py
@@ -151,9 +151,8 @@ class LaueOverlay(Overlay):
 
     @property
     def has_picks_data(self):
-        nan_pick = (np.nan, np.nan)
         for det_key, hkl_list in self.calibration_picks.items():
-            if any(x != nan_pick for x in hkl_list):
+            if hkl_list and not np.min(np.isnan(hkl_list)):
                 return True
 
         return False

--- a/hexrd/ui/overlays/laue_overlay.py
+++ b/hexrd/ui/overlays/laue_overlay.py
@@ -142,6 +142,22 @@ class LaueOverlay(Overlay):
     def default_refinements(self):
         return default_crystal_refinements()
 
+    def pad_picks_data(self):
+        for k, v in self.data.items():
+            num_hkls = len(self.data[k]['hkls'])
+            current = self.calibration_picks.setdefault(k, [])
+            while len(current) < num_hkls:
+                current.append((np.nan, np.nan))
+
+    @property
+    def has_picks_data(self):
+        nan_pick = (np.nan, np.nan)
+        for det_key, hkl_list in self.calibration_picks.items():
+            if any(x != nan_pick for x in hkl_list):
+                return True
+
+        return False
+
     def generate_overlay(self):
         instr = self.instrument
         display_mode = self.display_mode

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -54,6 +54,15 @@ class Overlay(ABC):
     def default_highlight_style(self):
         pass
 
+    @property
+    @abstractmethod
+    def has_picks_data(self):
+        pass
+
+    @abstractmethod
+    def pad_picks_data(self):
+        pass
+
     # Concrete methods
     def __init__(self, material_name, name=None, refinements=None,
                  calibration_picks=None, style=None, highlight_style=None,
@@ -317,10 +326,6 @@ class Overlay(ABC):
         self.reset_calibration_picks()
         self.calibration_picks.update(picks)
 
-    @property
-    def has_picks_data(self):
-        return any(v for v in self.calibration_picks.values())
-
     def _validate_picks(self, picks):
         for k in picks:
             if k not in self.data:
@@ -334,3 +339,4 @@ class Overlay(ABC):
         # Make an empty list for each detector
         self._calibration_picks.clear()
         self._calibration_picks |= {k: [] for k in self.data}
+        self.pad_picks_data()

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -55,8 +55,9 @@ class Overlay(ABC):
         pass
 
     # Concrete methods
-    def __init__(self, material_name, name=None, refinements=None, style=None,
-                 highlight_style=None, visible=True):
+    def __init__(self, material_name, name=None, refinements=None,
+                 calibration_picks=None, style=None, highlight_style=None,
+                 visible=True):
 
         self._material_name = material_name
 
@@ -66,6 +67,9 @@ class Overlay(ABC):
         if refinements is None:
             refinements = self.default_refinements
 
+        if calibration_picks is None:
+            calibration_picks = {}
+
         if style is None:
             style = self.default_style
 
@@ -74,6 +78,7 @@ class Overlay(ABC):
 
         self.name = name
         self.refinements = refinements
+        self._calibration_picks = calibration_picks
         self.style = style
         self.highlight_style = highlight_style
         self._visible = visible
@@ -107,6 +112,7 @@ class Overlay(ABC):
             'material_name',
             'name',
             'refinements',
+            'calibration_picks',
             'style',
             'highlight_style',
             'visible',
@@ -299,3 +305,28 @@ class Overlay(ABC):
     def on_new_images_loaded(self):
         # Do nothing by default. Subclasses can re-implement.
         pass
+
+    @property
+    def calibration_picks(self):
+        return self._calibration_picks
+
+    @calibration_picks.setter
+    def calibration_picks(self, picks):
+        self._validate_picks(picks)
+
+        self.reset_calibration_picks()
+        self.calibration_picks.update(picks)
+
+    def _validate_picks(self, picks):
+        for k in picks:
+            if k not in self.data:
+                msg = (
+                    f'Keys in picks "{list(picks.keys())}" do not match '
+                    f'keys in data "{list(self.data.keys())}"'
+                )
+                raise Exception(msg)
+
+    def reset_calibration_picks(self):
+        # Make an empty list for each detector
+        self._calibration_picks.clear()
+        self._calibration_picks |= {k: [] for k in self.data}

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -317,6 +317,10 @@ class Overlay(ABC):
         self.reset_calibration_picks()
         self.calibration_picks.update(picks)
 
+    @property
+    def has_picks_data(self):
+        return any(v for v in self.calibration_picks.values())
+
     def _validate_picks(self, picks):
         for k in picks:
             if k not in self.data:

--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -127,6 +127,22 @@ class PowderOverlay(Overlay):
     def default_refinements(self):
         return np.asarray([False] * 6)
 
+    def pad_picks_data(self):
+        for k, v in self.data.items():
+            num_hkls = len(self.data[k]['hkls'])
+            current = self.calibration_picks.setdefault(k, [])
+            while len(current) < num_hkls:
+                current.append([])
+
+    @property
+    def has_picks_data(self):
+        for det_key, hkl_list in self.calibration_picks.items():
+            for hkl_picks in hkl_list:
+                if hkl_picks:
+                    return True
+
+        return False
+
     def generate_overlay(self):
         instr = self.instrument
         plane_data = self.plane_data

--- a/hexrd/ui/overlays/rotation_series_overlay.py
+++ b/hexrd/ui/overlays/rotation_series_overlay.py
@@ -162,6 +162,15 @@ class RotationSeriesOverlay(Overlay):
     def default_refinements(self):
         return default_crystal_refinements()
 
+    def pad_picks_data(self):
+        # Rotation series overlays do not currently support picks data
+        pass
+
+    @property
+    def has_picks_data(self):
+        # Rotation series overlays do not currently support picks data
+        return False
+
     def generate_overlay(self):
         """
         Returns appropriate point groups for displaying bragg reflection

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -111,6 +111,7 @@
     <addaction name="action_show_detector_borders"/>
     <addaction name="action_view_indexing_config"/>
     <addaction name="action_view_fit_grains_config"/>
+    <addaction name="action_view_overlay_picks"/>
    </widget>
    <widget class="QMenu" name="menu_edit">
     <property name="title">
@@ -229,7 +230,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>775</height>
+          <height>753</height>
          </rect>
         </property>
         <attribute name="label">
@@ -242,7 +243,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>775</height>
+          <height>753</height>
          </rect>
         </property>
         <attribute name="label">
@@ -651,6 +652,11 @@
   <action name="action_run_hedm_calibration">
    <property name="text">
     <string>HEDM</string>
+   </property>
+  </action>
+  <action name="action_view_overlay_picks">
+   <property name="text">
+    <string>Overlay Picks</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/picks_tree_view_dialog.ui
+++ b/hexrd/ui/resources/ui/picks_tree_view_dialog.ui
@@ -48,6 +48,13 @@
      </item>
     </layout>
    </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -55,5 +62,38 @@
   <tabstop>import_picks</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>picks_tree_view_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>574</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>273</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>picks_tree_view_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>273</x>
+     <y>574</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>273</x>
+     <y>299</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/hexrd/ui/resources/ui/select_item_dialog.ui
+++ b/hexrd/ui/resources/ui/select_item_dialog.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>select_item_dialog</class>
+ <widget class="QDialog" name="select_item_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>374</width>
+    <height>93</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select Item</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QComboBox" name="options"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>options</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>select_item_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>select_item_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>217</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>217</x>
+     <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/select_item_dialog.py
+++ b/hexrd/ui/select_item_dialog.py
@@ -1,0 +1,77 @@
+from PySide2.QtCore import QObject, Signal
+
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import set_combobox_enabled_items
+
+
+class SelectItemDialog(QObject):
+
+    accepted = Signal(str)
+    rejected = Signal()
+
+    def __init__(self, options, disable_list=None, window_title=None,
+                 parent=None):
+        super().__init__(parent)
+
+        self.ui = UiLoader().load_file('select_item_dialog.ui', parent)
+
+        if disable_list is None:
+            disable_list = []
+
+        self.options = options
+        self.disable_list = disable_list
+
+        if window_title is not None:
+            self.ui.setWindowTitle(window_title)
+
+        self.setup_connections()
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    def setup_connections(self):
+        self.ui.button_box.accepted.connect(self.on_accepted)
+        self.ui.button_box.rejected.connect(self.on_rejected)
+
+    def on_accepted(self):
+        self.accepted.emit(self.selected_option)
+
+    def on_rejected(self):
+        self.rejected.emit()
+
+    @property
+    def selected_option(self):
+        return self.ui.options.currentText()
+
+    @property
+    def options(self):
+        w = self.ui.options
+        return [w.itemText(i) for i in range(w.count())]
+
+    @options.setter
+    def options(self, v):
+        w = self.ui.options
+        w.clear()
+        for item in v:
+            w.addItem(item)
+
+        # Make sure the disable list gets reset
+        self._disable_list = []
+
+    @property
+    def num_options(self):
+        return self.ui.options.count()
+
+    @property
+    def disable_list(self):
+        return self._disable_list
+
+    @disable_list.setter
+    def disable_list(self, v):
+        if self.disable_list == v:
+            return
+
+        self._disable_list = v
+
+        enable_list = [x not in v for x in self.options]
+        set_combobox_enabled_items(self.ui.options, enable_list)

--- a/hexrd/ui/utils/dicts.py
+++ b/hexrd/ui/utils/dicts.py
@@ -1,0 +1,42 @@
+import numpy as np
+
+
+def ensure_all_keys_match(dict1, dict2):
+    # This ensures that all keys in dict1 match the keys in dict2.
+    # If they do not match, a KeyError will be raised.
+    # A dict is returned where the keys in dict2 are sorted to match
+    # those in dict1.
+
+    def recurse(this, other, ret, path):
+        this_keys = sorted(this.keys())
+        other_keys = sorted(other.keys())
+        if this_keys != other_keys:
+            this_keys_str = ', '.join(f'"{x}"' for x in this_keys)
+            other_keys_str = ', '.join(f'"{x}"' for x in other_keys)
+            msg = (
+                f'keys1 {this_keys_str} failed to match keys2 {other_keys_str}'
+            )
+            if path:
+                path_str = ' -> '.join(path)
+                msg += f' for path "{path_str}"'
+            raise KeyError(msg)
+
+        for k, v in this.items():
+            if isinstance(v, dict):
+                ret[k] = {}
+                recurse(v, other[k], ret[k], path + [k])
+            else:
+                ret[k] = other[k]
+
+    ret = {}
+    recurse(dict1, dict2, ret, [])
+    return ret
+
+
+def ndarrays_to_lists(d):
+    # Convert all numpy arrays in a dict into lists
+    for k, v in d.items():
+        if isinstance(v, dict):
+            ndarrays_to_lists(v)
+        elif isinstance(v, np.ndarray):
+            d[k] = v.tolist()


### PR DESCRIPTION
This refactors the calibration runner to store the picks in the overlays. This also adds a few new features that are now possible from the refactor. New features are summarized as follows:

1. Overlay picks are now saved/loaded in state files.
2. The user may view the overlay picks from the main menu via "View"->"Overlay Picks". Here, they may also be edited, exported, and imported.
3. In the "Laue and Powder" calibration, there are now 4 options for picking each overlay: Current (just use what the overlay has currently), Auto, Hand, and Load (load the picks for this overlay from a file).

An example video of some of the functionality can be seen below.

https://user-images.githubusercontent.com/9558430/169612119-53bc0234-a2f8-42bd-8ef6-8a3dd9d7cbf5.mp4

One current limitation is that the overlay picks may only be viewed from the main window while in the polar view.

Fixes: #1107
Fixes: #1142