### PR TITLE
Simplify llnl import

### DIFF
--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -88,3 +88,10 @@ KNOWN_HDF5_PATHS = [
 DEFAULT_LIMITED_CMAPS = [
     'Greys', 'inferno', 'plasma', 'viridis', 'magma', 'Reds', 'Blues']
 ALL_CMAPS = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))
+
+
+class LLNLTransform:
+    IP2 = UI_TRANS_INDEX_FLIP_HORIZONTALLY
+    IP3 = UI_TRANS_INDEX_FLIP_VERTICALLY
+    IP4 = UI_TRANS_INDEX_FLIP_VERTICALLY
+    PXRDIP = UI_TRANS_INDEX_FLIP_HORIZONTALLY

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -138,13 +138,24 @@ class ImageFileManager(metaclass=Singleton):
         return ims
 
     def is_hdf(self, extension):
-        hdf_extensions = ['.h4', '.hdf4', '.hdf', '.h5', '.hdf5', '.he5']
-        if extension in hdf_extensions:
-            return True
+        return self.is_hdf4(extension) or self.is_hdf5(extension)
 
+    def is_hdf4(self, extension):
+        return extension in self.HDF4_FILE_EXTS
+
+    def is_hdf5(self, extension):
+        return extension in self.HDF5_FILE_EXTS
+
+    def hdf_path_exists(self, f):
+        ext = os.path.splitext(f)[1] if isinstance(f, str) else None
+        if self.is_hdf5(ext):
+            return self.hdf5_path_exists(f)
+        elif self.is_hdf4(ext):
+            # FIXME: implement an hdf4 path check
+            pass
         return False
 
-    def path_exists(self, f):
+    def hdf5_path_exists(self, f):
         all_paths = []
         if HexrdConfig().hdf5_path is not None:
             all_paths.append(HexrdConfig().hdf5_path)

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -26,6 +26,7 @@ class InteractiveTemplate:
         self.translating = True
         self.shape_styles = []
         self.translation = [0, 0]
+        self.complete = False
         self.parent.setFocusPolicy(Qt.ClickFocus)
 
     @property
@@ -41,6 +42,7 @@ class InteractiveTemplate:
         self.redraw()
 
     def create_shape(self, module, file_name, det, instr):
+        self.complete = False
         with resource_loader.resource_path(module, file_name) as f:
             data = np.loadtxt(f)
         verts = self.panels['default'].cartToPixel(data)
@@ -161,6 +163,7 @@ class InteractiveTemplate:
         self.shape = None
         self.press = None
         self.total_rotation = 0.
+        self.complete = True
 
     def mask(self):
         col, row = self.cropped_shape.T

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -21,7 +21,7 @@ from hexrd.ui.load_images_dialog import LoadImagesDialog
 from hexrd.ui import resource_loader
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.constants import (
-    UI_TRANS_INDEX_ROTATE_90, UI_TRANS_INDEX_FLIP_HORIZONTALLY, YAML_EXTS)
+    UI_TRANS_INDEX_ROTATE_90, YAML_EXTS, LLNLTransform)
 import hexrd.ui.resources.calibration
 
 from hexrd.ui.utils import instr_to_internal_dict
@@ -224,10 +224,20 @@ class LLNLImportToolDialog(QObject):
         scale = 1 - ((w - val) / w)
         self.it.scale_template(sx=scale)
 
-    def load_images(self):
+    def _set_transform(self):
         if self.instrument == 'PXRDIP':
