### PR TITLE
Add ability to delete grains in some dialogs

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -18,6 +18,7 @@ from pathlib import Path
 class FitGrainsOptionsDialog(QObject):
     accepted = Signal()
     rejected = Signal()
+    grains_table_modified = Signal()
 
     def __init__(self, grains_table, parent=None):
         super().__init__(parent)
@@ -44,6 +45,7 @@ class FitGrainsOptionsDialog(QObject):
         view = self.ui.grains_table_view
         view.data_model = self.data_model
         view.material = self.material
+        view.can_modify_grains = True
 
         ok_button = self.ui.button_box.button(QDialogButtonBox.Ok)
         ok_button.setText('Fit Grains')
@@ -86,6 +88,8 @@ class FitGrainsOptionsDialog(QObject):
         HexrdConfig().materials_dict_modified.connect(self.update_materials)
 
         self.ui.plot_grains.clicked.connect(self.plot_grains)
+        self.data_model.grains_table_modified.connect(
+            self.on_grains_table_modified)
 
     def all_widgets(self):
         """Only includes widgets directly related to config parameters"""
@@ -344,3 +348,7 @@ class FitGrainsOptionsDialog(QObject):
 
     def plot_grains(self):
         plot_grains(self.grains_table, None, parent=self.ui)
+
+    def on_grains_table_modified(self):
+        self.grains_table = self.data_model.full_grains_table
+        self.grains_table_modified.emit()

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -70,6 +70,11 @@ class FitGrainsResultsDialog(QObject):
         self.load_cmaps()
         self.reset_glyph_size(update_plot=False)
 
+        self.add_extra_data_columns()
+
+        self.setup_gui()
+
+    def add_extra_data_columns(self):
         # Add columns for equivalent strain and hydrostatic strain
         eqv_strain = np.zeros(self.num_grains)
         hydrostatic_strain = np.zeros(self.num_grains)
@@ -81,8 +86,6 @@ class FitGrainsResultsDialog(QObject):
 
         self.data = np.hstack((self.data, eqv_strain[:, np.newaxis]))
         self.data = np.hstack((self.data, hydrostatic_strain[:, np.newaxis]))
-
-        self.setup_gui()
 
     def setup_gui(self):
         self.update_selectors()
@@ -313,6 +316,9 @@ class FitGrainsResultsDialog(QObject):
         self.ui.convert_strain_to_stress.toggled.connect(
             self.convert_strain_to_stress_toggled)
 
+        self.data_model.grains_table_modified.connect(
+            self.on_grains_table_modified)
+
     def setup_plot(self):
         # Create the figure and axes to use
         canvas = FigureCanvas(Figure(tight_layout=True))
@@ -465,6 +471,7 @@ class FitGrainsResultsDialog(QObject):
         # Update the variables on the table view
         view.data_model = self.data_model
         view.material = self.material
+        view.can_modify_grains = True
 
     def show(self):
         self.ui.show()
@@ -570,6 +577,12 @@ class FitGrainsResultsDialog(QObject):
 
     def draw_idle(self):
         self.canvas.draw_idle()
+
+    def on_grains_table_modified(self):
+        # Update our grains table
+        self.data = self.data_model.full_grains_table
+        self.add_extra_data_columns()
+        self.update_plot()
 
 
 if __name__ == '__main__':

--- a/hexrd/ui/indexing/grains_table_model.py
+++ b/hexrd/ui/indexing/grains_table_model.py
@@ -79,7 +79,17 @@ class GrainsTableModel(QAbstractTableModel):
             any_modified = True
 
         if any_modified:
+            self.renumber_grains()
             self.grains_table_modified.emit()
+
+    def renumber_grains(self):
+        sorted_indices = np.argsort(self.full_grains_table[:, 0])
+        print(f'Renumbering grains from 0 to {len(sorted_indices) - 1}...')
+
+        for i, ind in enumerate(sorted_indices):
+            self.full_grains_table[ind, 0] = i
+
+        self.regenerate_grains_table()
 
     def remove_rows(self, rows):
         for row in rows:

--- a/hexrd/ui/indexing/grains_table_model.py
+++ b/hexrd/ui/indexing/grains_table_model.py
@@ -1,10 +1,12 @@
 import numpy as np
 
-from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt
+from PySide2.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal
 
 
 class GrainsTableModel(QAbstractTableModel):
     """Model for viewing grains"""
+
+    grains_table_modified = Signal()
 
     def __init__(self, grains_table, excluded_columns=None, parent=None):
         super().__init__(parent)
@@ -23,6 +25,9 @@ class GrainsTableModel(QAbstractTableModel):
 
         self.excluded_columns = excluded_columns if excluded_columns else []
 
+        self.regenerate_grains_table()
+
+    def regenerate_grains_table(self):
         self.grains_table = self.full_grains_table[:, self.included_columns]
         self.headers = [self.full_headers[x] for x in self.included_columns]
 
@@ -51,7 +56,36 @@ class GrainsTableModel(QAbstractTableModel):
 
         return len(self.grains_table)
 
+    def removeRows(self, row, count, parent):
+        while count > 0:
+            self.full_grains_table = np.delete(self.full_grains_table, row,
+                                               axis=0)
+            count -= 1
+
+        self.regenerate_grains_table()
+
+        return True
+
     # Custom methods
+
+    def delete_grains(self, grain_ids):
+        any_modified = False
+        for grain_id in grain_ids:
+            to_delete = np.where(self.full_grains_table[:, 0] == grain_id)[0]
+            if to_delete.size == 0:
+                continue
+
+            self.remove_rows(to_delete)
+            any_modified = True
+
+        if any_modified:
+            self.grains_table_modified.emit()
+
+    def remove_rows(self, rows):
+        for row in rows:
+            self.beginRemoveRows(QModelIndex(), row, row)
+            self.removeRow(row)
+            self.endRemoveRows()
 
     @property
     def included_columns(self):

--- a/hexrd/ui/indexing/run.py
+++ b/hexrd/ui/indexing/run.py
@@ -400,6 +400,12 @@ class FitGrainsRunner(Runner):
         dialog = FitGrainsOptionsDialog(self.grains_table, self.parent)
         dialog.accepted.connect(self.fit_grains_options_accepted)
         dialog.rejected.connect(self.clear)
+
+        def on_grains_table_modified():
+            # Update our grains table
+            self.grains_table = dialog.grains_table
+
+        dialog.grains_table_modified.connect(on_grains_table_modified)
         self.fit_grains_options_dialog = dialog
         dialog.show()
 


### PR DESCRIPTION
This adds the ability to delete grains in the fit grains options
dialog (before fit grains is ran), and in the fit grains results
dialog (after fit grains is ran).

The user may delete grains by right-clicking them in the table and
clicking "Delete grain(s)". Note that it is currently set up to not
allow the user to delete all grains.