### PR TITLE
Skip converting fast powder picks to polar

### DIFF
--- a/hexrd/ui/overlays/laue_overlay.py
+++ b/hexrd/ui/overlays/laue_overlay.py
@@ -180,6 +180,19 @@ class LaueOverlay(Overlay):
 
         instr = self.instrument
         display_mode = self.display_mode
+
+        point_groups = {}
+        keys = ['spots', 'ranges', 'hkls', 'labels', 'label_offsets']
+        for det_key in instr.detectors:
+            point_groups[det_key] = {key: [] for key in keys}
+
+        # This will be an empty list if there are none.
+        # And if there are none, the Laue simulator produces an error.
+        # Guard against that error.
+        sym_hkls = self.plane_data.getSymHKLs()
+        if not sym_hkls:
+            return point_groups
+
         sim_data = instr.simulate_laue_pattern(
             self.plane_data_no_exclusions,
             minEnergy=self.min_energy,
@@ -187,11 +200,7 @@ class LaueOverlay(Overlay):
             rmat_s=self.sample_rmat,
             grain_params=[self.crystal_params, ])
 
-        point_groups = {}
-        keys = ['spots', 'ranges', 'hkls']
         for det_key, psim in sim_data.items():
-            point_groups[det_key] = {key: [] for key in keys}
-
             # grab panel and split out simulation results
             # !!! note that the sim results are lists over number of grains
             #     and here we explicitly have one.


### PR DESCRIPTION
We are now storing the calibration picks as Cartesian coordinates -
not polar coordinates. As such, we do not need to convert to polar
coordinates anymore, but can set the Cartesian picks directly.

This fixes an issue where, if you were looking at the Cartesian view,
the auto picks would fail to convert to polar coordinates (due to the
fact that the Cartesian view has a fake instrument it uses).

This PR also fixes an issue where an error would occur if no Laue spots
could be generated due to a lack of HKLs.

Fixes: #1353