### PR TITLE
Add a viewer for the panel buffer

### DIFF
--- a/hexrd/ui/resources/ui/panel_buffer_dialog.ui
+++ b/hexrd/ui/resources/ui/panel_buffer_dialog.ui
@@ -95,17 +95,24 @@
       <attribute name="title">
        <string>Numpy</string>
       </attribute>
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
+      <layout class="QGridLayout" name="gridLayout_3">
+       <item row="0" column="1">
         <widget class="QLineEdit" name="file_name"/>
        </item>
-       <item>
+       <item row="0" column="2">
         <widget class="QPushButton" name="select_file_button">
          <property name="text">
           <string>Select NumPy Array File</string>
          </property>
          <property name="autoDefault">
           <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="2">
+        <widget class="QPushButton" name="show_panel_buffer">
+         <property name="text">
+          <string>Show Panel Buffer</string>
          </property>
         </widget>
        </item>
@@ -201,11 +208,14 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>config_mode</tabstop>
   <tabstop>tab_widget</tabstop>
-  <tabstop>file_name</tabstop>
-  <tabstop>select_file_button</tabstop>
   <tabstop>border_x_spinbox</tabstop>
   <tabstop>border_y_spinbox</tabstop>
+  <tabstop>file_name</tabstop>
+  <tabstop>select_file_button</tabstop>
+  <tabstop>show_panel_buffer</tabstop>
+  <tabstop>clear_panel_buffer</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This adds a button to the "Configure Panel Buffer" widget that allows
the user to view numpy panel buffers via a pop-up imshow.

If there is no numpy file selected, it shows the current panel buffer.
If there is a numpy file selected, it shows the panel buffer for the
numpy file.

The button is disabled if there is no numpy file selected, and the 
current panel buffer is in border mode rather than in numpy mode.

![image](https://user-images.githubusercontent.com/9558430/178580502-7d35e21d-a7c7-48a7-8247-d9abd749256f.png)

Fixes: #1081