### PR TITLE
Set tilt/transform to prevent zeros in pixel solid angles

### DIFF
--- a/hexrd/ui/resources/calibration/default_pxrdip_config.yml
+++ b/hexrd/ui/resources/calibration/default_pxrdip_config.yml
@@ -8,8 +8,8 @@ detectors:
       rows: 750
       size: [0.1, 0.1]
     transform:
-      tilt: [0.0, 0.0, 0.0]
-      translation: [0.0, 0.0, 0.0]
+      tilt: [-1.2091995761561454e+00, 1.2091995761561454e+00, -1.2091995761561454e+00]
+      translation: [-24.75, 0.0, -37.5]
 oscillation_stage:
   chi: 0.0
   translation: [0.0, 0.0, 0.0]

--- a/hexrd/ui/resources/calibration/default_tardis_config.yml
+++ b/hexrd/ui/resources/calibration/default_tardis_config.yml
@@ -9,8 +9,8 @@ detectors:
       size: [0.1, 0.1]
     buffer: [0.2, 0.2]
     transform:
-      tilt: [0.0, 0.0, 0.0]
-      translation: [0.0, 0.0, 0.0]
+      tilt: [-1.57079633e+00, 0.0, 0.0]
+      translation: [0.0, -11.565, -25.08]
 oscillation_stage:
   chi: 0.0
   translation: [0.0, 0.0, 0.0]


### PR DESCRIPTION
If not set and Apply Pixel Solid Angle Correction is toggled on pixel_solid_angles will contain zeros which will cause errors that result in infinite recursion when the LLNL Import dialog is opened and the default instrument config is loaded.

Fixes #1320 