### PR TITLE
Do not show frame for LLNL import tool

### DIFF
--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -43,7 +43,7 @@ class LLNLImportToolDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('llnl_import_tool_dialog.ui', parent)
         flags = self.ui.windowFlags()
-        self.ui.setWindowFlags(flags | Qt.Tool)
+        self.ui.setWindowFlags(flags | Qt.Tool | Qt.FramelessWindowHint)
 
         add_help_url(self.ui.button_box,
                      'configuration/images/#llnl-import-tool')


### PR DESCRIPTION
The frame goes away if you dock it, and it is confusing because dragging the frame will not allow you to dock it.

Just remove it altogether.