### PR TITLE
Limit colormaps

### DIFF
--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -68,6 +68,7 @@ class ColorMapEditor:
                 additional_cmaps = [c for c in cmaps if c not in limited]
                 self.ui.color_map.insertSeparator(len(limited))
                 self.ui.color_map.addItems(additional_cmaps)
+                self.ui.color_map.setCurrentText(old_selection)
             else:
                 if old_selection in limited:
                     self.ui.color_map.setCurrentText(old_selection)

--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -5,6 +5,7 @@ import matplotlib.colors
 
 import numpy as np
 
+from hexrd.ui import constants
 from hexrd.ui.brightness_contrast_editor import BrightnessContrastEditor
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.scaling import SCALING_OPTIONS
@@ -56,7 +57,7 @@ class ColorMapEditor:
 
     def load_cmaps(self):
         if not (cmaps := HexrdConfig().limited_cmaps_list):
-            cmaps = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))
+            cmaps = constants.ALL_CMAPS
 
         with block_signals(self.ui.color_map):
             old_selection = self.ui.color_map.currentText()
@@ -71,7 +72,7 @@ class ColorMapEditor:
 
     def load_all_cmaps(self):
         limited = HexrdConfig().default_cmap
-        cmaps = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))
+        cmaps = constants.ALL_CMAPS
         additional_cmaps = [c for c in cmaps if c not in limited]
         self.ui.color_map.insertSeparator(len(limited))
         self.ui.color_map.addItems(additional_cmaps)

--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -56,26 +56,26 @@ class ColorMapEditor:
             self.update_bc_editor()
 
     def load_cmaps(self):
-        if not (cmaps := HexrdConfig().limited_cmaps_list):
-            cmaps = constants.ALL_CMAPS
+        limited = HexrdConfig().limited_cmaps_list
 
         with block_signals(self.ui.color_map):
             old_selection = self.ui.color_map.currentText()
             self.ui.color_map.clear()
-            self.ui.color_map.addItems(cmaps)
+            self.ui.color_map.addItems(limited)
 
-        if old_selection in cmaps:
-            self.ui.color_map.setCurrentText(old_selection)
-        else:
-            self.ui.color_map.setCurrentText(HexrdConfig().default_cmap)
-        self.update_cmap()
-
-    def load_all_cmaps(self):
-        limited = HexrdConfig().default_cmap
-        cmaps = constants.ALL_CMAPS
-        additional_cmaps = [c for c in cmaps if c not in limited]
-        self.ui.color_map.insertSeparator(len(limited))
-        self.ui.color_map.addItems(additional_cmaps)
+            if HexrdConfig().show_all_colormaps:
+                cmaps = constants.ALL_CMAPS
+                additional_cmaps = [c for c in cmaps if c not in limited]
+                self.ui.color_map.insertSeparator(len(limited))
+                self.ui.color_map.addItems(additional_cmaps)
+            else:
+                if old_selection in limited:
+                    self.ui.color_map.setCurrentText(old_selection)
+                else:
+                    # We're viewing the limited list but the color map that
+                    # was selected is not in that list.
+                    self.ui.color_map.setCurrentIndex(0)
+                self.update_cmap()
 
     def setup_scaling_options(self):
         options = list(SCALING_OPTIONS.keys())

--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -5,7 +5,6 @@ import matplotlib.colors
 
 import numpy as np
 
-import hexrd.ui.constants
 from hexrd.ui.brightness_contrast_editor import BrightnessContrastEditor
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.scaling import SCALING_OPTIONS

--- a/hexrd/ui/color_map_editor.py
+++ b/hexrd/ui/color_map_editor.py
@@ -75,7 +75,9 @@ class ColorMapEditor:
                     # We're viewing the limited list but the color map that
                     # was selected is not in that list.
                     self.ui.color_map.setCurrentIndex(0)
-                self.update_cmap()
+
+                if self.ui.color_map.currentText():
+                    self.update_cmap()
 
     def setup_scaling_options(self):
         options = list(SCALING_OPTIONS.keys())

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -2,6 +2,8 @@ from enum import Enum
 
 from hexrd import constants
 
+from matplotlib import cm
+
 # Wavelength to kilo electron volt conversion
 WAVELENGTH_TO_KEV = constants.keVToAngstrom(1.)
 KEV_TO_WAVELENGTH = constants.keVToAngstrom(1.)
