### PR TITLE
Add Stereographic View Mode

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -22,11 +22,6 @@ class InstrumentViewer:
         self.type = ViewType.polar
         self.instr = create_hedm_instrument()
 
-        # Resolution settings
-        # As far as I can tell, self.pixel_size won't actually change
-        # anything for a polar plot, so just hard-code it.
-        self.pixel_size = 0.5
-
         self.draw_polar()
 
     @property

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -362,8 +362,7 @@ class PolarView:
         for name in HexrdConfig().visible_masks:
             if name not in HexrdConfig().masks:
                 continue
-            # This should be a numpy array, but convert it if it isn't
-            mask = np.asarray(HexrdConfig().masks[name])
+            mask = HexrdConfig().masks[name]
             total_mask = np.logical_or(total_mask, ~mask)
         if HexrdConfig().threshold_mask_status:
             idx = HexrdConfig().current_imageseries_idx

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -6,6 +6,7 @@ from skimage.morphology import rectangle
 from skimage.transform import warp
 
 from hexrd.transforms.xfcapi import detectorXYToGvec, mapAngle
+from hexrd.utils.decorators import memoize
 
 from hexrd import constants as ct
 from hexrd.xrdutil import _project_on_detector_plane
@@ -228,23 +229,18 @@ class PolarView:
         return self.warp_dict[det]
 
     def warp_image(self, img, panel):
-        angpts = self.angular_grid
-        dummy_ome = np.zeros((self.ntth * self.neta))
-
-        gvec_angs = np.vstack([
-                angpts[1].flatten(),
-                angpts[0].flatten(),
-                dummy_ome]).T
-
-        xypts = np.nan*np.ones((len(gvec_angs), 2))
-        valid_xys, rmats_s, on_plane = _project_on_detector_plane(
-                gvec_angs,
-                panel.rmat, np.eye(3),
-                self.chi,
-                panel.tvec, tvec_c, self.tvec_s,
-                panel.distortion,
-                beamVec=panel.bvec)
-        xypts[on_plane] = valid_xys
+        # The first 3 arguments of this function get converted into
+        # the first argument of `_project_on_detector_plane`, and then
+        # the rest are just passed as *args and **kwargs.
+        xypts = project_on_detector_plane(
+                    self.angular_grid,
+                    self.ntth,
+                    self.neta,
+                    panel.rmat, np.eye(3),
+                    self.chi,
+                    panel.tvec, tvec_c, self.tvec_s,
+                    panel.distortion,
+                    beamVec=panel.bvec)
 
         wimg = panel.interpolate_bilinear(
             xypts, img, pad_with_nans=True,
@@ -428,3 +424,26 @@ class PolarView:
     def reset_cached_distortion_fields(self):
         HexrdConfig().polar_corr_field_polar_dict = None
         HexrdConfig().polar_angular_grid = None
+
+
+# `_project_on_detector_plane()` is one of the functions that takes the
+# longest when generating the polar view.
+# Memoize this so we can regenerate the polar view faster
+@memoize(maxsize=16)
+def project_on_detector_plane(angular_grid, ntth, neta, *args, **kwargs):
+    # This will take `angular_grid`, `ntth`, and `neta`, and make the
+    # `gvec_angs` argument with them. Then, the `gvec_args` will be passed
+    # first to `_project_on_detector_plane`, along with any extra args and
+    # kwargs.
+    dummy_ome = np.zeros((ntth * neta))
+
+    gvec_angs = np.vstack([
+            angular_grid[1].flatten(),
+            angular_grid[0].flatten(),
+            dummy_ome]).T
+
+    xypts = np.nan * np.ones((len(gvec_angs), 2))
+    valid_xys, rmats_s, on_plane = _project_on_detector_plane(gvec_angs, *args, **kwargs)
+    xypts[on_plane] = valid_xys
+
+    return xypts

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -280,7 +280,7 @@ class PolarView:
         image1_warp = warp(pimg, displ_field, mode='edge')
 
         # image1_warp = rescale_intensity(image1_warp, out_range=np.uint32)
-        return np.ma.array(image1_warp) # , mask=mask_warp)
+        return np.ma.array(image1_warp)  # , mask=mask_warp)
 
     def generate_image(self):
         self.reset_cached_distortion_fields()
@@ -362,7 +362,8 @@ class PolarView:
         for name in HexrdConfig().visible_masks:
             if name not in HexrdConfig().masks:
                 continue
-            mask = HexrdConfig().masks[name]
+            # This should be a numpy array, but convert it if it isn't
+            mask = np.asarray(HexrdConfig().masks[name])
             total_mask = np.logical_or(total_mask, ~mask)
         if HexrdConfig().threshold_mask_status:
             idx = HexrdConfig().current_imageseries_idx
@@ -443,7 +444,8 @@ def project_on_detector_plane(angular_grid, ntth, neta, *args, **kwargs):
             dummy_ome]).T
 
     xypts = np.nan * np.ones((len(gvec_angs), 2))
-    valid_xys, rmats_s, on_plane = _project_on_detector_plane(gvec_angs, *args, **kwargs)
+    valid_xys, rmats_s, on_plane = _project_on_detector_plane(
+        gvec_angs, *args, **kwargs)
     xypts[on_plane] = valid_xys
 
     return xypts

--- a/hexrd/ui/calibration/stereo_plot.py
+++ b/hexrd/ui/calibration/stereo_plot.py
@@ -1,3 +1,6 @@
+from pathlib import Path
+
+import h5py
 import numpy as np
 
 from hexrd import constants as ct
@@ -137,3 +140,27 @@ class InstrumentViewer:
             self.pv.update_detector(det)
 
         self.draw_stereo()
+
+    def write_image(self, filename):
+        filename = Path(filename)
+
+        # Prepare the data to write out
+        data = {
+            'intensities': self.img,
+        }
+
+        # Delete the file if it already exists
+        if filename.exists():
+            filename.unlink()
+
+        # Check the file extension
+        ext = filename.suffix.lower()
+
+        if ext == '.npz':
+            # If it looks like npz, save as npz
+            np.savez(filename, **data)
+        else:
+            # Default to HDF5 format
+            with h5py.File(filename, 'w') as f:
+                for key, value in data.items():
+                    f.create_dataset(key, data=value)

--- a/hexrd/ui/calibration/stereo_plot.py
+++ b/hexrd/ui/calibration/stereo_plot.py
@@ -102,9 +102,8 @@ class InstrumentViewer:
         })
 
     def draw_stereo_from_polar(self):
-        # FIXME stereo: sometimes, some instrument settings are modified that
-        # should cause the polar view to be regenerated here, but it is not
-        # regenerated. We should perform some checks/memoization.
+        # We need to make sure `self.pv` is always updated when it needs
+        # to be. But that can be done elsewhere.
         if self.pv is None:
             # Don't redraw the polar view unless we have to
             self.draw_polar()

