### PR TITLE
Use `shutil.move()` instead of `os.rename()`

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1,5 +1,6 @@
 import os
 from pathlib import Path
+import shutil
 import tempfile
 
 import h5py
@@ -974,7 +975,7 @@ class MainWindow(QObject):
             HexrdConfig().imageseries_dict.clear()
 
             # Move the save file to the selected file
-            os.rename(save_file, selected_file)
+            shutil.move(save_file, selected_file)
 
             # Re-load the imageseries
             # Keep the file open and let the imageseries close it...


### PR DESCRIPTION
`os.rename()` cannot move files across filesystems and will error if
the source and destination are on different filesystems.

`shutil.move()`, however, *can* move files across filesystems.

This is preferred to use in case the user's temporary directory is
on a different filesystem from their state file.