### PR TITLE
Add pinhole distortion options to powder overlay editor

### DIFF
--- a/hexrd/ui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrd/ui/calibration/auto/powder_calibration_dialog.py
@@ -49,6 +49,9 @@ class PowderCalibrationDialog:
         self.ui.conv_tol.setValue(options['conv_tol'])
         self.ui.robust.setChecked(options['use_robust_optimization'])
 
+        self.auto_guess_initial_fwhm = options['auto_guess_initial_fwhm']
+        self.initial_fwhm = options['initial_fwhm']
+
         self.peak_fit_type = options['pk_type']
         self.background_type = options['bg_type']
 
@@ -62,6 +65,9 @@ class PowderCalibrationDialog:
         options['conv_tol'] = self.ui.conv_tol.value()
         options['use_robust_optimization'] = self.ui.robust.isChecked()
 
+        options['auto_guess_initial_fwhm'] = self.auto_guess_initial_fwhm
+        options['initial_fwhm'] = self.initial_fwhm
+
         options['pk_type'] = self.peak_fit_type
         options['bg_type'] = self.background_type
 
@@ -71,6 +77,22 @@ class PowderCalibrationDialog:
 
         self.update_config()
         return True
+
+    @property
+    def auto_guess_initial_fwhm(self):
+        return self.ui.auto_guess_initial_fwhm.isChecked()
+
+    @auto_guess_initial_fwhm.setter
+    def auto_guess_initial_fwhm(self, b):
+        self.ui.auto_guess_initial_fwhm.setChecked(b)
+
+    @property
+    def initial_fwhm(self):
+        return self.ui.initial_fwhm.value()
+
+    @initial_fwhm.setter
+    def initial_fwhm(self, v):
+        self.ui.initial_fwhm.setValue(v)
 
     @property
     def tth_tol(self):

--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -61,6 +61,11 @@ class PowderRunner(QObject):
         options = HexrdConfig().config['calibration']['powder']
         self.instr = create_hedm_instrument()
 
+        if options['auto_guess_initial_fwhm']:
+            fwhm_estimate = None
+        else:
+            fwhm_estimate = options['initial_fwhm']
+
         # Get an intensity-corrected masked dict of the images
         img_dict = HexrdConfig().masked_images_dict
 
@@ -74,6 +79,7 @@ class PowderRunner(QObject):
             'img_dict': img_dict,
             'flags': self.refinement_flags,
             'eta_tol': options['eta_tol'],
+            'fwhm_estimate': fwhm_estimate,
             'pktype': options['pk_type'],
             'bgtype': options['bg_type'],
             'tth_distortion': self.active_overlay.tth_distortion_dict,

--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -76,6 +76,7 @@ class PowderRunner(QObject):
             'eta_tol': options['eta_tol'],
             'pktype': options['pk_type'],
             'bgtype': options['bg_type'],
+            'tth_distortion': self.active_overlay.tth_distortion_dict,
         }
 
         self.pc = PowderCalibrator(**kwargs)

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -698,7 +698,8 @@ class CalibrationRunner(QObject):
         return funcs[overlay.type]()
 
     def auto_pick_powder_points(self):
-        material = self.active_overlay.material
+        overlay = self.active_overlay
+        material = overlay.material
         dialog = PowderCalibrationDialog(material, self.canvas)
         dialog.show_optimization_parameters(False)
         if not dialog.exec_():
@@ -715,7 +716,7 @@ class CalibrationRunner(QObject):
         statuses = HexrdConfig().get_statuses_instrument_format()
         self.instr.calibration_flags = statuses
 
-        all_flags = np.hstack([statuses, self.active_overlay.refinements])
+        all_flags = np.hstack([statuses, overlay.refinements])
         kwargs = {
             'instr': self.instr,
             'plane_data': material.planeData,
@@ -724,6 +725,7 @@ class CalibrationRunner(QObject):
             'eta_tol': options['eta_tol'],
             'pktype': options['pk_type'],
             'bgtype': options['bg_type'],
+            'tth_distortion': overlay.tth_distortion_dict,
         }
 
         self.auto_pc = PowderCalibrator(**kwargs)

--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -103,6 +103,7 @@ class InstrumentViewer:
         self.dpanel = self.dplane.display_panel(self.dpanel_sizes,
                                                 self.pixel_size,
                                                 self.instr.beam_vector)
+        self.dpanel.name = 'dpanel'
 
     @property
     def extent(self):

--- a/hexrd/ui/calibration/pick_based_calibration.py
+++ b/hexrd/ui/calibration/pick_based_calibration.py
@@ -498,9 +498,16 @@ class CompositeCalibration(object):
                     [self.instr.calibration_flags, lpflags]
                 )
                 param_flags.append(lpflags)
-                calib = PowderCalibrator(
-                    self.instr, pick_data['plane_data'], img_dict, flags
-                )
+
+                kwargs = {
+                    'instr': self.instr,
+                    'plane_data': pick_data['plane_data'],
+                    'img_dict': img_dict,
+                    'flags': flags,
+                    'tth_distortion': pick_data['tth_distortion'],
+                }
+                calib = PowderCalibrator(**kwargs)
+
                 params.append(calib.full_params[-calib.npe:])
                 calibrator_list.append(calib)
 

--- a/hexrd/ui/calibration/picks_tree_view_dialog.py
+++ b/hexrd/ui/calibration/picks_tree_view_dialog.py
@@ -186,10 +186,12 @@ def generate_picks_results(overlays):
     for overlay in overlays:
         # Convert hkls to numpy arrays
         hkls = {k: np.asarray(v) for k, v in overlay.hkls.items()}
+        extras = {}
         if overlay.is_powder:
             options = {
                 'tvec': overlay.tvec,
             }
+            extras['tth_distortion'] = overlay.tth_distortion_dict
         elif overlay.is_laue:
             options = {
                 'crystal_params': overlay.crystal_params,
@@ -204,6 +206,7 @@ def generate_picks_results(overlays):
             'refinements': overlay.refinements_with_labels,
             'hkls': hkls,
             'picks': overlay.calibration_picks,
+            **extras,
         })
 
     return pick_results

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1885,15 +1885,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @polar_tth_distortion_overlay.setter
     def polar_tth_distortion_overlay(self, overlay):
         if isinstance(overlay, overlays.Overlay):
-            self._polar_tth_distortion_overlay_name = overlay.name
+            name = overlay.name
         else:
-            # Assume it is the name
-            self._polar_tth_distortion_overlay_name = overlay
+            # Assume it is the name or None
+            name = overlay
 
