### PR TITLE
Add relative scaling for structure factor

### DIFF
--- a/hexrd/ui/azimuthal_overlay_manager.py
+++ b/hexrd/ui/azimuthal_overlay_manager.py
@@ -50,7 +50,7 @@ class AzimuthalOverlayManager:
         self.ui.save_plot.clicked.connect(
             HexrdConfig().azimuthal_plot_save_requested.emit)
         HexrdConfig().materials_added.connect(self.update_table)
-        HexrdConfig().material_renamed.connect(self.update_table)
+        HexrdConfig().material_renamed.connect(self.on_material_renamed)
         HexrdConfig().materials_removed.connect(self.update_table)
 
         HexrdConfig().state_loaded.connect(self.update_table)
@@ -59,6 +59,9 @@ class AzimuthalOverlayManager:
     def show(self):
         self.update_table()
         self.ui.show()
+
+    def on_material_renamed(self, old_name, new_name):
+        self.update_table()
 
     def create_materials_combo(self, v):
         materials = list(HexrdConfig().materials.keys())

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -133,8 +133,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when the materials dict is modified in any way"""
     materials_dict_modified = Signal()
 
-    """Emitted when a material is renamed"""
-    material_renamed = Signal()
+    """Emitted when a material is renamed
+
+    First argument is the old name, and second argument is the new name
+    """
+    material_renamed = Signal(str, str)
 
     """Emitted when materials were added"""
     materials_added = Signal()
@@ -309,7 +312,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         ]
 
         for signal in materials_dict_modified_signals:
-            signal.connect(self.materials_dict_modified.emit)
+            # Ignore all arguments when emitting that the materials dict was
+            # modified.
+            signal.connect(lambda *args: self.materials_dict_modified.emit())
 
         self.overlay_renamed.connect(self.on_overlay_renamed)
         self.material_modified.connect(self.check_active_material_changed)
@@ -1551,7 +1556,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # if we did self.active_material = new_name
             self.config['materials']['active_material'] = new_name
 
-        self.material_renamed.emit()
+        self.material_renamed.emit(old_name, new_name)
 
     def modify_material(self, name, material):
         if name not in self.materials:

--- a/hexrd/ui/overlay_manager.py
+++ b/hexrd/ui/overlay_manager.py
@@ -49,7 +49,7 @@ class OverlayManager:
         self.ui.edit_style_button.pressed.connect(self.edit_style)
         HexrdConfig().update_overlay_editor.connect(self.update_overlay_editor)
         HexrdConfig().materials_added.connect(self.update_table)
-        HexrdConfig().material_renamed.connect(self.update_table)
+        HexrdConfig().material_renamed.connect(self.on_material_renamed)
         HexrdConfig().materials_removed.connect(self.update_table)
 
         HexrdConfig().state_loaded.connect(self.update_table)
@@ -87,6 +87,9 @@ class OverlayManager:
         cb.currentIndexChanged.connect(self.update_config_materials)
         self.material_combos.append(cb)
         return self.create_table_widget(cb)
+
+    def on_material_renamed(self, old_name, new_name):
+        self.update_table()
 
     def create_type_combo(self, v):
         types = list(OverlayType)

--- a/hexrd/ui/reflections_table.py
+++ b/hexrd/ui/reflections_table.py
@@ -47,6 +47,7 @@ class ReflectionsTable:
         self.ui.table.selectionModel().selectionChanged.connect(
             self.update_selections)
 
+        HexrdConfig().materials_removed.connect(self.on_materials_removed)
         HexrdConfig().material_renamed.connect(self.on_material_renamed)
         HexrdConfig().materials_dict_modified.connect(
             self.on_materials_dict_modified)
@@ -117,6 +118,15 @@ class ReflectionsTable:
 
     def show(self):
         self.ui.show()
+
+    def on_materials_removed(self):
+        # If our material isn't the active material, and it was removed,
+        # hide it. If it is the active material, it will be changed elsewhere.
+        if HexrdConfig().active_material is self.material:
+            return
+
+        if self.material.name not in HexrdConfig().materials:
+            self.ui.hide()
 
     def on_material_renamed(self, old_name, new_name):
         if self.relative_scale_material_name == old_name:

--- a/hexrd/ui/reflections_table.py
+++ b/hexrd/ui/reflections_table.py
@@ -31,25 +31,61 @@ class ReflectionsTable:
         self.ui = loader.load_file('reflections_table.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
-        self.setup_connections()
 
         add_help_url(self.ui.button_box,
                      'configuration/materials/#reflections-table')
 
+        self.setup_connections()
+
         self.title_prefix = title_prefix
         self._material = material
         self.update_material_name()
+        self.populate_relative_scale_options()
         self.update_table()
 
     def setup_connections(self):
         self.ui.table.selectionModel().selectionChanged.connect(
             self.update_selections)
 
+        HexrdConfig().material_renamed.connect(self.on_material_renamed)
+        HexrdConfig().materials_dict_modified.connect(
+            self.on_materials_dict_modified)
         HexrdConfig().active_material_modified.connect(
             self.active_material_modified)
-        HexrdConfig().material_renamed.connect(self.update_material_name)
         HexrdConfig().update_reflections_tables.connect(
             self.update_table_if_name_matches)
+
+        self.ui.relative_scale_material.currentIndexChanged.connect(
+            self.on_relative_scale_material_changed)
+
+    def populate_relative_scale_options(self):
+        old_setting = self.relative_scale_material_name
+        if not old_setting:
+            old_setting = self.material.name
+
+        old_setting_found = False
+
+        w = self.ui.relative_scale_material
+        with block_signals(w):
+            w.clear()
+            names = list(HexrdConfig().materials)
+            w.addItems(names)
+
+            if old_setting in names:
+                w.setCurrentText(old_setting)
+                old_setting_found = True
+
+        if not old_setting_found:
+            # Default to the current material and trigger an update
+            w.setCurrentText(self.material.name)
+
+    def on_relative_scale_material_changed(self):
+        # For now, just update the whole table
+        self.update_table()
+
+    def on_materials_dict_modified(self):
+        # Re-populate the relative scale settings
+        self.populate_relative_scale_options()
 
     @property
     def material(self):
@@ -62,10 +98,33 @@ class ReflectionsTable:
 
         self._material = m
         self.update_material_name()
+        # Change the relative scale material name to match the
+        # new material's name.
+        self.relative_scale_material_name = self.material.name
         self.update_table()
+
+    @property
+    def relative_scale_material(self):
+        return HexrdConfig().material(self.relative_scale_material_name)
+
+    @property
+    def relative_scale_material_name(self):
+        return self.ui.relative_scale_material.currentText()
+
+    @relative_scale_material_name.setter
+    def relative_scale_material_name(self, v):
+        self.ui.relative_scale_material.setCurrentText(v)
 
     def show(self):
         self.ui.show()
+
+    def on_material_renamed(self, old_name, new_name):
+        if self.relative_scale_material_name == old_name:
+            # Need to update the combo box text
+            cb = self.ui.relative_scale_material
+            cb.setItemText(cb.currentIndex(), new_name)
+
+        self.update_material_name()
 
     def update_material_name(self):
         self.ui.setWindowTitle(f'{self.title_prefix}{self.material.name}')
@@ -125,6 +184,8 @@ class ReflectionsTable:
 
     def update_table_if_name_matches(self, name):
         if self.material.name == name:
+            # In case the relative material was deleted, update this
+            self.populate_relative_scale_options()
             self.update_table()
 
     def update_table(self):
@@ -147,9 +208,12 @@ class ReflectionsTable:
                     hkls = plane_data.getHKLs(asStr=True)
                     d_spacings = plane_data.getPlaneSpacings()
                     tth = plane_data.getTTh()
-                    sf = plane_data.structFact
                     powder_intensity = plane_data.powder_intensity
                     multiplicity = plane_data.getMultiplicity()
+
+                    # Since structure factors use arbitrary scaling, re-scale
+                    # them to a range that's easier on the eyes.
+                    sf = self.rescaled_structure_factor
 
             # Grab the hkl ids
             hkl_ids = [-1] * len(hkls)
@@ -160,10 +224,6 @@ class ReflectionsTable:
                     continue
                 else:
                     hkl_ids[idx] = hkl_data['hklID']
-
-            # Since structure factors use arbitrary scaling, re-scale them
-            # to a range that's easier on the eyes.
-            rescale_structure_factors(sf)
 
             self.update_hkl_index_maps(hkls)
 
@@ -253,6 +313,33 @@ class ReflectionsTable:
 
             item.setFlags(flags)
 
+    @property
+    def rescaled_structure_factor(self):
+        # Rescale structure factors according to the current relative
+        # material.
+
+        def get_sfact(pd):
+            # pd is a PlaneData object
+            with exclusions_off(pd):
+                with tth_max_off(pd):
+                    return pd.structFact
+
+        this_pd = self.material.planeData
+        compare_pd = self.relative_scale_material.planeData
+
+        sf = get_sfact(this_pd)
+        if len(sf) == 0:
+            return sf
+
+        if this_pd is compare_pd:
+            compare_sf = sf
+        else:
+            compare_sf = get_sfact(compare_pd)
+
+        # Rescale the other structure factor to be between 0 and 100
+        return ((sf - compare_sf.min()) /
+                (compare_sf.max() - compare_sf.min()) * 100)
+
 
 class HklTableItem(QTableWidgetItem):
     """Subclass so we can sort by HKLs instead of strings"""
@@ -310,11 +397,3 @@ def sorting_disabled(table):
         yield
     finally:
         table.setSortingEnabled(prev)
-
-
-def rescale_structure_factors(sf):
-    if len(sf) == 0:
-        return
-
-    # Rescale the structure factors to be between 0 and 100
-    sf[:] = np.interp(sf, (sf.min(), sf.max()), (0, 100))

--- a/hexrd/ui/resources/ui/reflections_table.ui
+++ b/hexrd/ui/resources/ui/reflections_table.ui
@@ -32,13 +32,20 @@
    </item>
    <item row="2" column="1">
     <widget class="QLabel" name="relative_scale_material_label">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scale the structure factor relative to the selected material (by default, the same material). The structure factor is then rescaled to be between 0 and 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
       <string>Scale |F|² relative to:</string>
      </property>
     </widget>
    </item>
    <item row="2" column="2">
-    <widget class="QComboBox" name="relative_scale_material"/>
+    <widget class="QComboBox" name="relative_scale_material">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Scale the structure factor relative to the selected material (by default, the same material). The structure factor is then rescaled to be between 0 and 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+    </widget>
    </item>
    <item row="0" column="0" colspan="3">
     <widget class="QTableWidget" name="table">

--- a/hexrd/ui/resources/ui/reflections_table.ui
+++ b/hexrd/ui/resources/ui/reflections_table.ui
@@ -10,10 +10,7 @@
     <height>329</height>
    </rect>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_7">
-   <property name="spacing">
-    <number>0</number>
-   </property>
+  <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>0</number>
    </property>
@@ -26,7 +23,24 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="relative_scale_material_label">
+     <property name="text">
+      <string>Scale |F|² relative to:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="2">
+    <widget class="QComboBox" name="relative_scale_material"/>
+   </item>
+   <item row="0" column="0" colspan="3">
     <widget class="QTableWidget" name="table">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;left click a row to activate the hkl&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -110,13 +124,6 @@
        <string>Multiplicity</string>
       </property>
      </column>
-    </widget>
-   </item>
-   <item>
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help</set>
-     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
This adds the ability to the reflections table to scale the structure
factor based upon a different material's structure factor.
    
This can be helpful, for instance, to compare how strong the signal will
be of one material compared to another.


https://user-images.githubusercontent.com/9558430/235229614-8dd70335-5a4c-40f1-9cdc-7cf10e6b7e40.mp4



Fixes: #1405