### PR TITLE
Maud

### DIFF
--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -158,6 +158,7 @@ class InstrumentViewer:
 
         with open(filename, 'w') as fid:
             eta_vec = np.degrees(self.angular_grid[0])
+            intensities = self.raw_rescaled_img
             for i, eta in enumerate(np.average(eta_vec, axis=1).flatten()):
                 if i == 0:
                     hstr = header0 % (i, np.linalg.norm(self.pv.tvec_s), eta)
@@ -166,7 +167,6 @@ class InstrumentViewer:
                 fid.write(hstr)
                 fid.write(block_hdr)
                 tth = HexrdConfig().last_unscaled_azimuthal_integral_data[0]
-                intensities = self.raw_rescaled_img
                 for rho, inten in zip(tth, intensities[i]):
                     vals = f' {rho}  {inten}\n'
                     fid.write(vals)

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -156,17 +156,17 @@ class InstrumentViewer:
     def write_maud(self, filename='polar_to_maud.esg'):
         filename = Path(filename)
 
-        with open(filename, 'wb') as fid:
+        with open(filename, 'w') as fid:
             eta_vec = np.degrees(self.angular_grid[0])
             for i, eta in enumerate(np.average(eta_vec, axis=1).flatten()):
                 if i == 0:
                     hstr = header0 % (i, np.linalg.norm(self.pv.tvec_s), eta)
                 else:
                     hstr = header % (i, eta)
-                fid.write(hstr.encode('ascii'))
-                fid.write(block_hdr.encode('ascii'))
+                fid.write(hstr)
+                fid.write(block_hdr)
                 tth = HexrdConfig().last_unscaled_azimuthal_integral_data[0]
                 intensities = self.raw_rescaled_img
                 for rho, inten in zip(tth, intensities[i]):
                     vals = f' {rho}  {inten}\n'
-                    fid.write(vals.encode('ascii'))
+                    fid.write(vals)

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -158,15 +158,25 @@ class InstrumentViewer:
 
         with open(filename, 'w') as fid:
             eta_vec = np.degrees(self.angular_grid[0])
-            intensities = self.raw_rescaled_img
+            intensities = self.img
+            first_block = True
             for i, eta in enumerate(np.average(eta_vec, axis=1).flatten()):
-                if i == 0:
+                if np.all(np.isnan(intensities[i])):
+                    # Skip this block
+                    continue
+
+                if first_block:
                     hstr = header0 % (i, np.linalg.norm(self.pv.tvec_s), eta)
+                    first_block = False
                 else:
                     hstr = header % (i, eta)
+
                 fid.write(hstr)
                 fid.write(block_hdr)
                 tth = HexrdConfig().last_unscaled_azimuthal_integral_data[0]
                 for rho, inten in zip(tth, intensities[i]):
+                    if np.isnan(inten):
+                        continue
+
                     vals = f' {rho}  {inten}\n'
                     fid.write(vals)

--- a/hexrd/ui/calibration/utils/maud_headers.py
+++ b/hexrd/ui/calibration/utils/maud_headers.py
@@ -1,0 +1,33 @@
+header0 = """_pd_block_id noTitle|#%d
+
+_diffrn_detector Image Plate
+_diffrn_detector_type Image Plate
+_pd_meas_step_count_time ?
+_diffrn_measurement_method ?
+_diffrn_measurement_distance_unit mm
+_pd_instr_dist_spec/detc %f
+_diffrn_radiation_wavelength ?
+_diffrn_source_target ?
+_diffrn_source_power ?
+_diffrn_source_current ?
+_pd_meas_angle_omega 0.0
+_pd_meas_angle_chi 0.0
+_pd_meas_angle_phi 0.0
+_riet_par_spec_displac_x 0
+_riet_par_spec_displac_y 0
+_riet_par_spec_displac_z 0
+_riet_meas_datafile_calibrated false
+_pd_meas_angle_eta %f
+"""
+
+header = """
+_pd_block_id noTitle|#%d
+
+_pd_meas_angle_eta %f
+"""
+
+block_hdr = """
+loop_
+_pd_proc_2theta_corrected
+_pd_meas_intensity_total
+"""

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1016,6 +1016,16 @@ class ImageCanvas(FigureCanvas):
 
         self.iviewer.write_image(filename)
 
