### PR TITLE
Fix non-responding widgets for multiple indexing runs

### DIFF
--- a/hexrd/ui/calibration_crystal_editor.py
+++ b/hexrd/ui/calibration_crystal_editor.py
@@ -2,7 +2,7 @@ import copy
 import numpy as np
 from numpy.linalg import LinAlgError
 
-from PySide2.QtCore import QObject, QSignalBlocker, Signal
+from PySide2.QtCore import QObject, Signal
 from PySide2.QtWidgets import QFileDialog
 
 from hexrd import instrument, matrixutil
@@ -16,7 +16,7 @@ from hexrd.ui.overlays.constants import crystal_refinement_labels
 from hexrd.ui.select_grains_dialog import SelectGrainsDialog
 from hexrd.ui.select_items_widget import SelectItemsWidget
 from hexrd.ui.ui_loader import UiLoader
-from hexrd.ui.utils import convert_angle_convention
+from hexrd.ui.utils import block_signals, convert_angle_convention
 
 
 class CalibrationCrystalEditor(QObject):
@@ -171,8 +171,8 @@ class CalibrationCrystalEditor(QObject):
         dup_ind = self.stretch_matrix_duplicates.get(ind)
         if dup_ind is not None:
             dup = getattr(self.ui, f'stretch_matrix_{dup_ind}')
-            blocker = QSignalBlocker(dup)  # noqa: F841
-            dup.setValue(w.value())
+            with block_signals(dup):
+                dup.setValue(w.value())
 
     def set_matrix_valid(self):
         self.set_matrix_style_sheet('background-color: white')
@@ -215,8 +215,8 @@ class CalibrationCrystalEditor(QObject):
             v = np.degrees(v)
 
         for i, w in enumerate(self.orientation_widgets):
-            blocker = QSignalBlocker(w)  # noqa: F841
-            w.setValue(v[i])
+            with block_signals(w):
+                w.setValue(v[i])
 
     @property
     def position(self):
@@ -225,8 +225,8 @@ class CalibrationCrystalEditor(QObject):
     @position.setter
     def position(self, v):
         for i, w in enumerate(self.position_widgets):
-            blocker = QSignalBlocker(w)  # noqa: F841
-            w.setValue(v[i])
+            with block_signals(w):
+                w.setValue(v[i])
 
     @property
     def inverse_stretch(self):
@@ -245,8 +245,8 @@ class CalibrationCrystalEditor(QObject):
     @stretch_matrix.setter
     def stretch_matrix(self, v):
         for i, w in enumerate(self.stretch_matrix_widgets):
-            blocker = QSignalBlocker(w)  # noqa: F841
-            w.setValue(v[i])
+            with block_signals(w):
+                w.setValue(v[i])
 
     @property
     def orientation_widgets(self):

--- a/hexrd/ui/calibration_crystal_slider_widget.py
+++ b/hexrd/ui/calibration_crystal_slider_widget.py
@@ -1,9 +1,10 @@
 from enum import IntEnum
 
-from PySide2.QtCore import QObject, QSignalBlocker, Signal
+from PySide2.QtCore import QObject, Signal
 from PySide2.QtWidgets import QProxyStyle, QStyle
 
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 class SpinBoxStyle(QProxyStyle):
@@ -90,9 +91,9 @@ class CalibrationCrystalSliderWidget(QObject):
 
         # Update spinbox values
         for i, w in enumerate(self.spinbox_widgets):
-            blocker = QSignalBlocker(w)  # noqa: F841
-            w.setSuffix(suffix)
-            w.setValue(data[i])
+            with block_signals(w):
+                w.setSuffix(suffix)
+                w.setValue(data[i])
 
         # Update slider positions
         self.ui.slider_range.setValue(srange)
@@ -123,10 +124,9 @@ class CalibrationCrystalSliderWidget(QObject):
         slider_value = value * self.CONF_VAL_TO_SLIDER_VAL
         w_name = f'slider_{index}'
         w = getattr(self.ui, w_name)