--- a/hexrd/ui/calibration/stereo_plot.py
+++ b/hexrd/ui/calibration/stereo_plot.py
@@ -90,9 +90,7 @@ class InstrumentViewer:
         self.pv.warp_all_images()
 
     def update_overlay_data(self):
-        # update_overlay_data(self.instr, self.type)
-        # FIXME stereo: no overlays yet for stereographic
-        pass
+        update_overlay_data(self.instr, self.type)
 
     def update_detector(self, det):
         if self.project_from_polar:

--- a/hexrd/ui/calibration/stereo_plot.py
+++ b/hexrd/ui/calibration/stereo_plot.py
@@ -1,9 +1,13 @@
 import numpy as np
 
+from hexrd import constants as ct
+from hexrd.transforms.xfcapi import detectorXYToGvec
+
 from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.overlays import update_overlay_data
+from hexrd.ui.utils.conversions import angles_to_stereo
 
 from .polarview import PolarView
 from .stereo_project import stereo_project, stereo_projection_of_polar_view
@@ -39,11 +43,47 @@ class InstrumentViewer:
     def project_from_polar(self):
         return HexrdConfig().stereo_project_from_polar
 
+    def detector_borders(self, det):
+        panel = self.instr.detectors[det]
+
+        # First, create the polar view version of the borders
+        # (this skips some things like trimming based upon tth/eta min/max)
+        row_vec, col_vec = panel.row_pixel_vec, panel.col_pixel_vec
+        x_start, x_stop = col_vec[0], col_vec[-1]
+        y_start, y_stop = row_vec[0], row_vec[-1]
+
+        # Create the borders in Cartesian
+        borders = [
+            [[x, y_start] for x in col_vec],
+            [[x, y_stop] for x in col_vec],
+            [[x_start, y] for y in row_vec],
+            [[x_stop, y] for y in row_vec]
+        ]
+
+        # Convert each border to angles, then stereo
+        for i, border in enumerate(borders):
+            angles, _ = detectorXYToGvec(
+                border, panel.rmat, ct.identity_3x3,
+                panel.tvec, ct.zeros_3, ct.zeros_3,
+                beamVec=panel.bvec, etaVec=panel.evec)
+            angles = np.asarray(angles)
+
+            # Swap positions of tth and eta
+            angles[:, [0, 1]] = angles[:, [1, 0]]
+
+            # Need to transpose angles before and after
+            borders[i] = angles_to_stereo(angles.T, self.instr,
+                                          self.stereo_size).T
+
+        return borders
+
     @property
     def all_detector_borders(self):
-        # return self.pv.all_detector_borders
-        # Until we compute this, just return an empty dict of detectors
-        return {k: [] for k in self.instr.detectors}
+        borders = {}
+        for key in self.instr.detectors:
+            borders[key] = self.detector_borders(key)
+
+        return borders
 
     def draw_stereo(self):
         if self.project_from_polar:

--- a/hexrd/ui/calibration/stereo_plot.py
+++ b/hexrd/ui/calibration/stereo_plot.py
@@ -110,11 +110,22 @@ class InstrumentViewer:
 
         polar_img = self.pv.img
 
-        tth_grid = np.degrees(self.pv.angular_grid[1][0, :])
-        eta_grid = np.degrees(self.pv.angular_grid[0][:, 0])
+        extent = np.degrees(self.pv.extent)
+        tth_range = extent[:2]
+        eta_range = np.sort(extent[2:])
+
+        tth_grid = np.linspace(*tth_range, polar_img.shape[1])
+        eta_grid = np.linspace(*eta_range, polar_img.shape[0])
+
+        # This is the old way of making the grids, but this would
+        # result in a small gap at eta == 360 for full coverage.
+        # tth_grid = np.degrees(self.pv.angular_grid[1][0, :])
+        # eta_grid = np.degrees(self.pv.angular_grid[0][:, 0])
 
         # Make eta between 0 and 360
-        eta_grid = np.mod(eta_grid, 360)
+        # The small extra tolerance at the end is to avoid a gap for full
+        # coverage.
+        eta_grid = np.mod(eta_grid, 360 + 1e-6)
         idx = np.argsort(eta_grid)
         eta_grid = eta_grid[idx]
         polar_img = polar_img[idx, :]

--- a/hexrd/ui/calibration/stereo_plot.py
+++ b/hexrd/ui/calibration/stereo_plot.py
@@ -1,0 +1,78 @@
+import numpy as np
+
+from hexrd.ui.constants import ViewType
+from hexrd.ui.create_hedm_instrument import create_hedm_instrument
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.overlays import update_overlay_data
+
+from .polarview import PolarView
+from .stereo_project import stereo_projection_of_polar_view
+
+
+def stereo_viewer():
+    return InstrumentViewer()
+
+
+class InstrumentViewer:
+
+    def __init__(self):
+        self.type = ViewType.stereo
+        self.instr = create_hedm_instrument()
+
+        self.pv = None
+
+        self.draw_stereo()
+
+    @property
+    def stereo_size(self):
+        return HexrdConfig().stereo_size
+
+    @property
+    def _extent(self):
+        # FIXME stereo: is this right for stereo?
+        return np.degrees(self.pv.extent)
+
+    @property
+    def all_detector_borders(self):
+        # return self.pv.all_detector_borders
+        # Until we compute this, just return an empty dict of detectors
+        return {k: [] for k in self.instr.detectors}
+
+    def draw_stereo(self):
+        if self.pv is None:
+            # Don't redraw the polar view unless we have to
+            self.draw_polar()
+
+        intensities = self.pv.raw_rescaled_img
+        intensities[self.pv.raw_mask] = np.nan
+
+        tth_grid = np.degrees(self.pv.angular_grid[1][0, :])
+        eta_grid = np.degrees(self.pv.angular_grid[0][:, 0])
+
+        # Make eta between 0 and 360
+        eta_grid = np.mod(eta_grid, 360)
+        idx = np.argsort(eta_grid)
+        eta_grid = eta_grid[idx]
+        intensities = intensities[idx, :]
+
+        self.img = stereo_projection_of_polar_view(**{
+            'pvarray': intensities,
+            'tth_grid': tth_grid,
+            'eta_grid': eta_grid,
+            'instr': self.instr,
+            'stereo_size': self.stereo_size,
+        })
+
+    def draw_polar(self):
+        """show polar view"""
+        self.pv = PolarView(self.instr)
+        self.pv.warp_all_images()
+
+    def update_overlay_data(self):
+        # update_overlay_data(self.instr, self.type)
+        # FIXME stereo: no overlays yet for stereographic
+        pass
+
+    def update_detector(self, det):
+        self.pv.update_detector(det)
+        self.draw_stereo()