@@ -82,3 +84,5 @@ KNOWN_HDF5_PATHS = [
     ['ATTRIBUTES/PSL_IMAGE/DATA', 'DATA'],
     ['DATA', 'DATA'],
 ]
+
+ALL_CMAPS = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -85,4 +85,6 @@ KNOWN_HDF5_PATHS = [
     ['DATA', 'DATA'],
 ]
 
+DEFAULT_LIMITED_CMAPS = [
+    'Greys', 'inferno', 'plasma', 'viridis', 'magma', 'Reds', 'Blues']
 ALL_CMAPS = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))

--- a/hexrd/ui/edit_colormap_list_dialog.py
+++ b/hexrd/ui/edit_colormap_list_dialog.py
@@ -34,11 +34,13 @@ class EditColormapListDialog(QObject):
 
     def setup_gui(self):
         all_cmaps = constants.ALL_CMAPS
-        self.ui.unused_colormaps.addItems(all_cmaps)
-        if not (defaults := HexrdConfig().limited_cmaps_list):
-            defaults = [self.ui.unused_colormaps.findItems(
+        used_list = HexrdConfig().limited_cmaps_list
+        unused_list = [cmap for cmap in all_cmaps if cmap not in used_list]
+        self.ui.unused_colormaps.addItems(unused_list)
+        if not used_list:
+            used_list = [self.ui.unused_colormaps.findItems(
                 HexrdConfig().default_cmap, Qt.MatchExactly)[0].text()]
-        self.ui.user_colormaps.addItems(defaults)
+        self.ui.user_colormaps.addItems(used_list)
 
     def add_cmap(self):
         selected_rows = self.ui.unused_colormaps.selectedIndexes()

--- a/hexrd/ui/edit_colormap_list_dialog.py
+++ b/hexrd/ui/edit_colormap_list_dialog.py
@@ -91,6 +91,6 @@ class EditColormapListDialog(QObject):
         HexrdConfig().limited_cmaps_list = self.user_colormaps
         HexrdConfig().default_cmap = self.default
         if HexrdConfig().show_all_colormaps:
-            self.cmap_editor.load_all_cmaps()
+            self.cmap_editor.load_cmaps()
         else:
             self.cmap_editor.load_cmaps()

--- a/hexrd/ui/edit_colormap_list_dialog.py
+++ b/hexrd/ui/edit_colormap_list_dialog.py
@@ -41,6 +41,7 @@ class EditColormapListDialog(QObject):
             used_list = [self.ui.unused_colormaps.findItems(
                 HexrdConfig().default_cmap, Qt.MatchExactly)[0].text()]
         self.ui.user_colormaps.addItems(used_list)
+        self.ui.default_colormap_text.setText(self.default)
 
     def add_cmap(self):
         selected_rows = self.ui.unused_colormaps.selectedIndexes()

--- a/hexrd/ui/edit_colormap_list_dialog.py
+++ b/hexrd/ui/edit_colormap_list_dialog.py
@@ -1,7 +1,6 @@
 from PySide2.QtCore import QObject, Qt
 
-from matplotlib import cm
-
+from hexrd.ui import constants
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -34,7 +33,7 @@ class EditColormapListDialog(QObject):
         self.ui.button_box.accepted.connect(self.finalize)
 
     def setup_gui(self):
-        all_cmaps = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))
+        all_cmaps = constants.ALL_CMAPS
         self.ui.unused_colormaps.addItems(all_cmaps)
         if not (defaults := HexrdConfig().limited_cmaps_list):
             defaults = [self.ui.unused_colormaps.findItems(

--- a/hexrd/ui/edit_colormap_list_dialog.py
+++ b/hexrd/ui/edit_colormap_list_dialog.py
@@ -8,8 +8,8 @@ from hexrd.ui.ui_loader import UiLoader
 
 class EditColormapListDialog(QObject):
 
-    def __init__(self, parent=None, cmap_editor=None):
-        super(EditColormapListDialog, self).__init__(parent)
+    def __init__(self, parent, cmap_editor):
+        super().__init__(parent)
         loader = UiLoader()
         self.ui = loader.load_file('edit_colormaps_dialog.ui', parent)
         flags = self.ui.windowFlags()

--- a/hexrd/ui/edit_colormap_list_dialog.py
+++ b/hexrd/ui/edit_colormap_list_dialog.py
@@ -1,0 +1,97 @@
+from PySide2.QtCore import QObject, Qt
+
+from matplotlib import cm
+
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class EditColormapListDialog(QObject):
+
+    def __init__(self, parent=None, cmap_editor=None):
+        super(EditColormapListDialog, self).__init__(parent)
+        loader = UiLoader()
+        self.ui = loader.load_file('edit_colormaps_dialog.ui', parent)
+        flags = self.ui.windowFlags()
+        self.ui.setWindowFlags(flags | Qt.Tool)
+
+        self.user_colormaps = HexrdConfig().limited_cmaps_list
+        self.default = HexrdConfig().default_cmap
+        self.cmap_editor = cmap_editor
+
+        self.setup_connections()
+        self.setup_gui()
+
+    def show(self):
+        self.ui.show()
+
+    def setup_connections(self):
+        self.ui.add.clicked.connect(self.add_cmap)
+        self.ui.remove.clicked.connect(self.remove_cmap)
+        self.ui.unused_colormaps.clicked.connect(self.cmap_selected)
+        self.ui.user_colormaps.clicked.connect(self.default_cmap_selected)
+        self.ui.make_default.clicked.connect(self.set_new_default)
+        self.ui.button_box.accepted.connect(self.finalize)
+
+    def setup_gui(self):
+        all_cmaps = sorted(i[:-2] for i in dir(cm) if i.endswith('_r'))
+        self.ui.unused_colormaps.addItems(all_cmaps)
+        if not (defaults := HexrdConfig().limited_cmaps_list):
+            defaults = [self.ui.unused_colormaps.findItems(
+                HexrdConfig().default_cmap, Qt.MatchExactly)[0].text()]
+        self.ui.user_colormaps.addItems(defaults)
+
+    def add_cmap(self):
+        selected_rows = self.ui.unused_colormaps.selectedIndexes()
+        selected = [i.text() for i in self.ui.unused_colormaps.selectedItems()]
+        self.ui.user_colormaps.addItems(selected)
+        for item in selected_rows:
+            self.ui.unused_colormaps.takeItem(item.row())
+
+    def remove_cmap(self):
+        selected_rows = self.ui.user_colormaps.selectedIndexes()
+        selected = [i.text() for i in self.ui.user_colormaps.selectedItems()]
+        self.ui.unused_colormaps.addItems(selected)
+        for idx, item in enumerate(selected_rows):
+            if selected[idx] == self.default:
+                continue
+            self.ui.user_colormaps.takeItem(item.row())
+        self.ui.remove.setEnabled(False)
+
+    def update_button_statuses(self):
+        add_enabled = len(self.ui.unused_colormaps.selectedItems())
+        user_cmaps = self.ui.user_colormaps.selectedItems()
+        if (remove_enabled := len(user_cmaps)) == 1:
+            remove_enabled = user_cmaps[0].text() != self.default
+        default_enabled = len(user_cmaps) == 1
+        self.ui.add.setEnabled(add_enabled)
+        self.ui.remove.setEnabled(remove_enabled)
+        self.ui.make_default.setEnabled(default_enabled)
+
+    def cmap_selected(self):
+        self.ui.user_colormaps.clearSelection()
+        self.update_button_statuses()
+
+    def default_cmap_selected(self):
+        self.ui.unused_colormaps.clearSelection()
+        self.update_button_statuses()
+
+    def set_new_default(self):
+        if selections := self.ui.user_colormaps.selectedItems():
+            default = selections[0].text()
+        self.default = default
+        self.ui.default_colormap_text.setText(self.default)
+        self.ui.user_colormaps.clearSelection()
+        self.ui.unused_colormaps.clearSelection()
+        self.update_button_statuses()
+
+    def finalize(self):
+        self.user_colormaps.clear()
+        for i in range(self.ui.user_colormaps.count()):
+            self.user_colormaps.append(self.ui.user_colormaps.item(i).text())
+        HexrdConfig().limited_cmaps_list = self.user_colormaps
+        HexrdConfig().default_cmap = self.default
+        if HexrdConfig().show_all_colormaps:
+            self.cmap_editor.load_all_cmaps()
+        else:
+            self.cmap_editor.load_cmaps()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -340,7 +340,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('_recent_images', {}),
             ('azimuthal_overlays', []),
             ('show_azimuthal_legend', True),
-            ('show_all_colormaps', False),
+            ('show_all_colormaps', True),
             ('limited_cmaps_list', []),
             ('default_cmap', constants.DEFAULT_CMAP)
         ]

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -341,7 +341,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('azimuthal_overlays', []),
             ('show_azimuthal_legend', True),
             ('show_all_colormaps', False),
-            ('limited_cmaps_list', []),
+            ('limited_cmaps_list', constants.DEFAULT_LIMITED_CMAPS),
             ('default_cmap', constants.DEFAULT_CMAP)
         ]
 
