### PR TITLE
Do not switch to raw upon apply pinhole mask

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -265,8 +265,7 @@ class MainWindow(QObject):
         HexrdConfig().detectors_changed.connect(
             self.on_detectors_changed)
         HexrdConfig().deep_rerender_needed.connect(self.deep_rerender)
-        HexrdConfig().raw_masks_changed.connect(
-            self.ui.image_tab_widget.load_images)
+        HexrdConfig().raw_masks_changed.connect(self.update_all)
         HexrdConfig().recent_images_changed.connect(
             self.update_view_recent_images_list)
 


### PR DESCRIPTION
The signal `raw_masks_changed` was previously causing the raw image mode to be loaded. This wasn't a problem before, because that signal was only emitted while the user was in the raw view.

However, the pinhole mask is now always being saved in the raw view, and if the user applies it while in the polar view, the view gets switched automatically to the raw view.

Now, the `raw_masks_changed` signal simply causes whatever view is current to update, so that we don't automatically switch to the raw view.