### PR TITLE
Increase default zoom box ranges

### DIFF
--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -54,7 +54,7 @@
         <double>0.200000000000000</double>
        </property>
        <property name="value">
-        <double>5.000000000000000</double>
+        <double>15.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -103,7 +103,7 @@
         <double>0.200000000000000</double>
        </property>
        <property name="value">
-        <double>10.000000000000000</double>
+        <double>60.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -54,8 +54,8 @@ class ZoomCanvas(FigureCanvas):
         self.disabled = False
 
         # user-specified ROI in degrees (from interactors)
-        self.tth_tol = 0.5
-        self.eta_tol = 10.0
+        self.tth_tol = 15
+        self.eta_tol = 60
 
         self.setup_connections()
 


### PR DESCRIPTION
Two theta is now 15 degrees, and eta is now 60 degrees.

Fixes: #1368