### PR TITLE
Only rerender stereo border when option changes

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -63,6 +63,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when the option to show the saturation level is changed"""
     show_saturation_level_changed = Signal()
 
+    """Emitted when the option to show the stereo border is changed"""
+    show_stereo_border_changed = Signal()
+
     """Emitted when the option to tab images is changed"""
     tab_images_changed = Signal()
 
@@ -1982,7 +1985,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def set_stereo_show_border(self, b):
         if b != self.stereo_size:
             self.config['image']['stereo']['show_border'] = b
-            self.rerender_needed.emit()
+            self.show_stereo_border_changed.emit()
 
     stereo_show_border = property(_stereo_show_border, set_stereo_show_border)
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -72,6 +72,8 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().overlay_config_changed.connect(self.update_overlays)
         HexrdConfig().show_saturation_level_changed.connect(
             self.show_saturation)
+        HexrdConfig().show_stereo_border_changed.connect(
+            self.draw_stereo_border)
         HexrdConfig().detector_transform_modified.connect(
             self.on_detector_transform_modified)
         HexrdConfig().rerender_detector_borders.connect(


### PR DESCRIPTION
If the user changes the option to show the stereo border, don't rerender the whole image. Only rerender the stereo border artist.