-        blocker = QSignalBlocker(w)  # noqa: F841
-        w.setValue(slider_value)
-
-        self.changed.emit(mode.value, index, value)
+        with block_signals(w):
+            w.setValue(slider_value)
+            self.changed.emit(mode.value, index, value)
 
     def reset_ranges(self):
         self._orientation_range = self.DEFAULT_SLIDER_RANGE
@@ -156,8 +156,8 @@ class CalibrationCrystalSliderWidget(QObject):
         data = self._orientation if self.mode == WidgetMode.ORIENTATION \
             else self._position
         for i, w in enumerate(self.spinbox_widgets):
-            blocker = QSignalBlocker(w)  # noqa: F841
-            w.setValue(data[i])
+            with block_signals(w):
+                w.setValue(data[i])
         self.update_ranges()
 
     def update_ranges(self):
@@ -169,6 +169,6 @@ class CalibrationCrystalSliderWidget(QObject):
         sliders = self.slider_widgets
         for i, slider in enumerate(sliders):
             val = data[i] * self.CONF_VAL_TO_SLIDER_VAL
-            blocker = QSignalBlocker(slider)  # noqa: F841
-            slider.setRange(val - delta, val + delta)
-            slider.setValue(val)
+            with block_signals(slider):
+                slider.setRange(val - delta, val + delta)
+                slider.setValue(val)

--- a/hexrd/ui/dev-guide.md
+++ b/hexrd/ui/dev-guide.md
@@ -109,6 +109,10 @@ class SomeWidget(QObject):
 For updating the GUI with internal config, the design pattern we typically
 use is as follows:
 ```
+from hexrd.ui.utils import block_signals
+
+...
+
     @property
     def all_widgets(self):
         return [
@@ -118,16 +122,14 @@ use is as follows:
         ]
 
     def update_gui(self):
-        blockers = [QSignalBlocker(x) for x in self.all_widgets]  # noqa: F841
-        self.ui.widget1.setValue(...)
-        ...
+        with block_signals(*self.all_widgets):
+            self.ui.widget1.setValue(...)
+            ...
 ```
 
 We need to block the widget signals when we are updating the values, so that
-they do not modify the config as well. The reason we use a list of
-QSignalBlockers is so that if an exception is raised, they will be unblocked
-automatically. `# noqa: F841` is necessary to tell `flake8` to ignore the
-fact that we don't use `blockers` (it is only being used in an RAII fashion).
+they do not modify the config as well. The reason we use a context manager
+is so that if an exception is raised, they will be unblocked automatically.
 
 Resources
 ---------

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -3,13 +3,14 @@ from functools import partial
 import multiprocessing
 import numpy as np
 
-from PySide2.QtCore import QObject, QSignalBlocker, Signal
+from PySide2.QtCore import QObject, Signal
 
 from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.create_raw_mask import apply_threshold_mask, remove_threshold_mask
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 class ImageModeWidget(QObject):
@@ -133,45 +134,45 @@ class ImageModeWidget(QObject):
         return widgets
 
     def update_gui_from_config(self):
