### PR TITLE
Simulated overlay

### DIFF
--- a/hexrd/ui/azimuthal_overlay_editor.py
+++ b/hexrd/ui/azimuthal_overlay_editor.py
@@ -1,0 +1,48 @@
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class AzimuthalOverlayEditor:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('azimuthal_overlay_editor.ui', parent)
+        self._selected_overlay = None
+
+        self.setup_connections()
+        self.enable_inputs(False)
+
+    def setup_connections(self):
+        self.ui.fwhm.valueChanged.connect(self.update_fwhm)
+        self.ui.scale.valueChanged.connect(self.update_scale)
+
+    @property
+    def selected_overlay(self):
+        return self._selected_overlay
+
+    @selected_overlay.setter
+    def selected_overlay(self, overlay):
+        self._selected_overlay = overlay
+        if overlay is not None:
+            self.ui.fwhm.setValue(overlay['fwhm'])
+            self.ui.scale.setValue(overlay['scale'])
+            self.ui.name_label.setText(overlay['name'])
+
+    def enable_inputs(self, enabled=False):
+        self.ui.fwhm_label.setEnabled(enabled)
+        self.ui.fwhm.setEnabled(enabled)
+        self.ui.scale_label.setEnabled(enabled)
+        self.ui.scale.setEnabled(enabled)
+        self.ui.name_label.setEnabled(enabled)
+
+    def update_fwhm(self, value):
+        self.selected_overlay['fwhm'] = value
+        HexrdConfig().azimuthal_overlay_modified.emit()
+
+    def update_scale(self, value):
+        self.selected_overlay['scale'] = value
+        HexrdConfig().azimuthal_overlay_modified.emit()
+
+    def update_name_label(self, name):
+        self.ui.name_label.setText(name)
+        HexrdConfig().azimuthal_overlay_modified.emit()

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -7,6 +7,7 @@ from hexrd.ui import utils
 
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.azimuthal_overlay_editor import AzimuthalOverlayEditor
+from hexrd.ui.azimuthal_overlay_style_picker import AzimuthalOverlayStylePicker
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
 
@@ -244,4 +245,5 @@ class AzimuthalOverlayManager:
         HexrdConfig().azimuthal_overlay_modified.emit()
 
     def edit_style(self):
