### PR TITLE
Skip missing keys in the config status setter

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -409,6 +409,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         def recurse(cur, config):
             for k, v in cur.items():
+                if k not in config:
+                    continue
+
                 if 'status' in config[k]:
                     config[k]['status'] = v
                 else:


### PR DESCRIPTION
There can sometimes be a mismatch, so just skip missing keys.