+    def export_to_maud(self, filename):
+        if self.mode != ViewType.polar:
+            msg = 'Must be in polar mode. Cannot export.'
+            raise Exception(msg)
+
+        if not self.iviewer:
+            raise Exception('No iviewer. Cannot export')
+
+        self.iviewer.write_maud(filename)
+
     def _polar_reset_needed(self, new_polar_config):
         # If any of the entries on this list were changed, a reset is needed
         reset_needed_list = [

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -352,6 +352,9 @@ class ImageTabWidget(QTabWidget):
     def polar_show_snip1d(self):
         self.image_canvases[0].polar_show_snip1d()
 
+    def export_to_maud(self, filename):
+        self.image_canvases[0].export_to_maud(filename)
+
 
 if __name__ == '__main__':
     import sys

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -822,7 +822,7 @@ class MainWindow(QObject):
         self.ui.action_run_wppf.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
         self.ui.action_edit_apply_powder_mask_to_polar.setEnabled(is_polar)
-        self.ui.action_export_to_maud.setEnabled(is_polar)
+        self.ui.action_export_to_maud.setEnabled(is_polar and has_images)
 
     def start_fast_powder_calibration(self):
         if not HexrdConfig().has_images:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -517,8 +517,9 @@ class MainWindow(QObject):
     def on_action_export_to_maud_triggered(self):
         filters = 'ESG files (*.esg)'
 
+        default_path = os.path.join(HexrdConfig().working_dir, "maud.esg")
         selected_file, selected_filter = QFileDialog.getSaveFileName(
-            self.ui, 'Export to Maud', HexrdConfig().working_dir, filters)
+            self.ui, 'Export to Maud', default_path, filters)
 
         if selected_file:
             HexrdConfig().working_dir = os.path.dirname(selected_file)

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -177,6 +177,8 @@ class MainWindow(QObject):
             self.on_action_load_state_triggered)
         self.ui.action_export_current_plot.triggered.connect(
             self.on_action_export_current_plot_triggered)
