### PR TITLE
Pinhole distortion fixes

### DIFF
--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -1,5 +1,3 @@
-import copy
-
 import numpy as np
 
 from hexrd import constants
@@ -420,22 +418,6 @@ class PowderOverlay(Overlay):
             ret[det_key] = f(panel)
 
         return ret
-
-    def generate_pinhole_panel_buffer(self, pinhole_radius, pinhole_thickness):
-        instr = copy.deepcopy(self.instrument)
-
-        if instr is None:
-            raise Exception('No instrument')
-
-        # make beam vector the pinhole axis on copy of instrument
-        instr.beam_vector = np.r_[0., 0., -1.]
-        ph_buffer = {}
-        for det_key, det in instr.detectors.items():
-            crit_angle = np.arctan(2 * pinhole_radius / pinhole_thickness)
-            ptth, peta = det.pixel_angles()
-            ph_buffer[det_key] = ptth < crit_angle
-
-        return ph_buffer
 
     @property
     def tth_displacement_field(self):

--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 
 from hexrd import constants
@@ -418,6 +420,22 @@ class PowderOverlay(Overlay):
             ret[det_key] = f(panel)
 
         return ret
+
+    def generate_pinhole_panel_buffer(self, pinhole_radius, pinhole_thickness):
+        instr = copy.deepcopy(self.instrument)
+
+        if instr is None:
+            raise Exception('No instrument')
+
+        # make beam vector the pinhole axis on copy of instrument
+        instr.beam_vector = np.r_[0., 0., -1.]
+        ph_buffer = {}
+        for det_key, det in instr.detectors.items():
+            crit_angle = np.arctan(2 * pinhole_radius / pinhole_thickness)
+            ptth, peta = det.pixel_angles()
+            ph_buffer[det_key] = ptth < crit_angle
+
+        return ph_buffer
 
     @property
     def tth_displacement_field(self):

--- a/hexrd/ui/pinhole_mask_dialog.py
+++ b/hexrd/ui/pinhole_mask_dialog.py
@@ -1,0 +1,19 @@
+from hexrd.ui.ui_loader import UiLoader
+
+
+class PinholeMaskDialog:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('pinhole_mask_dialog.ui', parent)
+
+    def exec_(self):
+        return self.ui.exec_()
+
+    @property
+    def pinhole_radius(self):
+        return self.ui.pinhole_radius.value() * 1e-3
+
+    @property
+    def pinhole_thickness(self):
+        return self.ui.pinhole_thickness.value() * 1e-3

--- a/hexrd/ui/pinhole_panel_buffer.py
+++ b/hexrd/ui/pinhole_panel_buffer.py
@@ -1,0 +1,20 @@
+import numpy as np
+
+
+def generate_pinhole_panel_buffer(instr, pinhole_radius, pinhole_thickness):
+    ph_buffer = {}
+
+    # Save the beam vector so we can restore it later
+    prev_beam_vector = instr.beam_vector
+
+    # make beam vector the pinhole axis on the instrument
+    instr.beam_vector = np.r_[0., 0., -1.]
+    try:
+        for det_key, det in instr.detectors.items():
+            crit_angle = np.arctan(2 * pinhole_radius / pinhole_thickness)
+            ptth, peta = det.pixel_angles()
+            ph_buffer[det_key] = ptth < crit_angle
+    finally:
+        instr.beam_vector = prev_beam_vector
+
+    return ph_buffer

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -422,16 +422,11 @@ class PowderOverlayEditor:
         if config is None or any(x not in config for x in required_keys):
             raise Exception(f'Failed to create panel buffer with {config=}')
 