-            HexrdConfig().load_panel_state['trans'] = (
-                [UI_TRANS_INDEX_FLIP_HORIZONTALLY])
+            flip = LLNLTransform.PXRDIP
+        elif self.instrument == 'TARDIS':
+            if self.detector == 'IMAGE-PLATE-2':
+                flip = LLNLTransform.IP2
+            elif self.detector == 'IMAGE-PLATE-3':
+                flip = LLNLTransform.IP3
+            elif self.detector == 'IMAGE-PLATE-4':
+                flip = LLNLTransform.IP4
+        HexrdConfig().load_panel_state['trans'] = [flip]
+
+    def load_images(self):
+        self._set_transform()
 
         caption = HexrdConfig().images_dirtion = 'Select file(s)'
         selected_file, selected_filter = QFileDialog.getOpenFileName(

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -25,6 +25,7 @@ from hexrd.ui.constants import (
 import hexrd.ui.resources.calibration
 
 from hexrd.ui.utils import instr_to_internal_dict
+from hexrd.ui.utils.dialog import add_help_url
 
 
 class LLNLImportToolDialog(QObject):
@@ -43,6 +44,9 @@ class LLNLImportToolDialog(QObject):
         self.ui = loader.load_file('llnl_import_tool_dialog.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
+
+        add_help_url(self.ui.button_box,
+                     'configuration/images/#llnl-import-tool')
 
         self.it = None
         self.instrument = None

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -252,7 +252,7 @@ class LLNLImportToolDialog(QObject):
             # If it is a hdf5 file allow the user to select the path
             ext = os.path.splitext(selected_file)[1]
             if (ImageFileManager().is_hdf(ext) and not
-                    ImageFileManager().path_exists(selected_file)):
+                    ImageFileManager().hdf_path_exists(selected_file)):
                 path_selected = ImageFileManager().path_prompt(selected_file)
                 if not path_selected:
                     return

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -370,13 +370,15 @@ class LLNLImportToolDialog(QObject):
 
     def swap_bounds_for_cropped(self):
         self.it.clear()
+        line, width, color = self.it.shape_styles[-1].values()
         self.it.create_shape(
             module=hexrd_resources,
             file_name=f'TARDIS_IMAGE-PLATE-3_bnd_cropped.txt',
             det=self.detector,
             instr=self.instrument)
-        line, width, color = self.it.shape_styles[-1].values()
-        self.it.update_style(line, width, color)
+        self.update_bbox_width(1330)
+        self.update_bbox_height(238)
+        self.it.update_style('--', width, color)
 
     def crop_and_mask(self):
         self.save_boundary_position()

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -122,7 +122,6 @@ class LLNLImportToolDialog(QObject):
             self.defaults = yaml.load(text, Loader=yaml.FullLoader)
         self.detector_defaults['default_config'] = self.defaults
         self.set_detector_options()
-        return True
 
     def set_detector_options(self):
         self.detectors.clear()
@@ -142,10 +141,7 @@ class LLNLImportToolDialog(QObject):
         self.ui.config_file_label.setText(os.path.basename(self.config_file))
         self.ui.config_file_label.setToolTip(self.config_file)
         if self.ui.instrument.isEnabled():
-            # Only set the instrument config once
-            success = self.get_instrument_defaults()
-            if not success:
-                return
+            self.get_instrument_defaults()
 
     def instrument_selected(self, idx):
         if HexrdConfig().show_beam_marker:
@@ -187,10 +183,7 @@ class LLNLImportToolDialog(QObject):
             self.enable_widgets(self.ui.load_config, self.ui.config_file_label,
                                 enabled=True)
         if self.ui.instrument.isEnabled():
-            # Only set the instrument config once
-            success = self.get_instrument_defaults()
-            if not success:
-                return
+            self.get_instrument_defaults()
 
     def update_config_load(self, checked):
         self.enable_widgets(self.ui.load_config, self.ui.config_file_label,

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -168,6 +168,7 @@ class LLNLImportToolDialog(QObject):
             self.parent().action_show_toolbar.setChecked(False)
             self.ui.config_file_label.setToolTip(
                 'Defaults to currently loaded configuration')
+            self.update_config_selection(self.ui.select_config.isChecked())
 
     def set_convention(self):
         new_conv = {'axes_order': 'zxz', 'extrinsic': False}
@@ -322,6 +323,12 @@ class LLNLImportToolDialog(QObject):
 
     def add_template(self):
         if self.it is None or self.instrument is None or self.detector is None:
+            return
+
+        if self.it.complete and self.instrument == 'TARDIS':
+            # For the TARDIS use case only one template is applied per image
+            # Only add a new template if the detector has not been completed
+            # or this is a single image use-case (i.e. PXRDIP, BBXRD)
             return
 
         self.it.clear()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -456,7 +456,7 @@ class MainWindow(QObject):
             # If it is a hdf5 file allow the user to select the path
             ext = os.path.splitext(selected_files[0])[1]
             if (ImageFileManager().is_hdf(ext) and not
-                    ImageFileManager().path_exists(selected_files[0])):
+                    ImageFileManager().hdf_path_exists(selected_files[0])):
 
                 selection = ImageFileManager().path_prompt(selected_files[0])
                 if not selection:

--- a/hexrd/ui/resources/ui/llnl_import_tool_dialog.ui
+++ b/hexrd/ui/resources/ui/llnl_import_tool_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>476</width>
-    <height>659</height>
+    <height>615</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -182,6 +182,50 @@
       </property>
       <layout class="QGridLayout" name="gridLayout_5">
        <item row="0" column="0">
+        <widget class="QFrame" name="frame">
+         <property name="frameShape">
+          <enum>QFrame::NoFrame</enum>
+         </property>
+         <property name="frameShadow">
+          <enum>QFrame::Raised</enum>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLabel" name="detector_label">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Current Detector</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="detectors">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="1" column="0">
         <widget class="QFrame" name="file_selection">
          <property name="enabled">
           <bool>true</bool>
@@ -237,7 +281,7 @@
          </layout>
         </widget>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QFrame" name="transform_img">
          <property name="enabled">
           <bool>false</bool>
@@ -261,6 +305,16 @@
           <property name="bottomMargin">
            <number>0</number>
           </property>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="add_transform">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="text">
+             <string>Add Transform</string>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="transform_label">
             <property name="text">
@@ -310,56 +364,7 @@
             </item>
            </widget>
           </item>
-          <item row="0" column="2">
-           <widget class="QPushButton" name="add_transform">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="text">
-             <string>Add Transform</string>
-            </property>
-           </widget>
-          </item>
          </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-    </item>
-    <item>
-     <widget class="QGroupBox" name="association">
-      <property name="enabled">
-       <bool>false</bool>
-      </property>
-      <property name="title">
-       <string>Association</string>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_8">
-       <item>
-        <widget class="QLabel" name="detector_label">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>Current Detector</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QComboBox" name="detectors">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="add_template">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>Add Detector Outline</string>
-         </property>
         </widget>
        </item>
       </layout>
@@ -410,15 +415,12 @@
         </widget>
        </item>
        <item row="1" column="1" alignment="Qt::AlignRight">
-        <widget class="QDialogButtonBox" name="button_box">
+        <widget class="QPushButton" name="accept_template">
          <property name="enabled">
           <bool>true</bool>
          </property>
-         <property name="standardButtons">
-          <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-         </property>
-         <property name="centerButtons">
-          <bool>true</bool>
+         <property name="text">
+          <string>Save detector boundary</string>
          </property>
         </widget>
        </item>
@@ -474,7 +476,7 @@
           <item alignment="Qt::AlignRight">
            <widget class="QLabel" name="width_label">
             <property name="enabled">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="text">
              <string>Width</string>

--- a/hexrd/ui/resources/ui/llnl_import_tool_dialog.ui
+++ b/hexrd/ui/resources/ui/llnl_import_tool_dialog.ui
@@ -674,7 +674,7 @@
           <bool>true</bool>
          </property>
          <property name="text">
-          <string>Cancel</string>
+          <string>Cancel LLNL Import</string>
          </property>
         </widget>
        </item>

--- a/hexrd/ui/resources/ui/llnl_import_tool_dialog.ui
+++ b/hexrd/ui/resources/ui/llnl_import_tool_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>476</width>
-    <height>615</height>
+    <height>646</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -702,6 +702,13 @@
         </widget>
        </item>
       </layout>
+     </widget>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="button_box">
+      <property name="standardButtons">
+       <set>QDialogButtonBox::NoButton</set>
+      </property>
      </widget>
     </item>
    </layout>

--- a/hexrd/ui/simple_image_series_dialog.py
+++ b/hexrd/ui/simple_image_series_dialog.py
@@ -300,7 +300,7 @@ class SimpleImageSeriesDialog(QObject):
 
         # Select the path if the file(s) are HDF5
         if (ImageFileManager().is_hdf(self.ext) and not
-                ImageFileManager().path_exists(selected_files[0])):
+                ImageFileManager().hdf_path_exists(selected_files[0])):
             if ImageFileManager().path_prompt(selected_files[0]) is None:
                 return
 


### PR DESCRIPTION
This adds a handful of features to simplify the LLNL workflow:

- The template is automatically applied when a detector is selected and an image is loaded (Fixes #1374)
- The cropped IP3 boundary uses the dashed line instead of a solid one (Fixes #1359)
- Automatically prompt user to apply the default transform associated with the current instrument/detector (Fixes #1363)
- Adds a help button to the documentation