### PR TITLE
Save calibration picks on overlay for fast powder

### DIFF
--- a/hexrd/ui/calibration/auto/__init__.py
+++ b/hexrd/ui/calibration/auto/__init__.py
@@ -1,7 +1,8 @@
 from .powder_calibration_dialog import PowderCalibrationDialog
-from .powder_runner import PowderRunner
+from .powder_runner import PowderRunner, save_picks_to_overlay
 
 __all__ = [
     'PowderCalibrationDialog',
     'PowderRunner',
+    'save_picks_to_overlay',
 ]


### PR DESCRIPTION
When the fast powder calibration method is ran, save the picks on
the overlay so that we may view them or use them later.