--- a/hexrd/ui/calibration/stereo_project.py
+++ b/hexrd/ui/calibration/stereo_project.py
@@ -1,0 +1,139 @@
+import copy
+
+import numpy as np
+from scipy.interpolate import RegularGridInterpolator
+
+from hexrd import constants
+
+
+def stereo_projection_of_polar_view(pvarray, tth_grid, eta_grid,
+                                    instr, stereo_size):
+
+    kwargs = {
+        'points': (eta_grid, tth_grid),
+        'values': pvarray,
+        'method': 'linear',
+        'bounds_error': False,
+        'fill_value': np.nan,
+    }
+    interp_obj = RegularGridInterpolator(**kwargs)
+
+    raw_bkgsub = project_intensities_to_raw(instr, interp_obj)
+
+    return stereo_project(instr, raw_bkgsub, stereo_size)
+
+
+def project_intensity_detector(det,
+                               interp_obj):
+    tth, eta = np.degrees(det.pixel_angles())
+    eta = np.mod(eta, 360)
+    xi = (eta, tth)
+    return interp_obj(xi)
+
+
+def project_intensities_to_raw(instr,
+                               interp_obj):
+    raw_bkgsub = dict.fromkeys(instr.detectors)
+    for d in instr.detectors:
+        det = instr.detectors[d]
+        raw_bkgsub[d] = project_intensity_detector(det,
+                                                   interp_obj)
+
+    return raw_bkgsub
+
+
+def stereo_project(instr, raw, stereo_size):
+    # copy instruments and set viewing direction
+    # to be centered at the VISAR
+    instr_cp = copy.deepcopy(instr)
+    instr_cp.beam_vector = constants.beam_vec
+
+    rad = (stereo_size - 1) / 2
+    x = np.linspace(0, stereo_size - 1, stereo_size)
+    [X, Y] = np.meshgrid(x, x)
+    X = (X - rad) / rad
+    Y = (Y - rad) / rad
+    condition = X**2 + Y**2 <= 1
+    X = np.where(condition, X, np.nan)
+    Y = np.where(condition, Y, np.nan)
+    den = 1 + X**2 + Y**2
+
+    vx = 2.0 * X / den
+    vy = 2.0 * Y / den
+    vz = (1.0 - X**2 - Y**2) / den
+
+    tth = np.arccos(vz)
+    eta = np.mod(np.arctan2(vy, vx), 2 * np.pi)
+    angs = np.vstack((tth.flatten(),
+                      eta.flatten())).T
+    mask = ~np.isnan(angs)
+    mask = np.logical_and(mask[:, 0], mask[:, 1])
+
+    stereo = np.zeros((stereo_size, stereo_size))
+    fmask = np.ones_like(stereo)
+    for d in instr_cp.detectors:
+        intensity = np.empty((angs.shape[0],))
+        det = instr_cp.detectors[d]
+        cart = det.angles_to_cart(angs[mask, :])
+        out = det.interpolate_bilinear(cart, raw[d])
+        intensity[mask] = out
+        im = np.reshape(intensity, (stereo_size, stereo_size))
+        im[~condition] = np.nan
+
+        im = np.ma.masked_array(im, mask=np.isnan(im))
+        stereo += im.filled(0)
+        fmask = np.logical_and(fmask, im.mask)
+
+    return np.ma.masked_array(stereo, mask=fmask)
+
+
+def prep_polar_data(fid):
+    pvarray = np.array(fid['intensities'])
+    tth_1dgrid = np.array(fid['tth_coordinates'])[0, :]
+    eta_1dgrid = np.array(fid['eta_coordinates'])[:, 0]
+
+    eta_1dgrid = np.mod(eta_1dgrid, 360)
+    idx = np.argsort(eta_1dgrid)
+    eta_1dgrid = eta_1dgrid[idx]
+    pvarray = pvarray[idx, :]
+
+    return (pvarray, tth_1dgrid, eta_1dgrid)
+
+
+def test_stereo_project(polar_file, state_file, stereo_size):
+    import cProfile
+    import pstats
+
+    import h5py
+    from matplotlib import pyplot as plt
+
+    from hexrd.instrument import HEDMInstrument
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+
+    with h5py.File(state_file) as ins:
+        instr = HEDMInstrument(instrument_config=ins)
+
+    with h5py.File(polar_file) as fid:
+        pvarray, tth_grid, eta_grid = prep_polar_data(fid)
+
+    stereo = stereo_projection_of_polar_view(pvarray, tth_grid, eta_grid,
+                                             instr, stereo_size)
+
+    profiler.disable()
+    pstats.Stats(profiler).sort_stats('tottime').print_stats(30)
+    pstats.Stats(profiler).sort_stats('cumtime').print_stats(30)
+
+    plt.figure()
+    plt.imshow(stereo, vmin=5, vmax=35)
+
+    plt.show()
+
+
+if __name__ == '__main__':
+    polar_file = 'polar_medium_res.h5'
+    state_file = 'xrs1_state_latest.h5'
+    stereo_size = 1501
+
+    test_stereo_project(polar_file, state_file, stereo_size)

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -40,6 +40,7 @@ class ViewType:
     raw = 'raw'
     cartesian = 'cartesian'
     polar = 'polar'
+    stereo = 'stereo'
 
 
 class OverlayType(Enum):

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1966,6 +1966,26 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         _cartesian_plane_normal_rotate_y,
         set_cartesian_plane_normal_rotate_y)
 
+    def _stereo_size(self):
+        return self.config['image']['stereo']['stereo_size']
+
+    def set_stereo_size(self, v):
+        if v != self.stereo_size:
+            self.config['image']['stereo']['stereo_size'] = v
+            self.rerender_needed.emit()
+
+    stereo_size = property(_stereo_size, set_stereo_size)
+
+    def _stereo_show_border(self):
+        return self.config['image']['stereo']['show_border']
+
+    def set_stereo_show_border(self, b):
+        if b != self.stereo_size:
+            self.config['image']['stereo']['show_border'] = b
+            self.rerender_needed.emit()
+
+    stereo_show_border = property(_stereo_show_border, set_stereo_show_border)
+
     def _apply_pixel_solid_angle_correction(self):
         return self.config['image']['apply_pixel_solid_angle_correction']
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1986,6 +1986,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     stereo_show_border = property(_stereo_show_border, set_stereo_show_border)
 
+    def _stereo_project_from_polar(self):
+        return self.config['image']['stereo']['project_from_polar']
+
+    def set_stereo_project_from_polar(self, b):
+        if b != self.stereo_project_from_polar:
+            self.config['image']['stereo']['project_from_polar'] = b
+            self.rerender_needed.emit()
+
+    stereo_project_from_polar = property(
+        _stereo_project_from_polar,
+        set_stereo_project_from_polar)
+
     def _apply_pixel_solid_angle_correction(self):
         return self.config['image']['apply_pixel_solid_angle_correction']
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1990,6 +1990,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self.config['image']['stereo']['project_from_polar']
 
     def set_stereo_project_from_polar(self, b):
