### PR TITLE
Allow clipping powder overlays with panel buffer

### DIFF
--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -20,7 +20,7 @@ class PowderOverlay(Overlay):
 
     def __init__(self, material_name, tvec=None, eta_steps=360,
                  tth_distortion_type=None, tth_distortion_kwargs=None,
-                 **overlay_kwargs):
+                 clip_with_panel_buffer=False, **overlay_kwargs):
         super().__init__(material_name, **overlay_kwargs)
 
         if tvec is None:
@@ -33,6 +33,7 @@ class PowderOverlay(Overlay):
         self.eta_steps = eta_steps
         self.tth_distortion_type = tth_distortion_type
         self.tth_distortion_kwargs = tth_distortion_kwargs
+        self.clip_with_panel_buffer = clip_with_panel_buffer
 
     @property
     def child_attributes_to_save(self):
@@ -43,6 +44,7 @@ class PowderOverlay(Overlay):
             'eta_steps',
             'tth_distortion_type',
             'tth_distortion_kwargs',
+            'clip_with_panel_buffer',
         ]
 
     @property
@@ -259,7 +261,7 @@ class PowderOverlay(Overlay):
 
             # clip to detector panel
             xys, on_panel = panel.clip_to_panel(
-                xys_full, buffer_edges=False
+                xys_full, buffer_edges=self.clip_with_panel_buffer
             )
 
             if apply_distortion:

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -110,6 +110,8 @@ class PowderOverlayEditor:
             self.distortion_type_gui = self.distortion_type_config
             self.distortion_kwargs_gui = self.distortion_kwargs_config
             self.refinements_with_labels = self.overlay.refinements_with_labels
+            self.clip_with_panel_buffer_gui = (
+                self.clip_with_panel_buffer_config)
 
             self.update_enable_states()
             self.update_reflections_table()
@@ -119,6 +121,7 @@ class PowderOverlayEditor:
         self.offset_config = self.offset_gui
         self.distortion_type_config = self.distortion_type_gui
         self.distortion_kwargs_config = self.distortion_kwargs_gui
+        self.clip_with_panel_buffer_config = self.clip_with_panel_buffer_gui
 
         self.overlay.update_needed = True
         HexrdConfig().overlay_config_changed.emit()
@@ -336,7 +339,8 @@ class PowderOverlayEditor:
         )
         return [
             self.ui.enable_width,
-            self.ui.tth_width
+            self.ui.tth_width,
+            self.ui.clip_with_panel_buffer,
         ] + distortion_widgets
 
     def material_tth_width_modified_externally(self, material_name):
@@ -456,3 +460,25 @@ class PowderOverlayEditor:
         # anyways since they won't be pressing the button very often.
         HexrdConfig().flag_overlay_updates_for_all_materials()
         HexrdConfig().rerender_needed.emit()
+
+    @property
+    def clip_with_panel_buffer_config(self):
+        if self.overlay is None:
+            return False
+
+        return self.overlay.clip_with_panel_buffer
+
+    @clip_with_panel_buffer_config.setter
+    def clip_with_panel_buffer_config(self, b):
+        if self.overlay is None:
+            return
+
+        self.overlay.clip_with_panel_buffer = b
+
+    @property
+    def clip_with_panel_buffer_gui(self):
+        return self.ui.clip_with_panel_buffer.isChecked()
+
+    @clip_with_panel_buffer_gui.setter
+    def clip_with_panel_buffer_gui(self, b):
+        self.ui.clip_with_panel_buffer.setChecked(b)

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -538,6 +538,16 @@
      </property>
     </spacer>
    </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="clip_with_panel_buffer">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Clip any points that are in the panel buffer.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Clip with panel buffer?</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>


### PR DESCRIPTION
This adds an option so that the user may clip powder overlays with the panel buffer. It seems to be working.