@@ -396,12 +396,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         """
         Update HexrdConfig using a loaded state.
         """
-
-        # The "active_material_name" is a special case that will be set to
-        # "previous_active_material".
-        # We need to set euler_angle_convention and overlays in a special way
         skip = [
+            # The "active_material_name" is a special case that will be set to
+            # "previous_active_material".
             'active_material_name',
+            # We need to set euler_angle_convention and overlays in a special way
             'euler_angle_convention',
             'overlays_dictified',
         ]
@@ -409,6 +408,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         if self.loading_state:
             # Do not load default materials if we are loading state
             skip.append('_imported_default_materials')
+            skip += [
+                # Skip colormap settings
+                'show_all_colormaps',
+                'limited_cmaps_list',
+                'default_cmap',
+            ]
 
         try:
             for name, value in state.items():

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -250,7 +250,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.max_cpus = None
         self.azimuthal_overlays = []
         self.show_azimuthal_legend = True
-        self.show_all_colormaps = True
+        self.show_all_colormaps = False
         self.limited_cmaps_list = constants.DEFAULT_LIMITED_CMAPS
         self.default_cmap = constants.DEFAULT_CMAP
 
@@ -340,7 +340,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('_recent_images', {}),
             ('azimuthal_overlays', []),
             ('show_azimuthal_legend', True),
