### PR TITLE
Store calibration picks in Cartesian coordinates

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -319,4 +319,4 @@ def save_picks_to_overlay(overlay, data_dict):
 
             picks[det_key].append(to_angles(hkl_picks, panel).tolist())
 
-    overlay.calibration_picks = picks
+    overlay.calibration_picks_polar = picks

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -239,7 +239,7 @@ class CalibrationRunner(QObject):
 
         # Set the new picks on the overlay
         updated_picks = tree_format_to_picks(results)
-        overlay.calibration_picks = updated_picks[0]['picks']
+        overlay.calibration_picks_polar = updated_picks[0]['picks']
         self.reset_overlay_picks()
 
         dialog = self.view_picks_table()
@@ -285,7 +285,7 @@ class CalibrationRunner(QObject):
         # Update all of the picks with the modified data
         updated_picks = tree_format_to_picks(dialog.dictionary)
         for i, new_picks in enumerate(updated_picks):
-            self.active_overlays[i].calibration_picks = new_picks['picks']
+            self.active_overlays[i].calibration_picks_polar = new_picks['picks']
 
         if self.active_overlay:
             self.reset_overlay_picks()
@@ -455,7 +455,7 @@ class CalibrationRunner(QObject):
         HexrdConfig().overlay_config_changed.emit()
 
     def reset_overlay_picks(self):
-        calibration_picks = self.active_overlay.calibration_picks
+        calibration_picks = self.active_overlay.calibration_picks_polar
         self.overlay_picks = copy.deepcopy(calibration_picks)
 
     def reset_overlay_data_index_map(self):
@@ -536,7 +536,7 @@ class CalibrationRunner(QObject):
         self.overlay_data_index_map = data_map
 
     def save_overlay_picks(self):
-        self.active_overlay.calibration_picks = copy.deepcopy(
+        self.active_overlay.calibration_picks_polar = copy.deepcopy(
             self.overlay_picks)
 
     @property

--- a/hexrd/ui/calibration/picks_tree_view_dialog.py
+++ b/hexrd/ui/calibration/picks_tree_view_dialog.py
@@ -205,7 +205,7 @@ def generate_picks_results(overlays):
             'options': options,
             'refinements': overlay.refinements_with_labels,
             'hkls': hkls,
-            'picks': overlay.calibration_picks,
+            'picks': overlay.calibration_picks_polar,
             **extras,
         })
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -977,7 +977,7 @@ class MainWindow(QObject):
             # Write the modified picks to the overlays
             updated_picks = tree_format_to_picks(dialog.dictionary)
             for i, new_picks in enumerate(updated_picks):
-                overlays[i].calibration_picks = new_picks['picks']
+                overlays[i].calibration_picks_polar = new_picks['picks']
 
         def on_finished():
             remove_all_highlighting()

--- a/hexrd/ui/overlays/overlay.py
+++ b/hexrd/ui/overlays/overlay.py
@@ -63,6 +63,16 @@ class Overlay(ABC):
     def pad_picks_data(self):
         pass
 
+    @property
+    @abstractmethod
+    def calibration_picks_polar(self):
+        pass
+
+    @calibration_picks_polar.setter
+    @abstractmethod
+    def calibration_picks_polar(self, picks):
+        pass
+
     # Concrete methods
     def __init__(self, material_name, name=None, refinements=None,
                  calibration_picks=None, style=None, highlight_style=None,

--- a/hexrd/ui/overlays/rotation_series_overlay.py
+++ b/hexrd/ui/overlays/rotation_series_overlay.py
@@ -166,6 +166,16 @@ class RotationSeriesOverlay(Overlay):
         # Rotation series overlays do not currently support picks data
         return False
 
+    @property
+    def calibration_picks_polar(self):
+        # Rotation series overlays do not currently support picks data
+        return []
+
+    @calibration_picks_polar.setter
+    def calibration_picks_polar(self, picks):
+        # Rotation series overlays do not currently support picks data
+        pass
+
     def generate_overlay(self):
         """
         Returns appropriate point groups for displaying bragg reflection


### PR DESCRIPTION
Previously, the calibration picks were being stored in angular coordinates. This was a problem, however, because if the instrument/detector parameters were modified, the picks would not be updated to reflect that change.

This commit changes the calibration picks to be stored in Cartesian coordinates instead (similar to how they are stored in the HDF5 file). And to alleviate the transition, a `calibration_picks_polar` property was added that automatically converts between the polar/cartesian coordinates.

Here are some images illustrating the issue and solution.

# Here are some auto picked points:

![original_overlay_picks](https://user-images.githubusercontent.com/9558430/208556689-26dc13e8-6bbb-4fed-a4d4-5c18942685b7.png)

# On master, if we modify the tilt of a detector, the picks no longer line up:

![original_overlay_picks_tilted](https://user-images.githubusercontent.com/9558430/208556764-acbef00b-330d-4802-9f5d-c4138576e60f.png)

# With this fix, the picks now line up correctly:

![fixed_overlay_picks_tilted](https://user-images.githubusercontent.com/9558430/208556787-7c946ff0-c2fc-496b-9081-7570841d770e.png)

Fixes: #1310 
