### PR TITLE
Fix convert_panel_buffer_to_2d_array()

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -2383,4 +2383,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             utils.convert_panel_buffer_to_2d_array(panel)
 
             # Add the mask
+            # NOTE: the mask here is False when pixels should be masked.
+            # This is the same as the panel buffer, which is why we are
+            # doing a `np.logical_and()`.
             panel.panel_buffer = np.logical_and(mask, panel.panel_buffer)

--- a/hexrd/ui/utils/__init__.py
+++ b/hexrd/ui/utils/__init__.py
@@ -482,12 +482,20 @@ def convert_panel_buffer_to_2d_array(panel):
         # Just make a panel buffer with all True values
         panel.panel_buffer = np.ones(panel.shape, dtype=np.bool)
     elif panel.panel_buffer.shape == (2,):
-        # The two integers are specifying the borders in x and y
-        borders = panel.panel_buffer.astype(int)
+        # The two floats are specifying the borders in mm for x and y.
+        # Convert to pixel borders. Swap x and y so we have i, j in pixels.
+        borders = np.round([
+            panel.panel_buffer[1] / panel.pixel_size_row,
+            panel.panel_buffer[0] / panel.pixel_size_col,
+        ]).astype(int)
 
         # Convert to array
         panel_buffer = np.zeros(panel.shape, dtype=np.bool)
-        panel_buffer[borders[0]:-borders[0], borders[1]:-borders[1]] = True
+
+        # We can't do `-borders[i]` since that doesn't work for 0,
+        # so we must do `panel.shape[i] - borders[i]` instead.
+        panel_buffer[borders[0]:panel.shape[0] - borders[0],
+                     borders[1]:panel.shape[1] - borders[1]] = True
         panel.panel_buffer = panel_buffer
     elif panel.panel_buffer.ndim != 2:
         raise NotImplementedError(panel.panel_buffer.ndim)


### PR DESCRIPTION
The 2-value panel buffer represents the `x, y` directions in mm,
not in pixels.

So we need to convert these values to pixels first, and then we also needed
to fix an issue where the logic wouldn't work if the borders were 0. This
would result in the whole array being `False`. That is now fixed.
