### PR TITLE
Skip masked regions during auto picking

### DIFF
--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -11,7 +11,7 @@ from hexrd.ui.async_runner import AsyncRunner
 from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
-from hexrd.ui.utils import instr_to_internal_dict
+from hexrd.ui.utils import instr_to_internal_dict, masks_applied_to_panel_buffers
 from hexrd.ui.utils.conversions import cart_to_angles
 
 from hexrd.ui.calibration.auto import PowderCalibrationDialog
@@ -100,9 +100,13 @@ class PowderRunner(QObject):
             'fit_tth_tol': options['fit_tth_tol'],
             'int_cutoff': options['int_cutoff'],
         }
-        # FIXME: currently coded to handle only a single material
-        #        so grabbing first (only) element
-        self.data_dict = self.ic.extract_points(**kwargs)[0]
+
+        # Apply any masks to the panel buffer for our instrument.
+        # This is done so that the auto picking will skip over masked regions.
+        with masks_applied_to_panel_buffers(self.instr):
+            # FIXME: currently coded to handle only a single material
+            #        so grabbing first (only) element
+            self.data_dict = self.ic.extract_points(**kwargs)[0]
 
         # Save the picks to the active overlay in case we need them later
         self.save_picks_to_overlay()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -2373,3 +2373,14 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             v[det] = imgs if isinstance(imgs, list) else [imgs]
         self._recent_images = v
         self.recent_images_changed.emit()
+
+    def apply_masks_to_panel_buffers(self, instr):
+        # Apply raw masks to the panel buffers on the passed instrument
+        for det_key, mask in self.raw_masks_dict.items():
+            panel = instr.detectors[det_key]
+
+            # Make sure it is a 2D array
+            utils.convert_panel_buffer_to_2d_array(panel)
+
+            # Add the mask
+            panel.panel_buffer = np.logical_and(mask, panel.panel_buffer)


### PR DESCRIPTION
Previously, masked regious could still have picks in it, since the masked regions were just treated as pixels with a value of zero.

To prevent masked regions from being auto picked, we are now applying the masked regions to the panel buffer during auto picking. The auto picker avoids panel buffer regions, so this fixes that issue.

Fixes: #1315