### PR TITLE
Make pinhole mask dialog more interactive

### DIFF
--- a/hexrd/ui/pinhole_mask_dialog.py
+++ b/hexrd/ui/pinhole_mask_dialog.py
@@ -1,14 +1,45 @@
+from PySide2.QtCore import QObject, Signal
+from PySide2.QtWidgets import QDialogButtonBox
+
+from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
 
-class PinholeMaskDialog:
+class PinholeMaskDialog(QObject):
+
+    # Arguments are radius, thickness
+    apply_clicked = Signal(float, float)
 
     def __init__(self, parent=None):
+        super().__init__(parent)
+
         loader = UiLoader()
         self.ui = loader.load_file('pinhole_mask_dialog.ui', parent)
+        self.load_settings()
+        self.setup_connections()
 
-    def exec_(self):
-        return self.ui.exec_()
+    def setup_connections(self):
+        apply_button = self.ui.button_box.button(QDialogButtonBox.Apply)
+        apply_button.clicked.connect(self.on_apply_clicked)
+
+    def show(self):
+        return self.ui.show()
+
+    def on_apply_clicked(self):
+        self.save_settings()
+        self.apply_clicked.emit(self.pinhole_radius, self.pinhole_thickness)
+
+    @property
+    def settings(self):
+        return HexrdConfig().config['image']['pinhole_mask_settings']
+
+    def load_settings(self):
+        for name, value in self.settings.items():
+            setattr(self, name, value)
+
+    def save_settings(self):
+        for name in self.settings:
+            self.settings[name] = getattr(self, name)
 
     @property
     def pinhole_radius(self):
@@ -17,3 +48,11 @@ class PinholeMaskDialog:
     @property
     def pinhole_thickness(self):
         return self.ui.pinhole_thickness.value() * 1e-3
+
+    @pinhole_radius.setter
+    def pinhole_radius(self, v):
+        self.ui.pinhole_radius.setValue(v / 1e-3)
+
+    @pinhole_thickness.setter
+    def pinhole_thickness(self, v):
+        self.ui.pinhole_thickness.setValue(v / 1e-3)

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -36,3 +36,6 @@ polarization:
   f_hor: 1.0
   f_vert: 0.0
 intensity_subtract_minimum: false
+pinhole_mask_settings:
+    pinhole_radius: 0.15
+    pinhole_thickness: 0.075

--- a/hexrd/ui/resources/ui/pinhole_mask_dialog.ui
+++ b/hexrd/ui/resources/ui/pinhole_mask_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>418</width>
-    <height>131</height>
+    <width>471</width>
+    <height>152</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -75,10 +75,17 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Apply</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>The pinhole mask may be deleted in the mask manager.</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
The pinhole mask settings are now saved so that they persist both in the same session and in between sessions.

Also, the dialog now stays open with an "Apply" button. When this is clicked, the previous pinhole mask is replaced with a mask generated with the new settings. This allows users to modify the values, create the pinhole mask, and then repeat in case the values need to be modified.

https://user-images.githubusercontent.com/9558430/234713408-bb08f7ac-79b4-488d-b246-441da0a62e18.mp4

Fixes: #1417