### PR TITLE
Save to NPZ for HEDM workflow output images

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -994,13 +994,13 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         data = []
         for det in self.detector_names:
             data.append({
-                'file': f'{det}.h5',
+                'file': f'{det}.npz',
                 'args': {'path': 'imageseries'},
                 'panel': det
             })
 
         image_series = {
-            'format': 'hdf5',
+            'format': 'frame-cache',
             'data': data
         }
 
@@ -1042,9 +1042,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             omaps['file'] = None
 
         cfg['material'] = material
-        cfg['instrument'] = 'instrument.yml'
+        cfg['instrument'] = 'instrument.hexrd'
         cfg['image_series'] = image_series
-        cfg['working_dir'] = str(Path(output_file).parent)
 
         with open(output_file, 'w') as f:
             yaml.dump(cfg, f)

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -701,16 +701,23 @@ class FitGrainsResultsDialog(QObject):
 
         HexrdConfig().save_indexing_config(full_path('workflow.yml'))
         HexrdConfig().save_materials(full_path('materials.h5'))
-        HexrdConfig().save_instrument_config(full_path('instrument.yml'))
+        HexrdConfig().save_instrument_config(full_path('instrument.hexrd'))
+
+        # Use the find-orientations threshold
+        threshold = HexrdConfig().indexing_config.get('find_orientations', {}).get('threshold')
+        if threshold is None or threshold < 0:
+            threshold = 0
 
         ims_dict = HexrdConfig().unagg_images
         for det in HexrdConfig().detector_names:
+            path = full_path(f'{det}.npz')
             kwargs = {
                 'ims': ims_dict.get(det),
                 'name': det,
-                'write_file': full_path(f'{det}.h5'),
-                'selected_format': 'hdf5',
-                'path': 'imageseries',
+                'write_file': path,
+                'selected_format': 'frame-cache',
+                'cache_file': path,
+                'threshold': threshold,
             }
             HexrdConfig().save_imageseries(**kwargs)
 
@@ -726,8 +733,8 @@ class FitGrainsResultsDialog(QObject):
         write_files = [
             'workflow.yml',
             'materials.h5',
-            'instrument.yml',
-        ] + [f'{det}.h5' for det in HexrdConfig().detector_names]
+            'instrument.hexrd',
+        ] + [f'{det}.npz' for det in HexrdConfig().detector_names]
 
         overwrite_files = []
         for f in write_files:


### PR DESCRIPTION
The unaggregated imageseries from the HEDM workflow were previously being saved as HDF5 files. This is a problem, because that data can be *very* large when it is fully expanded.

Instead, we should be saving it in the sparse frame-cache NPZ files.