-            ('show_all_colormaps', True),
+            ('show_all_colormaps', False),
             ('limited_cmaps_list', []),
             ('default_cmap', constants.DEFAULT_CMAP)
         ]

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -251,7 +251,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.azimuthal_overlays = []
         self.show_azimuthal_legend = True
         self.show_all_colormaps = True
-        self.limited_cmaps_list = [constants.DEFAULT_CMAP]
+        self.limited_cmaps_list = constants.DEFAULT_LIMITED_CMAPS
         self.default_cmap = constants.DEFAULT_CMAP
 
         self.setup_logging()

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -250,6 +250,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.max_cpus = None
         self.azimuthal_overlays = []
         self.show_azimuthal_legend = True
+        self.show_all_colormaps = True
+        self.limited_cmaps_list = [constants.DEFAULT_CMAP]
+        self.default_cmap = constants.DEFAULT_CMAP
 
         self.setup_logging()
 
@@ -337,6 +340,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('_recent_images', {}),
             ('azimuthal_overlays', []),
             ('show_azimuthal_legend', True),
+            ('show_all_colormaps', False),
+            ('limited_cmaps_list', [])
         ]
 
     # Provide a mapping from attribute names to the keys used in our state
@@ -417,6 +422,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.live_update = self.live_update == 'true'
         if not isinstance(self.show_azimuthal_legend, bool):
             self.show_azimuthal_legend = self.show_azimuthal_legend == 'true'
+        if not isinstance(self.show_all_colormaps, bool):
+            self.show_all_colormaps = self.show_all_colormaps == 'true'
 
         if self.azimuthal_overlays is None:
             self.azimuthal_overlays = []

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -341,7 +341,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('azimuthal_overlays', []),
             ('show_azimuthal_legend', True),
             ('show_all_colormaps', False),
-            ('limited_cmaps_list', [])
+            ('limited_cmaps_list', []),
+            ('default_cmap', constants.DEFAULT_CMAP)
         ]
 
     # Provide a mapping from attribute names to the keys used in our state

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -39,7 +39,7 @@ class ImageCanvas(FigureCanvas):
         self.overlay_artists = {}
         self.cached_detector_borders = []
         self.saturation_texts = []
-        self.cmap = hexrd.ui.constants.DEFAULT_CMAP
+        self.cmap = HexrdConfig().default_cmap
         self.norm = None
         self.iviewer = None
         self.azimuthal_integral_axis = None

--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -145,7 +145,11 @@ class ImageFileManager(metaclass=Singleton):
         return False
 
     def path_exists(self, f):
