### PR TITLE
Prune overlays immediately when materials change

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1499,10 +1499,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     def _set_materials(self, materials):
         self.config['materials']['materials'] = materials
+
+        self.prune_overlays()
+
         if materials.keys():
             self.active_material = list(materials.keys())[0]
 
-        self.prune_overlays()
         self.flag_overlay_updates_for_all_materials()
         self.overlay_config_changed.emit()
 


### PR DESCRIPTION
Previously, the overlays were being pruned *after* the active overlay was being set. Prune the overlays *before* instead to ensure that there are no invalid overlays.

This prevents an error where some invalid overlays would be asked to update upon loading a materials file that did not contain the overlay's material.