### PR TITLE
Fix Fast Powder calibration in Cartesian view

### DIFF
--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -332,13 +332,16 @@ class Overlay(ABC):
         self.calibration_picks.update(picks)
 
     def _validate_picks(self, picks):
-        for k in picks:
-            if k not in self.data:
-                msg = (
-                    f'Keys in picks "{list(picks.keys())}" do not match '
-                    f'keys in data "{list(self.data.keys())}"'
-                )
-                raise Exception(msg)
+        if self.display_mode != ViewType.cartesian:
+            # In Cartesian mode, a fake instrument is used, and thus
+            # we cannot validate the picks keys as easily.
+            for k in picks:
+                if k not in self.data:
+                    msg = (
+                        f'Keys in picks "{list(picks.keys())}" do not match '
+                        f'keys in data "{list(self.data.keys())}"'
+                    )
+                    raise Exception(msg)
 
     def reset_calibration_picks(self):
         # Make an empty list for each detector


### PR DESCRIPTION
If you ran the fast powder calibration within the cartesian view,
you would encounter a `KeyError` saying that the detector key is missing
from the dict when `overlay.hkls[det_key]` was called.

This is because the overlay in the cartesian view uses a fake instrument
that does not have the right detector keys.

However, we still need the correct hkls to save the calibration picks
correctly (since the calibration picks assume an order that is consistent
with the correct hkls).

Thus, now, if an overlay was generated using the Cartesian view, a temporary
overlay will be created in the raw view that has the correct hkls, and these
hkls will be used for saving the calibration data.

Fixes: #1261