### PR TITLE
Picks viewer: add options to show picks/overlays

### DIFF
--- a/hexrd/ui/calibration/picks_tree_view_dialog.py
+++ b/hexrd/ui/calibration/picks_tree_view_dialog.py
@@ -34,12 +34,21 @@ class PicksTreeViewDialog:
         # Default to a hidden button box
         self.button_box_visible = False
 
+        self.update_gui()
         self.setup_connections()
 
     def setup_connections(self):
         self.ui.finished.connect(self.on_finished)
         self.ui.export_picks.clicked.connect(self.export_picks_clicked)
         self.ui.import_picks.clicked.connect(self.import_picks_clicked)
+        self.ui.show_overlays.toggled.connect(HexrdConfig()._set_show_overlays)
+        self.ui.show_all_picks.toggled.connect(self.show_all_picks_toggled)
+
+        HexrdConfig().overlay_config_changed.connect(self.update_gui)
+
+    def update_gui(self):
+        self.ui.show_overlays.setChecked(HexrdConfig().show_overlays)
+        self.ui.show_all_picks.setChecked(self.tree_view.show_all_picks)
 
     def on_finished(self):
         self.tree_view.clear_artists()
@@ -117,6 +126,9 @@ class PicksTreeViewDialog:
         # Update the validated data
         data.clear()
         data.update(ret)
+
+    def show_all_picks_toggled(self):
+        self.tree_view.show_all_picks = self.ui.show_all_picks.isChecked()
 
     @property
     def dict_with_cart_coords(self):

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -92,6 +92,9 @@ class MaterialsPanel(QObject):
 
         self.ui.materials_tool_button.clicked.connect(self.tool_button_clicked)
 
+        HexrdConfig().overlay_config_changed.connect(
+            self.update_gui_from_config)
+
     def tool_button_clicked(self):
         if not hasattr(self, '_material_list_editor'):
             self._material_list_editor = MaterialListEditor(self.ui)

--- a/hexrd/ui/resources/ui/picks_tree_view_dialog.ui
+++ b/hexrd/ui/resources/ui/picks_tree_view_dialog.ui
@@ -31,18 +31,35 @@
     <layout class="QVBoxLayout" name="tree_view_layout"/>
    </item>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="1" column="2">
+      <widget class="QPushButton" name="import_picks">
+       <property name="text">
+        <string>Import Picks</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
       <widget class="QPushButton" name="export_picks">
        <property name="text">
         <string>Export Picks</string>
        </property>
       </widget>
      </item>
-     <item>
-      <widget class="QPushButton" name="import_picks">
+     <item row="0" column="1">
+      <widget class="QCheckBox" name="show_overlays">
        <property name="text">
-        <string>Import Picks</string>
+        <string>Show overlays?</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QCheckBox" name="show_all_picks">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, all picks will be shown in blue, and selected picks will be highlighted green.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Show all picks?</string>
        </property>
       </widget>
      </item>
@@ -58,6 +75,8 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>show_overlays</tabstop>
+  <tabstop>show_all_picks</tabstop>
   <tabstop>export_picks</tabstop>
   <tabstop>import_picks</tabstop>
  </tabstops>


### PR DESCRIPTION
This adds two checkboxes:

1. "Show overlays?": toggles whether overlays are shown
2. "Show all picks?": toggles whether all picks are shown

If all picks are shown, then the selected picks are highlighted a
different color - currently bright green. We probably want to make
some improvements on these colors/styles soon.

![image](https://user-images.githubusercontent.com/9558430/172706695-fa97c489-8833-4430-80a9-c3581c57dd05.png)