-        all_paths = [HexrdConfig().hdf5_path, *constants.KNOWN_HDF5_PATHS]
+        all_paths = []
+        if HexrdConfig().hdf5_path is not None:
+            all_paths.append(HexrdConfig().hdf5_path)
+        all_paths += constants.KNOWN_HDF5_PATHS
+
         with h5py.File(f, 'r') as h5:
             for path, dataname in all_paths:
                 if f'{path}/{dataname}' in h5:

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -18,7 +18,7 @@ from PySide2.QtWidgets import QFileDialog, QMenu, QMessageBox, QSizePolicy
 from hexrd.matrixutil import vecMVToSymm
 from hexrd.rotations import rotMatOfExpMap
 
-import hexrd.ui.constants
+from hexrd.ui import constants
 from hexrd.ui.async_runner import AsyncRunner
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.indexing.grains_table_model import GrainsTableModel
@@ -665,7 +665,7 @@ class FitGrainsResultsDialog(QObject):
             w2.setMinimum(w1.value())
 
     def load_cmaps(self):
-        cmaps = sorted(i[:-2] for i in dir(matplotlib.cm) if i.endswith('_r'))
+        cmaps = constants.ALL_CMAPS
         self.ui.color_maps.addItems(cmaps)
 
         # Set the combobox to be the default

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -55,7 +55,7 @@ class FitGrainsResultsDialog(QObject):
         self.async_runner = AsyncRunner(parent)
 
         self.ax = None
-        self.cmap = hexrd.ui.constants.DEFAULT_CMAP
+        self.cmap = HexrdConfig().default_cmap
         self.data = data
         self.data_model = GrainsTableModel(data)
         self.material = material
@@ -669,7 +669,7 @@ class FitGrainsResultsDialog(QObject):
         self.ui.color_maps.addItems(cmaps)
 
         # Set the combobox to be the default
-        self.ui.color_maps.setCurrentText(hexrd.ui.constants.DEFAULT_CMAP)
+        self.ui.color_maps.setCurrentText(HexrdConfig().default_cmap)
 
     def update_cmap(self):
         # Get the Colormap object from the name

--- a/hexrd/ui/indexing/indexing_results_dialog.py
+++ b/hexrd/ui/indexing/indexing_results_dialog.py
@@ -12,11 +12,10 @@ from hexrd.transforms import xfcapi
 from hexrd.ui.color_map_editor import ColorMapEditor
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.grains_viewer_dialog import GrainsViewerDialog
+from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
-
-import hexrd.ui.constants
 
 
 class IndexingResultsDialog(QObject):
@@ -32,7 +31,7 @@ class IndexingResultsDialog(QObject):
 
         self.ome_maps = ome_maps
         self.grains_table = grains_table
-        self.cmap = hexrd.ui.constants.DEFAULT_CMAP
+        self.cmap = HexrdConfig().default_cmap
         self.norm = None
         self.transform = lambda x: x
         self._plot_grains_mode = False

--- a/hexrd/ui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_viewer_dialog.py
@@ -47,7 +47,7 @@ class OmeMapsViewerDialog(QObject):
         self.ui = loader.load_file('ome_maps_viewer_dialog.ui', parent)
 
         self.data = data
-        self.cmap = hexrd.ui.constants.DEFAULT_CMAP
+        self.cmap = HexrdConfig().default_cmap
         self.norm = None
         self.transform = lambda x: x
         self.spots = None

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -136,6 +136,9 @@ class MainWindow(QObject):
 
         self.mask_manager_dialog = MaskManagerDialog(self.ui)
 
+        self._edit_colormap_list_dialog = EditColormapListDialog(
+            self.ui, self.color_map_editor)
+
         self.setup_connections()
 
         self.update_config_gui()
@@ -1254,5 +1257,4 @@ class MainWindow(QObject):
         HexrdConfig().show_all_colormaps = checked
 
     def on_action_edit_defaults_toggled(self):
-        dialog = EditColormapListDialog(self.ui, self.color_map_editor)
-        dialog.show()
+        self._edit_colormap_list_dialog.show()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -143,6 +143,8 @@ class MainWindow(QObject):
 
         self.set_live_update(HexrdConfig().live_update)
 
+        self.on_action_show_all_colormaps_toggled(HexrdConfig().show_all_colormaps)
+
         ImageFileManager().load_dummy_images(True)
 
         # In order to avoid both a not very nice looking black window,
