### PR TITLE
Remove Change Image Folder button

### DIFF
--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -237,7 +237,7 @@ class LLNLImportToolDialog(QObject):
     def load_images(self):
         self._set_transform()
 
-        caption = HexrdConfig().images_dirtion = 'Select file(s)'
+        caption = 'Select file(s)'
         selected_file, selected_filter = QFileDialog.getOpenFileName(
             self.ui, caption, dir=HexrdConfig().images_dir)
         if selected_file:

--- a/hexrd/ui/resources/ui/simple_image_series_dialog.ui
+++ b/hexrd/ui/resources/ui/simple_image_series_dialog.ui
@@ -6,95 +6,28 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>575</width>
-    <height>673</height>
+    <width>647</width>
+    <height>571</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Simple Image Series</string>
   </property>
   <widget class="QWidget" name="simple_image_series_contents">
-   <layout class="QVBoxLayout" name="verticalLayout_5">
+   <layout class="QVBoxLayout" name="verticalLayout">
     <item>
      <widget class="QGroupBox" name="file_reader_group">
       <property name="title">
        <string>File Reader</string>
       </property>
-      <layout class="QGridLayout" name="gridLayout_4">
-       <property name="leftMargin">
-        <number>0</number>
+      <layout class="QGridLayout" name="gridLayout">
+       <property name="verticalSpacing">
+        <number>1</number>
        </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <property name="spacing">
-        <number>0</number>
-       </property>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="aggregation">
-         <item>
-          <property name="text">
-           <string>None</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Maximum</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Median</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Average</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="QPushButton" name="image_files">
-         <property name="text">
-          <string>Select Image Files</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QPushButton" name="select_dark">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="text">
-          <string>Select Dark File</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QLabel" name="dark_label">
          <property name="text">
           <string>Dark Mode:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="files_label">
-         <property name="text">
-          <string>Image Files:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="transform_label">
-         <property name="text">
-          <string>Image Transform:</string>
          </property>
         </widget>
        </item>
@@ -135,13 +68,10 @@
          </item>
         </widget>
        </item>
-       <item row="4" column="2" rowspan="2">
-        <widget class="QPushButton" name="read">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
+       <item row="4" column="2">
+        <widget class="QPushButton" name="image_files">
          <property name="text">
-          <string>Read Files</string>
+          <string>Select Image Files</string>
          </property>
         </widget>
        </item>
@@ -152,7 +82,21 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="1" column="0">
+        <widget class="QLabel" name="transform_label">
+         <property name="text">
+          <string>Image Transform:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="files_label">
+         <property name="text">
+          <string>Image Files:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1" colspan="2">
         <widget class="QComboBox" name="transform">
          <item>
           <property name="text">
@@ -191,17 +135,54 @@
          </item>
         </widget>
        </item>
-       <item row="3" column="1">
-        <widget class="QPushButton" name="image_folder">
-         <property name="text">
-          <string>Change Image Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
+       <item row="4" column="1">
         <widget class="QCheckBox" name="reverse_frames">
          <property name="text">
           <string>Reverse Frame Order</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QPushButton" name="select_dark">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Select Dark File</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1" colspan="2">
+        <widget class="QComboBox" name="aggregation">
+         <item>
+          <property name="text">
+           <string>None</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Maximum</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Median</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Average</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+       <item row="5" column="1" colspan="2">
+        <widget class="QPushButton" name="read">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Read Files</string>
          </property>
         </widget>
        </item>

--- a/hexrd/ui/save_images_dialog.py
+++ b/hexrd/ui/save_images_dialog.py
@@ -34,7 +34,7 @@ class SaveImagesDialog:
         self.ui.change_directory.clicked.connect(self.change_directory)
 
     def change_directory(self):
-        caption = HexrdConfig().images_dirtion = 'Select directory for images'
+        caption = 'Select directory for images'
         new_dir = QFileDialog.getExistingDirectory(
             self.ui, caption, dir=self.parent_dir)
 

--- a/hexrd/ui/simple_image_series_dialog.py
+++ b/hexrd/ui/simple_image_series_dialog.py
@@ -199,7 +199,7 @@ class SimpleImageSeriesDialog(QObject):
     def select_dark_img(self, selected_file=False):
         if not selected_file:
             # This takes one image to use for dark subtraction.
-            caption = HexrdConfig().images_dirtion = 'Select image file'
+            caption = 'Select image file'
             selected_file, selected_filter = QFileDialog.getOpenFileName(
                 self.ui, caption, dir=self.parent_dir)
 
@@ -229,7 +229,7 @@ class SimpleImageSeriesDialog(QObject):
 
     def select_images(self):
         # This takes one or more images for a single detector.
-        caption = HexrdConfig().images_dirtion = 'Select image file(s)'
+        caption = 'Select image file(s)'
         selected_files, _ = QFileDialog.getOpenFileNames(
             self.ui, caption, dir=self.parent_dir)
 

--- a/hexrd/ui/simple_image_series_dialog.py
+++ b/hexrd/ui/simple_image_series_dialog.py
@@ -88,7 +88,6 @@ class SimpleImageSeriesDialog(QObject):
         HexrdConfig().detectors_changed.connect(self.config_changed)
         HexrdConfig().load_panel_state_reset.connect(self.config_changed)
 
-        self.ui.image_folder.clicked.connect(self.select_folder)
         self.ui.image_files.clicked.connect(self.select_images)
         self.ui.select_dark.clicked.connect(self.select_dark_img)
         self.ui.read.clicked.connect(self.read_data)
@@ -196,20 +195,6 @@ class SimpleImageSeriesDialog(QObject):
         elif self.state['dark'][self.idx] == UI_DARK_INDEX_FILE:
             self.select_dark_img(self.dark_files[self.idx])
         self.enable_read()
-
-    def select_folder(self, new_dir=None):
-        # This expects to define the root image folder.
-        if not new_dir:
-            caption = HexrdConfig().images_dirtion = 'Select directory for images'
-            new_dir = QFileDialog.getExistingDirectory(
-                self.ui, caption, dir=self.parent_dir)
-
-        # Only update if a new directory is selected
-        if new_dir and new_dir != HexrdConfig().images_dir:
-            self.ui.image_files.setEnabled(True)
-            HexrdConfig().set_images_dir(new_dir)
-            self.parent_dir = new_dir
-            self.dir_changed()
 
     def select_dark_img(self, selected_file=False):
         if not selected_file:


### PR DESCRIPTION
This was added in the very beginning when there was a specific file structure expected for data to be loaded. Now the Select Image Files option takes care of figuring out where all of the image files are located and this is no longer needed and just adds a bit of confusion.

New dialog layout:
![new_simple_image_series](https://user-images.githubusercontent.com/51238406/235710211-924a5545-9934-4e69-8ddb-80e69b64563c.png)