-        self.flag_overlay_updates_for_all_materials()
-        self.deep_rerender_needed.emit()
-        # self.rerender_needed.emit()
-        self.overlay_config_changed.emit()
+        if self._polar_tth_distortion_overlay_name != name:
+            self._polar_tth_distortion_overlay_name = name
+            self.flag_overlay_updates_for_all_materials()
+            self.overlay_config_changed.emit()
+            self.rerender_needed.emit()
 
     def on_overlay_renamed(self, old_name, new_name):
         if self._polar_tth_distortion_overlay_name == old_name:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -471,6 +471,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                     # Skip over ones that do not have a matching material
                     continue
 
+            self.update_material_energy(self.materials[material_name])
             self.overlays.append(overlays.from_dict(overlay_dict))
 
     def emit_update_status_bar(self, msg):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1893,7 +1893,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         if self._polar_tth_distortion_overlay_name != name:
             self._polar_tth_distortion_overlay_name = name
             self.flag_overlay_updates_for_all_materials()
-            self.overlay_config_changed.emit()
             self.rerender_needed.emit()
 
     def on_overlay_renamed(self, old_name, new_name):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1876,11 +1876,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @property
     def polar_tth_distortion_overlay(self):
-        try:
-            return overlays.Overlay.from_name(
-                self._polar_tth_distortion_overlay_name)
-        except Exception:
+        name = self._polar_tth_distortion_overlay_name
+        if name is None:
             return None
+
+        for overlay in self.overlays:
+            if overlay.name == name:
+                return overlay
+
+        # This overlay must not exist
+        return None
 
     @polar_tth_distortion_overlay.setter
     def polar_tth_distortion_overlay(self, overlay):

--- a/hexrd/ui/hidden_bar_tab_widget.py
+++ b/hexrd/ui/hidden_bar_tab_widget.py
@@ -1,0 +1,26 @@
+from PySide2.QtCore import QTimer
+from PySide2.QtWidgets import QTabWidget
+
+
+class HiddenBarTabWidget(QTabWidget):
+    """This tab widget has a hidden tab bar
+
+    It also resizes to match the size of the current tab.
+    """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.set_current_index_later(0)
+        self.tabBar().hide()
+
+    def set_current_index_later(self, index):
+        QTimer.singleShot(0, lambda: self.setCurrentIndex(index))
+
+    def sizeHint(self):
+        size = self.currentWidget().sizeHint()
+        size.setHeight(size.height() + 10)
+        return size
+
+    def minimumSizeHint(self):
+        size = self.currentWidget().minimumSizeHint()
+        size.setHeight(size.height() + 10)
+        return size

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -78,6 +78,7 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().oscillation_stage_changed.connect(
             self.oscillation_stage_changed)
         HexrdConfig().polar_masks_changed.connect(self.polar_masks_changed)
+        HexrdConfig().overlay_renamed.connect(self.overlay_renamed)
 
     def __del__(self):
         # This is so that the figure can be cleaned up
@@ -203,10 +204,25 @@ class ImageCanvas(FigureCanvas):
             self.remove_overlay_artists(key)
 
     def remove_overlay_artists(self, key):
+        if key not in self.overlay_artists:
+            return
+
         artists = self.overlay_artists[key]
         while artists:
             artists.pop(0).remove()
         del self.overlay_artists[key]
+
+    def prune_overlay_artists(self):
+        # Remove overlay artists that no longer have an overlay associated with them
+        overlay_names = [x.name for x in HexrdConfig().overlays]
+        for key in list(self.overlay_artists):
+            if key not in overlay_names:
+                self.remove_overlay_artists(key)
+
+    def overlay_renamed(self, old_name, new_name):
+        if old_name in self.overlay_artists:
+            self.overlay_artists[new_name] = self.overlay_artists[old_name]
+            self.overlay_artists.pop(old_name)
 
     def overlay_axes_data(self, overlay):
         # Return the axes and data for drawing the overlay
@@ -254,6 +270,10 @@ class ImageCanvas(FigureCanvas):
         if not overlay.visible:
             return
 
+        if overlay.name in self.overlay_artists:
+            # It's already present. Skip it.
+            return
+
         # Keep track of any overlays we need to highlight
         self.overlay_highlight_ids += self.get_overlay_highlight_ids(overlay)
 
@@ -261,13 +281,17 @@ class ImageCanvas(FigureCanvas):
         style = overlay.style
         highlight_style = overlay.highlight_style
         for axis, data in self.overlay_axes_data(overlay):
-            if id(data) in self.overlay_artists:
-                # It's already present. Skip it.
-                continue
+            kwargs = {
+                'artist_key': overlay.name,
+                'axis': axis,
+                'data': data,
+                'style': style,
+                'highlight_style': highlight_style,
+            }
+            self.overlay_draw_func(type)(**kwargs)
 
-            self.overlay_draw_func(type)(axis, data, style, highlight_style)
-
-    def draw_powder_overlay(self, axis, data, style, highlight_style):
+    def draw_powder_overlay(self, artist_key, axis, data, style,
+                            highlight_style):
         rings = data['rings']
         rbnds = data['rbnds']
         rbnd_indices = data['rbnd_indices']
@@ -278,8 +302,7 @@ class ImageCanvas(FigureCanvas):
         highlight_indices = [i for i, x in enumerate(rings)
                              if id(x) in self.overlay_highlight_ids]
 
-        artists = []
-        self.overlay_artists[id(data)] = artists
+        artists = self.overlay_artists.setdefault(artist_key, [])
         for i, pr in enumerate(rings):
             current_style = data_style
             if i in highlight_indices:
@@ -326,7 +349,8 @@ class ImageCanvas(FigureCanvas):
                 artist = az_axis.axvline(x, **current_style)
                 artists.append(artist)
 
-    def draw_laue_overlay(self, axis, data, style, highlight_style):
+    def draw_laue_overlay(self, artist_key, axis, data, style,
+                          highlight_style):
         spots = data['spots']
         ranges = data['ranges']
         labels = data['labels']
@@ -339,8 +363,7 @@ class ImageCanvas(FigureCanvas):
         highlight_indices = [i for i, x in enumerate(spots)
                              if id(x) in self.overlay_highlight_ids]
 
-        artists = []
-        self.overlay_artists[id(data)] = artists
+        artists = self.overlay_artists.setdefault(artist_key, [])
         for i, (x, y) in enumerate(spots):
             current_style = data_style
             if i in highlight_indices:
@@ -373,7 +396,8 @@ class ImageCanvas(FigureCanvas):
             artist, = axis.plot(x, y, **current_style)
             artists.append(artist)
 
