### PR TITLE
Add image calculator

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -599,6 +599,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self.imageseries_dict.get(name)
 
     @property
+    def is_unary_imageseries(self):
+        return self.imageseries_length == 1
+
+    @property
+    def imageseries_length(self):
+        if not self.imageseries_dict:
+            return 0
+
+        # Assume all imageseries are the same length
+        return len(next(iter(self.imageseries_dict.values())))
+
+    @property
     def has_dummy_images(self):
         if not self.imageseries_dict:
             return False

--- a/hexrd/ui/image_calculator.py
+++ b/hexrd/ui/image_calculator.py
@@ -1,0 +1,65 @@
+import numpy as np
+
+
+def add(img1, img2):
+    return img1 + img2
+
+
+def subtract(img1, img2):
+    return img1 - img2
+
+
+def multiply(img1, img2):
+    return img1 * img2
+
+
+def divide(img1, img2):
+    return img1 / img2
+
+
+def and_op(img1, img2):
+    return np.logical_and(img1, img2)
+
+
+def or_op(img1, img2):
+    return np.logical_or(img1, img2)
+
+
+def xor(img1, img2):
+    return np.logical_xor(img1, img2)
+
+
+def min(img1, img2):
+    return np.minimum(img1, img2)
+
+
+def max(img1, img2):
+    return np.maximum(img1, img2)
+
+
+def average(img1, img2):
+    return (img1 + img2) / 2
+
+
+def difference(img1, img2):
+    return np.abs(img1 - img2)
+
+
+def copy_op(img1, img2):
+    return np.copy(img2)
+
+
+IMAGE_CALCULATOR_OPERATIONS = {
+    'Add': add,
+    'Subtract': subtract,
+    'Multiply': multiply,
+    'Divide': divide,
+    'AND': and_op,
+    'OR': or_op,
+    'XOR': xor,
+    'Min': min,
+    'Max': max,
+    'Average': average,
+    'Difference': difference,
+    'Copy': copy_op,
+}

--- a/hexrd/ui/image_calculator_dialog.py
+++ b/hexrd/ui/image_calculator_dialog.py
@@ -1,0 +1,215 @@
+from pathlib import Path
+
+from PySide2.QtCore import QCoreApplication, QObject, Signal
+from PySide2.QtWidgets import QFileDialog, QInputDialog, QMessageBox
+
+from hexrd import imageseries
+
+from hexrd.ui.image_calculator import IMAGE_CALCULATOR_OPERATIONS
+from hexrd.ui.image_file_manager import ImageFileManager
+from hexrd.ui.progress_dialog import ProgressDialog
+from hexrd.ui.ui_loader import UiLoader
+
+
+class ImageCalculatorDialog(QObject):
+
+    accepted = Signal()
+    rejected = Signal()
+
+    def __init__(self, images_dict, parent=None):
+        super().__init__(parent)
+        self.ui = UiLoader().load_file('image_calculator_dialog.ui', parent)
+
+        self.images_dict = images_dict
+
+        self.progress_dialog = ProgressDialog(self.ui)
+
+        self.setup_detectors()
+        self.setup_operations()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.select_operand_file.clicked.connect(self.select_operand_file)
+        self.ui.accepted.connect(self.on_accepted)
+        self.ui.rejected.connect(self.on_rejected)
+
+    def show(self):
+        self.ui.show()
+
+    def hide(self):
+        self.ui.hide()
+
+    def on_accepted(self):
+        if not self.validate():
+            self.show()
+            return
+
+        self.accepted.emit()
+
+    def on_rejected(self):
+        self.rejected.emit()
+
+    def validate(self):
+        def error(msg):
+            print(msg)
+            QMessageBox.critical(self.ui, 'Image Calculator', msg)
+            return False
+
+        if not self.operand_file:
+            return error('Please select an operand file')
+
+        if not Path(self.operand_file).exists():
+            msg = f'Operand file:\n\n"{self.operand_file}"\n\n does not exist'
+            return error(msg)
+
+        # Try to load the operand
+        try:
+            self.operand
+        except Exception as e:
+            return error(f'Failed to load operand with message:\n\n{e}')
+
+        # Ensure the operand and the detector image are the same shape
+        if self.detector_image.shape != self.operand.shape:
+            msg = (
+                f'Operand shape "{self.operand.shape}" does not match '
+                f'detector image shape "{self.detector_image.shape}"'
+            )
+            return error(msg)
+
+        return True
+
+    def setup_detectors(self):
+        w = self.ui.detector
+
+        w.clear()
+        w.addItems(list(self.images_dict))
+        w.setEnabled(w.count() > 1)
+
+    def setup_operations(self):
+        w = self.ui.operation
+
+        w.clear()
+        w.addItems(list(IMAGE_CALCULATOR_OPERATIONS))
+
+    def select_operand_file(self):
+        selected_file, _ = QFileDialog.getOpenFileName(
+            self.ui, 'Select Operand File')
+
+        if selected_file:
+            self.operand_file = selected_file
+
+    @property
+    def detector(self):
+        return self.ui.detector.currentText()
+
+    @property
+    def detector_image(self):
+        return self.images_dict[self.detector]
+
+    @property
+    def operation(self):
+        return self.ui.operation.currentText()
+
+    @property
+    def operation_function(self):
+        return IMAGE_CALCULATOR_OPERATIONS[self.operation]
+
+    @property
+    def operand_file(self):
+        return self.ui.operand_file.text()
+
+    @operand_file.setter
+    def operand_file(self, v):
+        self.ui.operand_file.setText(v)
+
+    @property
+    def operand(self):
+        # Return the cached result if possible. Otherwise, generate a new one.
+        prev_operand_file = getattr(self, '_prev_operand_file', None)
+        prev_operand = getattr(self, '_prev_operand', None)
+
+        if self.operand_file == prev_operand_file:
+            # Return the cached result
+            return prev_operand
+
+        operand = self.load_operand_file()
+
+        self._prev_operand = operand
+        self._prev_operand_file = self.operand_file
+
+        return operand
+
+    def load_operand_file(self):
+        options = {
+            'empty-frames': 0,
+            'max-file-frames': 0,
+            'max-total-frames': 0,
+        }
+
+        # Open it in the standard hexrdgui way
+        ims = ImageFileManager().open_file(self.operand_file, options)
+
+        # Check if we need to perform aggregation
+        if len(ims) > 1:
+            ims = self.aggregate_imageseries(ims)
+            if ims is None:
+                msg = 'Aggregation is required for multi-frame images'
+                raise Exception(msg)
+
+        return ims[0]
+
+    def aggregate_imageseries(self, ims):
+        aggregation_methods = {
+            'Maximum': imageseries.stats.max_iter,
+            'Median': imageseries.stats.median_iter,
+            'Average': imageseries.stats.average_iter,
+        }
+
+        msg = (
+            f'Image Series is length {len(ims)}\n\nSelect aggregation '
+            'method'
+        )
+        method, ok = QInputDialog.getItem(self.ui, 'Image Calculator', msg,
+                                          list(aggregation_methods), 0, False)
+        if not ok:
+            return
+
+        agg_func = aggregation_methods[method]
+
+        self.progress_dialog.setWindowTitle('Aggregating Image Series')
+        self.progress_dialog.setRange(0, 100)
+        self.progress_dialog.reset_messages()
+        self.progress_dialog.ui.show()
+
+        num_frames = len(ims)
+        step = int(num_frames / 100)
+        step = step if step > 2 else 2
+        nchunk = int(num_frames / step)
+        if nchunk > num_frames or nchunk < 1:
+            # One last sanity check
+            nchunk = num_frames
+
+        for i, img in enumerate(agg_func(ims, nchunk)):
+            self.progress_dialog.setValue((i + 1) / nchunk * 100)
+            # Make sure the progress dialog gets redrawn
+            QCoreApplication.processEvents()
+
+        self.progress_dialog.ui.hide()
+
+        return [img]
+
+    def calculate(self):
+        # These should already be numpy arrays
+        terms = [
+            self.detector_image,
+            self.operand,
+        ]
+
+        # Run the operation
+        result = self.operation_function(*terms)
+
+        # Convert to original dtype
+        result = result.astype(self.detector_image.dtype)
+
+        # Turn it into an imageseries and return
+        return imageseries.open(None, 'array', data=result)

