### PR TITLE
Add check for panel buffer size

### DIFF
--- a/hexrd/ui/create_hedm_instrument.py
+++ b/hexrd/ui/create_hedm_instrument.py
@@ -4,6 +4,14 @@ from hexrd.ui.hexrd_config import HexrdConfig
 
 
 def create_hedm_instrument():
+    # Ensure that the panel buffer sizes match the pixel sizes.
+    # If not, clear the panel buffer and print a warning.
+    # It would be nice to avoid this check, but it is sometimes difficult to
+    # track down all of the places where there may be a synchronization issue.
+    # When there is a synchronization issue, it typically messes up the whole
+    # program. So keep this check here unless we find out a better way.
+    HexrdConfig().clean_panel_buffers()
+
     # HEDMInstrument expects None Euler angle convention for the
     # config. Let's get it as such.
     iconfig = HexrdConfig().instrument_config_none_euler_convention


### PR DESCRIPTION
Sometimes, we have a panel buffer that does not match the size of the detector.

To prevent this from happening entirely, add a check that will delete the panel buffer if the size does not match.

It would be nice to not have this check, but it is sometimes difficult to track down the many places where this synchronization issue may occur. Let's keep this check unless we figure out a better way.

Fixes: #1381
Fixes: #1398