### PR TITLE
Update new active hkl indexing for eta omega maps

### DIFF
--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -23,9 +23,10 @@ def create_indexing_config():
         raise Exception(f'Selected material {selected_material} not available')
 
     material = HexrdConfig().material(selected_material)
+    pd = material.planeData
 
     omaps = indexing_config['find_orientations']['orientation_maps']
-    omaps['active_hkls'] = list(range(len(material.planeData.getHKLs())))
+    omaps['active_hkls'] = pd.getHKLID(pd.getHKLs().T, master=True)
 
     # Set the active material on the config
     tmp = indexing_config.setdefault('material', {})

--- a/hexrd/ui/indexing/indexing_results_dialog.py
+++ b/hexrd/ui/indexing/indexing_results_dialog.py
@@ -92,9 +92,7 @@ class IndexingResultsDialog(QObject):
 
     @property
     def hkls(self):
-        hkl_indices = self.ome_maps.iHKLList
-        all_hkls = self.plane_data.getHKLs(asStr=True)
-        return [all_hkls[i] for i in hkl_indices]
+        return self.plane_data.getHKLs(*self.ome_maps.iHKLList, asStr=True)
 
     @property
     def show_all_grains(self):

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -416,9 +416,7 @@ class OmeMapsViewerDialog(QObject):
 
     @property
     def hkls(self):
-        hkl_indices = self.data.iHKLList
-        all_hkls = self.data.planeData.getHKLs(asStr=True)
-        return [all_hkls[i] for i in hkl_indices]
+        return self.data.planeData.getHKLs(*self.data.iHKLList, asStr=True)
 
     def update_hkl_options(self):
         # This won't trigger a re-draw. Can change in the future if needed.


### PR DESCRIPTION
We now use master hkl indices for the active hkl indexing in eta omega maps.
Update hexrdgui to reflect that.

Fixes: #1260
Depends on: hexrd/hexrd#454