### PR TITLE
Re-use IndexingResultsDialog to plot grains

### DIFF
--- a/hexrd/ui/grains_viewer_dialog.py
+++ b/hexrd/ui/grains_viewer_dialog.py
@@ -1,6 +1,7 @@
 from PySide2.QtWidgets import QDialog, QVBoxLayout
 
 from hexrd.ui.indexing.grains_table_model import GrainsTableModel
+from hexrd.ui.plot_grains import plot_grains
 from hexrd.ui.ui_loader import UiLoader
 
 
@@ -14,6 +15,11 @@ class GrainsViewerWidget:
 
         # pull_spots is not allowed with this grains table view
         self.ui.table_view.pull_spots_allowed = False
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.plot_grains.clicked.connect(self.plot_grains)
 
     @property
     def grains_table(self):
@@ -38,6 +44,17 @@ class GrainsViewerWidget:
         }
         view.data_model = GrainsTableModel(**kwargs)
 
+    def plot_grains(self):
+        plot_grains(self.grains_table, None, parent=self.ui)
+
+    @property
+    def plot_grains_visible(self):
+        return self.ui.plot_grains.isVisible()
+
+    @plot_grains_visible.setter
+    def plot_grains_visible(self, b):
+        self.ui.plot_grains.setVisible(b)
+
 
 class GrainsViewerDialog(QDialog):
     def __init__(self, grains_table, parent=None):
@@ -52,3 +69,11 @@ class GrainsViewerDialog(QDialog):
         self.resize(800, 200)
 
         UiLoader().install_dialog_enter_key_filters(self)
+
+    @property
+    def plot_grains_visible(self):
+        return self.widget.plot_grains_visible
+
+    @plot_grains_visible.setter
+    def plot_grains_visible(self, b):
+        self.widget.plot_grains_visible = b

--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -4,6 +4,7 @@ from PySide2.QtWidgets import QDialogButtonBox, QFileDialog, QHeaderView
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.indexing.grains_table_model import GrainsTableModel
+from hexrd.ui.plot_grains import plot_grains
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
@@ -83,6 +84,8 @@ class FitGrainsOptionsDialog(QObject):
             self.tolerance_data_modified)
 
         HexrdConfig().materials_dict_modified.connect(self.update_materials)
+
+        self.ui.plot_grains.clicked.connect(self.plot_grains)
 
     def all_widgets(self):
         """Only includes widgets directly related to config parameters"""
@@ -338,3 +341,6 @@ class FitGrainsOptionsDialog(QObject):
 
         if d:
             self.spots_path = d
+
+    def plot_grains(self):
+        plot_grains(self.grains_table, None, parent=self.ui)

--- a/hexrd/ui/indexing/indexing_results_dialog.py
+++ b/hexrd/ui/indexing/indexing_results_dialog.py
@@ -35,6 +35,7 @@ class IndexingResultsDialog(QObject):
         self.cmap = hexrd.ui.constants.DEFAULT_CMAP
         self.norm = None
         self.transform = lambda x: x
+        self._plot_grains_mode = False
 
         # Cache the sim results so we only have to compute them once
         self.cached_sim_results = {}
@@ -74,6 +75,10 @@ class IndexingResultsDialog(QObject):
     def show_all_grains_toggled(self):
         self.update_enable_states()
         self.update_spots()
+
+    def exec_(self):
+        self.update_plot()
+        self.ui.exec_()
 
     def show(self):
         self.update_plot()
@@ -233,6 +238,7 @@ class IndexingResultsDialog(QObject):
         if not hasattr(self, '_grains_viewer_dialog'):
             self._grains_viewer_dialog = GrainsViewerDialog(self.grains_table,
                                                             self.ui)
+            self._grains_viewer_dialog.plot_grains_visible = False
 
         self._grains_viewer_dialog.show()
 
@@ -349,3 +355,21 @@ class IndexingResultsDialog(QObject):
             return
 
         self.color_map_editor.update_bounds(self.scaled_image_data)
+
+    @property
+    def plot_grains_mode(self):
+        return self._plot_grains_mode
+
+    @plot_grains_mode.setter
+    def plot_grains_mode(self, b):
+        if self.plot_grains_mode == b:
+            return
+
+        title = 'Grains Plot' if b else 'Indexing Results'
+        show_results_text = 'Show grains?' if b else 'Show results?'
+
+        self.ui.button_box.setVisible(not b)
+        self.ui.setWindowTitle(title)
+        self.ui.show_results.setText(show_results_text)
+
+        self._plot_grains_mode = b

--- a/hexrd/ui/plot_grains.py
+++ b/hexrd/ui/plot_grains.py
@@ -1,0 +1,24 @@
+from PySide2.QtWidgets import QFileDialog
+
+from hexrd.xrdutil import EtaOmeMaps
+
+from hexrd.ui.hexrd_config import HexrdConfig
+
+
+def plot_grains(grains_table, ome_maps=None, parent=None):
+    # Avoid a circular import
+    from hexrd.ui.indexing.indexing_results_dialog import IndexingResultsDialog
+
+    if ome_maps is None:
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            parent, 'Load Eta Omega Maps', HexrdConfig().working_dir,
+            'NPZ files (*.npz)')
+
+        if not selected_file:
+            return
+
+        ome_maps = EtaOmeMaps(selected_file)
+
+    dialog = IndexingResultsDialog(ome_maps, grains_table, parent)
+    dialog.plot_grains_mode = True
+    dialog.exec_()

--- a/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
@@ -32,6 +32,13 @@
     </widget>
    </item>
    <item>
+    <widget class="QPushButton" name="plot_grains">
+     <property name="text">
+      <string>Plot Grains</string>
+     </property>
+    </widget>
+   </item>
+   <item>
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="2">
       <widget class="QComboBox" name="material"/>
@@ -357,6 +364,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>grains_table_view</tabstop>
+  <tabstop>plot_grains</tabstop>
   <tabstop>material</tabstop>
   <tabstop>choose_hkls</tabstop>
   <tabstop>npdiv</tabstop>

--- a/hexrd/ui/resources/ui/grains_viewer_widget.ui
+++ b/hexrd/ui/resources/ui/grains_viewer_widget.ui
@@ -21,6 +21,13 @@
      </property>
     </widget>
    </item>
+   <item>
+    <widget class="QPushButton" name="plot_grains">
+     <property name="text">
+      <string>Plot Grains</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -32,6 +39,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>table_view</tabstop>
+  <tabstop>plot_grains</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrd/ui/resources/ui/select_grains_dialog.ui
+++ b/hexrd/ui/resources/ui/select_grains_dialog.ui
@@ -83,6 +83,13 @@
    <item row="0" column="1">
     <widget class="QComboBox" name="method"/>
    </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QPushButton" name="plot_grains">
+     <property name="text">
+      <string>Plot Grains</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -95,9 +102,10 @@
  <tabstops>
   <tabstop>method</tabstop>
   <tabstop>tab_widget</tabstop>
-  <tabstop>table_view</tabstop>
   <tabstop>file_name</tabstop>
   <tabstop>select_file_button</tabstop>
+  <tabstop>table_view</tabstop>
+  <tabstop>plot_grains</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This re-uses the IndexingResultsDialog in several places to allow the
user to plot and visually inspect the grains.

In order to plot the grains, the user must load eta omega maps from
a file.