+        if not b:
+            print('Warning: projecting from raw is currently disabled\n',
+                  'Setting stereo mode to project from polar...')
+            b = True
+
         if b != self.stereo_project_from_polar:
             self.config['image']['stereo']['project_from_polar'] = b
             self.rerender_needed.emit()

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1109,12 +1109,19 @@ class ImageCanvas(FigureCanvas):
             self.update_overlays()
 
     def export_current_plot(self, filename):
-        if self.mode not in (ViewType.cartesian, ViewType.polar):
-            msg = 'Must be in cartesian or polar mode. Cannot export plot.'
-            raise Exception(msg)
+        allowed_view_types = [
+            ViewType.cartesian,
+            ViewType.polar,
+            ViewType.stereo,
+        ]
+        if self.mode not in allowed_view_types:
+            msg = (
+                f'View mode not implemented: {self.mode}. Cannot export.'
+            )
+            raise NotImplementedError(msg)
 
         if not self.iviewer:
-            raise Exception('No iviewer. Cannot export polar plot')
+            raise Exception('No iviewer. Cannot export')
 
         self.iviewer.write_image(filename)
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -641,8 +641,7 @@ class ImageCanvas(FigureCanvas):
         self.draw_idle()
 
     def beam_vector_changed(self):
-        if self.mode == ViewType.polar:
-            # FIXME stereo: do something with stereo
+        if self.mode == ViewType.polar or self.is_stereo_from_polar:
             # Polar needs a complete re-draw
             # Only emit this once every 100 milliseconds or so to avoid
             # too many updates if the slider widget is being used.
@@ -933,12 +932,19 @@ class ImageCanvas(FigureCanvas):
 
         return xlabel
 
+    @property
+    def is_stereo_from_polar(self):
+        return (
+            self.mode == ViewType.stereo and
+            self.iviewer and
+            self.iviewer.project_from_polar
+        )
+
     def polar_masks_changed(self):
         skip = (
             not self.iviewer or
             self.mode not in (ViewType.polar, ViewType.stereo) or
-            (self.mode == ViewType.stereo and
-             not self.iviewer.project_from_polar)
+            (self.mode == ViewType.stereo and not self.is_stereo_from_polar)
         )
         if skip:
             return

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -934,8 +934,13 @@ class ImageCanvas(FigureCanvas):
         return xlabel
 
     def polar_masks_changed(self):
-        # FIXME stereo: do something with stereo here
-        if not self.iviewer or self.mode not in ViewType.polar:
+        skip = (
+            not self.iviewer or
+            self.mode not in (ViewType.polar, ViewType.stereo) or
+            (self.mode == ViewType.stereo and
+             not self.iviewer.project_from_polar)
+        )
+        if skip:
             return
 
         self.iviewer.reapply_masks()

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -620,12 +620,6 @@ class ImageCanvas(FigureCanvas):
             self.draw_idle()
             return
 
-        # FIXME stereo: need to add stereo support for
-        # `transform_from_plain_cartesian_func()` before we can do this.
-        if self.mode == ViewType.stereo:
-            self.draw_idle()
-            return
-
         style = HexrdConfig().beam_marker_style
 
         instr = self.iviewer.instr

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -22,7 +22,9 @@ from hexrd.ui.constants import OverlayType, ViewType
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.snip_viewer_dialog import SnipViewerDialog
 from hexrd.ui import utils
-from hexrd.ui.utils.conversions import cart_to_angles, cart_to_pixels
+from hexrd.ui.utils.conversions import (
+    angles_to_stereo, cart_to_angles, cart_to_pixels,
+)
 import hexrd.ui.constants
 
 
@@ -1200,11 +1202,20 @@ def transform_from_plain_cartesian_func(mode):
         }
         return cart_to_angles(**kwargs)
 
-    # FIXME stereo: need to add stereo here
+    def to_stereo(xys, panel, iviewer):
+        # First convert to angles, then to stereo from there
+        angs = np.radians(to_angles(xys, panel, iviewer))
+        return angles_to_stereo(
+            angs,
+            iviewer.instr,
+            HexrdConfig().stereo_size,
+        )
+
     funcs = {
         ViewType.raw: to_pixels,
         ViewType.cartesian: transform_cart,
         ViewType.polar: to_angles,
+        ViewType.stereo: to_stereo,
     }
 
     if mode not in funcs:

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1105,7 +1105,6 @@ class ImageCanvas(FigureCanvas):
         # In polar/stereo mode, the overlays are clipped to the detectors, so
         # they must be re-drawn as well
         if self.mode in (ViewType.polar, ViewType.stereo):
-            # FIXME stereo: is this true? Are we clipping overlays to the detectors?
             HexrdConfig().flag_overlay_updates_for_all_materials()
             self.update_overlays()
 
@@ -1147,7 +1146,6 @@ class ImageCanvas(FigureCanvas):
         return False
 
     def polar_show_snip1d(self):
-        # FIXME stereo: should we show snip1d for stereo too?
         if self.mode != ViewType.polar:
             print('snip1d may only be shown in polar mode!')
             return

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -110,6 +110,8 @@ class ImageModeWidget(QObject):
             self.polar_tth_distortion_overlay_changed)
 
         self.ui.stereo_size.valueChanged.connect(HexrdConfig().set_stereo_size)
+        self.ui.stereo_show_border.toggled.connect(
+            HexrdConfig().set_stereo_show_border)
 
     def currentChanged(self, index):
         modes = {
@@ -147,6 +149,7 @@ class ImageModeWidget(QObject):
             self.ui.polar_apply_tth_distortion,
             self.ui.polar_tth_distortion_overlay,
             self.ui.stereo_size,
+            self.ui.stereo_show_border,
         ]
 
         return widgets
@@ -190,6 +193,8 @@ class ImageModeWidget(QObject):
             self.ui.polar_apply_erosion.setChecked(
                 HexrdConfig().polar_apply_erosion)
             self.ui.stereo_size.setValue(HexrdConfig().stereo_size)
+            self.ui.stereo_show_border.setChecked(
+                HexrdConfig().stereo_show_border)
 
             self.update_polar_tth_distortion_overlay_options()
             self.update_enable_states()

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -112,6 +112,8 @@ class ImageModeWidget(QObject):
         self.ui.stereo_size.valueChanged.connect(HexrdConfig().set_stereo_size)
         self.ui.stereo_show_border.toggled.connect(
             HexrdConfig().set_stereo_show_border)
+        self.ui.stereo_project_from_polar.toggled.connect(
+            HexrdConfig().set_stereo_project_from_polar)
 
     def currentChanged(self, index):
         modes = {
@@ -150,6 +152,7 @@ class ImageModeWidget(QObject):
             self.ui.polar_tth_distortion_overlay,
             self.ui.stereo_size,
             self.ui.stereo_show_border,
+            self.ui.stereo_project_from_polar,
         ]
 
         return widgets
