### PR TITLE
Do not override the QObject parent

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -122,13 +122,13 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
                     files[idx].append('/'.join([path, f]))
         return files
 
-    def read_data(self, files, data=None, parent=None):
+    def read_data(self, files, data=None, ui_parent=None):
         # When this is pressed read in a complete set of data for all detectors.
         # Run the imageseries processing in a background thread and display a
         # loading dialog
         self.parent_dir = HexrdConfig().images_dir
         self.set_state()
-        self.parent = parent
+        self.ui_parent = ui_parent
         self.files = files
         self.data = {} if data is None else data
         self.empty_frames = data['empty_frames'] if data else 0
@@ -140,8 +140,8 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
         self.live_update_status.emit(False)
 
         # Create threads and loading dialog
-        thread_pool = QThreadPool(self.parent)
-        progress_dialog = ProgressDialog(self.parent)
+        thread_pool = QThreadPool(self.ui_parent)
+        progress_dialog = ProgressDialog(self.ui_parent)
         progress_dialog.setWindowTitle('Loading Processed Imageseries')
         self.progress_text.connect(progress_dialog.setLabelText)
         self.progress_dialog = progress_dialog

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -258,7 +258,7 @@ class LLNLImportToolDialog(QObject):
             # closed after accepting the image selection. We're not positive
             # why this is the case but it may be related to being a parent to
             # the QProgressDialog.
-            ImageLoadManager().read_data(files, parent=self.ui.parent())
+            ImageLoadManager().read_data(files, ui_parent=self.ui.parent())
             self.cmap.block_updates(False)
             self.it = InteractiveTemplate(self.parent())
 
@@ -490,7 +490,7 @@ class LLNLImportToolDialog(QObject):
         # closed after accepting the image selection. We're not positive
         # why this is the case but it may be related to being a parent to
         # the QProgressDialog.
-        ImageLoadManager().read_data(files, parent=self.ui.parent())
+        ImageLoadManager().read_data(files, ui_parent=self.ui.parent())
 
         buffer_default = {'status': 0}
         for det in det_names:

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -459,7 +459,7 @@ class MainWindow(QObject):
                     pos = HexrdConfig().detector_names.index(d)
                     files[pos].append(f)
                 HexrdConfig().recent_images = image_files
-                ImageLoadManager().read_data(files, parent=self.ui)
+                ImageLoadManager().read_data(files, ui_parent=self.ui)
 
     def images_loaded(self, enabled=True):
         self.ui.action_transform_detectors.setEnabled(enabled)


### PR DESCRIPTION
Instead, save the ui parent as its own attribute, ui_parent.

Addresses part of #1335 