### PR TITLE
Fix places where `ArtistList.remove()` was used

### DIFF
--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -109,7 +109,7 @@ class InteractiveTemplate:
 
     def clear(self):
         if self.shape in self.raw_axes.patches:
-            self.raw_axes.patches.remove(self.shape)
+            self.shape.remove()
             self.redraw()
         self.total_rotation = 0.
 

--- a/hexrd/ui/interactive_template.py
+++ b/hexrd/ui/interactive_template.py
@@ -134,7 +134,8 @@ class InteractiveTemplate:
                     shape.set_closed(False)
                 self.raw_axes.add_patch(shape)
             if self.shape:
-                self.shape = self.raw_axes.patches.pop()
+                self.shape = self.raw_axes.patches[-1]
+                self.shape.remove()
                 self.shape.set_linestyle(self.shape_styles[-1]['line'])
                 self.raw_axes.add_patch(self.shape)
                 if self.translating:

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -235,14 +235,9 @@ class MaskRegionsDialog(QObject):
 
     def apply_masks(self):
         self.disconnect()
-        self.patches.clear()
-        self.added_patches.clear()
-        if hasattr(self.canvas, 'axis'):
-            self.canvas.axis.patches.clear()
-        for canvas in self.parent.image_tab_widget.active_canvases:
-            for axes in canvas.raw_axes.values():
-                axes.patches.clear()
         self.create_masks()
+        while self.added_patches:
+            self.discard_patch()
         self.new_mask_added.emit(self.image_mode)
 
     def cancel(self):

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -133,21 +133,14 @@ class MaskRegionsDialog(QObject):
     def discard_patch(self):
         det = self.added_patches.pop()
         self.raw_mask_coords.pop()
-        return self.patches[det].pop(), det
+        self.patches[det].pop().remove()
 
     def undo_selection(self):
         if not self.added_patches:
             return
 
-        last_patch, det = self.discard_patch()
-        if det == ViewType.polar and hasattr(self.canvas, 'axis'):
-            self.canvas.axis.patches.remove(last_patch)
-        else:
-            for a in self.canvas.raw_axes.values():
-                if a.get_title() == det:
-                    a.patches.remove(last_patch)
+        self.discard_patch()
         self.canvas.draw_idle()
-
         self.update_undo_enable_state()
 
     def axes_entered(self, event):
@@ -255,13 +248,6 @@ class MaskRegionsDialog(QObject):
     def cancel(self):
         while self.added_patches:
             self.discard_patch()
-
-        if hasattr(self.canvas, 'axis'):
-            self.canvas.axis.patches.clear()
-        else:
-            for canvas in self.parent.image_tab_widget.active_canvases:
-                for axes in canvas.raw_axes.values():
-                    axes.patches.clear()
 
         self.disconnect()
         if self.canvas is not None:


### PR DESCRIPTION
`ArtistList.remove()` is no longer a method in matplotlib, as of 3.7.0 (it was made immutable, see [here](https://matplotlib.org/stable/api/axes_api.html#matplotlib.axes.Axes.ArtistList), and it may be turned into a tuple soon).

As such, we encounter an error in these places for new versions of matplotlib.

Instead, we can call `remove()` on the artist itself, and this removes it from the `ArtistList` automatically. Do that instead.

This fixes some of the issues mentioned in #1397 where the rectangle/ellipse masking was not working.

This also potentially fixes another issue with the LLNL Import tool removing boundaries.