@@ -195,6 +198,8 @@ class ImageModeWidget(QObject):
             self.ui.stereo_size.setValue(HexrdConfig().stereo_size)
             self.ui.stereo_show_border.setChecked(
                 HexrdConfig().stereo_show_border)
+            self.ui.stereo_project_from_polar.setChecked(
+                HexrdConfig().stereo_project_from_polar)
 
             self.update_polar_tth_distortion_overlay_options()
             self.update_enable_states()

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -34,6 +34,12 @@ class ImageModeWidget(QObject):
         # Always start with raw tab
         self.ui.tab_widget.setCurrentIndex(0)
 
+        # Hide stereo_project_from_polar for now, as projecting from polar
+        # appears to give a better image (lines up better with overlays)
+        # than projecting from raw.
+        # FIXME: why is projecting from raw different?
+        self.ui.stereo_project_from_polar.setVisible(False)
+
         self.setup_connections()
         self.update_gui_from_config()
 

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -26,7 +26,7 @@ class ImageModeWidget(QObject):
     mask_applied = Signal()
 
     def __init__(self, parent=None):
-        super(ImageModeWidget, self).__init__(parent)
+        super().__init__(parent)
 
         loader = UiLoader()
         self.ui = loader.load_file('image_mode_widget.ui', parent)
@@ -109,11 +109,14 @@ class ImageModeWidget(QObject):
         self.ui.polar_tth_distortion_overlay.currentIndexChanged.connect(
             self.polar_tth_distortion_overlay_changed)
 
+        self.ui.stereo_size.valueChanged.connect(HexrdConfig().set_stereo_size)
+
     def currentChanged(self, index):
         modes = {
             0: ViewType.raw,
             1: ViewType.cartesian,
-            2: ViewType.polar
+            2: ViewType.polar,
+            3: ViewType.stereo,
         }
         ind = self.ui.tab_widget.currentIndex()
         self.tab_changed.emit(modes[ind])
@@ -143,6 +146,7 @@ class ImageModeWidget(QObject):
             self.ui.polar_apply_erosion,
             self.ui.polar_apply_tth_distortion,
             self.ui.polar_tth_distortion_overlay,
+            self.ui.stereo_size,
         ]
 
         return widgets
@@ -185,6 +189,7 @@ class ImageModeWidget(QObject):
                 HexrdConfig().polar_snip1d_numiter)
             self.ui.polar_apply_erosion.setChecked(
                 HexrdConfig().polar_apply_erosion)
+            self.ui.stereo_size.setValue(HexrdConfig().stereo_size)
 
             self.update_polar_tth_distortion_overlay_options()
             self.update_enable_states()

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -350,8 +350,11 @@ class ImageTabWidget(QTabWidget):
                 # The i and j need to be reversed here, because the function
                 # expects `i` to be the row and `j` to be the column.
                 stereo_size = HexrdConfig().stereo_size
-                tth, eta = stereo_to_angles(np.vstack([j, i]).T,
-                                            stereo_size)[:, 0]
+                tth, eta = stereo_to_angles(
+                    ij=np.vstack([j, i]).T,
+                    instr=iviewer.instr,
+                    stereo_size=stereo_size,
+                )
             else:
                 tth = np.radians(info['x_data'])
                 eta = np.radians(info['y_data'])

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -811,9 +811,11 @@ class MainWindow(QObject):
         is_cartesian = self.image_mode == ViewType.cartesian
         is_polar = self.image_mode == ViewType.polar
         is_raw = self.image_mode == ViewType.raw
+        is_stereo = self.image_mode == ViewType.stereo
 
         has_images = HexrdConfig().has_images
 
+        # FIXME stereo: should we add export support to stereo?
         self.ui.action_export_current_plot.setEnabled(
             (is_polar or is_cartesian) and has_images)
         self.ui.action_run_laue_and_powder_calibration.setEnabled(
@@ -909,6 +911,8 @@ class MainWindow(QObject):
         elif self.image_mode == ViewType.polar:
             rebuild_polar_masks()
             self.ui.image_tab_widget.show_polar()
+        elif self.image_mode == ViewType.stereo:
+            self.ui.image_tab_widget.show_stereo()
         else:
             rebuild_raw_masks()
             self.ui.image_tab_widget.load_images()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -507,8 +507,10 @@ class MainWindow(QObject):
             # We can do CSV and XY as well
             filters += ';; CSV files (*.csv);; XY files (*.xy)'
 
+        default_name = f'{self.image_mode}_view.h5'
+        default_path = os.path.join(HexrdConfig().working_dir, default_name)
         selected_file, selected_filter = QFileDialog.getSaveFileName(
-            self.ui, 'Save Current View', HexrdConfig().working_dir, filters)
+            self.ui, 'Save Current View', default_path, filters)
 
         if selected_file:
             HexrdConfig().working_dir = os.path.dirname(selected_file)
@@ -815,9 +817,8 @@ class MainWindow(QObject):
 
         has_images = HexrdConfig().has_images
 