-        pass
+        self._style_picker = AzimuthalOverlayStylePicker(self.active_overlay, self.ui)
+        self._style_picker.exec_()

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -1,0 +1,231 @@
+from PySide2.QtCore import Qt, QItemSelectionModel
+from PySide2.QtWidgets import (
+    QCheckBox, QComboBox, QHBoxLayout, QHeaderView, QSizePolicy,
+    QTableWidgetItem, QWidget
+)
+from hexrd.ui import utils
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
+
+
+COLUMNS = {
+    'name': 0,
+    'material': 1,
+    'visible': 2,
+}
+
+
+class AzimuthalOverlayManager:
+
+    def __init__(self, parent=None):
+        loader = UiLoader()
+        self.ui = loader.load_file('azimuthal_overlay_manager.ui', parent)
+
+        flags = self.ui.windowFlags()
+        self.ui.setWindowFlags(flags | Qt.Tool)
+
+        self.material_combos = []
+        self.visibility_boxes = []
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.table.selectionModel().selectionChanged.connect(
+            self.selection_changed)
+        self.ui.table.itemChanged.connect(self.table_item_changed)
+        self.ui.add_button.pressed.connect(self.add)
+        self.ui.remove_button.pressed.connect(self.remove)
+        self.ui.edit_style_button.pressed.connect(self.edit_style)
+
+    def show(self):
+        self.update_table()
+        self.ui.show()
+
+    def create_materials_combo(self, v):
+        materials = list(HexrdConfig().materials.keys())
+
+        if v not in materials:
+            raise Exception(f'Unknown material: {v}')
+
+        cb = QComboBox(self.ui.table)
+        size_policy = QSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        cb.setSizePolicy(size_policy)
+        for mat in materials:
+            cb.addItem(mat, mat)
+
+        cb.setCurrentIndex(materials.index(v))
+        cb.currentIndexChanged.connect(self.update_config_materials)
+        self.material_combos.append(cb)
+        return self.create_table_widget(cb)
+
+    def create_visibility_checkbox(self, v):
+        cb = QCheckBox(self.ui.table)
+        cb.setChecked(v)
+        cb.toggled.connect(self.update_visibilities)
+        self.visibility_boxes.append(cb)
+        return self.create_table_widget(cb)
+
+    def create_table_widget(self, w):
+        # These are required to center the widget...
+        tw = QWidget(self.ui.table)
+        layout = QHBoxLayout(tw)
+        layout.addWidget(w)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setContentsMargins(0, 0, 0, 0)
+        return tw
+
+    def clear_table(self):
+        self.material_combos.clear()
+        self.visibility_boxes.clear()
+        self.ui.table.clearContents()
+
+    def update_table(self):
+        block_list = [
+            self.ui.table,
+            self.ui.table.selectionModel()
+        ]
+
+        with block_signals(*block_list):
+            prev_selected = self.selected_row
+
+            self.clear_table()
+            self.ui.table.setRowCount(len(self.overlays))
+            for i, overlay in enumerate(self.overlays):
+                w = QTableWidgetItem(overlay['name'])
+                self.ui.table.setItem(i, COLUMNS['name'], w)
+
+                w = self.create_materials_combo(overlay['material'])
+                self.ui.table.setCellWidget(i, COLUMNS['material'], w)
+
+                w = self.create_visibility_checkbox(overlay['visible'])
+                self.ui.table.setCellWidget(i, COLUMNS['visible'], w)
+
+            if prev_selected is not None:
+                select_row = (prev_selected if prev_selected < len(self.overlays)
+                              else len(self.overlays) - 1)
+                self.select_row(select_row)
+
+            self.ui.table.resizeColumnsToContents()
+
+            # The last section isn't always stretching automatically, even
+            # though we have setStretchLastSection(True) set.
+            # Force it to stretch manually.
+            last_column = max(v for v in COLUMNS.values())
+            self.ui.table.horizontalHeader().setSectionResizeMode(
+                last_column, QHeaderView.Stretch)
+
+            # Just in case the selection actually changed...
+            self.selection_changed()
+
+    def select_row(self, i):
+        if i is None or i >= self.ui.table.rowCount():
+            # Out of range. Don't do anything.
+            return
+
+        # Select the row
+        selection_model = self.ui.table.selectionModel()
+        selection_model.clearSelection()
+
+        model_index = selection_model.model().index(i, 0)
+        command = QItemSelectionModel.Select | QItemSelectionModel.Rows
+        selection_model.select(model_index, command)
+
+    @property
+    def overlays(self):
+        return HexrdConfig().azimuthal_overlays
+
+    @property
+    def selected_row(self):
+        selected = self.ui.table.selectionModel().selectedRows()
+        return selected[0].row() if selected else None
+
+    def selection_changed(self):
+        self.update_enable_states()
+
+    def update_enable_states(self):
+        row_selected = self.selected_row is not None
+        self.ui.remove_button.setEnabled(row_selected)
+        self.ui.edit_style_button.setEnabled(row_selected)
+
+    def update_config_materials(self):
+        any_changed = False
+        for i in range(self.ui.table.rowCount()):
+            w = self.material_combos[i]
+            overlay = self.overlays[i]
+            if overlay['material'] != w.currentData():
+                overlay['material'] = w.currentData()
+                any_changed = True
+
+        if any_changed:
+            # In case the material was renamed
+            self.update_table()
+
+    def update_visibilities(self):
+        for i in range(self.ui.table.rowCount()):
+            w = self.visibility_boxes[i]
+            self.overlays[i]['visible'] = w.isChecked()
+
+    @property
+    def active_material_name(self):
+        return HexrdConfig().active_material_name
+
+    @property
+    def active_overlay(self):
+        i = self.selected_row
+        if i is None or i >= len(self.overlays):
+            return None
+
+        return self.overlays[i]
+
+    def table_item_changed(self, item):
+        col = item.column()
+        if col == COLUMNS['name']:
+            return self.overlay_name_edited(item)
+        else:
+            raise Exception(f'Item editing not implemented for column: {col}')
+
+    def overlay_name_edited(self, item):
+        row = item.row()
+        new_name = item.text()
+        modified_overlay = self.overlays[row]
+        old_name = modified_overlay['name']
+
+        # If the name matches any other overlay names, revert back so that
+        # we can keep unique names.
+        for overlay in self.overlays:
+            if new_name == overlay['name']:
+                # This name already exists. Revert changes.
+                item.setText(old_name)
+                return
+
+        modified_overlay['name'] = new_name
+
+    def create_unique_name(self):
+        existing_names = [o['name'] for o in self.overlays]
+        return utils.unique_name(existing_names, self.active_material_name)
+
+    def add_azimuthal_overlay(self):
+        data = {
+            'name': self.create_unique_name(),
+            'material': self.active_material_name,
+            'visible': True,
+            'fwhm': 0.25,
+            'scale': 1.0,
+            'color': '#ff0000',
+            'opacity': 0.3,
+        }
+        self.overlays.append(data)
+
+    def add(self):
+        self.add_azimuthal_overlay()
+        self.update_table()
+        self.select_row(len(self.overlays) - 1)
+
+    def remove(self):
+        self.overlays.pop(self.selected_row)
+        self.update_table()
+
+    def edit_style(self):
+        pass

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -6,6 +6,7 @@ from PySide2.QtWidgets import (
 from hexrd.ui import utils
 
 from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.azimuthal_overlay_editor import AzimuthalOverlayEditor
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
 
@@ -23,6 +24,8 @@ class AzimuthalOverlayManager:
         loader = UiLoader()
         self.ui = loader.load_file('azimuthal_overlay_manager.ui', parent)
 
+        self.overlay_editor = AzimuthalOverlayEditor(self.ui)
+        self.ui.overlay_editor_layout.addWidget(self.overlay_editor.ui)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
 
@@ -143,11 +146,19 @@ class AzimuthalOverlayManager:
 
     def selection_changed(self):
         self.update_enable_states()
+        self.update_overlay_editor()
 
     def update_enable_states(self):
         row_selected = self.selected_row is not None
         self.ui.remove_button.setEnabled(row_selected)
         self.ui.edit_style_button.setEnabled(row_selected)
+        self.overlay_editor.enable_inputs(row_selected)
+
+    def update_overlay_editor(self):
+        if self.selected_row is not None:
+            self.overlay_editor.selected_overlay = self.overlays[self.selected_row]
+        else:
+            self.overlay_editor.selected_overlay = None
 
     def update_config_materials(self):
         any_changed = False
@@ -203,6 +214,7 @@ class AzimuthalOverlayManager:
                 return
 
         modified_overlay['name'] = new_name
+        self.overlay_editor.update_name_label(new_name)
 
     def create_unique_name(self):
         existing_names = [o['name'] for o in self.overlays]

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -11,6 +11,7 @@ from hexrd.ui.azimuthal_overlay_style_picker import AzimuthalOverlayStylePicker
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
 
+import numpy as np
 
 COLUMNS = {
     'name': 0,
@@ -222,12 +223,13 @@ class AzimuthalOverlayManager:
         return utils.unique_name(existing_names, self.active_material_name)
 
     def add_azimuthal_overlay(self):
+        tth, sum = HexrdConfig().last_unscaled_azimuthal_integral_data
         data = {
             'name': self.create_unique_name(),
             'material': self.active_material_name,
             'visible': True,
-            'fwhm': 0.25,
-            'scale': 1.0,
+            'fwhm': 2.0,
+            'scale': np.max(sum)/100,
             'color': '#ff0000',
             'opacity': 0.3,
         }

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -47,6 +47,8 @@ class AzimuthalOverlayManager:
         self.ui.toggle_legend.toggled.connect(self.toggle_legend)
         self.ui.toggle_legend.setChecked(
             HexrdConfig().show_azimuthal_legend)
+        self.ui.save_plot.clicked.connect(
+            HexrdConfig().azimuthal_plot_saved.emit)
         HexrdConfig().materials_added.connect(self.update_table)
         HexrdConfig().material_renamed.connect(self.update_table)
         HexrdConfig().materials_removed.connect(self.update_table)

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -1,3 +1,4 @@
+import random
 from PySide2.QtCore import Qt, QItemSelectionModel
 from PySide2.QtWidgets import (
     QCheckBox, QComboBox, QHBoxLayout, QHeaderView, QSizePolicy,
@@ -243,7 +244,7 @@ class AzimuthalOverlayManager:
             'visible': True,
             'fwhm': 2.0,
             'scale': np.max(sum)/100,
-            'color': '#ff0000',
+            'color': f'#{random.randint(0, 0xFFFFFF):06x}',
             'opacity': 0.3,
         }
         self.overlays.append(data)

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -43,6 +43,9 @@ class AzimuthalOverlayManager:
         self.ui.add_button.pressed.connect(self.add)
         self.ui.remove_button.pressed.connect(self.remove)
         self.ui.edit_style_button.pressed.connect(self.edit_style)
+        self.ui.toggle_legend.toggled.connect(self.toggle_legend)
+        self.ui.toggle_legend.setChecked(
+            HexrdConfig().show_azimuthal_legend)
 
     def show(self):
         self.update_table()
@@ -249,3 +252,7 @@ class AzimuthalOverlayManager:
     def edit_style(self):
         self._style_picker = AzimuthalOverlayStylePicker(self.active_overlay, self.ui)
         self._style_picker.exec_()
+
+    def toggle_legend(self, value):
+        HexrdConfig().show_azimuthal_legend = value
+        HexrdConfig().azimuthal_overlay_modified.emit()

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -161,11 +161,13 @@ class AzimuthalOverlayManager:
         if any_changed:
             # In case the material was renamed
             self.update_table()
+            HexrdConfig().azimuthal_overlay_modified.emit()
 
     def update_visibilities(self):
         for i in range(self.ui.table.rowCount()):
             w = self.visibility_boxes[i]
             self.overlays[i]['visible'] = w.isChecked()
+        HexrdConfig().azimuthal_overlay_modified.emit()
 
     @property
     def active_material_name(self):
@@ -222,10 +224,12 @@ class AzimuthalOverlayManager:
         self.add_azimuthal_overlay()
         self.update_table()
         self.select_row(len(self.overlays) - 1)
+        HexrdConfig().azimuthal_overlay_modified.emit()
 
     def remove(self):
         self.overlays.pop(self.selected_row)
         self.update_table()
+        HexrdConfig().azimuthal_overlay_modified.emit()
 
     def edit_style(self):
         pass

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -46,6 +46,11 @@ class AzimuthalOverlayManager:
         self.ui.toggle_legend.toggled.connect(self.toggle_legend)
         self.ui.toggle_legend.setChecked(
             HexrdConfig().show_azimuthal_legend)
+        HexrdConfig().materials_added.connect(self.update_table)
+        HexrdConfig().material_renamed.connect(self.update_table)
+        HexrdConfig().materials_removed.connect(self.update_table)
+
+        HexrdConfig().state_loaded.connect(self.update_table)
 
     def show(self):
         self.update_table()

--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -171,6 +171,9 @@ class AzimuthalOverlayManager:
             w = self.material_combos[i]
             overlay = self.overlays[i]
             if overlay['material'] != w.currentData():
+                new_name = self.create_unique_name(w.currentData())
+                if overlay['material'] in overlay['name']:
+                    overlay['name'] = new_name
                 overlay['material'] = w.currentData()
                 any_changed = True
 
@@ -221,9 +224,11 @@ class AzimuthalOverlayManager:
         modified_overlay['name'] = new_name
         self.overlay_editor.update_name_label(new_name)
 
-    def create_unique_name(self):
+    def create_unique_name(self, name=None):
+        if name is None:
+            name = self.active_material_name
         existing_names = [o['name'] for o in self.overlays]
-        return utils.unique_name(existing_names, self.active_material_name)
+        return utils.unique_name(existing_names, name)
 
     def add_azimuthal_overlay(self):
         tth, sum = HexrdConfig().last_unscaled_azimuthal_integral_data

--- a/hexrd/ui/azimuthal_overlay_style_picker.py
+++ b/hexrd/ui/azimuthal_overlay_style_picker.py
@@ -1,5 +1,3 @@
-import copy
-
 from PySide2.QtCore import QObject
 from PySide2.QtGui import QColor
 from PySide2.QtWidgets import QColorDialog
@@ -41,7 +39,11 @@ class AzimuthalOverlayStylePicker(QObject):
         ]
 
     def reset_style(self):
-        if self.color == self.overlay['color'] and self.opacity == self.overlay['opacity']:
+        any_changes = (
+            self.color != self.overlay['color'] or
+            self.opacity != self.overlay['opacity']
+        )
+        if not any_changes:
             # Nothing really to do...
             return
 
@@ -76,4 +78,5 @@ class AzimuthalOverlayStylePicker(QObject):
             self.update_config()
 
     def update_button_colors(self):
-        self.ui.color.setStyleSheet('QPushButton {background-color: %s}' % self.ui.color.text())
+        self.ui.color.setStyleSheet(
+            'QPushButton {background-color: %s}' % self.ui.color.text())

--- a/hexrd/ui/azimuthal_overlay_style_picker.py
+++ b/hexrd/ui/azimuthal_overlay_style_picker.py
@@ -1,0 +1,79 @@
+import copy
+
+from PySide2.QtCore import QObject
+from PySide2.QtGui import QColor
+from PySide2.QtWidgets import QColorDialog
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils import block_signals
+
+
+class AzimuthalOverlayStylePicker(QObject):
+
+    def __init__(self, overlay, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('azimuthal_overlay_style_picker.ui', parent)
+
+        self.color = overlay['color']
+        self.opacity = overlay['opacity']
+        self.overlay = overlay
+        self.ui.material_name.setText(overlay['material'])
+
+        self.setup_connections()
+        self.update_gui()
+
+    def exec_(self):
+        self.ui.adjustSize()
+        return self.ui.exec_()
+
+    def setup_connections(self):
+        self.ui.color.pressed.connect(self.pick_color)
+        self.ui.opacity.valueChanged.connect(self.update_config)
+
+    @property
+    def all_widgets(self):
+        return [
+            self.ui.color,
+            self.ui.opacity,
+        ]
+
+    def reset_style(self):
+        if self.color == self.overlay['color'] and self.opacity == self.overlay['opacity']:
+            # Nothing really to do...
+            return
+
+        self.color = self.overlay['color']
+        self.opacity = self.overlay['opacity']
+        self.update_gui()
+        HexrdConfig().azimuthal_overlay_modified.emit()
+
+    def update_gui(self):
+        with block_signals(*self.all_widgets):
+            self.ui.color.setText(self.overlay['color'])
+            self.ui.opacity.setValue(self.overlay['opacity'])
+
+        self.update_button_colors()
+
+    def update_config(self):
+        self.overlay['color'] = self.ui.color.text()
+        self.overlay['opacity'] = self.ui.opacity.value()
+
+        HexrdConfig().azimuthal_overlay_modified.emit()
+
+    def pick_color(self):
+        # This should only be called by signals/slots
+        # It uses the sender() to get the button that called it
+        sender = self.sender()
+        color = sender.text()
+
+        dialog = QColorDialog(QColor(color), self.ui)
+        if dialog.exec_():
+            sender.setText(dialog.selectedColor().name())
+            self.update_button_colors()
+            self.update_config()
+
+    def update_button_colors(self):
+        self.ui.color.setStyleSheet('QPushButton {background-color: %s}' % self.ui.color.text())

--- a/hexrd/ui/calibration/auto/powder_runner.py
+++ b/hexrd/ui/calibration/auto/powder_runner.py
@@ -222,13 +222,10 @@ class PowderRunner(QObject):
             #        this array is the reduce lattice parameter set.
             refined_lattice_params = self.ic.full_params[self.ic.npi:]
             self.material.latticeParameters = refined_lattice_params
+            HexrdConfig().material_modified.emit(self.material.name)
 
         # Tell GUI that the overlays need to be re-computed
         HexrdConfig().flag_overlay_updates_for_material(self.material.name)
-
-        # update the materials panel
-        if self.material is HexrdConfig().active_material:
-            HexrdConfig().active_material_modified.emit()
 
         # redraw updated overlays
         HexrdConfig().overlay_config_changed.emit()

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -390,8 +390,7 @@ class CalibrationRunner(QObject):
                 mat = materials[mat_name]
                 mat.latticeParameters = calibrator.params
                 HexrdConfig().flag_overlay_updates_for_material(mat_name)
-                if mat is HexrdConfig().active_material:
-                    HexrdConfig().active_material_modified.emit()
+                HexrdConfig().material_modified.emit(mat_name)
             else:
                 overlay.crystal_params = calibrator.params
 

--- a/hexrd/ui/calibration/wppf_runner.py
+++ b/hexrd/ui/calibration/wppf_runner.py
@@ -82,9 +82,7 @@ class WppfRunner:
 
             mat.latticeParameters = lparms
             HexrdConfig().flag_overlay_updates_for_material(name)
-
-            if mat is HexrdConfig().active_material:
-                HexrdConfig().active_material_modified.emit()
+            HexrdConfig().material_modified.emit(name)
 
         HexrdConfig().overlay_config_changed.emit()
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1511,6 +1511,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         for overlay in self.overlays:
             if overlay.material_name == old_name:
                 overlay.material_name = new_name
+        for polar_overlay in self.azimuthal_overlays:
+            if polar_overlay['material'] == old_name:
+                polar_overlay['material'] = new_name
 
         if self.active_material_name == old_name:
             # Set the dict directly to bypass the updates that occur

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -196,6 +196,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when the loaded images change"""
     recent_images_changed = Signal()
 
+    """Emitted when an azimuthal overlay gets modified"""
+    azimuthal_overlay_modified = Signal()
+
+
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)
@@ -324,6 +328,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('overlays_dictified', []),
             ('_polar_tth_distortion_overlay_name', None),
             ('_recent_images', {}),
+            ('azimuthal_overlays', []),
         ]
 
     # Provide a mapping from attribute names to the keys used in our state

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1729,6 +1729,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.overlays = pruned_overlays
             self.overlay_list_modified.emit()
             self.overlay_config_changed.emit()
+        pruned_overlays = [x for x in self.azimuthal_overlays if x['material'] in mats]
+        if len(self.azimuthal_overlays) != len(pruned_overlays):
+            self.azimuthal_overlays = pruned_overlays
+            HexrdConfig().azimuthal_overlay_modified.emit()
 
     def append_overlay(self, material_name, type):
         kwargs = {

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -239,6 +239,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.polar_angular_grid = None
         self._recent_images = {}
         self.max_cpus = None
+        self.azimuthal_overlays = []
 
         self.setup_logging()
 
@@ -396,6 +397,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         # a boolean and convert if necessary
         if not isinstance(self.live_update, bool):
             self.live_update = self.live_update == 'true'
+        if not isinstance(self.azimuthal_legend, bool):
+            self.azimuthal_legend = self.azimuthal_legend == 'true'
+
+        if self.azimuthal_overlays is None:
+            self.azimuthal_overlays = []
 
         self.previous_active_material = state.get('active_material_name')
 

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -200,7 +200,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     azimuthal_overlay_modified = Signal()
 
     """Emitted when an azimuthal overlay gets modified"""
-    azimuthal_plot_saved = Signal()
+    azimuthal_plot_save_requested = Signal()
 
     """Emitted when material parameters are modified"""
     material_modified = Signal(str)
@@ -1742,7 +1742,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.overlays = pruned_overlays
             self.overlay_list_modified.emit()
             self.overlay_config_changed.emit()
-        pruned_overlays = [x for x in self.azimuthal_overlays if x['material'] in mats]
+
+        pruned_overlays = [x for x in self.azimuthal_overlays
+                           if x['material'] in mats]
         if len(self.azimuthal_overlays) != len(pruned_overlays):
             self.azimuthal_overlays = pruned_overlays
             HexrdConfig().azimuthal_overlay_modified.emit()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -244,7 +244,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self._recent_images = {}
         self.max_cpus = None
         self.azimuthal_overlays = []
-        self.azimuthal_legend = True
+        self.show_azimuthal_legend = True
 
         self.setup_logging()
 
@@ -330,7 +330,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('_polar_tth_distortion_overlay_name', None),
             ('_recent_images', {}),
             ('azimuthal_overlays', []),
-            ('azimuthal_legend', True),
+            ('show_azimuthal_legend', True),
         ]
 
     # Provide a mapping from attribute names to the keys used in our state
@@ -404,8 +404,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         # a boolean and convert if necessary
         if not isinstance(self.live_update, bool):
             self.live_update = self.live_update == 'true'
-        if not isinstance(self.azimuthal_legend, bool):
-            self.azimuthal_legend = self.azimuthal_legend == 'true'
+        if not isinstance(self.show_azimuthal_legend, bool):
+            self.show_azimuthal_legend = self.show_azimuthal_legend == 'true'
 
         if self.azimuthal_overlays is None:
             self.azimuthal_overlays = []

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -244,6 +244,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self._recent_images = {}
         self.max_cpus = None
         self.azimuthal_overlays = []
+        self.azimuthal_legend = True
 
         self.setup_logging()
 
@@ -329,6 +330,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('_polar_tth_distortion_overlay_name', None),
             ('_recent_images', {}),
             ('azimuthal_overlays', []),
+            ('azimuthal_legend', True),
         ]
 
     # Provide a mapping from attribute names to the keys used in our state

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -199,6 +199,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when an azimuthal overlay gets modified"""
     azimuthal_overlay_modified = Signal()
 
+    """Emitted when an azimuthal overlay gets modified"""
+    azimuthal_plot_saved = Signal()
+
 
     def __init__(self):
         # Should this have a parent?

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -202,6 +202,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when an azimuthal overlay gets modified"""
     azimuthal_plot_saved = Signal()
 
+    """Emitted when material parameters are modified"""
+    material_modified = Signal(str)
 
     def __init__(self):
         # Should this have a parent?
@@ -307,6 +309,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             signal.connect(self.materials_dict_modified.emit)
 
         self.overlay_renamed.connect(self.on_overlay_renamed)
+        self.material_modified.connect(self.check_active_material_changed)
 
     # Returns a list of tuples contain the names of attributes and their
     # default values that should be persisted as part of the configuration
@@ -1578,6 +1581,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     def material(self, name):
         return self.config['materials']['materials'].get(name)
+
+    def check_active_material_changed(self, material_name):
+        if material_name == self.active_material_name:
+            self.active_material_modified.emit()
 
     def _active_material(self):
         m = self.active_material_name

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1014,26 +1014,29 @@ class ImageCanvas(FigureCanvas):
         # Apply new, visible overlays
         tth, sum = HexrdConfig().last_unscaled_azimuthal_integral_data
         for overlay in HexrdConfig().azimuthal_overlays:
-            if overlay['visible']:
-                material = HexrdConfig().materials[overlay['material']]
-                material.compute_powder_overlay(tth, fwhm=overlay['fwhm'], scale=overlay['scale'])
-                result = material.powder_overlay
-                line, = self.azimuthal_integral_axis.plot(tth, result, lw=0)
-                fill = self.azimuthal_integral_axis.fill_between(
-                    tth,
-                    result,
-                    color=overlay['color'],
-                    alpha=overlay['opacity']
-                )
-                fill.set_label(overlay['name'])
-                self.azimuthal_overlay_artists.append({
-                    'name': overlay['name'],
-                    'material': overlay['material'],
-                    'artists' :{
-                        'fill': fill,
-                        'line': line,
-                    },
-                })
+            if not overlay['visible']:
+                continue
+            material = HexrdConfig().materials[overlay['material']]
+            material.compute_powder_overlay(tth, fwhm=overlay['fwhm'], scale=overlay['scale'])
+            result = material.powder_overlay
+            # Plot the result so that the plot scales correctly with the data
+            # since the fill artist is not taken into account for rescaling.
+            line, = self.azimuthal_integral_axis.plot(tth, result, lw=0)
+            fill = self.azimuthal_integral_axis.fill_between(
+                tth,
+                result,
+                color=overlay['color'],
+                alpha=overlay['opacity']
+            )
+            fill.set_label(overlay['name'])
+            self.azimuthal_overlay_artists.append({
+                'name': overlay['name'],
+                'material': overlay['material'],
+                'artists' :{
+                    'fill': fill,
+                    'line': line,
+                },
+            })
         if HexrdConfig().show_azimuthal_legend and len(self.azimuthal_overlay_artists):
             self.azimuthal_integral_axis.legend()
         elif self.azimuthal_integral_axis:

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1039,12 +1039,9 @@ class ImageCanvas(FigureCanvas):
             })
         if HexrdConfig().show_azimuthal_legend and len(self.azimuthal_overlay_artists):
             self.azimuthal_integral_axis.legend()
-        elif self.azimuthal_integral_axis:
-            try:
-                self.azimuthal_integral_axis.get_legend().remove()
-            except:
-                # No legend to remove
-                pass
+        elif (axis := self.azimuthal_integral_axis) and axis.get_legend():
+            # Only remove the legend if the axis exists and it has a legend
+            axis.get_legend().remove()
         self.draw_idle()
 
     def update_azimuthal_integral_plot(self):

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1022,12 +1022,21 @@ class ImageCanvas(FigureCanvas):
                     color=overlay['color'],
                     alpha=overlay['opacity']
                 )
+                artist.set_label(overlay['name'])
                 self.azimuthal_overlay_artists.append({
                     'name': overlay['name'],
                     'material': overlay['material'],
                     'artist': artist,
                     'line': line,
                 })
+        if HexrdConfig().azimuthal_legend and len(self.azimuthal_overlay_artists):
+            self.azimuthal_integral_axis.legend()
+        elif self.azimuthal_integral_axis:
+            try:
+                self.azimuthal_integral_axis.get_legend().remove()
+            except:
+                # No legend to remove
+                pass
         self.draw_idle()
 
     def update_azimuthal_integral_plot(self):

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1027,6 +1027,9 @@ class ImageCanvas(FigureCanvas):
         self.figure.savefig(selected_file, bbox_inches=new_extent)
 
     def update_azimuthal_plot_overlays(self):
+        if self.mode != ViewType.polar:
+            # Nothing to do. Just return.
+            return
         self.clear_azimuthal_integral_axis()
 
         # Apply new, visible overlays

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1029,7 +1029,7 @@ class ImageCanvas(FigureCanvas):
                     'artist': artist,
                     'line': line,
                 })
-        if HexrdConfig().azimuthal_legend and len(self.azimuthal_overlay_artists):
+        if HexrdConfig().show_azimuthal_legend and len(self.azimuthal_overlay_artists):
             self.azimuthal_integral_axis.legend()
         elif self.azimuthal_integral_axis:
             try:

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -91,6 +91,7 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().azimuthal_overlay_modified.connect(
             self.update_azimuthal_integral_plot)
         HexrdConfig().azimuthal_plot_saved.connect(self.save_azimuthal_plot)
+        HexrdConfig().material_modified.connect(self.update_azimuthal_plot_overlays)
 
     def __del__(self):
         # This is so that the figure can be cleaned up

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1017,6 +1017,7 @@ class ImageCanvas(FigureCanvas):
             if not overlay['visible']:
                 continue
             material = HexrdConfig().materials[overlay['material']]
+            density = round(material.unitcell.density, 2)
             material.compute_powder_overlay(tth, fwhm=overlay['fwhm'], scale=overlay['scale'])
             result = material.powder_overlay
             # Plot the result so that the plot scales correctly with the data
@@ -1028,7 +1029,7 @@ class ImageCanvas(FigureCanvas):
                 color=overlay['color'],
                 alpha=overlay['opacity']
             )
-            fill.set_label(overlay['name'])
+            fill.set_label(f'{overlay["name"]}({density}g cm^-3)')
             self.azimuthal_overlay_artists.append({
                 'name': overlay['name'],
                 'material': overlay['material'],

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -106,14 +106,14 @@ class ImageCanvas(FigureCanvas):
         self.raw_axes.clear()
         self.axes_images.clear()
         self.remove_all_overlay_artists()
-        self.clear_azimuthal_integral_axis()
+        self.clear_azimuthal_integral_artists()
         self.mode = None
 
     def clear_azimuthal_integral_axis(self):
         self.clear_wppf_plot()
         self.azimuthal_integral_axis = None
         self.azimuthal_line_artist = None
-        self.clear_azimuthal_integral_axis()
+        self.clear_azimuthal_integral_artists()
         HexrdConfig().last_unscaled_azimuthal_integral_data = None
 
     def clear_wppf_plot(self):
@@ -1004,7 +1004,7 @@ class ImageCanvas(FigureCanvas):
         masked = np.ma.masked_array(pimg, mask=np.isnan(pimg))
         return masked.sum(axis=0) / np.sum(~masked.mask, axis=0)
 
-    def clear_azimuthal_integral_axis(self):
+    def clear_azimuthal_integral_artists(self):
         while self.azimuthal_overlay_artists:
             item = self.azimuthal_overlay_artists.pop(0)
             for artist in item['artists'].values():
@@ -1030,7 +1030,8 @@ class ImageCanvas(FigureCanvas):
         if self.mode != ViewType.polar:
             # Nothing to do. Just return.
             return
-        self.clear_azimuthal_integral_axis()
+
+        self.clear_azimuthal_integral_artists()
 
         # Apply new, visible overlays
         tth, sum = HexrdConfig().last_unscaled_azimuthal_integral_data

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1013,8 +1013,7 @@ class ImageCanvas(FigureCanvas):
     def save_azimuthal_plot(self):
         # Save just the second axis (the azimuthal integral plot)
         selected_file, selected_filter = QFileDialog.getSaveFileName(
-            self, 'Save Azimuthal Integral Plot', HexrdConfig().working_dir,
-            'Image files (*.png, *.jpg, *.jpeg)')
+            self, 'Save Azimuthal Integral Plot', HexrdConfig().working_dir)
 
         if not selected_file:
             return
@@ -1048,7 +1047,7 @@ class ImageCanvas(FigureCanvas):
                 color=overlay['color'],
                 alpha=overlay['opacity']
             )
-            fill.set_label(f'{overlay["name"]}({density}g cm^-3)')
+            fill.set_label(f'{overlay["name"]}({density}g/cm³)')
             self.azimuthal_overlay_artists.append({
                 'name': overlay['name'],
                 'material': overlay['material'],

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -124,8 +124,6 @@ class ImageModeWidget(QObject):
         self.ui.stereo_project_from_polar.toggled.connect(
             HexrdConfig().set_stereo_project_from_polar)
 
-        self.ui.toggle_azimuthal_legend.toggled.connect(self.toggle_legend)
-
     def currentChanged(self, index):
         modes = {
             0: ViewType.raw,
@@ -211,8 +209,6 @@ class ImageModeWidget(QObject):
                 HexrdConfig().stereo_show_border)
             self.ui.stereo_project_from_polar.setChecked(
                 HexrdConfig().stereo_project_from_polar)
-            self.ui.toggle_azimuthal_legend.setChecked(
-                HexrdConfig().show_azimuthal_legend)
 
             self.update_polar_tth_distortion_overlay_options()
             self.update_enable_states()
@@ -422,10 +418,6 @@ class ImageModeWidget(QObject):
 
         self._overlay_manager = AzimuthalOverlayManager(self.ui)
         self._overlay_manager.show()
-
-    def toggle_legend(self, value):
-        HexrdConfig().show_azimuthal_legend = value
-        HexrdConfig().azimuthal_overlay_modified.emit()
 
 def compute_polar_params(panel, max_tth_ps, max_eta_ps, min_tth, max_tth):
     # Other than panel, all arguments are lists for appending results

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -212,7 +212,7 @@ class ImageModeWidget(QObject):
             self.ui.stereo_project_from_polar.setChecked(
                 HexrdConfig().stereo_project_from_polar)
             self.ui.toggle_azimuthal_legend.setChecked(
-                HexrdConfig().azimuthal_legend)
+                HexrdConfig().show_azimuthal_legend)
 
             self.update_polar_tth_distortion_overlay_options()
             self.update_enable_states()
@@ -424,7 +424,7 @@ class ImageModeWidget(QObject):
         self._overlay_manager.show()
 
     def toggle_legend(self, value):
-        HexrdConfig().azimuthal_legend = value
+        HexrdConfig().show_azimuthal_legend = value
         HexrdConfig().azimuthal_overlay_modified.emit()
 
 def compute_polar_params(panel, max_tth_ps, max_eta_ps, min_tth, max_tth):

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -4,6 +4,7 @@ import numpy as np
 
 from PySide2.QtCore import QObject, QTimer, Signal
 
+from hexrd.ui.azimuthal_overlay_manager import AzimuthalOverlayManager
 from hexrd.ui.constants import ViewType
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.create_raw_mask import apply_threshold_mask
@@ -97,6 +98,8 @@ class ImageModeWidget(QObject):
         self.ui.polar_show_snip1d.clicked.connect(self.polar_show_snip1d.emit)
 
         self.ui.tab_widget.currentChanged.connect(self.currentChanged)
+
+        self.ui.polar_azimuthal_overlays.pressed.connect(self.show_overlay_manager)
 
         HexrdConfig().mgr_threshold_mask_changed.connect(
             self.ui.raw_threshold_mask.setChecked)
@@ -407,6 +410,14 @@ class ImageModeWidget(QObject):
                 self.ui.polar_res_eta_min.setValue(min_value)
                 HexrdConfig().set_polar_res_eta_min(min_value, rerender=False)
         HexrdConfig().polar_res_eta_max = max_value
+
+    def show_overlay_manager(self):
+        if hasattr(self, '_overlay_manager'):
+            self._overlay_manager.ui.reject()
+            del self._overlay_manager
+
+        self._overlay_manager = AzimuthalOverlayManager(self.ui)
+        self._overlay_manager.show()
 
 
 def compute_polar_params(panel, max_tth_ps, max_eta_ps, min_tth, max_tth):

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -420,6 +420,7 @@ class ImageModeWidget(QObject):
         self._polar_overlay_manager = AzimuthalOverlayManager(self.ui)
         self._polar_overlay_manager.show()
 
+
 def compute_polar_params(panel, max_tth_ps, max_eta_ps, min_tth, max_tth):
     # Other than panel, all arguments are lists for appending results
     # pixel sizes

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -99,7 +99,8 @@ class ImageModeWidget(QObject):
 
         self.ui.tab_widget.currentChanged.connect(self.currentChanged)
 
-        self.ui.polar_azimuthal_overlays.pressed.connect(self.show_overlay_manager)
+        self.ui.polar_azimuthal_overlays.pressed.connect(
+            self.show_polar_overlay_manager)
 
         HexrdConfig().mgr_threshold_mask_changed.connect(
             self.ui.raw_threshold_mask.setChecked)
@@ -411,13 +412,13 @@ class ImageModeWidget(QObject):
                 HexrdConfig().set_polar_res_eta_min(min_value, rerender=False)
         HexrdConfig().polar_res_eta_max = max_value
 
-    def show_overlay_manager(self):
-        if hasattr(self, '_overlay_manager'):
-            self._overlay_manager.ui.reject()
-            del self._overlay_manager
+    def show_polar_overlay_manager(self):
+        if hasattr(self, '_polar_overlay_manager'):
+            self._polar_overlay_manager.ui.reject()
+            del self._polar_overlay_manager
 
-        self._overlay_manager = AzimuthalOverlayManager(self.ui)
-        self._overlay_manager.show()
+        self._polar_overlay_manager = AzimuthalOverlayManager(self.ui)
+        self._polar_overlay_manager.show()
 
 def compute_polar_params(panel, max_tth_ps, max_eta_ps, min_tth, max_tth):
     # Other than panel, all arguments are lists for appending results

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -124,6 +124,8 @@ class ImageModeWidget(QObject):
         self.ui.stereo_project_from_polar.toggled.connect(
             HexrdConfig().set_stereo_project_from_polar)
 
+        self.ui.toggle_azimuthal_legend.toggled.connect(self.toggle_legend)
+
     def currentChanged(self, index):
         modes = {
             0: ViewType.raw,
@@ -209,6 +211,8 @@ class ImageModeWidget(QObject):
                 HexrdConfig().stereo_show_border)
             self.ui.stereo_project_from_polar.setChecked(
                 HexrdConfig().stereo_project_from_polar)
+            self.ui.toggle_azimuthal_legend.setChecked(
+                HexrdConfig().azimuthal_legend)
 
             self.update_polar_tth_distortion_overlay_options()
             self.update_enable_states()
@@ -419,6 +423,9 @@ class ImageModeWidget(QObject):
         self._overlay_manager = AzimuthalOverlayManager(self.ui)
         self._overlay_manager.show()
 
+    def toggle_legend(self, value):
+        HexrdConfig().azimuthal_legend = value
+        HexrdConfig().azimuthal_overlay_modified.emit()
 
 def compute_polar_params(panel, max_tth_ps, max_eta_ps, min_tth, max_tth):
     # Other than panel, all arguments are lists for appending results

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -200,6 +200,7 @@ class MaterialsPanel(QObject):
         self.update_table()
         self.update_refinement_options()
         self.update_properties_tab()
+        HexrdConfig().material_modified.emit(self.current_material())
 
     def material_structure_edited(self):
         self.update_table()
@@ -276,7 +277,6 @@ class MaterialsPanel(QObject):
 
     def update_table(self):
         HexrdConfig().update_reflections_tables.emit(self.current_material())
-        HexrdConfig().azimuthal_overlay_modified.emit()
 
     def update_overlay_editor(self):
         if not hasattr(self, '_overlay_manager'):

--- a/hexrd/ui/materials_panel.py
+++ b/hexrd/ui/materials_panel.py
@@ -276,6 +276,7 @@ class MaterialsPanel(QObject):
 
     def update_table(self):
         HexrdConfig().update_reflections_tables.emit(self.current_material())
+        HexrdConfig().azimuthal_overlay_modified.emit()
 
     def update_overlay_editor(self):
         if not hasattr(self, '_overlay_manager'):

--- a/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
@@ -7,13 +7,23 @@
     <x>0</x>
     <y>0</y>
     <width>264</width>
-    <height>57</height>
+    <height>80</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="name_label">
+     <property name="text">
+      <string/>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>264</width>
-    <height>80</height>
+    <width>297</width>
+    <height>82</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,9 +37,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="fwhm">
+      <widget class="ScientificDoubleSpinBox" name="fwhm">
        <property name="enabled">
         <bool>true</bool>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
        </property>
        <property name="minimum">
         <double>0.010000000000000</double>
@@ -66,9 +69,12 @@
       </widget>
      </item>
      <item>
-      <widget class="QDoubleSpinBox" name="scale">
+      <widget class="ScientificDoubleSpinBox" name="scale">
        <property name="enabled">
         <bool>true</bool>
+       </property>
+       <property name="keyboardTracking">
+        <bool>false</bool>
        </property>
        <property name="decimals">
         <number>3</number>
@@ -88,6 +94,17 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.py</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>fwhm</tabstop>
+  <tabstop>scale</tabstop>
+ </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
@@ -77,7 +77,7 @@
         <bool>false</bool>
        </property>
        <property name="maximum">
-        <number>100</number>
+        <number>1000000000</number>
        </property>
        <property name="singleStep">
         <number>1</number>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>297</width>
+    <width>429</width>
     <height>82</height>
    </rect>
   </property>
@@ -51,7 +51,7 @@
         <double>360.000000000000000</double>
        </property>
        <property name="singleStep">
-        <double>0.010000000000000</double>
+        <double>0.100000000000000</double>
        </property>
        <property name="value">
         <double>0.250000000000000</double>
@@ -76,17 +76,17 @@
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
+       <property name="decimals">
+        <number>8</number>
+       </property>
        <property name="maximum">
-        <number>1000000000</number>
+        <double>1000000000.000000000000000</double>
        </property>
        <property name="singleStep">
-        <number>1</number>
+        <double>0.100000000000000</double>
        </property>
        <property name="value">
-        <number>1</number>
-       </property>
-       <property name="decimals" stdset="0">
-        <number>8</number>
+        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
@@ -76,17 +76,17 @@
        <property name="keyboardTracking">
         <bool>false</bool>
        </property>
-       <property name="decimals">
-        <number>3</number>
-       </property>
        <property name="maximum">
-        <double>1.000000000000000</double>
+        <number>100</number>
        </property>
        <property name="singleStep">
-        <double>0.010000000000000</double>
+        <number>1</number>
        </property>
        <property name="value">
-        <double>1.000000000000000</double>
+        <number>1</number>
+       </property>
+       <property name="decimals" stdset="0">
+        <number>8</number>
        </property>
       </widget>
      </item>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_editor.ui
@@ -1,0 +1,83 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>editor</class>
+ <widget class="QWidget" name="editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>264</width>
+    <height>57</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="fwhm_label">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>fwhm</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="fwhm">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="minimum">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.250000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="scale_label">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>scale</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="scale">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="decimals">
+        <number>3</number>
+       </property>
+       <property name="maximum">
+        <double>1.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.010000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>509</width>
-    <height>323</height>
+    <height>346</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -27,9 +27,9 @@
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QCheckBox" name="toggle_legend">
+       <widget class="QCheckBox" name="show_legend">
         <property name="text">
-         <string>Toggle Legend</string>
+         <string>Show Legend</string>
         </property>
        </widget>
       </item>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>492</width>
-    <height>245</height>
+    <width>509</width>
+    <height>323</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -16,43 +16,44 @@
     <height>0</height>
    </size>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>6</number>
-   </property>
-   <property name="topMargin">
-    <number>6</number>
-   </property>
-   <property name="rightMargin">
-    <number>6</number>
-   </property>
-   <property name="bottomMargin">
-    <number>6</number>
-   </property>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="remove_button">
-     <property name="enabled">
-      <bool>false</bool>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="plot_manager">
+     <property name="title">
+      <string>Plot Manager</string>
      </property>
-     <property name="text">
-      <string>Remove</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QCheckBox" name="toggle_legend">
+        <property name="text">
+         <string>Toggle Legend</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>246</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="save_plot">
+        <property name="text">
+         <string>Save Plot</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QPushButton" name="add_button">
-     <property name="text">
-      <string>Add</string>
-     </property>
-     <property name="autoDefault">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item>
     <widget class="QTableWidget" name="table">
      <property name="minimumSize">
       <size>
@@ -111,10 +112,34 @@
      </column>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <layout class="QVBoxLayout" name="overlay_editor_layout"/>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="add_button">
+       <property name="text">
+        <string>Add</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="remove_button">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Remove</string>
+       </property>
+       <property name="autoDefault">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="3" column="0" colspan="2">
+   <item>
     <widget class="QPushButton" name="edit_style_button">
      <property name="enabled">
       <bool>false</bool>
@@ -126,6 +151,9 @@
       <bool>false</bool>
      </property>
     </widget>
+   </item>
+   <item>
+    <layout class="QVBoxLayout" name="overlay_editor_layout"/>
    </item>
   </layout>
  </widget>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>overlay_manager</class>
+ <widget class="QDialog" name="overlay_manager">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>492</width>
+    <height>245</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>0</height>
+   </size>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="remove_button">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Remove</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QPushButton" name="add_button">
+     <property name="text">
+      <string>Add</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QTableWidget" name="table">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>150</height>
+      </size>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select row to edit&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="dragDropOverwriteMode">
+      <bool>false</bool>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::SingleSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="rowCount">
+      <number>4</number>
+     </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>70</number>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>150</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <row/>
+     <row/>
+     <row/>
+     <row/>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Material</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Visible</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="overlay_editor_layout"/>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QPushButton" name="edit_style_button">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string>Edit Style</string>
+     </property>
+     <property name="autoDefault">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>table</tabstop>
+  <tabstop>add_button</tabstop>
+  <tabstop>remove_button</tabstop>
+  <tabstop>edit_style_button</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
@@ -16,6 +16,9 @@
     <height>0</height>
    </size>
   </property>
+  <property name="windowTitle">
+   <string>Azimuthal Overlay Manager</string>
+  </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QGroupBox" name="plot_manager">

--- a/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_manager.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>overlay_manager</class>
- <widget class="QDialog" name="overlay_manager">
+ <class>azimuthal_overlay_manager</class>
+ <widget class="QDialog" name="azimuthal_overlay_manager">
   <property name="geometry">
    <rect>
     <x>0</x>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_style_picker.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>overlay_style_picker</class>
- <widget class="QDialog" name="overlay_style_picker">
+ <class>azimuthal_overlay_style_picker</class>
+ <widget class="QDialog" name="azimuthal_overlay_style_picker">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>632</width>
-    <height>136</height>
+    <height>157</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -58,6 +58,9 @@
       </item>
       <item row="0" column="3">
        <widget class="ScientificDoubleSpinBox" name="opacity">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
         <property name="decimals">
          <number>8</number>
         </property>
@@ -110,7 +113,7 @@
   <connection>
    <sender>button_box</sender>
    <signal>accepted()</signal>
-   <receiver>overlay_style_picker</receiver>
+   <receiver>azimuthal_overlay_style_picker</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -126,7 +129,7 @@
   <connection>
    <sender>button_box</sender>
    <signal>rejected()</signal>
-   <receiver>overlay_style_picker</receiver>
+   <receiver>azimuthal_overlay_style_picker</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/hexrd/ui/resources/ui/azimuthal_overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_style_picker.ui
@@ -1,0 +1,143 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>overlay_style_picker</class>
+ <widget class="QDialog" name="overlay_style_picker">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>632</width>
+    <height>136</height>
+   </rect>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="material_name">
+     <property name="text">
+      <string>MaterialName</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="style_group">
+     <property name="title">
+      <string>Style</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="2">
+       <widget class="QLabel" name="opacity_label">
+        <property name="text">
+         <string>Opacity:</string>
+        </property>
+        <property name="buddy">
+         <cstring>opacity</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="color">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="ScientificDoubleSpinBox" name="opacity">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.010000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.300000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>color</cstring>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.py</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>color</tabstop>
+  <tabstop>opacity</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>overlay_style_picker</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>296</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>196</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>overlay_style_picker</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>296</x>
+     <y>80</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>196</x>
+     <y>47</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/azimuthal_overlay_style_picker.ui
+++ b/hexrd/ui/resources/ui/azimuthal_overlay_style_picker.ui
@@ -10,6 +10,9 @@
     <height>157</height>
    </rect>
   </property>
+  <property name="windowTitle">
+   <string>Azimuthal Overlay Style Editor</string>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>6</number>
@@ -68,7 +71,7 @@
          <double>1.000000000000000</double>
         </property>
         <property name="singleStep">
-         <double>0.010000000000000</double>
+         <double>0.100000000000000</double>
         </property>
         <property name="value">
          <double>0.300000000000000</double>
@@ -88,13 +91,6 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -109,38 +105,5 @@
   <tabstop>opacity</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>button_box</sender>
-   <signal>accepted()</signal>
-   <receiver>azimuthal_overlay_style_picker</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>296</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>196</x>
-     <y>47</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>button_box</sender>
-   <signal>rejected()</signal>
-   <receiver>azimuthal_overlay_style_picker</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>296</x>
-     <y>80</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>196</x>
-     <y>47</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -374,34 +374,6 @@
               <property name="spacing">
                <number>0</number>
               </property>
-              <item row="0" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_tth">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000100000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>10.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.050000000000000</double>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="7">
                <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
                 <property name="alignment">
@@ -427,12 +399,62 @@
                 </property>
                </widget>
               </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>2θ Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="6">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="6">
+               <widget class="QLabel" name="label_11">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>n iter:</string>
+                </property>
+               </widget>
+              </item>
               <item row="3" column="0" colspan="8">
                <widget class="Line" name="line_above_snip">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
                </widget>
+              </item>
+              <item row="4" column="5">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
               <item row="0" column="6">
                <widget class="QLabel" name="label_2">
@@ -441,6 +463,23 @@
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Pixel Size:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="3">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>min</string>
                 </property>
                </widget>
               </item>
@@ -463,13 +502,136 @@
                 </item>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_4">
+              <item row="0" column="3">
+               <widget class="QLabel" name="label_6">
                 <property name="text">
-                 <string>2θ Range:</string>
+                 <string>2θ:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="5" colspan="3">
+               <widget class="QComboBox" name="polar_tth_distortion_overlay">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="7">
+               <widget class="QCheckBox" name="polar_apply_erosion">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Apply binary erosion to eliminate edge artifacts.</string>
+                </property>
+                <property name="text">
+                 <string>Apply erosion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000100000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="3" colspan="2">
+               <widget class="QPushButton" name="polar_show_snip1d">
+                <property name="text">
+                 <string>Show SNIP</string>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="0" colspan="8">
+               <widget class="QPushButton" name="polar_azimuthal_overlays">
+                <property name="text">
+                 <string>Azimuthal Overlays</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2">
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>η Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0" colspan="8">
+               <widget class="Line" name="line_above_tth_distortion">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
                </widget>
               </item>
@@ -501,16 +663,6 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="6">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>max</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
               <item row="7" column="0" colspan="4">
                <widget class="QCheckBox" name="polar_apply_tth_distortion">
                 <property name="enabled">
@@ -524,90 +676,8 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="7" column="5" colspan="3">
-               <widget class="QComboBox" name="polar_tth_distortion_overlay">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="3" colspan="2">
-               <widget class="QPushButton" name="polar_show_snip1d">
-                <property name="text">
-                 <string>Show SNIP</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="7">
-               <widget class="QCheckBox" name="polar_apply_erosion">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                 <string>Apply binary erosion to eliminate edge artifacts.</string>
-                </property>
-                <property name="text">
-                 <string>Apply erosion?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="7">
-               <widget class="QSpinBox" name="polar_snip1d_numiter">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="minimum">
-                 <number>1</number>
-                </property>
-                <property name="maximum">
-                 <number>10000</number>
-                </property>
-                <property name="value">
-                 <number>2</number>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="polar_apply_snip1d">
-                <property name="text">
-                 <string>Apply SNIP?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="6">
-               <widget class="QLabel" name="label_11">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>n iter:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
+              <item row="0" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_tth">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
@@ -621,20 +691,26 @@
                  <number>8</number>
                 </property>
                 <property name="minimum">
-                 <double>-360.000000000000000</double>
+                 <double>0.000100000000000</double>
                 </property>
                 <property name="maximum">
-                 <double>360.000000000000000</double>
+                 <double>10.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
                 </property>
                 <property name="value">
-                 <double>-180.000000000000000</double>
+                 <double>0.050000000000000</double>
                 </property>
                </widget>
               </item>
-              <item row="0" column="3">
-               <widget class="QLabel" name="label_6">
+              <item row="4" column="3">
+               <widget class="QLabel" name="label_10">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
                 <property name="text">
-                 <string>2θ:</string>
+                 <string>w:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -672,25 +748,40 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="3">
-               <widget class="QLabel" name="label_14">
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="polar_apply_snip1d">
                 <property name="text">
-                 <string>min</string>
+                 <string>Apply SNIP?</string>
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Pixel Size:</string>
-                </property>
+              <item row="2" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-360.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>-180.000000000000000</double>
+                </property>
                </widget>
               </item>
-              <item row="2" column="6">
-               <widget class="QLabel" name="label_15">
+              <item row="1" column="6">
+               <widget class="QLabel" name="label_5">
                 <property name="text">
                  <string>max</string>
                 </property>
@@ -699,116 +790,39 @@
                 </property>
                </widget>
               </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>η Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="5">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="0" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000100000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.200000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QLabel" name="label_12">
-                <property name="text">
-                 <string>min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="3">
-               <widget class="QLabel" name="label_10">
+              <item row="4" column="7">
+               <widget class="QSpinBox" name="polar_snip1d_numiter">
                 <property name="enabled">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
-                <property name="text">
-                 <string>w:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0" colspan="8">
-               <widget class="Line" name="line_above_tth_distortion">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                 <property name="keyboardTracking">
                  <bool>false</bool>
                 </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
                 <property name="minimum">
-                 <double>0.000010000000000</double>
+                 <number>1</number>
                 </property>
                 <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
+                 <number>10000</number>
                 </property>
                 <property name="value">
-                 <double>1.000000000000000</double>
+                 <number>2</number>
                 </property>
                </widget>
               </item>
-              <item row="8" column="0" colspan="8">
-               <widget class="QPushButton" name="polar_azimuthal_overlays">
+              <item row="9" column="0" colspan="3">
+               <widget class="QCheckBox" name="toggle_azimuthal_legend">
                 <property name="text">
-                 <string>Azimuthal Overlays</string>
+                 <string>Toggle legend</string>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="6" colspan="2">
+               <widget class="QPushButton" name="save_azimuthal_plot">
+                <property name="text">
+                 <string>Save Plot</string>
                 </property>
                </widget>
               </item>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -374,7 +374,100 @@
               <property name="spacing">
                <number>0</number>
               </property>
-              <item row="2" column="7">
+              <item row="4" column="1">
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="5" column="0">
+               <widget class="QComboBox" name="polar_snip1d_algorithm">
+                <item>
+                 <property name="text">
+                  <string>Fast SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 2D</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Pixel Size:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="5">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>η Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>2θ Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="8" column="0" colspan="7">
+               <widget class="QPushButton" name="polar_azimuthal_overlays">
+                <property name="text">
+                 <string>Azimuthal Overlays</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="2" colspan="2">
+               <widget class="QPushButton" name="polar_show_snip1d">
+                <property name="text">
+                 <string>Show SNIP</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="6">
                <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -399,64 +492,14 @@
                 </property>
                </widget>
               </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_4">
-                <property name="text">
-                 <string>2θ Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="6">
-               <widget class="QLabel" name="label_15">
-                <property name="text">
-                 <string>max</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
+              <item row="1" column="2">
                <widget class="QLabel" name="label_12">
                 <property name="text">
                  <string>min</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="6">
-               <widget class="QLabel" name="label_11">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>n iter:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0" colspan="8">
-               <widget class="Line" name="line_above_snip">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="5">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="0" column="6">
+              <item row="0" column="5">
                <widget class="QLabel" name="label_2">
                 <property name="text">
                  <string>η:</string>
@@ -466,217 +509,7 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Pixel Size:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="0">
-               <widget class="QComboBox" name="polar_snip1d_algorithm">
-                <item>
-                 <property name="text">
-                  <string>Fast SNIP 1D</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>SNIP 1D</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>SNIP 2D</string>
-                 </property>
-                </item>
-               </widget>
-              </item>
               <item row="0" column="3">
-               <widget class="QLabel" name="label_6">
-                <property name="text">
-                 <string>2θ:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>1.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="5" colspan="3">
-               <widget class="QComboBox" name="polar_tth_distortion_overlay">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="7">
-               <widget class="QCheckBox" name="polar_apply_erosion">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                 <string>Apply binary erosion to eliminate edge artifacts.</string>
-                </property>
-                <property name="text">
-                 <string>Apply erosion?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000100000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.200000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="3" colspan="2">
-               <widget class="QPushButton" name="polar_show_snip1d">
-                <property name="text">
-                 <string>Show SNIP</string>
-                </property>
-               </widget>
-              </item>
-              <item row="8" column="0" colspan="8">
-               <widget class="QPushButton" name="polar_azimuthal_overlays">
-                <property name="text">
-                 <string>Azimuthal Overlays</string>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="2">
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>η Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="6" column="0" colspan="8">
-               <widget class="Line" name="line_above_tth_distortion">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>20.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="7" column="0" colspan="4">
-               <widget class="QCheckBox" name="polar_apply_tth_distortion">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-                </property>
-                <property name="text">
-                 <string>Apply 2θ distortion?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="4">
                <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_tth">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -704,20 +537,176 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="3">
-               <widget class="QLabel" name="label_10">
+              <item row="7" column="0" colspan="3">
+               <widget class="QCheckBox" name="polar_apply_tth_distortion">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Apply 2θ distortion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="6">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>20.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="7">
+               <widget class="Line" name="line_above_snip">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="6" column="0" colspan="7">
+               <widget class="Line" name="line_above_tth_distortion">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="5">
+               <widget class="QLabel" name="label_11">
                 <property name="enabled">
                  <bool>true</bool>
                 </property>
                 <property name="text">
-                 <string>w:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                 <string>n iter:</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="4">
+              <item row="2" column="3">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-360.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>-180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="6">
+               <widget class="QCheckBox" name="polar_apply_erosion">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Apply binary erosion to eliminate edge artifacts.</string>
+                </property>
+                <property name="text">
+                 <string>Apply erosion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000100000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="3">
                <widget class="ScientificDoubleSpinBox" name="polar_snip1d_width">
                 <property name="enabled">
                  <bool>false</bool>
@@ -748,49 +737,30 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="polar_apply_snip1d">
+              <item row="0" column="2">
+               <widget class="QLabel" name="label_6">
                 <property name="text">
-                 <string>Apply SNIP?</string>
+                 <string>2θ:</string>
                 </property>
-               </widget>
-              </item>
-              <item row="2" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>-360.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>-180.000000000000000</double>
-                </property>
                </widget>
               </item>
-              <item row="1" column="6">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>max</string>
+              <item row="4" column="4">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
                 </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
                 </property>
-               </widget>
+               </spacer>
               </item>
-              <item row="4" column="7">
+              <item row="4" column="6">
                <widget class="QSpinBox" name="polar_snip1d_numiter">
                 <property name="enabled">
                  <bool>false</bool>
@@ -812,17 +782,33 @@
                 </property>
                </widget>
               </item>
-              <item row="9" column="0" colspan="3">
-               <widget class="QCheckBox" name="toggle_azimuthal_legend">
-                <property name="text">
-                 <string>Toggle legend</string>
+              <item row="7" column="4" colspan="3">
+               <widget class="QComboBox" name="polar_tth_distortion_overlay">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>
-              <item row="9" column="6" colspan="2">
-               <widget class="QPushButton" name="save_azimuthal_plot">
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="polar_apply_snip1d">
                 <property name="text">
-                 <string>Save Plot</string>
+                 <string>Apply SNIP?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2">
+               <widget class="QLabel" name="label_10">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>w:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -26,7 +26,7 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <item row="0" column="0" rowspan="2">
+   <item row="0" column="0">
     <widget class="QTabWidget" name="tab_widget">
      <property name="styleSheet">
       <string notr="true"/>
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>2</number>
      </property>
      <property name="iconSize">
       <size>
@@ -374,23 +374,6 @@
               <property name="spacing">
                <number>0</number>
               </property>
-              <item row="2" column="3">
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="6">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>max</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
               <item row="0" column="4">
                <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_tth">
                 <property name="alignment">
@@ -419,55 +402,8 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="2" column="0">
-               <widget class="QLabel" name="label_13">
-                <property name="text">
-                 <string>η Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Pixel Size:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0" colspan="8">
-               <widget class="Line" name="line_above_snip">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="polar_apply_snip1d">
-                <property name="text">
-                 <string>Apply SNIP?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+              <item row="2" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
@@ -481,16 +417,59 @@
                  <number>8</number>
                 </property>
                 <property name="minimum">
-                 <double>0.000010000000000</double>
+                 <double>-360.000000000000000</double>
                 </property>
                 <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
+                 <double>360.000000000000000</double>
                 </property>
                 <property name="value">
-                 <double>1.000000000000000</double>
+                 <double>180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="3" column="0" colspan="8">
+               <widget class="Line" name="line_above_snip">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="QLabel" name="label_2">
+                <property name="text">
+                 <string>η:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0">
+               <widget class="QComboBox" name="polar_snip1d_algorithm">
+                <item>
+                 <property name="text">
+                  <string>Fast SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 1D</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>SNIP 2D</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="1" column="0">
+               <widget class="QLabel" name="label_4">
+                <property name="text">
+                 <string>2θ Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                </widget>
               </item>
@@ -522,13 +501,56 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="6">
-               <widget class="QLabel" name="label_11">
+              <item row="1" column="6">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="0" colspan="4">
+               <widget class="QCheckBox" name="polar_apply_tth_distortion">
                 <property name="enabled">
                  <bool>true</bool>
                 </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
                 <property name="text">
-                 <string>n iter:</string>
+                 <string>Apply 2θ distortion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="2">
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="7" column="5" colspan="3">
+               <widget class="QComboBox" name="polar_tth_distortion_overlay">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="3" colspan="2">
+               <widget class="QPushButton" name="polar_show_snip1d">
+                <property name="text">
+                 <string>Show SNIP</string>
                 </property>
                </widget>
               </item>
@@ -545,8 +567,47 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
+              <item row="4" column="7">
+               <widget class="QSpinBox" name="polar_snip1d_numiter">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>10000</number>
+                </property>
+                <property name="value">
+                 <number>2</number>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="0">
+               <widget class="QCheckBox" name="polar_apply_snip1d">
+                <property name="text">
+                 <string>Apply SNIP?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="6">
+               <widget class="QLabel" name="label_11">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>n iter:</string>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
@@ -560,31 +621,15 @@
                  <number>8</number>
                 </property>
                 <property name="minimum">
-                 <double>0.000100000000000</double>
+                 <double>-360.000000000000000</double>
                 </property>
                 <property name="maximum">
                  <double>360.000000000000000</double>
                 </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
                 <property name="value">
-                 <double>0.200000000000000</double>
+                 <double>-180.000000000000000</double>
                 </property>
                </widget>
-              </item>
-              <item row="4" column="5">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
               </item>
               <item row="0" column="3">
                <widget class="QLabel" name="label_6">
@@ -593,33 +638,6 @@
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="0">
-               <widget class="QLabel" name="label_4">
-                <property name="text">
-                 <string>2θ Range:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="6">
-               <widget class="QLabel" name="label_15">
-                <property name="text">
-                 <string>max</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="QLabel" name="label_12">
-                <property name="text">
-                 <string>min</string>
                 </property>
                </widget>
               </item>
@@ -654,45 +672,89 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="7">
-               <widget class="QSpinBox" name="polar_snip1d_numiter">
-                <property name="enabled">
-                 <bool>false</bool>
+              <item row="2" column="3">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>min</string>
                 </property>
+               </widget>
+              </item>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Pixel Size:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="6">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="0">
+               <widget class="QLabel" name="label_13">
+                <property name="text">
+                 <string>η Range:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="4" column="5">
+               <spacer name="horizontalSpacer_2">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="0" column="7">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
                 <property name="keyboardTracking">
                  <bool>false</bool>
                 </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
                 <property name="minimum">
-                 <number>1</number>
+                 <double>0.000100000000000</double>
                 </property>
                 <property name="maximum">
-                 <number>10000</number>
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
                 </property>
                 <property name="value">
-                 <number>2</number>
+                 <double>0.200000000000000</double>
                 </property>
                </widget>
               </item>
-              <item row="5" column="0">
-               <widget class="QComboBox" name="polar_snip1d_algorithm">
-                <item>
-                 <property name="text">
-                  <string>Fast SNIP 1D</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>SNIP 1D</string>
-                 </property>
-                </item>
-                <item>
-                 <property name="text">
-                  <string>SNIP 2D</string>
-                 </property>
-                </item>
+              <item row="1" column="3">
+               <widget class="QLabel" name="label_12">
+                <property name="text">
+                 <string>min</string>
+                </property>
                </widget>
               </item>
               <item row="4" column="3">
@@ -708,73 +770,6 @@
                 </property>
                </widget>
               </item>
-              <item row="0" column="6">
-               <widget class="QLabel" name="label_2">
-                <property name="text">
-                 <string>η:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="3" colspan="2">
-               <widget class="QPushButton" name="polar_show_snip1d">
-                <property name="text">
-                 <string>Show SNIP</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="7">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>-360.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>180.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="4">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>-360.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>-180.000000000000000</double>
-                </property>
-               </widget>
-              </item>
               <item row="6" column="0" colspan="8">
                <widget class="Line" name="line_above_tth_distortion">
                 <property name="orientation">
@@ -782,26 +777,38 @@
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="4">
-               <widget class="QCheckBox" name="polar_apply_tth_distortion">
-                <property name="enabled">
-                 <bool>true</bool>
+              <item row="1" column="4">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
                 </property>
-                <property name="text">
-                 <string>Apply 2θ distortion?</string>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
                 </property>
                </widget>
               </item>
-              <item row="7" column="5" colspan="3">
-               <widget class="QComboBox" name="polar_tth_distortion_overlay">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <item row="8" column="0" colspan="8">
+               <widget class="QPushButton" name="polar_azimuthal_overlays">
+                <property name="text">
+                 <string>Azimuthal Overlays</string>
                 </property>
                </widget>
               </item>
@@ -941,7 +948,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>tab_widget</tabstop>
   <tabstop>raw_tabbed_view</tabstop>
   <tabstop>raw_show_saturation</tabstop>
   <tabstop>raw_threshold_mask</tabstop>

--- a/hexrd/ui/resources/ui/overlay_manager.ui
+++ b/hexrd/ui/resources/ui/overlay_manager.ui
@@ -16,6 +16,9 @@
     <height>0</height>
    </size>
   </property>
+  <property name="windowTitle">
+   <string>Overlay Manager</string>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>6</number>


### PR DESCRIPTION
~WIP~

Still needs:
- [x] Naming testing
- [x] Do not disable editor inputs (on first entry)
- [x] Make state persistent between sessions
- [x] Save selections to state file
- [x] Make sure plot is re-scaled to fit all data as overlays are added/changed
- [x] Suggest default `fwhm`/`scale` values?
- [x] Re-apply overlays when toggling away from/back to polar view
- [x] Ability to save azimuthal plot
- [x] Refactor/clean-up the changes made in the plot update
- [x] Add legend

~Most of these are pretty simple fixes and should be in soon. Just making this branch available in the meantime as a preview.~

![azimuthal_plot](https://user-images.githubusercontent.com/51238406/227802673-3a01131d-3063-460f-8d47-91cede9f9603.png)

This branch should be ready now. Fixes #1319 
