### PR TITLE
Add ability to save lineout as xy or csv

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -99,6 +99,22 @@ class InstrumentViewer:
         # Re-format the data so that it is in 2 columns
         azimuthal_integration = np.array(azimuthal_integration).T
 
+        # Lineout suffixes and their delimiters
+        lineout_suffixes = {
+            '.csv': ',',
+            '.xy': ' ',
+        }
+        if filename.suffix in lineout_suffixes:
+            # Just save the lineout
+            delimiter = lineout_suffixes[filename.suffix]
+
+            # Delete the file if it already exists
+            if filename.exists():
+                filename.unlink()
+
+            np.savetxt(filename, azimuthal_integration, delimiter=delimiter)
+            return
+
         intensities = self.raw_rescaled_img
         intensities[self.raw_mask] = np.nan
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -465,9 +465,13 @@ class MainWindow(QObject):
             return HexrdConfig().save_materials(selected_file)
 
     def on_action_export_current_plot_triggered(self):
+        filters = 'HDF5 files (*.h5 *.hdf5);; NPZ files (*.npz)'
+        if self.image_mode == ViewType.polar:
+            # We can do CSV and XY as well
+            filters += ';; CSV files (*.csv);; XY files (*.xy)'
+
         selected_file, selected_filter = QFileDialog.getSaveFileName(
-            self.ui, 'Save Current View', HexrdConfig().working_dir,
-            'HDF5 files (*.h5 *.hdf5);; NPZ files (*.npz)')
+            self.ui, 'Save Current View', HexrdConfig().working_dir, filters)
 
         if selected_file:
             HexrdConfig().working_dir = os.path.dirname(selected_file)


### PR DESCRIPTION
If the image mode is "Polar", and the user selects
"File" -> "Export" -> "Current View", and they
name their file with a ".xy" or ".csv" extension, the azimuthal
integral plot is written in XY or CSV format, respectively. This
follows the previous pattern where the user could write out to NPZ
format by specifying a ".npz" extension.

However, there may certainly be some room to make this more visible
or user friendly. I'm open to suggestions. Maybe right-clicking the
azimuthal integral plot in the polar view should bring up a context
menu with the option to export it, and then they choose which file
format (XY or CSV)? They could likewise do this for exporting other
views.

This PR is also a good first step.

Fixes: #1188
Fixes: #1232