### PR TITLE
Add extra sample points for masks

### DIFF
--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -5,10 +5,15 @@ from skimage.draw import polygon
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.calibration.polarview import PolarView
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils import add_sample_points
 from hexrd.ui.utils.conversions import pixels_to_angles
 
 
 def convert_raw_to_polar(det, line):
+    # Make sure there at least 50 sample points so that the conversion
+    # looks correct.
+    line = add_sample_points(line, 50)
+
     instr = create_hedm_instrument()
     kwargs = {
         'ij': line,

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -6,6 +6,7 @@ from skimage.draw import polygon
 from hexrd.ui import constants
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.utils import add_sample_points
 from hexrd.ui.utils.conversions import angles_to_pixels
 
 
@@ -37,6 +38,9 @@ def create_threshold_mask(img):
 def convert_polar_to_raw(line_data):
     raw_line_data = []
     for line in line_data:
+        # Make sure there are at least 50 sample points
+        # so that the conversion will appear correct.
+        line = add_sample_points(line, 50)
         for key, panel in create_hedm_instrument().detectors.items():
             raw = angles_to_pixels(line, panel)
             if all([np.isnan(x) for x in raw.flatten()]):

--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -9,6 +9,7 @@ from matplotlib.widgets import Cursor
 
 from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import add_sample_points
 
 
 class HandDrawnMaskDialog(QObject):
@@ -120,6 +121,11 @@ class HandDrawnMaskDialog(QObject):
             return
 
         linebuilder.disconnect()
+
+        # Make sure there are at least 50 points, so that conversions
+        # between raw/polar views come out okay.
+        ring_data = add_sample_points(ring_data, 50)
+
         self.ring_data.append(ring_data)
         self.dets.append(self.ax.get_title())
         self.drawing = False

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -6,6 +6,7 @@ from hexrd.ui.utils import unique_name
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.constants import ViewType
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import add_sample_points
 
 from matplotlib import patches
 
@@ -186,6 +187,11 @@ class MaskRegionsDialog(QObject):
     def save_line_data(self):
         data_coords = self.patch.get_patch_transform().transform(
             self.patch.get_path().vertices[:-1])
+
+        # So that this gets converted between raw and polar correctly,
+        # make sure there are at least 50 points.
+        data_coords = add_sample_points(data_coords, 50)
+
         if self.image_mode == ViewType.raw:
             self.raw_mask_coords.append((self.det, data_coords))
         elif self.image_mode == ViewType.polar:

--- a/hexrd/ui/utils/__init__.py
+++ b/hexrd/ui/utils/__init__.py
@@ -446,3 +446,30 @@ def set_combobox_enabled_items(cb, enable_list):
             new_index = -1
 
     cb.setCurrentIndex(new_index)
+
+
+def add_sample_points(points, min_output_length):
+    """Add extra sample points to a 2D array of points
+
+    This takes a 2D array of points and uses np.linspace() to add extra
+    points in between each point and its nearest index neighbors (nearest
+    neighbors by index, not by distance).
+
+    The min_output_length is the minimum number of points for the output.
+    The actual output will likely have more points than this.
+    """
+    if len(points) > min_output_length:
+        # It's already greater than what was specified
+        return points
+
+    # Figure out how many repititions we should have with np.linspace
+    num_reps = int(np.ceil(min_output_length / len(points)))
+
+    # Roll the points over so we can pair each point with its neighbor
+    rolled = np.roll(points, -1, axis=0)
+
+    # Generate the extra points between each point and its neighbor
+    output = np.linspace(points, rolled, num=num_reps)
+
+    # Transform back into the correct shape and return
+    return output.T.reshape(2, -1).T


### PR DESCRIPTION
For masks with few points (such as the rectangle mask, which only had
four corners for the points, and hand drawn masks with few points),
the masks would not be converted between the polar/raw views very well.

For example, for the rectangle mask, the four corners would be converted
between the views correctly. But the edges in the converted form would be
straight, when they would often need to be curved.

We need to add extra sample points for the masks so that conversions from
straight edges to curved edges are performed correctly. This commit does
that.

Here is an example that illustrates this:

# Rectangular mask created in polar view
![masked_polar](https://user-images.githubusercontent.com/9558430/210108337-e304e26d-d1a7-4347-ad19-53a095116bc4.png)

# Current master branch conversion to raw view
![masked_raw](https://user-images.githubusercontent.com/9558430/210108381-11856874-410c-42a1-9c57-a5860ab00895.png)

You can see that the rectangle covers up most of the powder line in the polar view. But in the raw view,
it does not. The point coordinates were converted to the raw view correctly, but because there are only
four points, the edges are straight when they should be curved.

Adding extra sample points in between fixes this.

# This branch conversion to raw view
![masked_raw_correct](https://user-images.githubusercontent.com/9558430/210108492-45fa2254-8a8c-4734-a52d-dd73061aa1f1.png)