@@ -256,6 +258,8 @@ class MainWindow(QObject):
             self.on_action_llnl_import_tool_triggered)
         self.ui.action_image_stack.triggered.connect(
             self.on_action_image_stack_triggered)
+        self.ui.action_show_all_colormaps.triggered.connect(
+            self.on_action_show_all_colormaps_toggled)
 
         self.image_mode_widget.polar_show_snip1d.connect(
             self.ui.image_tab_widget.polar_show_snip1d)
@@ -316,6 +320,7 @@ class MainWindow(QObject):
             'action_show_live_updates': 'live_update',
             'action_show_detector_borders': 'show_detector_borders',
             'action_show_beam_marker': 'show_beam_marker',
+            'action_show_all_colormaps': 'show_all_colormaps',
         }
 
         for cb_name, attr_name in checkbox_to_hexrd_config_mappings.items():
@@ -1237,3 +1242,10 @@ class MainWindow(QObject):
 
     def on_action_documentation_triggered(self):
         QDesktopServices.openUrl(QUrl(DOCUMENTATION_URL))
+
+    def on_action_show_all_colormaps_toggled(self, checked):
+        if checked:
+            self.color_map_editor.load_all_cmaps()
+        else:
+            self.color_map_editor.load_cmaps()
+        HexrdConfig().show_all_colormaps = checked

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1251,10 +1251,7 @@ class MainWindow(QObject):
 
     def on_action_show_all_colormaps_toggled(self, checked):
         HexrdConfig().show_all_colormaps = checked
-        if checked:
-            self.color_map_editor.load_cmaps()
-        else:
-            self.color_map_editor.load_cmaps()
+        self.color_map_editor.load_cmaps()
 
     def on_action_edit_defaults_toggled(self):
         self._edit_colormap_list_dialog.show()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -4,6 +4,7 @@ import shutil
 import tempfile
 
 import h5py
+from hexrd.ui.edit_colormap_list_dialog import EditColormapListDialog
 import numpy as np
 from skimage import measure
 
@@ -260,6 +261,8 @@ class MainWindow(QObject):
             self.on_action_image_stack_triggered)
         self.ui.action_show_all_colormaps.triggered.connect(
             self.on_action_show_all_colormaps_toggled)
+        self.ui.action_edit_defaults.triggered.connect(
+            self.on_action_edit_defaults_toggled)
 
         self.image_mode_widget.polar_show_snip1d.connect(
             self.ui.image_tab_widget.polar_show_snip1d)
@@ -1249,3 +1252,7 @@ class MainWindow(QObject):
         else:
             self.color_map_editor.load_cmaps()
         HexrdConfig().show_all_colormaps = checked
+
+    def on_action_edit_defaults_toggled(self):
+        dialog = EditColormapListDialog(self.ui, self.color_map_editor)
+        dialog.show()

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1250,11 +1250,11 @@ class MainWindow(QObject):
         QDesktopServices.openUrl(QUrl(DOCUMENTATION_URL))
 
     def on_action_show_all_colormaps_toggled(self, checked):
+        HexrdConfig().show_all_colormaps = checked
         if checked:
-            self.color_map_editor.load_all_cmaps()
+            self.color_map_editor.load_cmaps()
         else:
             self.color_map_editor.load_cmaps()
-        HexrdConfig().show_all_colormaps = checked
 
     def on_action_edit_defaults_toggled(self):
         self._edit_colormap_list_dialog.show()