-        blocked = [QSignalBlocker(x) for x in self.all_widgets()]  # noqa: F841
-        self.ui.raw_threshold_comparison.setCurrentIndex(
-            HexrdConfig().threshold_comparison)
-        self.ui.raw_threshold_value.setValue(
-            HexrdConfig().threshold_value)
-        self.ui.raw_threshold_mask.setChecked(
-            HexrdConfig().threshold_mask_status)
-        self.ui.cartesian_pixel_size.setValue(
-            HexrdConfig().cartesian_pixel_size)
-        self.ui.cartesian_virtual_plane_distance.setValue(
-            HexrdConfig().cartesian_virtual_plane_distance)
-        self.ui.cartesian_plane_normal_rotate_x.setValue(
-            HexrdConfig().cartesian_plane_normal_rotate_x)
-        self.ui.cartesian_plane_normal_rotate_y.setValue(
-            HexrdConfig().cartesian_plane_normal_rotate_y)
-        self.ui.polar_pixel_size_tth.setValue(
-            HexrdConfig().polar_pixel_size_tth)
-        self.ui.polar_pixel_size_eta.setValue(
-            HexrdConfig().polar_pixel_size_eta)
-        self.ui.polar_res_tth_min.setValue(
-            HexrdConfig().polar_res_tth_min)
-        self.ui.polar_res_tth_max.setValue(
-            HexrdConfig().polar_res_tth_max)
-        self.ui.polar_res_eta_min.setValue(
-            HexrdConfig().polar_res_eta_min)
-        self.ui.polar_res_eta_max.setValue(
-            HexrdConfig().polar_res_eta_max)
-        self.ui.polar_snip1d_algorithm.setCurrentIndex(
-            HexrdConfig().polar_snip1d_algorithm)
-        self.ui.polar_apply_snip1d.setChecked(
-            HexrdConfig().polar_apply_snip1d)
-        self.ui.polar_snip1d_width.setValue(
-            HexrdConfig().polar_snip1d_width)
-        self.ui.polar_snip1d_numiter.setValue(
-            HexrdConfig().polar_snip1d_numiter)
-        self.ui.polar_apply_erosion.setChecked(
-            HexrdConfig().polar_apply_erosion)
+        with block_signals(*self.all_widgets()):
+            self.ui.raw_threshold_comparison.setCurrentIndex(
+                HexrdConfig().threshold_comparison)
+            self.ui.raw_threshold_value.setValue(
+                HexrdConfig().threshold_value)
+            self.ui.raw_threshold_mask.setChecked(
+                HexrdConfig().threshold_mask_status)
+            self.ui.cartesian_pixel_size.setValue(
+                HexrdConfig().cartesian_pixel_size)
+            self.ui.cartesian_virtual_plane_distance.setValue(
+                HexrdConfig().cartesian_virtual_plane_distance)
+            self.ui.cartesian_plane_normal_rotate_x.setValue(
+                HexrdConfig().cartesian_plane_normal_rotate_x)
+            self.ui.cartesian_plane_normal_rotate_y.setValue(
+                HexrdConfig().cartesian_plane_normal_rotate_y)
+            self.ui.polar_pixel_size_tth.setValue(
+                HexrdConfig().polar_pixel_size_tth)
+            self.ui.polar_pixel_size_eta.setValue(
+                HexrdConfig().polar_pixel_size_eta)
+            self.ui.polar_res_tth_min.setValue(
+                HexrdConfig().polar_res_tth_min)
+            self.ui.polar_res_tth_max.setValue(
+                HexrdConfig().polar_res_tth_max)
+            self.ui.polar_res_eta_min.setValue(
+                HexrdConfig().polar_res_eta_min)
+            self.ui.polar_res_eta_max.setValue(
+                HexrdConfig().polar_res_eta_max)
+            self.ui.polar_snip1d_algorithm.setCurrentIndex(
+                HexrdConfig().polar_snip1d_algorithm)
+            self.ui.polar_apply_snip1d.setChecked(
+                HexrdConfig().polar_apply_snip1d)
+            self.ui.polar_snip1d_width.setValue(
+                HexrdConfig().polar_snip1d_width)
+            self.ui.polar_snip1d_numiter.setValue(
+                HexrdConfig().polar_snip1d_numiter)
+            self.ui.polar_apply_erosion.setChecked(
+                HexrdConfig().polar_apply_erosion)
 
-        self.update_enable_states()
+            self.update_enable_states()
 
     def update_enable_states(self):
         apply_snip1d = self.ui.polar_apply_snip1d.isChecked()
@@ -280,9 +281,9 @@ class ImageModeWidget(QObject):
             max_value = min_value + 360.0
             update_max = True
         if update_max:
