### PR TITLE
Add argument parser and a couple of command line arguments

### DIFF
--- a/hexrd/ui/argument_parser.py
+++ b/hexrd/ui/argument_parser.py
@@ -1,0 +1,25 @@
+import argparse
+
+
+class ArgumentParser(argparse.ArgumentParser):
+    """The ArgumentParser used by HEXRDGUI
+
+    This class defines the arguments used by HEXRDGUI on the command line.
+    It is created and stored in the HexrdConfig() object, so that it is
+    accessible throughout the program.
+    """
+    def __init__(self, *args, **kwargs):
+
+        # Add hexrdgui-specific stuff here
+        kwargs.update(dict(
+            description='High energy x-ray diffraction data analysis',
+        ))
+
+        super().__init__(*args, **kwargs)
+
+        # Add arguments here
+        self.add_argument(
+            '--ignore-settings',
+            action='store_true',
+            help='Ignore previous settings when HEXRDGUI starts',
+        )

--- a/hexrd/ui/argument_parser.py
+++ b/hexrd/ui/argument_parser.py
@@ -1,6 +1,21 @@
 import argparse
 
 
+def check_positive_int(value):
+    """Ensure the value is a positive int"""
+    error_msg = f"invalid positive int value: {value}"
+
+    try:
+        ivalue = int(value)
+    except ValueError:
+        raise argparse.ArgumentTypeError(error_msg)
+
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(error_msg)
+
+    return ivalue
+
+
 class ArgumentParser(argparse.ArgumentParser):
     """The ArgumentParser used by HEXRDGUI
 
@@ -22,4 +37,10 @@ class ArgumentParser(argparse.ArgumentParser):
             '--ignore-settings',
             action='store_true',
             help='Ignore previous settings when HEXRDGUI starts',
+        )
+
+        self.add_argument(
+            '-n', '--ncpus',
+            type=check_positive_int,
+            help='Set the number of CPUs to use for parallel operations',
         )

--- a/hexrd/ui/calibration/calibrationutil.py
+++ b/hexrd/ui/calibration/calibrationutil.py
@@ -162,27 +162,6 @@ def det_panel_mask(instr, img_dict, tolerance=1e-6):
         panel.panel_buffer = mask
 
 
-# instrument
-def load_instrument(yml):
-    try:
-        with h5py.File(yml, 'r') as f:
-            instr = instrument.HEDMInstrument(f)
-    except(OSError):
-        with open(yml, 'r') as f:
-            instr = instrument.HEDMInstrument(yaml.safe_load(f))
-    return instr
-
-
-# instrument
-def load_crystal(yml):
-    with open(yml, 'r') as f:
-        icfg = yaml.load(f)
-        expmap = np.r_[icfg['calibration_crystal']['orientation']]
-        tvec = np.r_[icfg['calibration_crystal']['position']]
-        vinv = np.r_[icfg['calibration_crystal']['inv_stretch']]
-    return expmap, tvec, vinv
-
-
 def load_images(img_stem, ip_keys,
                 threshold=None,
                 denoise=False,

--- a/hexrd/ui/create_hedm_instrument.py
+++ b/hexrd/ui/create_hedm_instrument.py
@@ -7,7 +7,12 @@ def create_hedm_instrument():
     # HEDMInstrument expects None Euler angle convention for the
     # config. Let's get it as such.
     iconfig = HexrdConfig().instrument_config_none_euler_convention
-    rme = HexrdConfig().rotation_matrix_euler()
+    kwargs = {
+        'instrument_config': iconfig,
+        'tilt_calibration_mapping': HexrdConfig().rotation_matrix_euler(),
+    }
 
-    return HEDMInstrument(instrument_config=iconfig,
-                          tilt_calibration_mapping=rme)
+    if HexrdConfig().max_cpus is not None:
+        kwargs['max_workers'] = HexrdConfig().max_cpus
+
+    return HEDMInstrument(**kwargs)

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import sys
 
-from PySide2.QtCore import Signal, QCoreApplication, QObject, QSettings, QTimer
+from PySide2.QtCore import Signal, QObject, QSettings, QTimer
 
 import h5py
 import numpy as np
@@ -17,6 +17,7 @@ from hexrd.material import load_materials_hdf5, save_materials_hdf5, Material
 from hexrd.rotations import RotMatEuler
 from hexrd.valunits import valWUnit
 
+from hexrd.ui.argument_parser import ArgumentParser
 from hexrd.ui import constants
 from hexrd.ui import overlays
 from hexrd.ui import resource_loader
@@ -250,7 +251,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.config['materials'] = copy.deepcopy(
             self.default_config['materials'])
 
-        if '--ignore-settings' not in QCoreApplication.arguments():
+        self.parse_args()
+
+        if not self._initial_load_ignore_settings:
             self.load_settings()
 
         self.set_defaults_if_missing()
@@ -295,6 +298,32 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             signal.connect(self.materials_dict_modified.emit)
 
         self.overlay_renamed.connect(self.on_overlay_renamed)
+
+    def parse_args(self):
+        """Create the argument parser and parse the arguments
+
+        The ArgumentParser object adds all of the command line arguments that
+        may be used by HEXRDGUI. We then parse these arguments and cache the
+        results on the HexrdConfig() object.
+
+        We are doing this on the HexrdConfig() object so that the parsed
+        arguments are accessible throughout the program.
+
+        Note that the program will exit early when this function is called
+        if `--help` was passed.
+        """
+        self._arg_parser = ArgumentParser()
+        self._program_args = self._arg_parser.parse_args()
+
+        # Set some of these on the HexrdConfig object
+        # The key is the parsed variable name. The value is the attribute to
+        # set on HexrdConfig().
+        to_set = {
+            'ignore_settings': '_initial_load_ignore_settings',
+        }
+
+        for k, v in to_set.items():
+            setattr(self, v, getattr(self._program_args, k))
 
     # Returns a list of tuples contain the names of attributes and their
     # default values that should be persisted as part of the configuration

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -316,14 +316,15 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self._program_args = self._arg_parser.parse_args()
 
         # Set some of these on the HexrdConfig object
-        # The key is the parsed variable name. The value is the attribute to
-        # set on HexrdConfig().
+        # The key is the attribute to set on HexrdConfig().
+        # The value is the parsed variable name.
         to_set = {
-            'ignore_settings': '_initial_load_ignore_settings',
+            '_initial_load_ignore_settings': 'ignore_settings',
+            'max_cpus': 'ncpus',
         }
 
         for k, v in to_set.items():
-            setattr(self, v, getattr(self._program_args, k))
+            setattr(self, k, getattr(self._program_args, v))
 
     # Returns a list of tuples contain the names of attributes and their
     # default values that should be persisted as part of the configuration

--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -446,9 +446,11 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
         :param f: The aggregation function
         :param ims_dict: The imageseries to aggregate
         """
