### PR TITLE
modified key input deltas for crop

### DIFF
--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -220,14 +220,15 @@ class InteractiveTemplate:
 
     def on_key_translate(self, event):
         dx, dy = 0, 0
+        delta = 0.5
         if event.key == 'right':
-            dx = 1
+            dx = delta
         elif event.key == 'left':
-            dx = -1
+            dx = -delta
         elif event.key == 'up':
-            dy = -1
+            dy = -delta
         elif event.key == 'down':
-            dy = 1
+            dy = delta
         else:
             return
 
@@ -314,7 +315,7 @@ class InteractiveTemplate:
         self.redraw()
 
     def on_key_rotate(self, event):
-        angle = 0.01
+        angle = 0.00175
         if event.key == 'left' or event.key == 'up':
             angle *= -1
         elif event.key != 'right' and event.key != 'down':

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -385,6 +385,8 @@ class LLNLImportToolDialog(QObject):
         self.it.cropped_image(height, width)
 
         img, panel_buffer = self.it.masked_image
+        if self.instrument == 'PXRDIP':
+            panel_buffer = panel_buffer.T[::-1, :]  # !!! need to rotate buffers
 
         self.edited_images[self.detector] = {
             'img': img,


### PR DESCRIPTION
The previous delta for arrow key input for crop boundary rotation was 0.01 radians (~0.573°); changed to 0.00175 radians (~0.1°).

Likewise the previous delta for translation was 1 pixel; reduced to 0.5.