-            blocked = QSignalBlocker(self.ui.polar_res_eta_max)  # noqa: F841
-            self.ui.polar_res_eta_max.setValue(max_value)
-            HexrdConfig().set_polar_res_eta_max(max_value, rerender=False)
+            with block_signals(self.ui.polar_res_eta_max):
+                self.ui.polar_res_eta_max.setValue(max_value)
+                HexrdConfig().set_polar_res_eta_max(max_value, rerender=False)
         HexrdConfig().polar_res_eta_min = min_value
 
     def on_eta_max_changed(self, max_value):
@@ -296,9 +297,9 @@ class ImageModeWidget(QObject):
             min_value = max_value - 360.0
             update_min = True
         if update_min:
-            blocked = QSignalBlocker(self.ui.polar_res_eta_min)  # noqa: F841
-            self.ui.polar_res_eta_min.setValue(min_value)
-            HexrdConfig().set_polar_res_eta_min(min_value, rerender=False)
+            with block_signals(self.ui.polar_res_eta_min):
+                self.ui.polar_res_eta_min.setValue(min_value)
+                HexrdConfig().set_polar_res_eta_min(min_value, rerender=False)
         HexrdConfig().polar_res_eta_max = max_value
 
 

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -1,11 +1,12 @@
 from PySide2.QtCore import (
-    QItemSelectionModel, QModelIndex, QObject, QSignalBlocker, Qt, Signal)
+    QItemSelectionModel, QModelIndex, QObject, Qt, Signal)
 from PySide2.QtWidgets import QDialogButtonBox, QFileDialog, QHeaderView
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.indexing.grains_table_model import GrainsTableModel
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 from hexrd.ui.indexing.fit_grains_tolerances_model import (
     FitGrainsToleranceModel)
@@ -221,47 +222,47 @@ class FitGrainsOptionsDialog(QObject):
         indexing_config['_write_spots'] = self.ui.write_out_spots.isChecked()
 
     def update_gui_from_config(self, config):
-        blocked = [QSignalBlocker(x) for x in self.all_widgets()]
-        self.ui.npdiv.setValue(config.get('npdiv'))
-        self.ui.refit_pixel_scale.setValue(config.get('refit')[0])
-        self.ui.refit_ome_step_scale.setValue(config.get('refit')[1])
-        self.ui.threshold.setValue(config.get('threshold'))
+        with block_signals(*self.all_widgets()):
+            self.ui.npdiv.setValue(config.get('npdiv'))
+            self.ui.refit_pixel_scale.setValue(config.get('refit')[0])
+            self.ui.refit_ome_step_scale.setValue(config.get('refit')[1])
+            self.ui.threshold.setValue(config.get('threshold'))
 
-        tth_max = config.get('tth_max')
-        if isinstance(tth_max, bool):
-            enabled = tth_max
-            instrument = tth_max
-            value = 0.0
-        else:
-            enabled = True
-            instrument = False
-            value = tth_max
+            tth_max = config.get('tth_max')
+            if isinstance(tth_max, bool):
+                enabled = tth_max
+                instrument = tth_max
+                value = 0.0
+            else:
+                enabled = True
+                instrument = False
+                value = tth_max
 
-        self.ui.tth_max_enable.setChecked(enabled)
+            self.ui.tth_max_enable.setChecked(enabled)
 
-        self.ui.tth_max_instrument.setEnabled(enabled)
-        self.ui.tth_max_instrument.setChecked(instrument)
+            self.ui.tth_max_instrument.setEnabled(enabled)
+            self.ui.tth_max_instrument.setChecked(instrument)
 
-        self.ui.tth_max_specify.setEnabled(enabled)
-        self.ui.tth_max_specify.setChecked(not instrument)
+            self.ui.tth_max_specify.setEnabled(enabled)
+            self.ui.tth_max_specify.setChecked(not instrument)
 
-        self.ui.tth_max_value.setEnabled(enabled and (not instrument))
-        self.ui.tth_max_value.setValue(value)
+            self.ui.tth_max_value.setEnabled(enabled and (not instrument))
+            self.ui.tth_max_value.setValue(value)
 
