### PR TITLE
Add a few help buttons for instrument docs

### DIFF
--- a/hexrd/ui/calibration/panel_buffer_dialog.py
+++ b/hexrd/ui/calibration/panel_buffer_dialog.py
@@ -10,6 +10,7 @@ import numpy as np
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
+from hexrd.ui.utils.dialog import add_help_url
 
 CONFIG_MODE_BORDER = 'border'
 CONFIG_MODE_NUMPY = 'numpy'
@@ -27,6 +28,9 @@ class PanelBufferDialog(QObject):
         self.detector = detector
         loader = UiLoader()
         self.ui = loader.load_file('panel_buffer_dialog.ui')
+
+        add_help_url(self.ui.button_box,
+                     'configuration/instrument/#panel-buffer')
 
         # Hide the tab bar. It gets selected by changes to the combo box.
         self.ui.tab_widget.tabBar().hide()

--- a/hexrd/ui/input_dialog.py
+++ b/hexrd/ui/input_dialog.py
@@ -1,0 +1,42 @@
+from PySide2.QtWidgets import (
+    QComboBox, QDialog, QDialogButtonBox, QLabel, QVBoxLayout
+)
+
+from hexrd.ui.utils.dialog import add_help_url
+
+
+class InputDialog(QDialog):
+    @classmethod
+    def getItem(cls, parent, title, label, items, current=0, editable=True,
+                help_url=None):
+        # This is made after `QInputDialog.getItem()`, but allows for help
+        # text to also be provided.
+        dialog = cls(parent=parent)
+        dialog.setWindowTitle(title)
+
+        layout = QVBoxLayout()
+        dialog.setLayout(layout)
+
+        label = QLabel(label)
+        layout.addWidget(label)
+
+        combo_box = QComboBox()
+        combo_box.addItems(items)
+        combo_box.setCurrentIndex(current)
+        combo_box.setEditable(editable)
+        layout.addWidget(combo_box)
+
+        buttons = QDialogButtonBox.Ok | QDialogButtonBox.Cancel
+        button_box = QDialogButtonBox(buttons)
+        button_box.accepted.connect(dialog.accept)
+        button_box.rejected.connect(dialog.reject)
+        layout.addWidget(button_box)
+
+        if help_url:
+            add_help_url(button_box, help_url)
+
+        if not dialog.exec_():
+            return None, False
+
+        name = combo_box.currentText()
+        return name, True

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -12,8 +12,7 @@ from PySide2.QtCore import (
 )
 from PySide2.QtGui import QDesktopServices
 from PySide2.QtWidgets import (
-    QApplication, QDockWidget, QFileDialog, QInputDialog, QMainWindow,
-    QMessageBox
+    QApplication, QDockWidget, QFileDialog, QMainWindow, QMessageBox
 )
 
 from hexrd.ui.about_dialog import AboutDialog
@@ -28,6 +27,7 @@ from hexrd.ui.hand_drawn_mask_dialog import HandDrawnMaskDialog
 from hexrd.ui.image_stack_dialog import ImageStackDialog
 from hexrd.ui.indexing.run import FitGrainsRunner, IndexingRunner
 from hexrd.ui.indexing.fit_grains_results_dialog import FitGrainsResultsDialog
+from hexrd.ui.input_dialog import InputDialog
 from hexrd.ui.instrument_form_view_widget import InstrumentFormViewWidget
 from hexrd.ui.calibration.calibration_runner import CalibrationRunner
 from hexrd.ui.calibration.auto.powder_runner import PowderRunner
@@ -625,9 +625,11 @@ class MainWindow(QObject):
         current = HexrdConfig().euler_angle_convention
         ind = corresponding_values.index(current)
 
-        name, ok = QInputDialog.getItem(self.ui, 'HEXRD',
-                                        'Select Euler Angle Convention',
-                                        allowed_conventions, ind, False)
+        help_url = 'configuration/instrument/#euler-angle-convention'
+        name, ok = InputDialog.getItem(self.ui, 'HEXRD',
+                                       'Select Euler Angle Convention',
+                                       allowed_conventions, ind, False,
+                                       help_url=help_url)
 
         if not ok:
             # User canceled...

--- a/hexrd/ui/resources/ui/panel_buffer_dialog.ui
+++ b/hexrd/ui/resources/ui/panel_buffer_dialog.ui
@@ -7,14 +7,78 @@
     <x>0</x>
     <y>0</y>
     <width>478</width>
