### PR TITLE
Clear unaggregated images also during images clear

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -757,6 +757,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                                      **kwargs)
 
     def clear_images(self, initial_load=False):
+        self.reset_unagg_imgs()
         self.imageseries_dict.clear()
         if self.load_panel_state is not None and not initial_load:
             self.load_panel_state.clear()


### PR DESCRIPTION
Previously, we were not clearing unaggregated images in
`HexrdConfig().clear_images()`. Clear them as well so that all of the
images data is fully cleared.

This issue resulted in a bug where, if you had an aggregated image series
loaded, and then you loaded a new instrument config, the unaggregated images
would be used and would have extra incorrect detectors in it.

The unaggregated images are only used if an aggregated image series is loaded,
in order to make a backup of the unaggregated images.

See the bug here:

https://user-images.githubusercontent.com/9558430/185171809-99b8eac9-2448-4b7d-a996-70436b1c1240.mp4

And see it fixed with this PR here:

https://user-images.githubusercontent.com/9558430/185171872-fb19adb1-0b9f-40e0-9b42-8aa960a1a63a.mp4