-        ph_radius = config['pinhole_radius']
-        ph_thickness = config['pinhole_thickness']
-
-        # make beam vector the pinhole axis on copy of instrument
-        instr.beam_vector = np.r_[0., 0., -1.]
-        ph_buffer = {}
-        for det_key, det in instr.detectors.items():
-            crit_angle = np.arctan(2*ph_radius/ph_thickness)
-            ptth, peta = det.pixel_angles()
-            ph_buffer[det_key] = ptth < crit_angle
+        kwargs = {
+            'pinhole_radius': config['pinhole_radius'],
+            'pinhole_thickness': config['pinhole_thickness'],
+        }
+        ph_buffer = self.overlay.generate_pinhole_panel_buffer(**kwargs)
 
         # merge with any existing panel buffer
         for det_key, det in instr.detectors.items():

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -6,6 +6,7 @@ from PySide2.QtWidgets import QCheckBox, QComboBox, QDoubleSpinBox, QMessageBox
 
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.pinhole_panel_buffer import generate_pinhole_panel_buffer
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.select_items_widget import SelectItemsWidget
 from hexrd.ui.ui_loader import UiLoader
@@ -423,10 +424,11 @@ class PowderOverlayEditor:
             raise Exception(f'Failed to create panel buffer with {config=}')
 
         kwargs = {
+            'instr': instr,
             'pinhole_radius': config['pinhole_radius'],
             'pinhole_thickness': config['pinhole_thickness'],
         }
-        ph_buffer = self.overlay.generate_pinhole_panel_buffer(**kwargs)
+        ph_buffer = generate_pinhole_panel_buffer(**kwargs)
 
         # merge with any existing panel buffer
         for det_key, det in instr.detectors.items():

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -46,6 +46,8 @@ class PowderOverlayEditor:
 
         self.ui.distortion_type.currentIndexChanged.connect(
             self.distortion_type_changed)
+        self.ui.pinhole_correction_type.currentIndexChanged.connect(
+            self.pinhole_correction_type_changed)
 
         self.ui.ph_apply_panel_buffers.clicked.connect(
             self.ph_apply_panel_buffers)
@@ -385,6 +387,10 @@ class PowderOverlayEditor:
         self.validate_distortion_type()
         self.update_config()
 
+    def pinhole_correction_type_changed(self):
+        self.validate_distortion_type()
+        self.update_config()
+
     def validate_distortion_type(self):
         if self.distortion_type == 'Pinhole Camera Correction':
             # Warn the user if there is a non-zero oscillation stage vector
@@ -396,17 +402,17 @@ class PowderOverlayEditor:
                 )
                 QMessageBox.critical(self.ui, 'HEXRD', msg)
 
-            # FIXME: do we need to produce this warning for PinholeDistortion?
-            beam = HexrdConfig().instrument_config['beam']
-            source_distance = beam.get('source_distance', np.inf)
-            if source_distance is None or source_distance == np.inf:
-                msg = (
-                    'WARNING: the source distance is infinite.\n\nThe '
-                    'Pinhole Camera Correction will have no effect '
-                    'unless the source distance is finite.\n\nThe source '
-                    'distance may be edited in the Instrument "Form View"'
-                )
-                QMessageBox.critical(self.ui, 'HEXRD', msg)
+            if self.distortion_type_gui == 'SampleLayerDistortion':
+                beam = HexrdConfig().instrument_config['beam']
+                source_distance = beam.get('source_distance', np.inf)
+                if source_distance is None or source_distance == np.inf:
+                    msg = (
+                        'WARNING: the source distance is infinite.\n\nThe '
+                        'Sample Layer Distortion will have no effect '
+                        'unless the source distance is finite.\n\nThe source '
+                        'distance may be edited in the Instrument "Form View"'
+                    )
+                    QMessageBox.critical(self.ui, 'HEXRD', msg)
 
     def ph_apply_panel_buffers(self):
         instr = create_hedm_instrument()

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -290,8 +290,8 @@ class PowderOverlayEditor:
             'sl_layer_standoff': ('layer_standoff', 0.15),
             'sl_layer_thickness': ('layer_thickness', 0.005),
             'sl_pinhole_thickness': ('pinhole_thickness', 0.1),
-            'ph_radius': ('pinhole_radius', 0.1),
-            'ph_thickness': ('pinhole_thickness', 0.1),
+            'ph_radius': ('pinhole_radius', 0.15),
+            'ph_thickness': ('pinhole_thickness', 0.075),
         }
 
         dtype = self.distortion_type_gui