-    def draw_rotation_series_overlay(self, axis, data, style, highlight_style):
+    def draw_rotation_series_overlay(self, artist_key, axis, data, style,
+                                     highlight_style):
         is_aggregated = HexrdConfig().is_aggregated
         ome_range = HexrdConfig().omega_ranges
         aggregated = data['aggregated'] or is_aggregated or ome_range is None
@@ -395,8 +419,7 @@ class ImageCanvas(FigureCanvas):
         data_style = style['data']
         ranges_style = style['ranges']
 
-        artists = []
-        self.overlay_artists[id(data)] = artists
+        artists = self.overlay_artists.setdefault(artist_key, [])
         for i in indices_in_range:
             # data
             x, y = data_points[i]
@@ -411,14 +434,9 @@ class ImageCanvas(FigureCanvas):
             artist, = axis.plot(x, y, **ranges_style)
             artists.append(artist)
 
-    def remove_artists_for_overlay(self, overlay):
-        for data_id in list(self.overlay_artists):
-            if any(data_id == id(x) for x in overlay.data.values()):
-                self.remove_overlay_artists(data_id)
-
     def redraw_overlay(self, overlay):
         # Remove the artists for this overlay
-        self.remove_artists_for_overlay(overlay)
+        self.remove_overlay_artists(overlay.name)
 
         # Redraw the overlay
         self.draw_overlay(overlay)
@@ -432,31 +450,20 @@ class ImageCanvas(FigureCanvas):
         if not self.iviewer:
             return
 
+        self.remove_all_overlay_artists()
         if not HexrdConfig().show_overlays:
             self.remove_all_overlay_artists()
             self.draw_idle()
             return
 
-        def overlay_with_data_id(data_id):
-            for overlay in HexrdConfig().overlays:
-                if overlay.update_needed or not overlay.visible:
-                    # Don't return modified or hidden overlays
-                    continue
-
-                if any([data_id == id(x) for x in overlay.data.values()]):
-                    return overlay
-
-            return None
-
         # Remove any artists that:
         # 1. Are no longer in the list of overlays
         # 2. Are not visible
         # 3. Need updating
-        for key in list(self.overlay_artists.keys()):
-            overlay = overlay_with_data_id(key)
-            if overlay is None:
-                self.remove_overlay_artists(key)
-                continue
+        self.prune_overlay_artists()
+        for overlay in HexrdConfig().overlays:
+            if overlay.update_needed or not overlay.visible:
+                self.remove_overlay_artists(overlay.name)
 
         self.iviewer.update_overlay_data()
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -330,6 +330,10 @@ class ImageCanvas(FigureCanvas):
             az_axis = self.azimuthal_integral_axis
             for pr in rings:
                 x, _ = self.extract_ring_coords(pr)
+                if len(x) == 0:
+                    # Skip over rings that are out of bounds
+                    continue
+
                 # Average the points together for the vertical line
                 x = np.nanmean(x)
                 artist = az_axis.axvline(x, **data_style)
@@ -338,6 +342,10 @@ class ImageCanvas(FigureCanvas):
             # Add the rbnds too
             for ind, pr in zip(rbnd_indices, rbnds):
                 x, _ = self.extract_ring_coords(pr)
+                if len(x) == 0:
+                    # Skip over rbnds that are out of bounds
+                    continue
+
                 # Average the points together for the vertical line
                 x = np.nanmean(x)
 

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -102,14 +102,7 @@ class ImageModeWidget(QObject):
             self.update_polar_tth_distortion_overlay_options)
         HexrdConfig().overlay_renamed.connect(
             self.update_polar_tth_distortion_overlay_options)
