### PR TITLE
Allow state file argument to be instrument also

### DIFF
--- a/hexrd/ui/argument_parser.py
+++ b/hexrd/ui/argument_parser.py
@@ -45,7 +45,7 @@ class ArgumentParser(argparse.ArgumentParser):
         # Add arguments here
         self.add_argument(
             'state_file',
-            help='Load a state file during startup',
+            help='Load a state file or instrument config file during startup',
             type=check_state_file,
             nargs='?',
         )

--- a/hexrd/ui/main.py
+++ b/hexrd/ui/main.py
@@ -43,8 +43,8 @@ def main():
     window.show()
 
     if parsed_args.state_file is not None:
-        # Load the state file
-        window.load_state_file(parsed_args.state_file)
+        # Load the entrypoint file
+        window.load_entrypoint_file(parsed_args.state_file)
 
     sys.exit(app.exec_())
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1131,6 +1131,18 @@ class MainWindow(QObject):
 
         HexrdConfig().working_dir = os.path.dirname(selected_file)
 
+    def load_entrypoint_file(self, filepath):
+        # First, identify what type of entrypoint file it is, and then
+        # load based upon whatever it is.
+
+        filepath = Path(filepath)
+        if filepath.suffix in ('.yml', '.hexrd'):
+            # It is an instrument file
+            return HexrdConfig().load_instrument_config(str(filepath))
+
+        # Assume it is a state file
+        return self.load_state_file(filepath)
+
     def on_action_load_state_triggered(self):
         selected_file, selected_filter = QFileDialog.getOpenFileName(
             self.ui, 'Load State', HexrdConfig().working_dir,


### PR DESCRIPTION
This allows us to alternatively load in an instrument config file by command line instead of a state file.