+        max_workers = HexrdConfig().max_cpus
+
         futures = []
         progress_dict = {key: 0.0 for key in ims_dict.keys()}
-        with ThreadPoolExecutor() as tp:
+        with ThreadPoolExecutor(max_workers=max_workers) as tp:
             for (key, ims) in ims_dict.items():
                 futures.append(tp.submit(f, key, ims, progress_dict=progress_dict))
 
@@ -483,9 +485,11 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
                             the aggregation, frames is number of images to aggregate, and
                             ims is the image series to perform the aggregation on.
         """
+        max_workers = HexrdConfig().max_cpus
+
         futures = []
         progress_dict = {key: 0.0 for key in aggr_op_dict.keys()}
-        with ThreadPoolExecutor() as tp:
+        with ThreadPoolExecutor(max_workers=max_workers) as tp:
             for (key, (op, frames, ims)) in aggr_op_dict.items():
                 futures.append(tp.submit(
                     self.aggregate_dark, key, op, ims, frames, progress_dict))

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -31,6 +31,10 @@ def create_indexing_config():
     # Make a copy to modify
     indexing_config = copy.deepcopy(HexrdConfig().indexing_config)
 
+    if HexrdConfig().max_cpus is not None:
+        # Set the max number of CPUs
+        indexing_config['multiprocessing'] = HexrdConfig().max_cpus
+
     # Set the active material on the config
     tmp = indexing_config.setdefault('material', {})
     tmp['active'] = material.name

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -6,6 +6,7 @@ from PySide2.QtGui import QIcon, QPixmap
 from PySide2.QtWidgets import QApplication
 
 from hexrd.ui import resource_loader
+from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.main_window import MainWindow
 import hexrd.ui.resources.icons
 
@@ -20,6 +21,10 @@ def main():
     QCoreApplication.setApplicationName('hexrd')
 
     app = QApplication(sys.argv)
+
+    # Initialize the HexrdConfig object so that it will parse arguments
+    # and exit early if needed.
+    HexrdConfig()
 
     data = resource_loader.load_resource(hexrd.ui.resources.icons,
                                          'hexrd.ico', binary=True)


### PR DESCRIPTION
This adds an argument parser and a couple of command line arguments to HEXRDGUI.

The argument parser will make it easier for us to add more arguments in the future.

Here is the current help menu, if you run `hexrdgui -h`:

```
$ hexrdgui -h
usage: hexrdgui [-h] [--ignore-settings] [-n NCPUS]

High energy x-ray diffraction data analysis

options:
  -h, --help            show this help message and exit
  --ignore-settings     Ignore previous settings when HEXRDGUI starts
  -n NCPUS, --ncpus NCPUS
                        Set the number of CPUs to use for parallel operations
```

I tested the `--ncpus` option with the HEDM workflow, and it seemed to work.

Fixes: #1328

This is identical to #1339, except that the target branch is correct...