-
-        # FIXME: it would be nice if we did not have to update our
-        # combo box for every kind of change to the overlays.
-        # For instance, this updates the combo box if the beam energy
-        # changes. What we probably need is a couple of signals that
-        # indicate when overlays were removed/added or changed type, and
-        # that would probably work here instead of every possible change.
-        HexrdConfig().overlay_config_changed.connect(
+        HexrdConfig().overlay_list_modified.connect(
             self.update_polar_tth_distortion_overlay_options)
 
         self.ui.polar_apply_tth_distortion.toggled.connect(

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -337,9 +337,10 @@ class ImageModeWidget(QObject):
                 # distortion. This is so that we can toggle on/off and
                 # keep the same one selected.
                 w.setCurrentText(prev_text)
-                if self.polar_apply_tth_distortion:
-                    # Make sure this change gets saved to the config
-                    self.polar_tth_distortion_overlay_changed()
+
+            if self.polar_apply_tth_distortion:
+                # Make sure any changes get saved to the config
+                self.polar_tth_distortion_overlay_changed()
 
         enable = w.count() != 0
         self.ui.polar_apply_tth_distortion.setEnabled(enable)

--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -132,9 +132,11 @@ class LinePickerDialog(QObject):
         self.canvas.draw_idle()
 
     def zoom_width_changed(self):
-        self.zoom_canvas.tth_tol = self.ui.zoom_tth_width.value()
-        self.zoom_canvas.eta_tol = self.ui.zoom_eta_width.value()
-        self.zoom_canvas.render()
+        canvas = self.zoom_canvas
+        canvas.tth_tol = self.ui.zoom_tth_width.value()
+        canvas.eta_tol = self.ui.zoom_eta_width.value()
+        if all(x is not None for x in (canvas.xdata, canvas.ydata)):
+            canvas.render()
 
     def zoom_point_picked(self, event):
         self.zoom_frozen = False

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -232,8 +232,12 @@ class OverlayManager:
 
     @property
     def active_overlay(self):
+        overlays = HexrdConfig().overlays
         i = self.selected_row
-        return HexrdConfig().overlays[i] if i is not None else None
+        if i is None or i >= len(overlays):
+            return None
+
+        return overlays[i]
 
     def update_refinement_options(self):
         self.overlay_editor.update_refinement_options()
@@ -260,6 +264,7 @@ class OverlayManager:
                 return
 
         modified_overlay.name = new_name
+        HexrdConfig().overlay_renamed.emit(old_name, new_name)
 
     def add(self):
         HexrdConfig().append_overlay(self.active_material_name,

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -274,6 +274,7 @@ class OverlayManager:
 
     def remove(self):
         HexrdConfig().overlays.pop(self.selected_row)
+        HexrdConfig().overlay_list_modified.emit()
         HexrdConfig().overlay_config_changed.emit()
         self.update_table()
 

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -196,17 +196,23 @@ class OverlayManager:
         self.overlay_editor.overlay = self.active_overlay
 
     def update_config_materials(self):
+        any_changed = False
         for i in range(self.ui.table.rowCount()):
             w = self.material_combos[i]
             overlay = HexrdConfig().overlays[i]
             if overlay.material_name != w.currentData():
                 overlay.material_name = w.currentData()
+                any_changed = True
 
-                # In case the active widget depends on material settings
-                self.overlay_editor.update_active_widget_gui()
+        if any_changed:
+            # In case the material was renamed
+            self.update_table()
 
-        HexrdConfig().update_visible_material_energies()
-        HexrdConfig().overlay_config_changed.emit()
+            # In case the active widget depends on material settings
+            self.overlay_editor.update_active_widget_gui()
+
+            HexrdConfig().update_visible_material_energies()
+            HexrdConfig().overlay_config_changed.emit()
 
     def update_config_types(self):
         for i in range(self.ui.table.rowCount()):

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -167,8 +167,14 @@ class Overlay(ABC):
         if self.material_name == v:
             return
 
+        need_rename = self.name.startswith(self._non_unique_name)
+
         self._material_name = v
         self.update_needed = True
+
+        if need_rename:
+            # Update the name to reflect the new material
+            self.name = self._generate_unique_name()
 
     @property
     def material(self):

--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -311,9 +311,15 @@ class PowderOverlay(Overlay):
                 eidx = np.argsort(ang_crds[:, 0])
                 ang_crds = ang_crds[eidx, :]
 
+                diff = np.diff(ang_crds[:, 0])
+                if len(diff) == 0:
+                    skipped_tth.append(i)
+                    continue
+
                 # branch cut
                 # FIXME: still is not quite right
-                delta_eta_est = np.median(np.diff(ang_crds[:, 0]))
+                delta_eta_est = np.median(diff)
+
                 cut_on_panel = bool(
                     xfcapi.angularDifference(
                         np.min(ang_crds[:, 0]),

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -375,6 +375,17 @@ class PowderOverlayEditor:
                 )
                 QMessageBox.critical(self.ui, 'HEXRD', msg)
 
+            beam = HexrdConfig().instrument_config['beam']
+            source_distance = beam.get('source_distance', np.inf)
+            if source_distance is None or source_distance == np.inf:
+                    msg = (
+                        'WARNING: the source distance is infinite.\n\nThe '
+                        'Pinhole Camera Correction will have no effect '
+                        'unless the source distance is finite.\n\nThe source '
+                        'distance may be edited in the Instrument "Form View"'
+                    )
+                    QMessageBox.critical(self.ui, 'HEXRD', msg)
+
     def validate_pinhole_correction_type(self):
         if self.pinhole_correction_type == 'Pinhole':
             # Warn the user that we have not yet implemented this method

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -2,7 +2,7 @@ import copy
 
 import numpy as np
 
-from PySide2.QtWidgets import QCheckBox, QDoubleSpinBox, QMessageBox
+from PySide2.QtWidgets import QCheckBox, QComboBox, QDoubleSpinBox, QMessageBox
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.reflections_table import ReflectionsTable
@@ -31,6 +31,8 @@ class PowderOverlayEditor:
                 w.valueChanged.connect(self.update_config)
             elif isinstance(w, QCheckBox):
                 w.toggled.connect(self.update_config)
+            elif isinstance(w, QComboBox):
+                w.currentIndexChanged.connect(self.update_config)
 
         self.ui.enable_width.toggled.connect(self.update_enable_states)
         self.refinements_selector.selection_changed.connect(
@@ -42,7 +44,7 @@ class PowderOverlayEditor:
             self.material_tth_width_modified_externally)
 
         self.ui.distortion_type.currentIndexChanged.connect(
-            self.validate_distortion_type)
+            self.distortion_type_changed)
         self.ui.pinhole_correction_type.currentIndexChanged.connect(
             self.validate_pinhole_correction_type)
 
@@ -103,6 +105,8 @@ class PowderOverlayEditor:
         with block_signals(*self.widgets):
             self.tth_width_gui = self.tth_width_config
             self.offset_gui = self.offset_config
+            self.distortion_type_gui = self.distortion_type_config
+            self.distortion_kwargs_gui = self.distortion_kwargs_config
             self.refinements_with_labels = self.overlay.refinements_with_labels
 
             self.update_enable_states()
@@ -111,6 +115,8 @@ class PowderOverlayEditor:
     def update_config(self):
         self.tth_width_config = self.tth_width_gui
         self.offset_config = self.offset_gui
+        self.distortion_type_config = self.distortion_type_gui
+        self.distortion_kwargs_config = self.distortion_kwargs_gui
 
         self.overlay.update_needed = True
         HexrdConfig().overlay_config_changed.emit()
@@ -176,15 +182,136 @@ class PowderOverlayEditor:
             w.setValue(v[i])
 
     @property
+    def distortion_type_config(self):
+        if self.overlay is None:
+            return None
+
+        return self.overlay.tth_distortion_type
+
+    @distortion_type_config.setter
+    def distortion_type_config(self, v):
+        if self.overlay is None:
+            return
+
+        self.overlay.tth_distortion_type = v
+
+    @property
+    def distortion_type_gui(self):
+        if self.ui.distortion_type.currentText() == 'Offset':
+            return None
+
+        v = self.ui.pinhole_correction_type.currentText()
+
+        conversions = {
+            'Sample Layer': 'SampleLayerDistortion',
+        }
+        if v in conversions:
+            v = conversions[v]
+
+        return v
+
+    @distortion_type_gui.setter
+    def distortion_type_gui(self, v):
+        widgets = [self.ui.distortion_type, self.ui.pinhole_correction_type]
+        with block_signals(*widgets):
+            if v is None:
+                self.ui.distortion_type.setCurrentText('Offset')
+                idx = self.ui.distortion_type.currentIndex()
+                self.ui.distortion_tab_widget.setCurrentIndex(idx)
+                return
+
+            self.ui.distortion_type.setCurrentText('Pinhole Camera Correction')
+            idx = self.ui.distortion_type.currentIndex()
+            self.ui.distortion_tab_widget.setCurrentIndex(idx)
+
+            conversions = {
+                'SampleLayerDistortion': 'Sample Layer',
+            }
+            if v in conversions:
+                v = conversions[v]
+
+            self.ui.pinhole_correction_type.setCurrentText(v)
+            idx = self.ui.pinhole_correction_type.currentIndex()
+            self.ui.pinhole_correction_type_tab_widget.setCurrentIndex(idx)
+
+    @property
+    def distortion_kwargs_config(self):
+        if self.overlay is None:
+            return
+
+        return self.overlay.tth_distortion_kwargs
+
+    @distortion_kwargs_config.setter
+    def distortion_kwargs_config(self, v):
+        if self.overlay is None:
+            return
+
+        self.overlay.tth_distortion_kwargs = v
+
+    @property
+    def distortion_kwargs_gui(self):
+        dtype = self.distortion_type_gui
+        if dtype is None:
+            return None
+        elif dtype == 'SampleLayerDistortion':
+            return {
+                'layer_standoff': self.ui.sl_layer_standoff.value(),
+                'layer_thickness': self.ui.sl_layer_thickness.value(),
+                'pinhole_thickness': self.ui.sl_pinhole_thickness.value(),
+            }
+        elif dtype == 'Pinhole':
+            return {
+                'diameter': self.ui.ph_diameter.value(),
+                'thickness': self.ui.ph_thickness.value(),
+            }
+
+        raise Exception(f'Not implemented for: {dtype}')
+
+    @distortion_kwargs_gui.setter
+    def distortion_kwargs_gui(self, v):
+        dtype = self.distortion_type_gui
+        if dtype is None:
+            return
+        elif dtype == 'SampleLayerDistortion':
+            self.ui.sl_layer_standoff.setValue(v.get('layer_standoff', 0))
+            self.ui.sl_layer_thickness.setValue(v.get('layer_thickness', 0))
+            self.ui.sl_pinhole_thickness.setValue(v.get('pinhole_thickness',
+                                                        0))
+        elif dtype == 'Pinhole':
+            self.ui.ph_diameter.setValue(v.get('diameter', 0))
+            self.ui.thickness.setValue(v.get('thickness', 0))
+        else:
+            raise Exception(f'Not implemented for: {dtype}')
+
+    @property
     def offset_widgets(self):
         return [getattr(self.ui, f'offset_{i}') for i in range(3)]
 
     @property
+    def sample_layer_widgets(self):
+        widgets = [
+            'sl_layer_standoff',
+            'sl_layer_thickness',
+            'sl_pinhole_thickness',
+        ]
+        return [getattr(self.ui, w) for w in widgets]
+
+    @property
+    def pinhole_widgets(self):
+        return [self.ui.ph_diameter, self.ui.ph_thickness]
+
+    @property
     def widgets(self):
+        distortion_widgets = (
+            self.offset_widgets +
+            self.sample_layer_widgets +
+            self.pinhole_widgets +
+            [self.ui.distortion_type, self.ui.pinhole_correction_type]
+        )
         return [
             self.ui.enable_width,
             self.ui.tth_width
-        ] + self.offset_widgets
+        ] + distortion_widgets
 
     def material_tth_width_modified_externally(self, material_name):
         if not self.material:
@@ -223,6 +350,15 @@ class PowderOverlayEditor:
     @pinhole_correction_type.setter
     def pinhole_correction_type(self, v):
         self.ui.pinhole_correction_type.setCurrentText(v)
+
+    def reset_offsets(self):
+        self.offset_gui = [0, 0, 0]
+        self.offset_config = [0, 0, 0]
+
+    def distortion_type_changed(self):
+        # If the distortion type is changed, zero the offsets
+        self.reset_offsets()
+        self.validate_distortion_type()
 
     def validate_distortion_type(self):
         if self.distortion_type == 'Pinhole Camera Correction':

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -255,14 +255,14 @@ class PowderOverlayEditor:
             return None
         elif dtype == 'SampleLayerDistortion':
             return {
-                'layer_standoff': self.ui.sl_layer_standoff.value(),
-                'layer_thickness': self.ui.sl_layer_thickness.value(),
-                'pinhole_thickness': self.ui.sl_pinhole_thickness.value(),
+                'layer_standoff': self.ui.sl_layer_standoff.value() * 1e-3,
+                'layer_thickness': self.ui.sl_layer_thickness.value() * 1e-3,
+                'pinhole_thickness': self.ui.sl_pinhole_thickness.value() * 1e-3,
             }
         elif dtype == 'Pinhole':
             return {
-                'diameter': self.ui.ph_diameter.value(),
-                'thickness': self.ui.ph_thickness.value(),
+                'diameter': self.ui.ph_diameter.value() * 1e-3,
+                'thickness': self.ui.ph_thickness.value() * 1e-3,
             }
 
         raise Exception(f'Not implemented for: {dtype}')
@@ -273,13 +273,13 @@ class PowderOverlayEditor:
         if dtype is None:
             return
         elif dtype == 'SampleLayerDistortion':
-            self.ui.sl_layer_standoff.setValue(v.get('layer_standoff', 0))
-            self.ui.sl_layer_thickness.setValue(v.get('layer_thickness', 0))
+            self.ui.sl_layer_standoff.setValue(v.get('layer_standoff', 0) * 1e3)
+            self.ui.sl_layer_thickness.setValue(v.get('layer_thickness', 0) * 1e3)
             self.ui.sl_pinhole_thickness.setValue(v.get('pinhole_thickness',
-                                                        0))
+                                                        0) * 1e3)
         elif dtype == 'Pinhole':