-        # FIXME stereo: should we add export support to stereo?
         self.ui.action_export_current_plot.setEnabled(
-            (is_polar or is_cartesian) and has_images)
+            (is_polar or is_cartesian or is_stereo) and has_images)
         self.ui.action_run_laue_and_powder_calibration.setEnabled(
             is_polar and has_images)
         self.ui.action_edit_apply_hand_drawn_mask.setEnabled(

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -913,6 +913,8 @@ class MainWindow(QObject):
             rebuild_polar_masks()
             self.ui.image_tab_widget.show_polar()
         elif self.image_mode == ViewType.stereo:
+            # Need to rebuild the polar masks since stereo may be using them
+            rebuild_polar_masks()
             self.ui.image_tab_widget.show_stereo()
         else:
             rebuild_raw_masks()

--- a/hexrd/ui/mask_manager_dialog.py
+++ b/hexrd/ui/mask_manager_dialog.py
@@ -319,7 +319,7 @@ class MaskManagerDialog(QObject):
         if self.image_mode == ViewType.raw:
             rebuild_raw_masks()
             HexrdConfig().raw_masks_changed.emit()
-        elif self.image_mode == ViewType.polar:
+        elif self.image_mode in (ViewType.polar, ViewType.stereo):
             rebuild_polar_masks()
             HexrdConfig().polar_masks_changed.emit()
 

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -157,7 +157,7 @@ class MaskRegionsDialog(QObject):
         self.axes = None
 
     def button_pressed(self, event):
-        if self.image_mode == ViewType.cartesian:
+        if self.image_mode not in (ViewType.raw, ViewType.polar):
             print('Masking must be done in raw or polar view')
             return
 

--- a/hexrd/ui/overlays/rotation_series_overlay.py
+++ b/hexrd/ui/overlays/rotation_series_overlay.py
@@ -9,6 +9,7 @@ from hexrd.ui.overlays.constants import (
     default_crystal_refinements,
 )
 from hexrd.ui.overlays.overlay import Overlay
+from hexrd.ui.utils.conversions import angles_to_stereo
 
 
 class RotationSeriesOverlay(Overlay):
@@ -198,6 +199,8 @@ class RotationSeriesOverlay(Overlay):
             DESCRIPTION.
 
         """
+        from hexrd.ui.hexrd_config import HexrdConfig
+
         instr = self.instrument
         display_mode = self.display_mode
         sim_data = instr.simulate_rotation_series(
@@ -220,6 +223,12 @@ class RotationSeriesOverlay(Overlay):
 
             if display_mode == ViewType.polar:
                 data = np.degrees(angles)
+            elif display_mode == ViewType.stereo:
+                data = angles_to_stereo(
+                    angles,
+                    instr,
+                    HexrdConfig().stereo_size,
+                )
             elif display_mode in [ViewType.raw, ViewType.cartesian]:
                 data = valid_xys[0]
                 if display_mode == ViewType.raw:
@@ -269,10 +278,19 @@ class RotationSeriesOverlay(Overlay):
         return self.rectangular_range_data(spots, display_mode, panel)
 
     def rectangular_range_data(self, spots, display_mode, panel):
+        from hexrd.ui.hexrd_config import HexrdConfig
+
         range_corners = self.range_corners(spots)
         if display_mode == ViewType.polar:
             # All done...
             return np.degrees(range_corners)
+        elif display_mode == ViewType.stereo:
+            # Convert the angles to stereo ij
+            return [angles_to_stereo(
+                angles,
+                self.instrument,
+                HexrdConfig().stereo_size,
+            ) for angles in range_corners]
 
         # The range data is curved for raw and cartesian.
         # Get more intermediate points so the data reflects this.

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -15,6 +15,8 @@ cartesian:
   virtual_plane_distance: 1000.0
   plane_normal_rotate_x: 0.0
   plane_normal_rotate_y: 0.0
+stereo:
+  stereo_size: 1501
 colormap:
   min: 0
 show_detector_borders: true

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -18,6 +18,7 @@ cartesian:
 stereo:
   stereo_size: 1501
   show_border: true
+  project_from_polar: false
 colormap:
   min: 0
 show_detector_borders: true

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -17,6 +17,7 @@ cartesian:
   plane_normal_rotate_y: 0.0
 stereo:
   stereo_size: 1501
+  show_border: true
 colormap:
   min: 0
 show_detector_borders: true

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -18,7 +18,7 @@ cartesian:
 stereo:
   stereo_size: 1501
   show_border: true
-  project_from_polar: false
+  project_from_polar: true
 colormap:
   min: 0
 show_detector_borders: true

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -846,7 +846,7 @@
             <number>1</number>
            </property>
            <property name="maximum">
-            <number>10000</number>
+            <number>100000</number>
            </property>
            <property name="value">
             <number>1501</number>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -834,16 +834,6 @@
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <layout class="QGridLayout" name="stereo_tab_grid_layout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="stereo_size_label">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of pixels used for both width and height of the projection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="text">
-            <string>Stereo Size:</string>
-           </property>
-          </widget>
-         </item>
          <item row="1" column="0">
           <widget class="QCheckBox" name="stereo_show_border">
            <property name="toolTip">
@@ -854,15 +844,28 @@
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
-          <widget class="QCheckBox" name="stereo_project_from_polar">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to create the stereographic projection from the polar view.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This can be helpful, for instance, if SNIP background subtraction is important. However, it also means that the polar view must be generated beforehand, which may take some time depending on its resolution settings. The current polar view settings are used, and thus, those settings will have a direct impact on the stereographic view.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If unchecked, the stereo view is projected from the raw images.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <item row="2" column="0" colspan="2">
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
            </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <widget class="QLabel" name="stereo_description">
            <property name="text">
-            <string>Project from Polar?</string>
+            <string>The stereographic view is generated from the polar view and includes all image processing such as background subtraction, intensity correction, etc.</string>
            </property>
-           <property name="checked">
+           <property name="wordWrap">
             <bool>true</bool>
            </property>
           </widget>
@@ -886,31 +889,28 @@
            </property>
           </widget>
          </item>
-         <item row="3" column="0" colspan="2">
-          <widget class="QLabel" name="stereo_description">
-           <property name="text">
-            <string>The stereographic view is generated from the polar view and includes all image processing such as background subtraction, intensity correction, etc.</string>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="stereo_project_from_polar">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to create the stereographic projection from the polar view.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This can be helpful, for instance, if SNIP background subtraction is important. However, it also means that the polar view must be generated beforehand, which may take some time depending on its resolution settings. The current polar view settings are used, and thus, those settings will have a direct impact on the stereographic view.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If unchecked, the stereo view is projected from the raw images.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
-           <property name="wordWrap">
+           <property name="text">
+            <string>Project from Polar?</string>
+           </property>
+           <property name="checked">
             <bool>true</bool>
            </property>
           </widget>
          </item>
-         <item row="2" column="0" colspan="2">
-          <spacer name="verticalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Vertical</enum>
+         <item row="0" column="0">
+          <widget class="QLabel" name="stereo_size_label">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of pixels used for both width and height of the projection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
-           <property name="sizeType">
-            <enum>QSizePolicy::Fixed</enum>
+           <property name="text">
+            <string>Stereo Size:</string>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          </widget>
          </item>
         </layout>
        </item>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -834,13 +834,6 @@
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <layout class="QGridLayout" name="stereo_tab_grid_layout">
-         <item row="0" column="0">
-          <widget class="QLabel" name="stereo_size_label">
-           <property name="text">
-            <string>Stereo Size:</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="1">
           <widget class="QSpinBox" name="stereo_size">
            <property name="keyboardTracking">
@@ -854,6 +847,20 @@
            </property>
            <property name="value">
             <number>1501</number>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="stereo_size_label">
+           <property name="text">
+            <string>Stereo Size:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="stereo_show_border">
+           <property name="text">
+            <string>Show Stereo Border?</string>
            </property>
           </widget>
          </item>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>596</width>
-    <height>222</height>
+    <width>817</width>
+    <height>779</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_4">
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <property name="iconSize">
       <size>
@@ -824,6 +824,53 @@
           </item>
          </layout>
         </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="stereo_tab">
+      <attribute name="title">
+       <string>Stereo</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_4">
+       <item>
+        <layout class="QGridLayout" name="stereo_tab_grid_layout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="stereo_size_label">
+           <property name="text">
+            <string>Stereo Size:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="stereo_size">
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>10000</number>
+           </property>
+           <property name="value">
+            <number>1501</number>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -834,25 +834,6 @@
       <layout class="QVBoxLayout" name="verticalLayout_4">
        <item>
         <layout class="QGridLayout" name="stereo_tab_grid_layout">
-         <item row="0" column="1">
-          <widget class="QSpinBox" name="stereo_size">
-           <property name="toolTip">
-            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of pixels used for both width and height of the projection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="minimum">
-            <number>1</number>
-           </property>
-           <property name="maximum">
-            <number>100000</number>
-           </property>
-           <property name="value">
-            <number>1501</number>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="stereo_size_label">
            <property name="toolTip">
@@ -881,7 +862,55 @@
            <property name="text">
             <string>Project from Polar?</string>
            </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
           </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QSpinBox" name="stereo_size">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of pixels used for both width and height of the projection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>100000</number>
+           </property>
+           <property name="value">
+            <number>1501</number>
+           </property>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <widget class="QLabel" name="stereo_description">
+           <property name="text">
+            <string>The stereographic view is generated from the polar view and includes all image processing such as background subtraction, intensity correction, etc.</string>
+           </property>
+           <property name="wordWrap">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Fixed</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -836,6 +836,9 @@
         <layout class="QGridLayout" name="stereo_tab_grid_layout">
          <item row="0" column="1">
           <widget class="QSpinBox" name="stereo_size">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of pixels used for both width and height of the projection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="keyboardTracking">
             <bool>false</bool>
            </property>
@@ -852,15 +855,31 @@
          </item>
          <item row="0" column="0">
           <widget class="QLabel" name="stereo_size_label">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The number of pixels used for both width and height of the projection.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>Stereo Size:</string>
            </property>
           </widget>
          </item>
-         <item row="1" column="1">
+         <item row="1" column="0">
           <widget class="QCheckBox" name="stereo_show_border">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to draw the border around the stereographic region. Pixels beyond the border are NaN.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
            <property name="text">
             <string>Show Stereo Border?</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="QCheckBox" name="stereo_project_from_polar">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Whether to create the stereographic projection from the polar view.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This can be helpful, for instance, if SNIP background subtraction is important. However, it also means that the polar view must be generated beforehand, which may take some time depending on its resolution settings. The current polar view settings are used, and thus, those settings will have a direct impact on the stereographic view.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If unchecked, the stereo view is projected from the raw images.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Project from Polar?</string>
            </property>
           </widget>
          </item>

--- a/hexrd/ui/utils/__init__.py
+++ b/hexrd/ui/utils/__init__.py
@@ -17,6 +17,7 @@ from hexrd import imageutil
 from hexrd.imageseries.omega import OmegaImageSeries
 from hexrd.rotations import angleAxisOfRotMat, RotMatEuler
 from hexrd.transforms.xfcapi import makeRotMatOfExpMap
+from hexrd.utils.decorators import memoize
 
 
 class SnipAlgorithmType(IntEnum):
@@ -142,6 +143,11 @@ def run_snip1d(img):
     numiter = HexrdConfig().polar_snip1d_numiter
     algorithm = HexrdConfig().polar_snip1d_algorithm
 
+    # Call the memoized function
+    return _run_snip1d(img, snip_width, numiter, algorithm)
+
+@memoize
+def _run_snip1d(img, snip_width, numiter, algorithm):
     if algorithm == SnipAlgorithmType.Fast_SNIP_1D:
         return imageutil.fast_snip1d(img, snip_width, numiter)
     elif algorithm == SnipAlgorithmType.SNIP_1D:

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -48,8 +48,18 @@ def pixels_to_angles(ij, panel, eta_period, tvec_s=None, tvec_c=None):
 
 
 def stereo_to_angles(ij, instr, stereo_size):
+    # Returns radians
     return stereo_ij2ang(
         ij=ij,
+        stereo_size=stereo_size,
+        bvec=instr.beam_vector,
+    )
+
+
+def angles_to_stereo(angs, instr, stereo_size):
+    # angs is in radians
+    return ang2stereo_ij(
+        angs=angs,
         stereo_size=stereo_size,
         bvec=instr.beam_vector,
     )

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -43,3 +43,22 @@ def pixels_to_angles(ij, panel, eta_period, tvec_s=None, tvec_c=None):
         'tvec_c': tvec_c,
     }
     return cart_to_angles(xys, panel, **kwargs)
+
+
+def stereo_to_angles(ij, stereo_size):
+    rad = (stereo_size - 1) / 2
+    X = (ij[:, 0] - rad) / rad
+    Y = (ij[:, 1] - rad) / rad
+    condition = X**2 + Y**2 <= 1
+    X = np.where(condition, X, np.nan)
+    Y = np.where(condition, Y, np.nan)
+    den = 1 + X**2 + Y**2
+
+    vx = 2.0 * X / den
+    vy = 2.0 * Y / den
+    vz = (1.0 - X**2 - Y**2) / den
+
+    tth = np.arccos(vz)
+    eta = np.mod(np.arctan2(vy, vx), 2 * np.pi)
+
+    return np.array([tth, eta])

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from hexrd.transforms.xfcapi import mapAngle
 
+from .stereo2angle import ij2ang as stereo_ij2ang, ang2ij as ang2stereo_ij
+
 
 def cart_to_pixels(xys, panel):
     return panel.cartToPixel(xys)[:, [1, 0]]
@@ -45,20 +47,9 @@ def pixels_to_angles(ij, panel, eta_period, tvec_s=None, tvec_c=None):
     return cart_to_angles(xys, panel, **kwargs)
 
 
-def stereo_to_angles(ij, stereo_size):
-    rad = (stereo_size - 1) / 2
-    X = (ij[:, 0] - rad) / rad
-    Y = (ij[:, 1] - rad) / rad
-    condition = X**2 + Y**2 <= 1
-    X = np.where(condition, X, np.nan)
-    Y = np.where(condition, Y, np.nan)
-    den = 1 + X**2 + Y**2
-
-    vx = 2.0 * X / den
-    vy = 2.0 * Y / den
-    vz = (1.0 - X**2 - Y**2) / den
-
-    tth = np.arccos(vz)
-    eta = np.mod(np.arctan2(vy, vx), 2 * np.pi)
-
-    return np.array([tth, eta])
+def stereo_to_angles(ij, instr, stereo_size):
+    return stereo_ij2ang(
+        ij=ij,
+        stereo_size=stereo_size,
+        bvec=instr.beam_vector,
+    )

--- a/hexrd/ui/utils/stereo2angle.py
+++ b/hexrd/ui/utils/stereo2angle.py
@@ -1,0 +1,216 @@
+import numpy as np
+from hexrd.transforms.xfcapi import makeEtaFrameRotMat, anglesToDVec, Xl
+
+
+def ij2xy(ij, stereo_size):
+    """
+    simple routine to convert pixel
+    coordinates to normalized coordinates
+
+    Parameters
+    ----------
+    ij : numpy.ndarray
+        (nx2) size of pixel coordinates
+    stereo_size: int
+        size of stereographic projection
+        in pixels
+
+    Returns
+    -------
+     numpy.ndarray
+        size is same as ij. Values outside
+        stereographic circle are nans
+    """
+    r = 0.5*(stereo_size-1)
+    res = (ij -r)/r
+    mask = np.sum(res**2, axis=1) > 1.0
+    res[mask, :] = np.nan
+    return res
+
+
+def xy2ij(xy, stereo_size):
+    """
+    simple routine to convert normalized
+    coordinate on stereo projection to
+    the floating point pixel coordinate
+
+    Parameters
+    ----------
+    xy : numpy.ndarray
+        (nx2) size of stereographic coordinates
+    stereo_size: int
+        size of stereographic projection
+        in pixels
+
+    Returns
+    -------
+     numpy.ndarray
+        size is same as xy.
+    """
+    r = 0.5*(stereo_size-1)
+    return (xy + 1.0)*r
+
+
+def xy2v3d(xy):
+    """
+    simple function to convert xy
+    normalized coordinates to the
+    3d vector in the lab frame
+
+    Parameters
+    ----------
+    xy : numpy.ndarray
+        stereographic coordinates of unit vector
+        size is (nx2)
+
+    Returns
+    -------
+    numpy.ndarray
+        unit vector
+        size is (nx3)
+    """
+    xy2 = np.sum(xy**2, axis=1)
+    den = 1 + xy2
+
+    vx = 2.0*xy[:,0]/den
+    vy = 2.0*xy[:,1]/den
+    vz = -(1.0-xy2)/den
+    return np.array([vx, vy, vz]).T
+
+
+def v3d2xy(vec):
+    """
+    simple function to convert 3d vector
+    to normalized stereographic coordinates
+
+    Parameters
+    ----------
+    vec : numpy.ndarray
+        stereographic coordinates of unit vector
+        size is (nx3)
+
+    Returns
+    -------
+    numpy.ndarray
+        stereographic coordinates
+        size is (nx2)
+    """
+    den = np.tile(1 + np.abs(vec[:,2]),[2,1]).T
+    return vec[:,0:2]/den
+
+
+def ij2ang(ij,
+           stereo_size,
+           bvec):
+    """
+    simple routine to convert pixel
+    coordinates to angles in the beam
+    frame
+
+    Parameters
+    ----------
+    ij : numpy.ndarray
+        pixel coordinates in sterepgraphic image
+        size is (nx2)
+    stereo_size : int
+        size of stereographi image in pixels
+    bvec: numpy.ndarray
+        shape (1x3)
+        can be found in HEDMInstrument.beam_vector
+
+    Returns
+    -------
+    numpy.ndarray
+        (tth, eta) angular coodinates (IN RADIANS)
+        size is (nx2)
+        NOTE: eta is returned in [0, 360] range which
+        can be mapped back to whatever range the user
+        specifies.
+
+    """
+    ij_cp = np.atleast_2d(ij)
+    vhat_l = xy2v3d(ij2xy(ij_cp, stereo_size))
+
+    tth = np.squeeze(np.arccos(np.dot(bvec, vhat_l.T)))
+
+    rm = makeEtaFrameRotMat(bvec, Xl)
+
+    vx, vy = np.dot(rm[:,0:2].T, vhat_l.T)
+    # vx = np.dot(rm[:,0], vhat_l.T)
+    # vy = np.dot(rm[:,1], vhat_l.T)
+    eta = np.mod(np.squeeze(np.arctan2(vy, vx)), 2*np.pi)
+
+    return np.array([tth, eta]).T
+
+
+def ang2ij(angs,
+           stereo_size,
+           bvec):
+    """
+    simple routine to convert angle in beam
+    frame to the pixel coordinates in the
+    stereographic image
+
+    Parameters
+    ----------
+    angs : numpy.ndarray
+        angular coodinates (tth, eta) [IN RADIANS]
+        size is (nx2)
+    stereo_size : int
+        size of stereographi image in pixels
+    bvec: numpy.ndarray
+        shape (1x3)
+        can be found in HEDMInstrument.beam_vector
+
+    Returns
+    -------
+    numpy.ndarray
+        (tth, eta) angular coodinates
+        size is (nx2)
+    """
+    angs_cp = np.atleast_2d(angs)
+    zrs = np.zeros((angs_cp.shape[0],1))
+    vhat_l = anglesToDVec(np.hstack((angs_cp,zrs)),
+             bHat_l=bvec)
+    return xy2ij(v3d2xy(vhat_l), stereo_size)
+
+
+if __name__ == '__main__':
+    """
+    Example code
+    """
+    from matplotlib import pyplot as plt
+
+    stereo_size = 1001
+
+    # this variable is available in
+    # HEDMInstrument.beam_vector
+
+    bvec = np.atleast_2d(np.array(
+           [ 4.84809620e-01, 0.0, -8.74619707e-01]
+           ))
+
+    i = np.linspace(0,1000,1001)
+    X,Y = np.meshgrid(i,i)
+
+    X = np.reshape(X, (np.prod(X.shape),))
+    Y = np.reshape(Y, (np.prod(Y.shape),))
+
+    ij = np.vstack((X,Y)).T
+
+    # very fast code
+    ang = np.degrees(ij2ang(ij, stereo_size, bvec))
+
+    tth = np.reshape(ang[:,0],[stereo_size, stereo_size])
+    eta = np.reshape(ang[:,1],[stereo_size, stereo_size])
+
+    plt.figure()
+    plt.imshow(tth)
+
+    plt.figure()
+    plt.imshow(eta)
+
+    # slower one since it uses anglesToDVec
+    ij = ang2ij(ang, stereo_size, bvec)
+
+    plt.show()


### PR DESCRIPTION
This adds a new stereographic view mode. An example is shown below.

![image](https://user-images.githubusercontent.com/9558430/213896463-3490f64b-67b5-4543-bfd3-8b3e6256b8d7.png)

This view can be generated either from the raw images or from the polar view.

To do list:

- [x] add option for view resolution
- [x] add stereo border
- [x] add option to either project from raw or polar view
- [x] ensure polar view is regenerated when anything changes that modifies the polar view (such as detector transform)
- [x] memoize the time-consuming parts of generating the polar view so that switching back and forth between views, or re-using the polar view in the stereo view, does not require regenerating the whole polar view from scratch
- [x] draw detector borders
- [x] draw overlays
- [x] mouse hover info
- [x] ~~hand draw masks~~ (will not tackle in this PR, now being tracked in #1325)
- [x] export image data
- [x] view calibration picks for fast powder calibration
- [x] ~~figure out if we should change the axes labels~~ (skipping for now - we can change this later)
- [x] draw beam marker
- [x] thoroughly verify that all types of overlays (powder, laue, and rotation series) are correct for stereo

Fixes: #465
Fixes: #1327