-    <height>296</height>
+    <height>361</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Configure panel buffer</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="4" column="0">
+   <item row="5" column="1">
+    <widget class="QPushButton" name="clear_panel_buffer">
+     <property name="text">
+      <string>Clear Panel Buffer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="modesLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>The panel buffer can be set in two ways. Either by provided the border in mm or through a NumPy array, interpretation is boolean with true marking valid pixels.</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLabel" name="config_mode_label">
+       <property name="text">
+        <string>Configuration Mode:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="config_mode">
+       <property name="currentText">
+        <string>Border</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Border</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>NumPy</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0" colspan="2">
     <widget class="QTabWidget" name="tab_widget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -30,17 +94,17 @@
        <string>Border</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="0">
-        <widget class="QLabel" name="border_x_label">
-         <property name="text">
-          <string>X Border (mm):</string>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="0">
         <widget class="QLabel" name="border_y_label">
          <property name="text">
           <string>Y Border (mm):</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="border_x_label">
+         <property name="text">
+          <string>X Border (mm):</string>
          </property>
         </widget>
        </item>
@@ -57,8 +121,8 @@
          </property>
         </spacer>
        </item>
-       <item row="3" column="1">
-        <widget class="ScientificDoubleSpinBox" name="border_y_spinbox">
+       <item row="1" column="1">
+        <widget class="ScientificDoubleSpinBox" name="border_x_spinbox">
          <property name="decimals">
           <number>8</number>
          </property>
@@ -73,8 +137,8 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
-        <widget class="ScientificDoubleSpinBox" name="border_x_spinbox">
+       <item row="3" column="1">
+        <widget class="ScientificDoubleSpinBox" name="border_y_spinbox">
          <property name="decimals">
           <number>8</number>
          </property>
@@ -120,60 +184,25 @@
      </widget>
     </widget>
    </item>
-   <item row="1" column="0">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLabel" name="config_mode_label">
-       <property name="text">
-        <string>Configuration Mode:</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="config_mode">
-       <property name="currentText">
-        <string>Border</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Border</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>NumPy</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
    <item row="5" column="0">
+    <spacer name="horizontalSpacer_3">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="7" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout_4">
-     <item>
-      <widget class="QPushButton" name="clear_panel_buffer">
-       <property name="text">
-        <string>Clear Panel Buffer</string>
-       </property>
-      </widget>
-     </item>
      <item>
       <widget class="QDialogButtonBox" name="button_box">
        <property name="standardButtons">
-        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
        </property>
        <property name="centerButtons">
         <bool>false</bool>
@@ -182,21 +211,21 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="modesLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="6" column="1">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-     <property name="text">
-      <string>The panel buffer can be set in two ways. Either by provided the border in mm or through a NumPy array, interpretation is boolean with true marking valid pixels.</string>
+     <property name="sizeType">
+      <enum>QSizePolicy::Fixed</enum>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>30</height>
+      </size>
      </property>
-    </widget>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -215,7 +244,6 @@
   <tabstop>file_name</tabstop>
   <tabstop>select_file_button</tabstop>
   <tabstop>show_panel_buffer</tabstop>
-  <tabstop>clear_panel_buffer</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/hexrd/ui/xray_energy_selection_dialog.py
+++ b/hexrd/ui/xray_energy_selection_dialog.py
@@ -14,6 +14,7 @@ from hexrd.utils.decorators import memoize
 from hexrd.ui.resource_loader import load_resource
 from hexrd.ui.tree_views.dict_tree_view import DictTreeViewDialog
 from hexrd.ui.ui_loader import UiLoader
+from hexrd.ui.utils.dialog import add_help_url
 
 
 class XRayEnergySelectionDialog(DictTreeViewDialog):
@@ -46,6 +47,7 @@ class XRayEnergySelectionDialog(DictTreeViewDialog):
         button_box = QDialogButtonBox(buttons, self)
         button_box.accepted.connect(self.accept)
         button_box.rejected.connect(self.reject)
+        add_help_url(button_box, 'configuration/instrument/#x-ray-energy-selection')
         self.layout().addWidget(button_box)
 
         UiLoader().install_dialog_enter_key_filters(self)


### PR DESCRIPTION
Documentation was added for [the instrument config](https://hexrdgui.readthedocs.io/en/latest/configuration/instrument/).

Add a few help buttons that refer to these docs.