-            self.ui.ph_diameter.setValue(v.get('diameter', 0))
-            self.ui.thickness.setValue(v.get('thickness', 0))
+            self.ui.ph_diameter.setValue(v.get('diameter', 0) * 1e3)
+            self.ui.thickness.setValue(v.get('thickness', 0) * 1e3)
         else:
             raise Exception(f'Not implemented for: {dtype}')
 

--- a/hexrd/ui/resources/calibration/default_calibration_config.yml
+++ b/hexrd/ui/resources/calibration/default_calibration_config.yml
@@ -7,6 +7,8 @@ powder:
   pk_type: 'pvoigt'
   bg_type: 'linear'
   use_robust_optimization: false
+  auto_guess_initial_fwhm: true
+  initial_fwhm: 0.5
 laue_auto_picker:
   npdiv: 2
   tth_tol: 5.0

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -104,7 +104,7 @@
            </item>
            <item>
             <property name="text">
-             <string>eqaul to</string>
+             <string>equal to</string>
             </property>
            </item>
           </widget>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>596</width>
-    <height>187</height>
+    <height>222</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="iconSize">
       <size>
@@ -374,139 +374,10 @@
               <property name="spacing">
                <number>0</number>
               </property>
-              <item row="2" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>-360.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>180.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="QLabel" name="label_2">
+              <item row="2" column="3">
+               <widget class="QLabel" name="label_14">
                 <property name="text">
-                 <string>η:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0">
-               <widget class="QCheckBox" name="polar_apply_snip1d">
-                <property name="text">
-                 <string>Apply SNIP?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>-360.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>-180.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>η Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_snip1d_width">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>100.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.200000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>1.000000000000000</double>
+                 <string>min</string>
                 </property>
                </widget>
               </item>