--- a/hexrd/ui/resources/ui/image_calculator_dialog.ui
+++ b/hexrd/ui/resources/ui/image_calculator_dialog.ui
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>image_calculator_dialog</class>
+ <widget class="QDialog" name="image_calculator_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>429</width>
+    <height>166</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="windowTitle">
+   <string>Image Calculator</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="operation_label">
+     <property name="text">
+      <string>Operation:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLineEdit" name="operand_file"/>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="detector_label">
+     <property name="text">
+      <string>Detector:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="operand_file_label">
+     <property name="text">
+      <string>Operand:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QPushButton" name="select_operand_file">
+     <property name="text">
+      <string>Select</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QComboBox" name="operation"/>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="detector"/>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>detector</tabstop>
+  <tabstop>operation</tabstop>
+  <tabstop>operand_file</tabstop>
+  <tabstop>select_operand_file</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>image_calculator_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>227</x>
+     <y>118</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>137</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>image_calculator_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>268</x>
+     <y>124</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>277</x>
+     <y>137</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -143,6 +143,7 @@
     <addaction name="menu_masks"/>
     <addaction name="action_transform_detectors"/>
     <addaction name="action_edit_refinements"/>
+    <addaction name="action_image_calculator"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -681,6 +682,14 @@
    </property>
    <property name="toolTip">
     <string>Draw a marker where the beam intersects with any detectors</string>
+   </property>
+  </action>
+  <action name="action_image_calculator">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Image Calculator</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Similar to the image calculator in ImageJ, this allows you to perform
arithmetic or logical operations between images.

In hexrdgui, the user first selects a detector to use. Then they select
the operation to perform. Finally, they select the operand (technically,
the second operand) via selecting a file.

When "OK" is clicked, some validation is performed, with some informative
error messages in case any errors occur. Additionally, if the operand is
an image series with more than one frame, a dialog will appear asking the
user to select an aggregation to perform.

Once the operation is complete, the image in the selected detector will
be replaced with the result of the operation.

Note: this feature is only enabled in the GUI if the loaded image series
is either aggregated or only has a length of 1.

A couple of examples are shown below.

https://user-images.githubusercontent.com/9558430/179277230-ec8d45a5-8345-4ba9-90ef-e0b4d2c8431b.mp4

https://user-images.githubusercontent.com/9558430/179277252-4b75c78a-02fc-4a82-9a94-6971afdf320c.mp4

Fixes: #1233