-        tolerances = config.get('tolerance')
-        self.tolerances_model.update_from_config(tolerances)
+            tolerances = config.get('tolerance')
+            self.tolerances_model.update_from_config(tolerances)
 
-        indexing_config = HexrdConfig().indexing_config
-        self.selected_material = indexing_config.get('_selected_material')
-        working_dir = indexing_config.get(
-            'working_dir', str(Path(HexrdConfig().working_dir).parent))
-        analysis_name = indexing_config.get(
-            'analysis_name', Path(HexrdConfig().working_dir).stem)
-        self.spots_path = str(Path(working_dir) / analysis_name)
-        write_spots = indexing_config.get('_write_spots', False)
-        self.ui.write_out_spots.setChecked(write_spots)
+            indexing_config = HexrdConfig().indexing_config
+            self.selected_material = indexing_config.get('_selected_material')
+            working_dir = indexing_config.get(
+                'working_dir', str(Path(HexrdConfig().working_dir).parent))
+            analysis_name = indexing_config.get(
+                'analysis_name', Path(HexrdConfig().working_dir).stem)
+            self.spots_path = str(Path(working_dir) / analysis_name)
+            write_spots = indexing_config.get('_write_spots', False)
+            self.ui.write_out_spots.setChecked(write_spots)
 
-        self.update_num_hkls()
+            self.update_num_hkls()
 
     def run(self):
         self.ui.show()

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -12,7 +12,7 @@ import matplotlib.ticker as ticker
 from matplotlib.backends.backend_qt5agg import FigureCanvas
 from matplotlib.figure import Figure
 
-from PySide2.QtCore import QObject, QSignalBlocker, QTimer, Qt, Signal
+from PySide2.QtCore import QObject, QTimer, Qt, Signal
 from PySide2.QtWidgets import QFileDialog, QMenu, QSizePolicy
 
 from hexrd.matrixutil import vecMVToSymm
@@ -23,6 +23,7 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.indexing.grains_table_model import GrainsTableModel
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 COORDS_SLICE = slice(6, 9)
@@ -445,13 +446,11 @@ class FitGrainsResultsDialog(QObject):
 
         prev_ind = self.ui.plot_color_option.currentIndex()
 
-        blocker = QSignalBlocker(self.ui.plot_color_option)  # noqa: F841
-        self.ui.plot_color_option.clear()
+        with block_signals(self.ui.plot_color_option):
+            self.ui.plot_color_option.clear()
 
-        for item in items:
-            self.ui.plot_color_option.addItem(*item)
-
-        del blocker
+            for item in items:
+                self.ui.plot_color_option.addItem(*item)
 
         if hasattr(self, '_first_selector_update'):
             self.ui.plot_color_option.setCurrentIndex(prev_ind)
@@ -525,8 +524,8 @@ class FitGrainsResultsDialog(QObject):
         self.ranges_mpl = self.ranges_gui
 
     def update_ranges_gui(self):
-        blocked = [QSignalBlocker(w) for w in self.range_widgets]  # noqa: F841
-        self.ranges_gui = self.ranges_mpl
+        with block_signals(*self.range_widgets):
+            self.ranges_gui = self.ranges_mpl
 
     def backup_ranges(self):
         self._ranges_backup = self.ranges_mpl

--- a/hexrd/ui/matrix_editor.py
+++ b/hexrd/ui/matrix_editor.py
@@ -1,9 +1,10 @@
 import numpy as np
 
-from PySide2.QtCore import QSignalBlocker, Signal
+from PySide2.QtCore import Signal
 from PySide2.QtWidgets import QGridLayout, QWidget
 
 from hexrd.ui.scientificspinbox import ScientificDoubleSpinBox
+from hexrd.ui.utils import block_signals
 
 DEFAULT_ENABLED_STYLE_SHEET = 'background-color: white'
 DEFAULT_DISABLED_STYLE_SHEET = 'background-color: #F0F0F0'
@@ -94,10 +95,10 @@ class MatrixEditor(QWidget):
 
     @gui_data.setter
     def gui_data(self, v):
