### PR TITLE
Remove use of Pathlib in state files

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -997,6 +997,10 @@ class MainWindow(QObject):
         path = Path(selected_file)
         HexrdConfig().working_dir = str(path.parent)
 
+        # Some older state files have issues that need to be resolved.
+        # Perform an update, if needed, to fix them, before reading.
+        state.update_if_needed(selected_file)
+
         # The image series will take care of closing the file
         h5_file = h5py.File(selected_file, "r")
         try:

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -7,6 +7,7 @@ import yaml
 from hexrd import imageseries
 
 import hexrd.ui
+from hexrd.ui import state_compatibility
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_load_manager import ImageLoadManager
 
@@ -232,3 +233,7 @@ def load_imageseries_dict(h5_file):
 
     ImageLoadManager().update_status = HexrdConfig().live_update
     ImageLoadManager().finish_processing_ims()
+
+
+def update_if_needed(file_path):
+    return state_compatibility.update_if_needed(file_path)

--- a/hexrd/ui/state.py
+++ b/hexrd/ui/state.py
@@ -1,5 +1,3 @@
-from pathlib import Path
-
 from PySide2.QtCore import QTimer
 
 import h5py
@@ -13,7 +11,7 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_load_manager import ImageLoadManager
 
 CONFIG_PREFIX = "config"
-CONFIG_YAML_PATH = str(Path(CONFIG_PREFIX) / "yaml")
+CONFIG_YAML_PATH = f'{CONFIG_PREFIX}/yaml'
 
 
 class H5StateLoader(yaml.SafeLoader):
@@ -91,10 +89,9 @@ class H5StateDumper(yaml.Dumper):
         if path is None:
             raise ValueError("Unable to determine array path.")
 
-        path = Path(*path)
+        path = '/'.join(path)
         if self.prefix:
-            path = Path(self.prefix) / path
-        path = str(path)
+            path = f'{self.prefix}/{path}'
 
         self.h5_file.create_dataset(path, data.shape, data.dtype, data=data)
 

--- a/hexrd/ui/state_compatibility.py
+++ b/hexrd/ui/state_compatibility.py
@@ -1,5 +1,7 @@
 import h5py
 
+from hexrd.ui.hexrd_config import HexrdConfig
+
 
 def update_if_needed(file_path):
     # Find and fix any issues with the state file
@@ -17,7 +19,8 @@ def fix_issue_1227(file_path):
     if not has_issue_1227(file_path):
         return
 
-    print('State file found to contain issue #1227. Fixing it up...')
+    logger = HexrdConfig().logger
+    logger.warning('State file found to contain issue #1227. Fixing it up...')
 
     from hexrd.ui.state import _load_config, _save_config
 

--- a/hexrd/ui/state_compatibility.py
+++ b/hexrd/ui/state_compatibility.py
@@ -1,0 +1,43 @@
+import h5py
+
+
+def update_if_needed(file_path):
+    # Find and fix any issues with the state file
+    fix_issue_1227(file_path)
+
+
+def has_issue_1227(file_path):
+    # Issue 1227 is where `\` was used on Windows for paths inside the HDF5
+    # file instead of `/`
+    with h5py.File(file_path, 'r') as rf:
+        return any(x.startswith('config\\') for x in rf.keys())
+
+
+def fix_issue_1227(file_path):
+    if not has_issue_1227(file_path):
+        return
+
+    print('State file found to contain issue #1227. Fixing it up...')
+
+    from hexrd.ui.state import _load_config, _save_config
+
+    with h5py.File(file_path, 'a') as f:
+
+        # First, convert the yaml config and load it.
+        # It is currently using paths with '\' internally.
+        key = 'config\\yaml'
+        new_path = '/'.join(key.split('\\'))
+        f[new_path] = f[key]
+        del f[key]
+
+        # Load the config while it is still using '\' paths
+        config = _load_config(f)
+        del f[new_path]
+
+        # Remove any other keys that contain '\\'
+        for key in list(f.keys()):
+            if key.startswith('config\\'):
+                del f[key]
+
+        # Now, save the config back in with updated paths
+        _save_config(f, config)


### PR DESCRIPTION
Pathlib was previously being used to refer to paths within the HDF5 state file. This meant that on Windows, paths would use `\` instead of `/`.

Fix up the state file code so that `/` is always used, and add automatic fixing of old state files that have the Windows issue. We now check for the Windows issue upon reading any state file, and if the issue is found, it is fixed automatically.

An example state file with the issue is attached.

[windows_broken.h5.gz](https://github.com/HEXRD/hexrdgui/files/8778869/windows_broken.h5.gz)

Fixes: #1227