@@ -517,176 +388,6 @@
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000100000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.200000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="7">
-               <widget class="QSpinBox" name="polar_snip1d_numiter">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="minimum">
-                 <number>1</number>
-                </property>
-                <property name="maximum">
-                 <number>10000</number>
-                </property>
-                <property name="value">
-                 <number>2</number>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="5">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="1" column="3">
-               <widget class="QLabel" name="label_12">
-                <property name="text">
-                 <string>min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="3">
-               <widget class="QLabel" name="label_10">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>w:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Pixel Size:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>2θ:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_4">
-                <property name="text">
-                 <string>2θ Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QComboBox" name="polar_snip1d_algorithm">
-                <item>
-                 <property name="text">
-                  <string>Fast SNIP 1D</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>SNIP 1D</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>SNIP 2D</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
-              <item row="3" column="6">
-               <widget class="QLabel" name="label_11">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>n iter:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>20.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -718,7 +419,7 @@
                 </property>
                </widget>
               </item>
-              <item row="3" column="2">
+              <item row="4" column="2">
                <spacer name="horizontalSpacer">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -731,17 +432,177 @@
                 </property>
                </spacer>
               </item>
-              <item row="4" column="3" colspan="2">
-               <widget class="QPushButton" name="polar_show_snip1d">
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_13">
                 <property name="text">
-                 <string>Show SNIP</string>
+                 <string>η Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
-              <item row="2" column="3">
-               <widget class="QLabel" name="label_14">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_3">
                 <property name="text">
-                 <string>min</string>
+                 <string>Pixel Size:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="8">
+               <widget class="Line" name="line_above_snip">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="polar_apply_snip1d">
+                <property name="text">
+                 <string>Apply SNIP?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>20.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="6">
+               <widget class="QLabel" name="label_11">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>n iter:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="7">
+               <widget class="QCheckBox" name="polar_apply_erosion">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Apply binary erosion to eliminate edge artifacts.</string>
+                </property>
+                <property name="text">
+                 <string>Apply erosion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000100000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="5">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="3">
+               <widget class="QLabel" name="label_6">
+                <property name="text">
+                 <string>2θ:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>2θ Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -755,16 +616,192 @@
                 </property>
                </widget>
               </item>
+              <item row="1" column="3">
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_snip1d_width">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>100.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
               <item row="4" column="7">
-               <widget class="QCheckBox" name="polar_apply_erosion">
+               <widget class="QSpinBox" name="polar_snip1d_numiter">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>10000</number>
+                </property>
+                <property name="value">
+                 <number>2</number>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QComboBox" name="polar_snip1d_algorithm">
+                <item>
+                 <property name="text">
+                  <string>Fast SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 2D</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="4" column="3">
+               <widget class="QLabel" name="label_10">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>w:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>η:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="3" colspan="2">
+               <widget class="QPushButton" name="polar_show_snip1d">
+                <property name="text">
+                 <string>Show SNIP</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-360.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-360.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>-180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0" colspan="8">
+               <widget class="Line" name="line_above_tth_distortion">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0" colspan="4">
+               <widget class="QCheckBox" name="polar_apply_tth_distortion">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Apply 2θ distortion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="5" colspan="3">
+               <widget class="QComboBox" name="polar_tth_distortion_overlay">
                 <property name="enabled">
                  <bool>false</bool>
                 </property>
                 <property name="toolTip">
-                 <string>Apply binary erosion to eliminate edge artifacts.</string>
-                </property>
-                <property name="text">
-                 <string>Apply erosion?</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
@@ -826,5 +863,22 @@
   <tabstop>polar_apply_erosion</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>polar_apply_tth_distortion</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>polar_tth_distortion_overlay</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>103</x>
+     <y>202</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>473</x>
+     <y>202</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/hexrd/ui/resources/ui/instrument_form_view_widget.ui
+++ b/hexrd/ui/resources/ui/instrument_form_view_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>692</width>
-    <height>834</height>
+    <height>872</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -458,7 +458,7 @@
           </widget>
          </item>
          <item row="3" column="1">
-          <widget class="QDoubleSpinBox" name="beam_vector_magnitude">
+          <widget class="ScientificDoubleSpinBox" name="beam_vector_magnitude">
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -467,6 +467,9 @@
            </property>
            <property name="keyboardTracking">
             <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string> mm</string>
            </property>
            <property name="decimals">
             <number>8</number>

--- a/hexrd/ui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrd/ui/resources/ui/powder_calibration_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>672</width>
-    <height>400</height>
+    <width>744</width>
+    <height>479</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
@@ -76,10 +76,43 @@
       <item row="3" column="3">
        <widget class="QComboBox" name="peak_fit_type"/>
       </item>
-      <item row="1" column="2">
-       <widget class="QLabel" name="fit_tth_tol_label">
+      <item row="2" column="2">
+       <widget class="QLabel" name="int_cutoff_label">
         <property name="text">
-         <string>Max fit |Δ2θ|/2θ₀ error:</string>
+         <string>Min Peak Amplitude (raw units):</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="3">
+       <widget class="QComboBox" name="background_type"/>
+      </item>
+      <item row="4" column="2">
+       <widget class="QLabel" name="background_type_label">
+        <property name="text">
+         <string>Background type:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="5" column="2" colspan="2">
+       <widget class="QCheckBox" name="auto_guess_initial_fwhm">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The initial FWHM cannot always be accurately guessed, and in some cases it is essential to start with an accurate value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Automatically guess initial FWHM?</string>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="peak_fit_type_label">
+        <property name="text">
+         <string>Peak fitting type:</string>
         </property>
        </widget>
       </item>
@@ -115,29 +148,50 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
-       <widget class="QLabel" name="int_cutoff_label">
+      <item row="1" column="2">
+       <widget class="QLabel" name="fit_tth_tol_label">
         <property name="text">
-         <string>Min Peak Amplitude (raw units):</string>
+         <string>Max fit |Δ2θ|/2θ₀ error:</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
-       <widget class="QLabel" name="peak_fit_type_label">
+      <item row="6" column="2">
+       <widget class="QLabel" name="initial_fwhm_label">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The initial FWHM cannot always be accurately guessed, and in some cases it is essential to start with an accurate value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
-         <string>Peak fitting type:</string>
+         <string>Initial FWHM:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="2">
-       <widget class="QLabel" name="background_type_label">
-        <property name="text">
-         <string>Background type:</string>
+      <item row="6" column="3">
+       <widget class="ScientificDoubleSpinBox" name="initial_fwhm">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The initial FWHM cannot always be accurately guessed, and in some cases it is essential to start with an accurate value.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-10000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.500000000000000</double>
         </property>
        </widget>
