### PR TITLE
Make sure the transform dialog uses the read_data path

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -122,18 +122,18 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
                     files[idx].append('/'.join([path, f]))
         return files
 
-    def read_data(self, files, data=None, ui_parent=None):
+    def read_data(self, files=None, data=None, ui_parent=None, **kwargs):
         # When this is pressed read in a complete set of data for all detectors.
         # Run the imageseries processing in a background thread and display a
         # loading dialog
-        self.parent_dir = HexrdConfig().images_dir
-        self.set_state()
-        self.ui_parent = ui_parent
-        self.files = files
+        if files:
+            self.parent_dir = HexrdConfig().images_dir
+            self.files = files
+            self.empty_frames = data['empty_frames'] if data else 0
         self.data = {} if data is None else data
-        self.empty_frames = data['empty_frames'] if data else 0
-
-        self.begin_processing()
+        self.ui_parent = ui_parent
+        self.set_state(kwargs.get('state', None))
+        self.begin_processing(kwargs.get('postprocess', False))
 
     def begin_processing(self, postprocess=False):
         self.update_status = HexrdConfig().live_update

--- a/hexrd/ui/transform_dialog.py
+++ b/hexrd/ui/transform_dialog.py
@@ -72,5 +72,4 @@ class TransformDialog:
             'agg': state.get('agg', 0),
         }
 
-        ilm.set_state(new_state)
-        ilm.begin_processing(postprocess=True)
+        ilm.read_data(ui_parent=self.ui, state=new_state, postprocess=True)


### PR DESCRIPTION
This makes sure that no matter how the data is loaded (manually or via state file) all required attributes are correctly set in the ImageLoadManager.

Fixes #1335 