--- a/hexrd/ui/resources/ui/edit_colormaps_dialog.ui
+++ b/hexrd/ui/resources/ui/edit_colormaps_dialog.ui
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>EditColormapsDialog</class>
+ <widget class="QDialog" name="EditColormapsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>475</width>
+    <height>303</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Default Colormaps</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_2">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="default_colormap_label">
+       <property name="text">
+        <string>Default Colormap:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="default_colormap_text">
+       <property name="text">
+        <string>Greys</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QGroupBox" name="unused_colormaps_group">
+       <property name="title">
+        <string>Unused Colormaps</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <item>
+         <widget class="QListWidget" name="unused_colormaps">
+          <property name="dragDropMode">
+           <enum>QAbstractItemView::DragDrop</enum>
+          </property>
+          <property name="defaultDropAction">
+           <enum>Qt::MoveAction</enum>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ExtendedSelection</enum>
+          </property>
+          <property name="selectionBehavior">
+           <enum>QAbstractItemView::SelectRows</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="buttons_layout">
+       <item>
+        <widget class="QPushButton" name="add">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Add</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="remove">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Remove</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="make_default">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Make default</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <widget class="QGroupBox" name="user_colormaps_group">
+       <property name="title">
+        <string>User Colormaps</string>
+       </property>
+       <layout class="QVBoxLayout" name="verticalLayout_5">
+        <item>
+         <widget class="QListWidget" name="user_colormaps">
+          <property name="dragDropMode">
+           <enum>QAbstractItemView::DragDrop</enum>
+          </property>
+          <property name="defaultDropAction">
+           <enum>Qt::MoveAction</enum>
+          </property>
+          <property name="selectionMode">
+           <enum>QAbstractItemView::ExtendedSelection</enum>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>EditColormapsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>EditColormapsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/edit_colormaps_dialog.ui
+++ b/hexrd/ui/resources/ui/edit_colormaps_dialog.ui
@@ -122,7 +122,7 @@
      <item>
       <widget class="QGroupBox" name="user_colormaps_group">
        <property name="title">
-        <string>User Colormaps</string>
+        <string>Used Colormaps</string>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_5">
         <item>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -269,8 +269,8 @@
          <rect>
           <x>0</x>
           <y>0</y>
-          <width>550</width>
-          <height>775</height>
+          <width>127</width>
+          <height>49</height>
          </rect>
         </property>
         <attribute name="label">
@@ -752,7 +752,7 @@
     <bool>true</bool>
    </property>
    <property name="checked">
-    <bool>true</bool>
+    <bool>false</bool>
    </property>
    <property name="text">
     <string>Show all colormaps</string>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -111,6 +111,13 @@
       <string>Loaded Images</string>
      </property>
     </widget>
+    <widget class="QMenu" name="colormaps_menu">
+     <property name="title">
+      <string>Colormaps</string>
+     </property>
+     <addaction name="action_show_all_colormaps"/>
+     <addaction name="action_edit_defaults"/>
+    </widget>
     <addaction name="view_dock_widgets"/>
     <addaction name="action_show_toolbar"/>
     <addaction name="action_show_live_updates"/>
@@ -120,6 +127,7 @@
     <addaction name="action_view_fit_grains_config"/>
     <addaction name="action_view_overlay_picks"/>
     <addaction name="view_recent_images"/>
+    <addaction name="colormaps_menu"/>
    </widget>
    <widget class="QMenu" name="menu_edit">
     <property name="title">
@@ -249,7 +257,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>753</height>
+          <height>775</height>
          </rect>
         </property>
         <attribute name="label">
@@ -262,7 +270,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>753</height>
+          <height>775</height>
          </rect>
         </property>
         <attribute name="label">
@@ -737,6 +745,22 @@
   <action name="action_edit_apply_pinhole_mask">
    <property name="text">
     <string>Apply Pinhole Mask</string>
+   </property>
+  </action>
+  <action name="action_show_all_colormaps">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="checked">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Show all colormaps</string>
+   </property>
+  </action>
+  <action name="action_edit_defaults">
+   <property name="text">
+    <string>Edit defaults</string>
    </property>
   </action>
  </widget>

--- a/hexrd/ui/snip_viewer_dialog.py
+++ b/hexrd/ui/snip_viewer_dialog.py
@@ -9,7 +9,6 @@ from PySide2.QtCore import Qt
 from PySide2.QtWidgets import QFileDialog, QSizePolicy
 
 from hexrd.ui.color_map_editor import ColorMapEditor
-from hexrd.ui.constants import DEFAULT_CMAP
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
@@ -22,7 +21,7 @@ class SnipViewerDialog:
         self.data = data
         self.extent = extent
 
-        self.cmap = DEFAULT_CMAP
+        self.cmap = HexrdConfig().default_cmap
         self.norm = None
         self.transform = lambda x: x
 


### PR DESCRIPTION
Adds new menu options: `View->Colormaps->Show all colormaps` and `View->Colormaps->Edit defaults`

The `Show all colormaps` is a toggle option that will update the list of colormaps available. The `Edit defaults` option opens a dialog that allows users to select one or more colormaps and either add or remove them with the buttons or by dragging and dropping options between the lists.

Fixes #1370