-      </item>
-      <item row="4" column="3">
-       <widget class="QComboBox" name="background_type"/>
       </item>
      </layout>
     </widget>
@@ -235,6 +289,8 @@
   <tabstop>int_cutoff</tabstop>
   <tabstop>peak_fit_type</tabstop>
   <tabstop>background_type</tabstop>
+  <tabstop>auto_guess_initial_fwhm</tabstop>
+  <tabstop>initial_fwhm</tabstop>
   <tabstop>conv_tol</tabstop>
   <tabstop>max_iter</tabstop>
   <tabstop>robust</tabstop>
@@ -270,6 +326,38 @@
     <hint type="destinationlabel">
      <x>217</x>
      <y>113</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>auto_guess_initial_fwhm</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>initial_fwhm_label</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>483</x>
+     <y>208</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>378</x>
+     <y>243</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>auto_guess_initial_fwhm</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>initial_fwhm</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>483</x>
+     <y>208</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>616</x>
+     <y>243</y>
     </hint>
    </hints>
   </connection>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -6,14 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>737</width>
-    <height>420</height>
+    <width>815</width>
+    <height>590</height>
    </rect>
   </property>
   <property name="minimumSize">
    <size>
     <width>0</width>
-    <height>420</height>
+    <height>590</height>
    </size>
   </property>
   <property name="windowTitle">
@@ -24,18 +24,25 @@
 </string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="1" colspan="4">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="enable_width">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
+     <property name="text">
+      <string>Enable Width</string>
      </property>
-    </spacer>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="4">
+    <widget class="QPushButton" name="reflections_table">
+     <property name="focusPolicy">
+      <enum>Qt::NoFocus</enum>
+     </property>
+     <property name="text">
+      <string>Reflections Table</string>
+     </property>
+    </widget>
    </item>
    <item row="1" column="2" colspan="3">
     <widget class="ScientificDoubleSpinBox" name="tth_width">
@@ -74,81 +81,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="4">
-    <widget class="ScientificDoubleSpinBox" name="offset_2">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="minimum">
-      <double>-100000.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="3">
-    <widget class="ScientificDoubleSpinBox" name="offset_1">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="minimum">
-      <double>-100000.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="2">
-    <widget class="ScientificDoubleSpinBox" name="offset_0">
-     <property name="alignment">
-      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-     </property>
-     <property name="keyboardTracking">
-      <bool>false</bool>
-     </property>
-     <property name="decimals">
-      <number>8</number>
-     </property>
-     <property name="minimum">
-      <double>-100000.000000000000000</double>
-     </property>
-     <property name="maximum">
-      <double>1000000.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QCheckBox" name="enable_width">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable 2θ width for the overlay's material.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Enable Width</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QLabel" name="offset_label">
-     <property name="text">
-      <string>Offset:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="4">
+   <item row="5" column="1" colspan="4">
     <widget class="QGroupBox" name="refinements_group">
      <property name="title">
       <string>Refinements</string>
@@ -160,15 +93,410 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="1" colspan="4">
-    <widget class="QPushButton" name="reflections_table">
-     <property name="focusPolicy">
-      <enum>Qt::NoFocus</enum>
+   <item row="2" column="1" colspan="4">
+    <widget class="QGroupBox" name="distortion_group">
+     <property name="styleSheet">
+      <string notr="true">QGroupBox{padding-top:15px; margin-top:-20px}</string>
      </property>
-     <property name="text">
-      <string>Reflections Table</string>
+     <property name="title">
+      <string/>
      </property>
+     <layout class="QGridLayout" name="gridLayout_6">
+      <item row="0" column="0">
+       <widget class="QLabel" name="distortion_type_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Distortion:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="distortion_type">
+        <item>
+         <property name="text">
+          <string>Offset</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>Pinhole Camera Correction</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="HiddenBarTabWidget" name="distortion_tab_widget">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="currentIndex">
+         <number>1</number>
+        </property>
+        <widget class="QWidget" name="distortion_offset_tab">
+         <attribute name="title">
+          <string>Offset</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="1" column="1">
+           <widget class="ScientificDoubleSpinBox" name="offset_0">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="decimals">
+             <number>8</number>
+            </property>
+            <property name="minimum">
+             <double>-100000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="offset_label">
+            <property name="text">
+             <string>Offset:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="ScientificDoubleSpinBox" name="offset_1">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="decimals">
+             <number>8</number>
+            </property>
+            <property name="minimum">
+             <double>-100000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="3">
+           <widget class="ScientificDoubleSpinBox" name="offset_2">
+            <property name="minimumSize">
+             <size>
+              <width>0</width>
+              <height>30</height>
+             </size>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+            </property>
+            <property name="keyboardTracking">
+             <bool>false</bool>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="decimals">
+             <number>8</number>
+            </property>
+            <property name="minimum">
+             <double>-100000.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>1000000.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="2">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>1</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="distortion_pinhole_camera_correction_tab">
+         <attribute name="title">
+          <string>Pinhole Camera Correction</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="0" column="0">
+           <widget class="QLabel" name="pinhole_correction_type_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>Correction Type:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QComboBox" name="pinhole_correction_type">
+            <item>
+             <property name="text">
+              <string>Sample Layer</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Pinhole</string>
+             </property>
+            </item>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="2">
+           <widget class="HiddenBarTabWidget" name="pinhole_correction_type_tab_widget">
+            <property name="currentIndex">
+             <number>1</number>
+            </property>
+            <widget class="QWidget" name="sample_layer_tab">
+             <attribute name="title">
+              <string>Sample Layer</string>
+             </attribute>
+             <layout class="QGridLayout" name="gridLayout_4">
+              <item row="0" column="0">
+               <widget class="QLabel" name="sl_layer_standoff_label">
+                <property name="text">
+                 <string>Layer Standoff</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="ScientificDoubleSpinBox" name="sl_layer_standoff">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="suffix">
+                 <string> μm</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-10000000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>10000000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QLabel" name="sl_layer_thickness_label">
+                <property name="text">
+                 <string>Layer Thickness</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="ScientificDoubleSpinBox" name="sl_layer_thickness">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="suffix">
+                 <string> μm</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-10000000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>10000000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="2">
+               <widget class="QLabel" name="sl_pinhole_thickness_label">
+                <property name="text">
+                 <string>Pinhole Thickness</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="2">
+               <widget class="ScientificDoubleSpinBox" name="sl_pinhole_thickness">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="suffix">
+                 <string> μm</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-10000000.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>10000000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <spacer name="verticalSpacer_3">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>1</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+            <widget class="QWidget" name="pinhole_correction_stacked_widgetPage2">
+             <attribute name="title">
+              <string>Pinhole</string>
+             </attribute>
+             <layout class="QGridLayout" name="gridLayout_5">
+              <item row="0" column="1">
+               <widget class="QLabel" name="ph_thickness_label">
+                <property name="text">
+                 <string>Pinhole Thickness</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="1">
+               <widget class="QDoubleSpinBox" name="ph_thickness">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="maximum">
+                 <double>100000000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QDoubleSpinBox" name="ph_diameter">
+                <property name="minimumSize">
+                 <size>
+                  <width>0</width>
+                  <height>30</height>
+                 </size>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="maximum">
+                 <double>100000000.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="ph_diameter_label">
+                <property name="text">
+                 <string>Pinhole Diameter</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="1">
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>10</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+     </layout>
     </widget>
