### PR TITLE
Use masked images in fast powder calibration

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -58,8 +58,8 @@ class PowderRunner(QObject):
         options = HexrdConfig().config['calibration']['powder']
         self.instr = create_hedm_instrument()
 
-        # Assume there is only one image in each image series for now...
-        img_dict = {k: x[0] for k, x in HexrdConfig().imageseries_dict.items()}
+        # Get an intensity-corrected masked dict of the images
+        img_dict = HexrdConfig().masked_images_dict
 
         statuses = self.refinement_flags_without_overlays
         self.cf = statuses

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -698,6 +698,21 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         """Default to intensity corrected images dict"""
         return self.intensity_corrected_images_dict
 
+    @property
+    def masked_images_dict(self):
+        """Get an images dict where masks have been applied"""
+        images_dict = self.images_dict
+        for name, img in images_dict.items():
+            for mask_name, data in self.masks.items():
+                if mask_name not in self.visible_masks:
+                    continue
+
+                for det, mask in data:
+                    if det == name:
+                        img[~mask] = 0
+
+        return images_dict
+
     def save_imageseries(self, ims, name, write_file, selected_format,
                          **kwargs):
         hexrd.imageseries.save.write(ims, write_file, selected_format,

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -9,7 +9,6 @@ from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 import matplotlib.pyplot as plt
-from matplotlib.colors import LogNorm
 
 import numpy as np
 
@@ -171,8 +170,7 @@ class ImageCanvas(FigureCanvas):
     def unscaled_image_dict(self):
         # Returns a dict of the unscaled images
         if self.mode == ViewType.raw:
-            # Apply masks first
-            return apply_masks_to_raw(HexrdConfig().images_dict)
+            return HexrdConfig().masked_images_dict
         else:
             # Masks are already applied...
             return {'img': self.iviewer.img}
@@ -1020,17 +1018,3 @@ def transform_from_plain_cartesian_func(mode):
         raise Exception(f'Unknown mode: {mode}')
 
     return funcs[mode]
-
-
-def apply_masks_to_raw(images_dict):
-    # Apply needed masks to an image
-    for name, img in images_dict.items():
-        for mask_name, data in HexrdConfig().masks.items():
-            if mask_name not in HexrdConfig().visible_masks:
-                continue
-
-            for det, mask in data:
-                if det == name:
-                    img[~mask] = 0
-
-    return images_dict


### PR DESCRIPTION
This moves the raw image masking logic to HexrdConfig(), and re-uses
it to get masked images in the fast powder calibration.

Fixes: #1240