### PR TITLE
Make a deep copy of materials in indexing config

### DIFF
--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -1,8 +1,6 @@
 import copy
 import os
 
-import numpy as np
-
 from hexrd.config.root import RootConfig
 from hexrd.config.material import MaterialConfig
 from hexrd.config.instrument import Instrument as InstrumentConfig
@@ -26,7 +24,6 @@ def create_indexing_config():
     # Creates a hexrd.config class from the indexing configuration
 
     material = get_indexing_material()
-    pd = material.planeData
 
     # Make a copy to modify
     indexing_config = copy.deepcopy(HexrdConfig().indexing_config)
@@ -45,11 +42,8 @@ def create_indexing_config():
 
     # Create and set material config
     mconfig = MaterialConfig(config)
-    mconfig.materials = HexrdConfig().materials
+    mconfig.materials = copy.deepcopy(HexrdConfig().materials)
     config.material = mconfig
-
-    # Set this so the config won't over-write our tThWidth
-    config.set('material:tth_width', np.degrees(material.planeData.tThWidth))
 
     ims_dict = HexrdConfig().omega_imageseries_dict
     if ims_dict is None:

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -1,6 +1,8 @@
 import copy
 import os
 
+import numpy as np
+
 from hexrd.config.root import RootConfig
 from hexrd.config.material import MaterialConfig
 from hexrd.config.instrument import Instrument as InstrumentConfig
@@ -44,6 +46,11 @@ def create_indexing_config():
     mconfig = MaterialConfig(config)
     mconfig.materials = copy.deepcopy(HexrdConfig().materials)
     config.material = mconfig
+
+    tth_width = material.planeData.tThWidth
+    if tth_width is not None:
+        # Set this so it will be used in HEXRD
+        config.set('material:tth_width', np.degrees(tth_width))
 
     ims_dict = HexrdConfig().omega_imageseries_dict
     if ims_dict is None:


### PR DESCRIPTION
HEXRD sometimes modifies these materials. This is why we were originally
setting tth width on the config, so that our material would not be modified.
    
However, HEXRD also sometimes modifies other properties. So make a deep copy
of the materials so that they do not get unintentionally modified in HEXRDGUI.

This also fixes the error that would occur when `np.degrees()` was being called on the `tth_width` when it was `None`.

Fixes: #1331