### PR TITLE
Always use eta period directly from HexrdConfig()

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1513,7 +1513,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         kwargs = {
             'material_name': material_name,
             'type': type,
-            'eta_period': self.polar_res_eta_period,
         }
         overlay = overlays.create_overlay(**kwargs)
         self.overlays.append(overlay)
@@ -1532,7 +1531,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         kwargs = {
             'material_name': overlay.material_name,
             'type': type,
-            'eta_period': self.polar_res_eta_period,
         }
         new_overlay = overlays.create_overlay(**kwargs)
         new_overlay.instrument = self.overlays[i].instrument
@@ -1600,11 +1598,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def set_polar_res_eta_min(self, v, rerender=True):
         self.config['image']['polar']['eta_min'] = v
 
-        # Update the eta period on all overlays
+        # Update all overlays
         # The eta period is currently only affected by the min value
-        for overlay in self.overlays:
-            overlay.eta_period = self.polar_res_eta_period
-
         self.flag_overlay_updates_for_all_materials()
 
         if not rerender:

--- a/hexrd/ui/overlays/compatibility.py
+++ b/hexrd/ui/overlays/compatibility.py
@@ -21,6 +21,10 @@ def to_dict(overlay):
 def from_dict(cls, d):
     version = d.pop('_version', 1)
 
+    if 'eta_period' in d:
+        # This is now always taken from HexrdConfig() and is not a setting
+        del d['eta_period']
+
     if version != CURRENT_DICT_VERSION:
         # Convert to the current version
         type_str = cls.type.value

--- a/hexrd/ui/overlays/laue_overlay.py
+++ b/hexrd/ui/overlays/laue_overlay.py
@@ -22,8 +22,8 @@ class LaueOverlay(Overlay):
 
     def __init__(self, material_name, crystal_params=None, sample_rmat=None,
                  min_energy=5, max_energy=35, tth_width=None, eta_width=None,
-                 eta_period=None, width_shape=None, label_type=None,
-                 label_offsets=None, **overlay_kwargs):
+                 width_shape=None, label_type=None, label_offsets=None,
+                 **overlay_kwargs):
         super().__init__(material_name, **overlay_kwargs)
 
         if crystal_params is None:
@@ -31,9 +31,6 @@ class LaueOverlay(Overlay):
 
         if sample_rmat is None:
             sample_rmat = constants.identity_3x3.copy()
-
-        if eta_period is None:
-            eta_period = np.r_[-180., 180.]
 
         if width_shape is None:
             width_shape = LaueRangeShape.ellipse
@@ -47,7 +44,6 @@ class LaueOverlay(Overlay):
         self._max_energy = max_energy
         self.tth_width = tth_width
         self.eta_width = eta_width
-        self.eta_period = eta_period
         self.width_shape = width_shape
         self.label_type = label_type
         self.label_offsets = label_offsets
@@ -63,7 +59,6 @@ class LaueOverlay(Overlay):
             'max_energy',
             'tth_width',
             'eta_width',
-            'eta_period',
             'width_shape',
             'label_type',
             'label_offsets',
@@ -121,18 +116,6 @@ class LaueOverlay(Overlay):
     def widths_enabled(self):
         widths = ['tth_width', 'eta_width']
         return all(getattr(self, x) is not None for x in widths)
-
-    @property
-    def eta_period(self):
-        return self._eta_period
-
-    @eta_period.setter
-    def eta_period(self, x):
-        x = np.asarray(x, float).flatten()
-        assert len(x) == 2, "eta period must be a 2-element sequence"
-        if xfcapi.angularDifference(x[0], x[1], units='degrees') > 1e-4:
-            raise RuntimeError("period specification is not 360 degrees")
-        self._eta_period = x
 
     @property
     def refinement_labels(self):

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -180,6 +180,11 @@ class Overlay(ABC):
         return self.material.planeData
 
     @property
+    def eta_period(self):
+        from hexrd.ui.hexrd_config import HexrdConfig
+        return HexrdConfig().polar_res_eta_period
+
+    @property
     def style(self):
         return self._style
 

--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -15,18 +15,14 @@ class PowderOverlay(Overlay):
     hkl_data_key = 'rings'
 
     def __init__(self, material_name, tvec=None, eta_steps=360,
-                 eta_period=None, **overlay_kwargs):
+                 **overlay_kwargs):
         super().__init__(material_name, **overlay_kwargs)
 
         if tvec is None:
             tvec = constants.zeros_3.copy()
 
-        if eta_period is None:
-            eta_period = np.r_[-180., 180.]
-
         self.tvec = tvec
         self.eta_steps = eta_steps
-        self.eta_period = eta_period
 
     @property
     def child_attributes_to_save(self):
@@ -35,7 +31,6 @@ class PowderOverlay(Overlay):
         return [
             'tvec',
             'eta_steps',
-            'eta_period',
         ]
 
     @property
@@ -64,18 +59,6 @@ class PowderOverlay(Overlay):
     @property
     def delta_eta(self):
         return 360 / self.eta_steps
-
-    @property
-    def eta_period(self):
-        return self._eta_period
-
-    @eta_period.setter
-    def eta_period(self, x):
-        x = np.asarray(x, float).flatten()
-        assert len(x) == 2, "eta period must be a 2-element sequence"
-        if xfcapi.angularDifference(x[0], x[1], units='degrees') > 1e-4:
-            raise RuntimeError("period specification is not 360 degrees")
-        self._eta_period = x
 
     @property
     def all_refinements(self):

--- a/hexrd/ui/overlays/rotation_series_overlay.py
+++ b/hexrd/ui/overlays/rotation_series_overlay.py
@@ -17,10 +17,10 @@ class RotationSeriesOverlay(Overlay):
     hkl_data_key = 'data'
 
     def __init__(self, material_name, crystal_params=None, eta_ranges=None,
-                 ome_ranges=None, ome_period=None, eta_period=None,
-                 aggregated=True, ome_width=np.radians(5.0).item(),
-                 tth_width=None, eta_width=None, sync_ome_period=True,
-                 sync_ome_ranges=True, **overlay_kwargs):
+                 ome_ranges=None, ome_period=None, aggregated=True,
+                 ome_width=np.radians(5.0).item(), tth_width=None,
+                 eta_width=None, sync_ome_period=True, sync_ome_ranges=True,
+                 **overlay_kwargs):
         super().__init__(material_name, **overlay_kwargs)
 
         if crystal_params is None:
@@ -35,14 +35,10 @@ class RotationSeriesOverlay(Overlay):
         if ome_period is None:
             ome_period = [-np.pi, np.pi]
 
-        if eta_period is None:
-            eta_period = np.r_[-180., 180.]
-
         self.crystal_params = crystal_params
         self.eta_ranges = eta_ranges
         self.ome_ranges = ome_ranges
         self.ome_period = ome_period
-        self.eta_period = eta_period
         self.aggregated = aggregated
         self.ome_width = ome_width
         self.tth_width = tth_width
@@ -62,7 +58,6 @@ class RotationSeriesOverlay(Overlay):
             'eta_ranges',
             'ome_ranges',
             'ome_period',
-            'eta_period',
             'aggregated',
             'ome_width',
             'tth_width',


### PR DESCRIPTION
This avoids synchronization issues that we have been running into, such as
in #1235. Now, the eta period for the overlays can never be out of sync with
the eta period for the view.

Fixes: #1235