### PR TITLE
Include position for rotation series angles

### DIFF
--- a/hexrd/ui/overlays/rotation_series_overlay.py
+++ b/hexrd/ui/overlays/rotation_series_overlay.py
@@ -213,8 +213,15 @@ class RotationSeriesOverlay(Overlay):
         for det_key, psim in sim_data.items():
             panel = instr.detectors[det_key]
             valid_ids, valid_hkls, valid_angs, valid_xys, ang_pixel_size = psim
-            angles = valid_angs[0][:, :2]
             omegas = valid_angs[0][:, 2]
+
+            # !!! FIXME: these angles do not change with a change in grain position
+            # Is this expected? See: https://github.com/HEXRD/hexrdgui/issues/1383#issuecomment-1501950293
+            # For now, do not use them, and instead take the valid_xys and convert
+            # them to angles.
+            # angles = valid_angs[0][:, :2]
+            # !!! FIXME: does the above issue also mean the omegas are wrong?
+            angles, _ = panel.cart_to_angles(valid_xys[0], tvec_c=self.tvec_c)
 
             # Fix eta period
             angles[:, 1] = mapAngle(


### PR DESCRIPTION
For some reason, the `valid_angs` coming out of `simulate_roation_series()` are not modified when the grain position changes. I'm not sure if this is expected behavior or not (see [here](https://github.com/HEXRD/hexrdgui/issues/1383#issuecomment-1501950293)).

This was causing the ranges for the overlays to not be updated correctly in the raw and cartesian views when the grain positions were modified (although the center spot was still updated correctly). And it also meant that both the spots and ranges were not updated in the polar and stereo views.

Instead of using these angles, convert from the `valid_xys`, which do include grain position info.

This means, however, that the omegas likely do not include any grain position info as well (which may be an issue for non-aggregated views).

May resolve issue #1383 (need confirmation after merging).