### PR TITLE
Make fixes for new make_reflection_patches()

### DIFF
--- a/hexrd/ui/calibration/pick_based_calibration.py
+++ b/hexrd/ui/calibration/pick_based_calibration.py
@@ -249,7 +249,7 @@ class LaueCalibrator(object):
             reflInfoList = []
             img = raw_img_dict[det_key]
             native_area = det.pixel_area
-            num_patches = len(refl_patches)
+            num_patches = len(valid_angs)
             meas_xy = np.nan*np.ones((num_patches, 2))
             meas_angs = np.nan*np.ones((num_patches, 2))
             for iRefl, patch in enumerate(refl_patches):


### PR DESCRIPTION
In hexrd/hexrd#511, `make_reflection_patches()` is now returning an iterator instead of a list.

Instead of getting the number of points based upon the length of the output, compute it based upon the input. From reading `make_reflection_patches()`, it appears that the number of patches is equal to the number of input angles.