--- a/hexrd/ui/powder_overlay_editor.py
+++ b/hexrd/ui/powder_overlay_editor.py
@@ -435,7 +435,7 @@ class PowderOverlayEditor:
             pb = det.panel_buffer
             if pb is not None:
                 if pb.ndim == 2:
-                    new_buff = np.logical_or(pb, ph_buffer[det_key])
+                    new_buff = np.logical_and(pb, ph_buffer[det_key])
                 elif pb.ndim == 1:
                     # have edge buffer
                     ebuff = np.ones(det.shape, dtype=bool)
@@ -445,7 +445,7 @@ class PowderOverlayEditor:
                     ebuff[-npix_row:, :] = False
                     ebuff[:, :npix_col] = False
                     ebuff[:, -npix_col:] = False
-                    new_buff = np.logical_or(ebuff, ph_buffer[det_key])
+                    new_buff = np.logical_and(ebuff, ph_buffer[det_key])
                 det.panel_buffer = new_buff
             else:
                 det.panel_buffer = ph_buffer[det_key]

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -132,6 +132,7 @@
      <addaction name="action_edit_apply_laue_mask_to_polar"/>
      <addaction name="action_edit_apply_polygon_mask"/>
      <addaction name="action_edit_apply_powder_mask_to_polar"/>
+     <addaction name="action_edit_apply_pinhole_mask"/>
      <addaction name="action_open_mask_manager"/>
     </widget>
     <widget class="QMenu" name="menu_intensity_corrections">
@@ -247,7 +248,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>775</height>
+          <height>753</height>
          </rect>
         </property>
         <attribute name="label">
@@ -260,7 +261,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>775</height>
+          <height>753</height>
          </rect>
         </property>
         <attribute name="label">
@@ -719,6 +720,11 @@
   <action name="action_about_2">
    <property name="text">
     <string>About</string>
+   </property>
+  </action>
+  <action name="action_edit_apply_pinhole_mask">
+   <property name="text">
+    <string>Apply Pinhole Mask</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/resources/ui/pinhole_mask_dialog.ui
+++ b/hexrd/ui/resources/ui/pinhole_mask_dialog.ui
@@ -1,0 +1,133 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>pinhole_mask_dialog</class>
+ <widget class="QDialog" name="pinhole_mask_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>418</width>
+    <height>131</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Create Pinhole Mask</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true"/>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="pinhole_radius_label">
+     <property name="text">
+      <string>Pinhole Radius:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="ScientificDoubleSpinBox" name="pinhole_radius">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="suffix">
+      <string> μm</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>100000000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>150.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="pinhole_thickness_label">
+     <property name="text">
+      <string>Pinhole Thickness:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="ScientificDoubleSpinBox" name="pinhole_thickness">
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="suffix">
+      <string> μm</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="maximum">
+      <double>100000000.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>75.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>pinhole_radius</tabstop>
+  <tabstop>pinhole_thickness</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>pinhole_mask_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>312</x>
+     <y>110</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>312</x>
+     <y>65</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>pinhole_mask_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>312</x>
+     <y>110</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>312</x>
+     <y>65</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/powder_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/powder_overlay_editor.ui
@@ -457,6 +457,9 @@
                 <property name="singleStep">
                  <double>0.010000000000000</double>
                 </property>
+                <property name="value">
+                 <double>75.000000000000000</double>
+                </property>
                </widget>
               </item>
               <item row="3" column="1">
@@ -501,6 +504,9 @@
                 </property>
                 <property name="singleStep">
                  <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>150.000000000000000</double>
                 </property>
                </widget>
               </item>


### PR DESCRIPTION
This adds various features/fixes to the pinhole distortion, the most important of which are:

1. Fixed applying pinhole panel buffer to be correct (needed `logical_and()` instead of `logical_or()`)
2. Added ability to create a mask from pinhole dimensions