+   </item>
+   <item row="6" column="1" colspan="4">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -178,15 +506,62 @@
    <extends>QDoubleSpinBox</extends>
    <header>scientificspinbox.py</header>
   </customwidget>
+  <customwidget>
+   <class>HiddenBarTabWidget</class>
+   <extends>QTabWidget</extends>
+   <header>hidden_bar_tab_widget</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>reflections_table</tabstop>
   <tabstop>enable_width</tabstop>
   <tabstop>tth_width</tabstop>
+  <tabstop>distortion_type</tabstop>
+  <tabstop>distortion_tab_widget</tabstop>
   <tabstop>offset_0</tabstop>
   <tabstop>offset_1</tabstop>
   <tabstop>offset_2</tabstop>
+  <tabstop>pinhole_correction_type</tabstop>
+  <tabstop>pinhole_correction_type_tab_widget</tabstop>
+  <tabstop>sl_layer_standoff</tabstop>
+  <tabstop>sl_layer_thickness</tabstop>
+  <tabstop>sl_pinhole_thickness</tabstop>
+  <tabstop>ph_diameter</tabstop>
+  <tabstop>ph_thickness</tabstop>
  </tabstops>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>distortion_type</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>distortion_tab_widget</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>452</x>
+     <y>109</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>405</x>
+     <y>241</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>pinhole_correction_type</sender>
+   <signal>currentIndexChanged(int)</signal>
+   <receiver>pinhole_correction_type_tab_widget</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>476</x>
+     <y>192</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>405</x>
+     <y>276</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -286,7 +286,7 @@
           <item row="1" column="0" colspan="2">
            <widget class="HiddenBarTabWidget" name="pinhole_correction_type_tab_widget">
             <property name="currentIndex">
-             <number>1</number>
+             <number>0</number>
             </property>
             <widget class="QWidget" name="sample_layer_tab">
              <attribute name="title">
@@ -445,6 +445,9 @@
                 <property name="keyboardTracking">
                  <bool>false</bool>
                 </property>
+                <property name="suffix">
+                 <string> μm</string>
+                </property>
                 <property name="decimals">
                  <number>8</number>
                 </property>
@@ -466,6 +469,9 @@
                 </property>
                 <property name="keyboardTracking">
                  <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string> μm</string>
                 </property>
                 <property name="decimals">
                  <number>8</number>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -308,6 +308,9 @@
                   <height>30</height>
                  </size>
                 </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
                 <property name="suffix">
                  <string> μm</string>
                 </property>
@@ -315,13 +318,16 @@
                  <number>8</number>
                 </property>
                 <property name="minimum">
-                 <double>-10000000.000000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>10000000.000000000000000</double>
                 </property>
                 <property name="singleStep">
                  <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>150.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -340,6 +346,9 @@
                   <height>30</height>
                  </size>
                 </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
                 <property name="suffix">
                  <string> μm</string>
                 </property>
@@ -347,13 +356,16 @@
                  <number>8</number>
                 </property>
                 <property name="minimum">
-                 <double>-10000000.000000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>10000000.000000000000000</double>
                 </property>
                 <property name="singleStep">
                  <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>5.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -372,6 +384,9 @@
                   <height>30</height>
                  </size>
                 </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
                 <property name="suffix">
                  <string> μm</string>
                 </property>
@@ -379,13 +394,16 @@
                  <number>8</number>
                 </property>
                 <property name="minimum">
-                 <double>-10000000.000000000000000</double>
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>10000000.000000000000000</double>
                 </property>
                 <property name="singleStep">
                  <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>100.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -417,12 +435,15 @@
                </widget>
               </item>
               <item row="1" column="1">
-               <widget class="QDoubleSpinBox" name="ph_thickness">
+               <widget class="ScientificDoubleSpinBox" name="ph_thickness">
                 <property name="minimumSize">
                  <size>
                   <width>0</width>
                   <height>30</height>
                  </size>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
                 </property>
                 <property name="decimals">
                  <number>8</number>
@@ -436,12 +457,15 @@
                </widget>
               </item>
               <item row="1" column="0">
-               <widget class="QDoubleSpinBox" name="ph_diameter">
+               <widget class="ScientificDoubleSpinBox" name="ph_diameter">
                 <property name="minimumSize">
                  <size>
                   <width>0</width>
                   <height>30</height>
                  </size>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
                 </property>
                 <property name="decimals">
                  <number>8</number>

--- a/hexrd/ui/ui_loader.py
+++ b/hexrd/ui/ui_loader.py
@@ -17,6 +17,7 @@ class UiLoader(QUiLoader, metaclass=QSingleton):
 
     def register_custom_widgets(self):
         # Import these here to avoid circular imports
+        from hexrd.ui.hidden_bar_tab_widget import HiddenBarTabWidget
         from hexrd.ui.indexing.grains_table_view import GrainsTableView
         from hexrd.ui.image_canvas import ImageCanvas
         from hexrd.ui.image_tab_widget import ImageTabWidget
@@ -24,6 +25,7 @@ class UiLoader(QUiLoader, metaclass=QSingleton):
 
         register_list = [
             GrainsTableView,
+            HiddenBarTabWidget,
             ImageCanvas,
             ImageTabWidget,
             ScientificDoubleSpinBox,


### PR DESCRIPTION
This adds pinhole distortion options to the powder overlay editor to be used in calibration. These pinhole settings are being added in hexrd in hexrd/hexrd#446.

https://user-images.githubusercontent.com/9558430/187340753-43735eef-e81e-4b5a-ac08-d2e585d739e7.mp4

Depends on: hexrd/hexrd#446
Depends on: #1271
Fixes: #1273
Fixes: #1279