### PR TITLE
Parse the arguments within the main() method

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -4,7 +4,7 @@ import os
 from pathlib import Path
 import sys
 
-from PySide2.QtCore import Signal, QObject, QSettings, QTimer
+from PySide2.QtCore import Signal, QCoreApplication, QObject, QSettings, QTimer
 
 import h5py
 import numpy as np
@@ -239,6 +239,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.polar_corr_field_polar_dict = None
         self.polar_angular_grid = None
         self._recent_images = {}
+        self.max_cpus = None
 
         self.setup_logging()
 
@@ -251,9 +252,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.config['materials'] = copy.deepcopy(
             self.default_config['materials'])
 
-        self.parse_args()
-
-        if not self._initial_load_ignore_settings:
+        # We can't use the parsed args yet for this since this is in the
+        # __init__ method. So just check for this flag manually.
+        if '--ignore-settings' not in QCoreApplication.arguments():
             self.load_settings()
 
         self.set_defaults_if_missing()
@@ -319,7 +320,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         # The key is the attribute to set on HexrdConfig().
         # The value is the parsed variable name.
         to_set = {
-            '_initial_load_ignore_settings': 'ignore_settings',
             'max_cpus': 'ncpus',
         }
 

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -22,9 +22,9 @@ def main():
 
     app = QApplication(sys.argv)
 
-    # Initialize the HexrdConfig object so that it will parse arguments
-    # and exit early if needed.
-    HexrdConfig()
+    # Initialize the HexrdConfig object and parse the arguments
+    # so that it will exit early if needed.
+    HexrdConfig().parse_args()
 
     data = resource_loader.load_resource(hexrd.ui.resources.icons,
                                          'hexrd.ico', binary=True)


### PR DESCRIPTION
This makes it so that the argument parsing does not happen except in the `hexrdgui` entrypoint.

This is helpful for things like `pytest`, where we don't want HEXRDGUI to parse the `pytest` arguments.

It could also allow us to develop other scripts while skipping the arg parsing.