### PR TITLE
force nsteps to be integer

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -334,7 +334,6 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
                     nsteps = data['nsteps'][i]
                     start = data['omega_min'][i]
                     stop = data['omega_max'][i]
-
                     omw.addwedge(start, stop, nsteps)
             ims_dict[key].metadata['omega'] = omw.omegas
             ims_dict[key] = OmegaImageSeries(ims_dict[key])


### PR DESCRIPTION
The `nsteps` was coming back as a float from the stack importer in some cases, causing an exception.