### PR TITLE
Round auto-generated values for nicer display

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -131,8 +131,11 @@ class ColorMapEditor:
 
     def bc_editor_modified(self):
         with block_signals(self.ui.minimum, self.ui.maximum):
-            self.ui.minimum.setValue(self.bc_editor.ui_min)
-            self.ui.maximum.setValue(self.bc_editor.ui_max)
+            # Round these values for a nicer display
+            bc_min = round(self.bc_editor.ui_min, 2)
+            bc_max = round(self.bc_editor.ui_max, 2)
+            self.ui.minimum.setValue(bc_min)
+            self.ui.maximum.setValue(bc_max)
             self.range_edited()
 
     def update_mins_and_maxes(self):
@@ -171,6 +174,10 @@ class ColorMapEditor:
 
         if h - l < 5:
             h = l + 5
+
+        # Round these to two decimal places
+        l = round(l, 2)
+        h = round(h, 2)
 
         return l, h
 

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -240,8 +240,10 @@ class ImageModeWidget(QObject):
         average_size = sum([x[0] + x[1] for x in sizes]) / (2 * len(sizes))
 
         cart_config = HexrdConfig().config['image']['cartesian']
-        cart_config['pixel_size'] = average_size * 5
-        cart_config['virtual_plane_distance'] = abs(average_dist)
+
+        # Round these to two for a nicer display
+        cart_config['pixel_size'] = round(average_size * 5, 2)
+        cart_config['virtual_plane_distance'] = round(abs(average_dist), 2)
 
         # Get the GUI to update with the new values
         self.update_gui_from_config()
@@ -275,6 +277,10 @@ class ImageModeWidget(QObject):
         # Sometimes, this is too big. Bring it down if it is.
         px_eta = params['pixel_size_eta']
         params['pixel_size_eta'] = px_eta if px_eta < 90 else 5
+
+        # Round these to two decimal places for a nicer display
+        for k, v in params.items():
+            params[k] = round(v, 2)
 
         HexrdConfig().config['image']['polar'].update(params)
 


### PR DESCRIPTION
The auto-generated values were being displayed to many decimal places.

Round them so that they look nicer. They don't really need that many decimal places anyways.

Fixes: #1365