+        self.ui.action_export_to_maud.triggered.connect(
+            self.on_action_export_to_maud_triggered)
         self.ui.action_edit_euler_angle_convention.triggered.connect(
             self.on_action_edit_euler_angle_convention)
         self.ui.action_edit_apply_hand_drawn_mask.triggered.connect(
@@ -512,6 +514,16 @@ class MainWindow(QObject):
             HexrdConfig().working_dir = os.path.dirname(selected_file)
             return self.ui.image_tab_widget.export_current_plot(selected_file)
 
+    def on_action_export_to_maud_triggered(self):
+        filters = 'ESG files (*.esg)'
+
+        selected_file, selected_filter = QFileDialog.getSaveFileName(
+            self.ui, 'Export to Maud', HexrdConfig().working_dir, filters)
+
+        if selected_file:
+            HexrdConfig().working_dir = os.path.dirname(selected_file)
+            return self.ui.image_tab_widget.export_to_maud(selected_file)
+
     def on_action_run_laue_and_powder_calibration_triggered(self):
         if not hasattr(self, '_calibration_runner_async_runner'):
             # Initialize this only once and keep it around, so we don't
@@ -810,6 +822,7 @@ class MainWindow(QObject):
         self.ui.action_run_wppf.setEnabled(is_polar and has_images)
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
         self.ui.action_edit_apply_powder_mask_to_polar.setEnabled(is_polar)
+        self.ui.action_export_to_maud.setEnabled(is_polar)
 
     def start_fast_powder_calibration(self):
         if not HexrdConfig().has_images:

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -504,6 +504,9 @@
    <property name="text">
     <string>To Maud</string>
    </property>
+   <property name="toolTip">
+    <string>Export to Maud ESG format. Only available in the polar view.</string>
+   </property>
   </action>
   <action name="action_edit_reset_instrument_config">
    <property name="text">

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -80,6 +80,7 @@
       <string>Export</string>
      </property>
      <addaction name="action_export_current_plot"/>
+     <addaction name="action_export_to_maud"/>
     </widget>
     <widget class="QMenu" name="menu_import">
      <property name="title">
@@ -494,6 +495,14 @@
    </property>
    <property name="text">
     <string>Current View</string>
+   </property>
+  </action>
+  <action name="action_export_to_maud">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>To Maud</string>
    </property>
   </action>
   <action name="action_edit_reset_instrument_config">


### PR DESCRIPTION
~~WIP~~

First pass at exporting the required file format for Maud. The [new function](https://github.com/HEXRD/hexrdgui/compare/master...bnmajor:maud?expand=1#diff-da700bf8138e505bdb7fb2d673146b9567d8505912dad974e22c3f757d976754R156-R176) to write out the file has been adapted from of the original script by Joel:
```
import h5py
​
import numpy as np
​
header0 = """
_pd_block_id noTitle|#%d
​
_diffrn_detector Image Plate
_diffrn_detector_type Image Plate
_pd_meas_step_count_time ?
_diffrn_measurement_method ?
_diffrn_measurement_distance_unit mm
_pd_instr_dist_spec/detc %f
_diffrn_radiation_wavelength ?
_diffrn_source_target ?
_diffrn_source_power ?
_diffrn_source_current ?
_pd_meas_angle_omega 0.0
_pd_meas_angle_chi 0.0
_pd_meas_angle_phi 0.0
_riet_par_spec_displac_x 0
_riet_par_spec_displac_y 0
_riet_par_spec_displac_z 0
_riet_meas_datafile_calibrated false
"""
​
header = "_pd_block_id noTitle|#%d"
​
block_hdr = """
%s
​
_pd_meas_angle_eta %f
​
loop_
_pd_proc_2theta_corrected
_pd_meas_intensity_total
"""
​
with open('dummy.esg', 'w') as fid:
    for i, eta in enumerate(np.average(eta_vec.reshape(36, 50), axis=1).flatten()):
        if i == 0:
            hstr = header0 % (i, np.linalg.norm(panel.tvec))
        else:
            hstr = header % i
        print(block_hdr % (hstr, eta), file=fid)
        tth_eta = np.vstack([tth_vec, np.tile(eta, len(tth_vec))]).T
        det_xy = panel.angles_to_cart(np.radians(tth_eta))
        radii = np.sqrt(np.sum(det_xy*det_xy, axis=1))
        for rho, inten in zip(radii, summed[i]):
            print('{0:.6f}  {1:.6f}'.format(rho, inten), file=fid)
```
- [Headers](https://github.com/HEXRD/hexrdgui/compare/master...bnmajor:maud?expand=1#diff-77b66f4b11bb957c24e405592be9ef58e55a664ded06b89d94af94cd3776c2c4R1-R33) have been updated and tested and appear to be correct now
- `eta_vec` created ~~[here](https://github.com/HEXRD/hexrdgui/compare/master...bnmajor:maud?expand=1#diff-f9308985cbba0fcd56144d0011f8be6cdc78d2fde975680c1ea9f13b7da95c64R123-R125)~~ [here](https://github.com/HEXRD/hexrdgui/pull/1322/files#diff-da700bf8138e505bdb7fb2d673146b9567d8505912dad974e22c3f757d976754R160)
- `tvec` pulled from [instrument](https://github.com/HEXRD/hexrdgui/blob/master/hexrd/ui/calibration/polarview.py#L60-L61)
- `tth_eta` ~~built from `tth_vec` computed [here](https://github.com/HEXRD/hexrdgui/compare/master...bnmajor:maud?expand=1#diff-f9308985cbba0fcd56144d0011f8be6cdc78d2fde975680c1ea9f13b7da95c64R119-R121)~~ pulled from [azimuthal integration](https://github.com/HEXRD/hexrdgui/pull/1322/files#diff-da700bf8138e505bdb7fb2d673146b9567d8505912dad974e22c3f757d976754R168)
- `summed` is pulled from the [raw re-scaled image](https://github.com/HEXRD/hexrdgui/compare/master...bnmajor:maud?expand=1#diff-da700bf8138e505bdb7fb2d673146b9567d8505912dad974e22c3f757d976754R173)

The file is written out and can be loaded by Maud but is not loaded properly (no plot is generated). No errors or feedback given.