-        blockers = [QSignalBlocker(w) for w in self.all_widgets]  # noqa: F841
-        for i in range(self.rows):
-            for j in range(self.cols):
-                self.set_gui_value(i, j, v[i][j])
+        with block_signals(*self.all_widgets):
+            for i in range(self.rows):
+                for j in range(self.cols):
+                    self.set_gui_value(i, j, v[i][j])
 
     @property
     def all_widgets(self):

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -1,4 +1,4 @@
-from PySide2.QtCore import Qt, QItemSelectionModel, QSignalBlocker
+from PySide2.QtCore import Qt, QItemSelectionModel
 from PySide2.QtWidgets import (
     QCheckBox, QComboBox, QHBoxLayout, QHeaderView, QSizePolicy,
     QTableWidgetItem, QWidget
@@ -9,6 +9,7 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlay_editor import OverlayEditor
 from hexrd.ui.overlay_style_picker import OverlayStylePicker
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 COLUMNS = {
@@ -127,42 +128,42 @@ class OverlayManager:
             self.ui.table,
             self.ui.table.selectionModel()
         ]
-        blockers = [QSignalBlocker(x) for x in block_list]  # noqa: F841
 
-        prev_selected = self.selected_row
+        with block_signals(*block_list):
+            prev_selected = self.selected_row
 
-        overlays = HexrdConfig().overlays
-        self.clear_table()
-        self.ui.table.setRowCount(len(overlays))
-        for i, overlay in enumerate(overlays):
-            w = QTableWidgetItem(overlay.name)
-            self.ui.table.setItem(i, COLUMNS['name'], w)
+            overlays = HexrdConfig().overlays
+            self.clear_table()
+            self.ui.table.setRowCount(len(overlays))
+            for i, overlay in enumerate(overlays):
+                w = QTableWidgetItem(overlay.name)
+                self.ui.table.setItem(i, COLUMNS['name'], w)
 
-            w = self.create_materials_combo(overlay.material_name)
-            self.ui.table.setCellWidget(i, COLUMNS['material'], w)
+                w = self.create_materials_combo(overlay.material_name)
+                self.ui.table.setCellWidget(i, COLUMNS['material'], w)
 
-            w = self.create_type_combo(overlay.type)
-            self.ui.table.setCellWidget(i, COLUMNS['type'], w)
+                w = self.create_type_combo(overlay.type)
+                self.ui.table.setCellWidget(i, COLUMNS['type'], w)
 
-            w = self.create_visibility_checkbox(overlay.visible)
-            self.ui.table.setCellWidget(i, COLUMNS['visible'], w)
+                w = self.create_visibility_checkbox(overlay.visible)
+                self.ui.table.setCellWidget(i, COLUMNS['visible'], w)
 
-        if prev_selected is not None:
-            select_row = (prev_selected if prev_selected < len(overlays)
-                          else len(overlays) - 1)
-            self.select_row(select_row)
+            if prev_selected is not None:
+                select_row = (prev_selected if prev_selected < len(overlays)
+                              else len(overlays) - 1)
+                self.select_row(select_row)
 
-        self.ui.table.resizeColumnsToContents()
+            self.ui.table.resizeColumnsToContents()
 
-        # The last section isn't always stretching automatically, even
-        # though we have setStretchLastSection(True) set.
-        # Force it to stretch manually.
-        last_column = max(v for v in COLUMNS.values())
-        self.ui.table.horizontalHeader().setSectionResizeMode(
-            last_column, QHeaderView.Stretch)
+            # The last section isn't always stretching automatically, even
+            # though we have setStretchLastSection(True) set.
+            # Force it to stretch manually.
+            last_column = max(v for v in COLUMNS.values())
+            self.ui.table.horizontalHeader().setSectionResizeMode(
+                last_column, QHeaderView.Stretch)
 
-        # Just in case the selection actually changed...
-        self.selection_changed()
+            # Just in case the selection actually changed...
+            self.selection_changed()
 
     def select_row(self, i):
         if i is None or i >= self.ui.table.rowCount():

--- a/hexrd/ui/overlay_style_picker.py
+++ b/hexrd/ui/overlay_style_picker.py
@@ -2,13 +2,14 @@ import copy
 
 from matplotlib.font_manager import weight_dict
 
-from PySide2.QtCore import QObject, QSignalBlocker
+from PySide2.QtCore import QObject
 from PySide2.QtGui import QColor
 from PySide2.QtWidgets import QColorDialog
 
 from hexrd.ui.constants import OverlayType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 class OverlayStylePicker(QObject):
@@ -122,22 +123,20 @@ class OverlayStylePicker(QObject):
         ranges = self.style['ranges']
         keys = self.keys
 
-        blockers = [QSignalBlocker(x) for x in self.all_widgets]
-        self.ui.data_color.setText(data[keys['data_color']])
-        self.ui.data_style.setCurrentText(data[keys['data_style']])
-        self.ui.data_size.setValue(data[keys['data_size']])
-        self.ui.range_color.setText(ranges[keys['range_color']])
-        self.ui.range_style.setCurrentText(ranges[keys['range_style']])
-        self.ui.range_size.setValue(ranges[keys['range_size']])
+        with block_signals(*self.all_widgets):
+            self.ui.data_color.setText(data[keys['data_color']])
+            self.ui.data_style.setCurrentText(data[keys['data_style']])
+            self.ui.data_size.setValue(data[keys['data_size']])
+            self.ui.range_color.setText(ranges[keys['range_color']])
+            self.ui.range_style.setCurrentText(ranges[keys['range_style']])
+            self.ui.range_size.setValue(ranges[keys['range_size']])
 
-        if self.include_labels:
-            labels = self.style['labels']
-            self.ui.label_color.setText(labels[keys['label_color']])
-            self.ui.label_size.setValue(labels[keys['label_size']])
-            self.ui.label_weight.setCurrentText(labels[keys['label_weight']])
-
-        # Unblock
-        del blockers
+            if self.include_labels:
+                labels = self.style['labels']
+                self.ui.label_color.setText(labels[keys['label_color']])
+                self.ui.label_size.setValue(labels[keys['label_size']])
+                self.ui.label_weight.setCurrentText(
+                    labels[keys['label_weight']])
 
         self.update_button_colors()
 

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -2,13 +2,13 @@ import copy
 
 import numpy as np
 
-from PySide2.QtCore import QSignalBlocker
 from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.select_items_widget import SelectItemsWidget
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
 
 
 class PowderOverlayEditor:
@@ -95,14 +95,13 @@ class PowderOverlayEditor:
         if self.overlay is None:
             return
 
-        blockers = [QSignalBlocker(w) for w in self.widgets]  # noqa: F841
+        with block_signals(*self.widgets):
+            self.tth_width_gui = self.tth_width_config
+            self.offset_gui = self.offset_config
+            self.refinements_with_labels = self.overlay.refinements_with_labels
 
-        self.tth_width_gui = self.tth_width_config
-        self.offset_gui = self.offset_config
-        self.refinements_with_labels = self.overlay.refinements_with_labels
-
-        self.update_enable_states()
-        self.update_reflections_table()
+            self.update_enable_states()
+            self.update_reflections_table()
 
     def update_config(self):
         self.tth_width_config = self.tth_width_gui


### PR DESCRIPTION
The previous design pattern created a list of `QSignalBlocker` objects,
and it relied on Python to perform reference counting and delete this list
at the end of the function, so that the widgets would become unblocked.

For some reason, if you run indexing multiple times, it appears that this
list is sometimes not deleted at the end of the function.

Instead of relying on Python to perform reference counting correctly,
let's use a context manager so that we can be sure the widgets get
unblocked.

This fixes an issue where widgets were not emitting signals in the eta
omega maps viewer when running the HEDM workflow multiple times.

We should also go back and fix any other cases of the design pattern, since
it appears to be error-prone.