### PR TITLE
Add option to display polar x-axis as Q

### DIFF
--- a/hexrd/ui/calibration_slider_widget.py
+++ b/hexrd/ui/calibration_slider_widget.py
@@ -223,7 +223,7 @@ class CalibrationSliderWidget(QObject):
             iconfig = HexrdConfig().config['instrument']
             if key == 'energy':
                 iconfig['beam'][key]['value'] = val
-                HexrdConfig().update_visible_material_energies()
+                HexrdConfig().beam_energy_modified.emit()
             elif key == 'polar':
                 iconfig['beam']['vector']['polar_angle']['value'] = val
                 HexrdConfig().beam_vector_changed.emit()

--- a/hexrd/ui/constants.py
+++ b/hexrd/ui/constants.py
@@ -51,6 +51,13 @@ class OverlayType(Enum):
     rotation_series = 'rotation_series'
 
 
+class PolarXAxisType:
+    # Two theta
+    tth = 'tth'
+    # Q scattering vector
+    q = 'q'
+
+
 DEFAULT_EULER_ANGLE_CONVENTION = {
     'axes_order': 'xyz',
     'extrinsic': True

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -54,6 +54,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when overlay configuration has changed"""
     overlay_config_changed = Signal()
 
+    """Emitted when the beam energy was modified"""
+    beam_energy_modified = Signal()
+
     """Emitted when beam vector has changed"""
     beam_vector_changed = Signal()
 
@@ -321,6 +324,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         self.overlay_renamed.connect(self.on_overlay_renamed)
         self.material_modified.connect(self.check_active_material_changed)
+        self.beam_energy_modified.connect(
+            self.update_visible_material_energies)
 
     # Returns a list of tuples contain the names of attributes and their
     # default values that should be persisted as part of the configuration
@@ -1333,7 +1338,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         # If the beam energy was modified, update the visible materials
         if path == ['beam', 'energy', 'value']:
-            self.update_visible_material_energies()
+            self.beam_energy_modified.emit()
             return
 
         if path[:2] == ['beam', 'vector']:

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -160,6 +160,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when a new polar mask has been created"""
     polar_masks_changed = Signal()
 
+    """Emitted when the polar x-axis type changes"""
+    polar_x_axis_type_changed = Signal()
+
     """Emitted when reflections tables for a given material should update
 
     The string argument is the material name.
@@ -1982,6 +1985,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self._polar_tth_distortion_overlay_name = name
             self.flag_overlay_updates_for_all_materials()
             self.rerender_needed.emit()
+
+    @property
+    def polar_x_axis_type(self):
+        return self.config['image']['polar']['x_axis_type']
+
+    @polar_x_axis_type.setter
+    def polar_x_axis_type(self, v):
+        if v == self.polar_x_axis_type:
+            return
+
+        self.config['image']['polar']['x_axis_type'] = v
+        self.polar_x_axis_type_changed.emit()
 
     def on_overlay_renamed(self, old_name, new_name):
         if self._polar_tth_distortion_overlay_name == old_name:

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -94,6 +94,8 @@ class ImageCanvas(FigureCanvas):
             self.save_azimuthal_plot)
         HexrdConfig().polar_x_axis_type_changed.connect(
             self.on_polar_x_axis_type_changed)
+        HexrdConfig().beam_energy_modified.connect(
+            self.on_beam_energy_modified)
 
     def __del__(self):
         # This is so that the figure can be cleaned up
@@ -942,6 +944,15 @@ class ImageCanvas(FigureCanvas):
 
         msg = 'Stereo view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
+
+    def on_beam_energy_modified(self):
+        # Update the beam energy on our instrument if we have one
+        if not self.iviewer:
+            # No need to do anything
+            return
+
+        # Update the beam energy on the instrument
+        self.iviewer.instr.beam_energy = HexrdConfig().beam_energy
 
     @property
     def polar_x_axis_type(self):

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -967,7 +967,7 @@ class ImageCanvas(FigureCanvas):
             return formatter.default_formatter(x, pos)
         elif x_axis_type == PolarXAxisType.q:
             q = tth_to_q(x, self.iviewer.instr.beam_energy)
-            return f'{q:0.1g}'
+            return f'{q:0.4g}'
 
         raise NotImplementedError(x_axis_type)
 

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -370,6 +370,14 @@ class ImageTabWidget(QTabWidget):
             info['dsp'] = dsp
             info['hkl'] = hkl
             info['Q'] = tth_to_q(info['tth'], iviewer.instr.beam_energy)
+        elif mode == ViewType.polar:
+            # No intensities in the polar view implies we are in the azimuthal
+            # integral plot. Compute Q.
+            info['is_lineout'] = True
+            info['tth'] = info['x_data']
+
+            iviewer = self.image_canvases[0].iviewer
+            info['Q'] = tth_to_q(info['tth'], iviewer.instr.beam_energy)
 
         self.new_mouse_position.emit(info)
 

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -8,7 +8,7 @@ from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_canvas import ImageCanvas
 from hexrd.ui.image_series_toolbar import ImageSeriesToolbar
 from hexrd.ui.navigation_toolbar import NavigationToolbar
-from hexrd.ui.utils.conversions import stereo_to_angles
+from hexrd.ui.utils.conversions import stereo_to_angles, tth_to_q
 from hexrd.ui import utils
 
 
@@ -369,6 +369,7 @@ class ImageTabWidget(QTabWidget):
             info['eta'] = np.degrees(eta)
             info['dsp'] = dsp
             info['hkl'] = hkl
+            info['Q'] = tth_to_q(info['tth'], iviewer.instr.beam_energy)
 
         self.new_mouse_position.emit(info)
 

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1034,10 +1034,20 @@ class MainWindow(QObject):
         dialog.ui.finished.connect(on_finished)
 
     def new_mouse_position(self, info):
+        if self.image_mode == ViewType.polar:
+            # Use a special function for polar
+            labels = self.polar_mouse_info_labels(info)
+        else:
+            labels = self.default_mouse_info_labels(info)
+
+        delimiter = ',  '
+        msg = delimiter.join(labels)
+        self.ui.status_bar.showMessage(msg)
+
+    def default_mouse_info_labels(self, info):
         labels = []
         labels.append(f'x = {info["x_data"]:8.3f}')
         labels.append(f'y = {info["y_data"]:8.3f}')
-        delimiter = ',  '
 
         intensity = info['intensity']
         if intensity is not None:
@@ -1048,8 +1058,27 @@ class MainWindow(QObject):
             labels.append(f'Q = {info["Q"]:8.3f}')
             labels.append(f'hkl = {info["hkl"]}')
 
-        msg = delimiter.join(labels)
-        self.ui.status_bar.showMessage(msg)
+        return labels
+
+    def polar_mouse_info_labels(self, info):
+        labels = []
+        # Assume x is tth in the polar view
+        labels.append(f'tth = {info["x_data"]:8.3f}')
+
+        if info.get('is_lineout'):
+            # We are in the azimuthal integration plot
+            labels.append(f'intensity = {info["y_data"]:8.3f}')
+            # Q should have still be calculated.
+            labels.append(f'Q = {info["Q"]:8.3f}')
+        else:
+            # We are in the main polar canvas
+            labels.append(f'eta = {info["y_data"]:8.3f}')
+            labels.append(f'value = {info["intensity"]:8.3f}')
+            labels.append(f'dsp = {info["dsp"]:8.3f}')
+            labels.append(f'Q = {info["Q"]:8.3f}')
+            labels.append(f'hkl = {info["hkl"]}')
+
+        return labels
 
     def on_action_transform_detectors_triggered(self):
         mask_state = HexrdConfig().threshold_mask_status

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1045,6 +1045,7 @@ class MainWindow(QObject):
             labels.append(f'tth = {info["tth"]:8.3f}')
             labels.append(f'eta = {info["eta"]:8.3f}')
             labels.append(f'dsp = {info["dsp"]:8.3f}')
+            labels.append(f'Q = {info["Q"]:8.3f}')
             labels.append(f'hkl = {info["hkl"]}')
 
         msg = delimiter.join(labels)

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -10,6 +10,7 @@ polar:
   snip1d_width: 0.2
   snip1d_numiter: 2
   apply_erosion: false
+  x_axis_type: 'tth'
 cartesian:
   pixel_size: 0.5
   virtual_plane_distance: 1000.0

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -374,20 +374,17 @@
               <property name="spacing">
                <number>0</number>
               </property>
-              <item row="4" column="1">
-               <spacer name="horizontalSpacer">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+              <item row="0" column="0">
+               <widget class="QLabel" name="label_3">
+                <property name="text">
+                 <string>Pixel Size:</string>
                 </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-               </spacer>
+               </widget>
               </item>
-              <item row="5" column="0">
+              <item row="9" column="0">
                <widget class="QComboBox" name="polar_snip1d_algorithm">
                 <item>
                  <property name="text">
@@ -406,33 +403,6 @@
                 </item>
                </widget>
               </item>
-              <item row="2" column="2">
-               <widget class="QLabel" name="label_14">
-                <property name="text">
-                 <string>min</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="0">
-               <widget class="QLabel" name="label_3">
-                <property name="text">
-                 <string>Pixel Size:</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="5">
-               <widget class="QLabel" name="label_15">
-                <property name="text">
-                 <string>max</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
               <item row="2" column="0">
                <widget class="QLabel" name="label_13">
                 <property name="text">
@@ -440,6 +410,82 @@
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="9" column="2" colspan="2">
+               <widget class="QPushButton" name="polar_show_snip1d">
+                <property name="text">
+                 <string>Show SNIP</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="6">
+               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000100000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.100000000000000</double>
+                </property>
+                <property name="value">
+                 <double>0.200000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="5">
+               <widget class="QLabel" name="label_11">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>n iter:</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="6">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>180.000000000000000</double>
+                </property>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>20.000000000000000</double>
                 </property>
                </widget>
               </item>
@@ -453,22 +499,15 @@
                 </property>
                </widget>
               </item>
-              <item row="8" column="0" colspan="7">
-               <widget class="QPushButton" name="polar_azimuthal_overlays">
+              <item row="7" column="0">
+               <widget class="QCheckBox" name="polar_apply_snip1d">
                 <property name="text">
-                 <string>Azimuthal Overlays</string>
+                 <string>Apply SNIP?</string>
                 </property>
                </widget>
               </item>
-              <item row="5" column="2" colspan="2">
-               <widget class="QPushButton" name="polar_show_snip1d">
-                <property name="text">
-                 <string>Show SNIP</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="6">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
+              <item row="2" column="3">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
@@ -488,21 +527,95 @@
                  <double>360.000000000000000</double>
                 </property>
                 <property name="value">
+                 <double>-180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="5">
+               <widget class="QLabel" name="label_15">
+                <property name="text">
+                 <string>max</string>
+                </property>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+               </widget>
+              </item>
+              <item row="10" column="0" colspan="7">
+               <widget class="Line" name="line_above_tth_distortion">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="14" column="0" colspan="7">
+               <widget class="QPushButton" name="polar_azimuthal_overlays">
+                <property name="text">
+                 <string>Azimuthal Overlays</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="3">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>0.000010000000000</double>
+                </property>
+                <property name="maximum">
                  <double>180.000000000000000</double>
                 </property>
-               </widget>
-              </item>
-              <item row="1" column="2">
-               <widget class="QLabel" name="label_12">
-                <property name="text">
-                 <string>min</string>
+                <property name="singleStep">
+                 <double>0.010000000000000</double>
+                </property>
+                <property name="value">
+                 <double>1.000000000000000</double>
                 </property>
                </widget>
               </item>
-              <item row="0" column="5">
-               <widget class="QLabel" name="label_2">
+              <item row="9" column="6">
+               <widget class="QCheckBox" name="polar_apply_erosion">
+                <property name="enabled">
+                 <bool>false</bool>
+                </property>
+                <property name="toolTip">
+                 <string>Apply binary erosion to eliminate edge artifacts.</string>
+                </property>
                 <property name="text">
-                 <string>η:</string>
+                 <string>Apply erosion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="7" column="1">
+               <spacer name="horizontalSpacer">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+              <item row="7" column="2">
+               <widget class="QLabel" name="label_10">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+                <property name="text">
+                 <string>w:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -537,176 +650,52 @@
                 </property>
                </widget>
               </item>
-              <item row="7" column="0" colspan="3">
-               <widget class="QCheckBox" name="polar_apply_tth_distortion">
+              <item row="7" column="6">
+               <widget class="QSpinBox" name="polar_snip1d_numiter">
                 <property name="enabled">
-                 <bool>true</bool>
+                 <bool>false</bool>
                 </property>
-                <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>10000</number>
+                </property>
+                <property name="value">
+                 <number>2</number>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="5">
+               <widget class="QLabel" name="label_2">
                 <property name="text">
-                 <string>Apply 2θ distortion?</string>
+                 <string>η:</string>
                 </property>
-               </widget>
-              </item>
-              <item row="1" column="3">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_min">
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>1.000000000000000</double>
-                </property>
                </widget>
               </item>
-              <item row="1" column="6">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_tth_max">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000010000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>180.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.010000000000000</double>
-                </property>
-                <property name="value">
-                 <double>20.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="3" column="0" colspan="7">
-               <widget class="Line" name="line_above_snip">
+              <item row="7" column="4">
+               <spacer name="horizontalSpacer_2">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
                 </property>
-               </widget>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>40</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </spacer>
               </item>
-              <item row="6" column="0" colspan="7">
-               <widget class="Line" name="line_above_tth_distortion">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-               </widget>
-              </item>
-              <item row="1" column="5">
-               <widget class="QLabel" name="label_5">
-                <property name="text">
-                 <string>max</string>
-                </property>
-                <property name="alignment">
-                 <set>Qt::AlignCenter</set>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="5">
-               <widget class="QLabel" name="label_11">
-                <property name="enabled">
-                 <bool>true</bool>
-                </property>
-                <property name="text">
-                 <string>n iter:</string>
-                </property>
-               </widget>
-              </item>
-              <item row="2" column="3">
-               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_min">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>-360.000000000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="value">
-                 <double>-180.000000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="5" column="6">
-               <widget class="QCheckBox" name="polar_apply_erosion">
-                <property name="enabled">
-                 <bool>false</bool>
-                </property>
-                <property name="toolTip">
-                 <string>Apply binary erosion to eliminate edge artifacts.</string>
-                </property>
-                <property name="text">
-                 <string>Apply erosion?</string>
-                </property>
-               </widget>
-              </item>
-              <item row="0" column="6">
-               <widget class="ScientificDoubleSpinBox" name="polar_pixel_size_eta">
-                <property name="alignment">
-                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="suffix">
-                 <string>°</string>
-                </property>
-                <property name="decimals">
-                 <number>8</number>
-                </property>
-                <property name="minimum">
-                 <double>0.000100000000000</double>
-                </property>
-                <property name="maximum">
-                 <double>360.000000000000000</double>
-                </property>
-                <property name="singleStep">
-                 <double>0.100000000000000</double>
-                </property>
-                <property name="value">
-                 <double>0.200000000000000</double>
-                </property>
-               </widget>
-              </item>
-              <item row="4" column="3">
+              <item row="7" column="3">
                <widget class="ScientificDoubleSpinBox" name="polar_snip1d_width">
                 <property name="enabled">
                  <bool>false</bool>
@@ -747,42 +736,30 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="4">
-               <spacer name="horizontalSpacer_2">
-                <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
-                </property>
-                <property name="sizeHint" stdset="0">
-                 <size>
-                  <width>40</width>
-                  <height>20</height>
-                 </size>
-                </property>
-               </spacer>
-              </item>
-              <item row="4" column="6">
-               <widget class="QSpinBox" name="polar_snip1d_numiter">
+              <item row="11" column="0" colspan="3">
+               <widget class="QCheckBox" name="polar_apply_tth_distortion">
                 <property name="enabled">
-                 <bool>false</bool>
+                 <bool>true</bool>
+                </property>
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Apply 2θ distortion?</string>
+                </property>
+               </widget>
+              </item>
+              <item row="1" column="5">
+               <widget class="QLabel" name="label_5">
+                <property name="text">
+                 <string>max</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
                 </property>
-                <property name="keyboardTracking">
-                 <bool>false</bool>
-                </property>
-                <property name="minimum">
-                 <number>1</number>
-                </property>
-                <property name="maximum">
-                 <number>10000</number>
-                </property>
-                <property name="value">
-                 <number>2</number>
-                </property>
                </widget>
               </item>
-              <item row="7" column="4" colspan="3">
+              <item row="11" column="4" colspan="3">
                <widget class="QComboBox" name="polar_tth_distortion_overlay">
                 <property name="enabled">
                  <bool>false</bool>
@@ -792,20 +769,76 @@
                 </property>
                </widget>
               </item>
-              <item row="4" column="0">
-               <widget class="QCheckBox" name="polar_apply_snip1d">
+              <item row="1" column="2">
+               <widget class="QLabel" name="label_12">
                 <property name="text">
-                 <string>Apply SNIP?</string>
+                 <string>min</string>
                 </property>
                </widget>
               </item>
-              <item row="4" column="2">
-               <widget class="QLabel" name="label_10">
-                <property name="enabled">
-                 <bool>true</bool>
+              <item row="2" column="6">
+               <widget class="ScientificDoubleSpinBox" name="polar_res_eta_max">
+                <property name="alignment">
+                 <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                </property>
+                <property name="keyboardTracking">
+                 <bool>false</bool>
+                </property>
+                <property name="suffix">
+                 <string>°</string>
+                </property>
+                <property name="decimals">
+                 <number>8</number>
+                </property>
+                <property name="minimum">
+                 <double>-360.000000000000000</double>
+                </property>
+                <property name="maximum">
+                 <double>360.000000000000000</double>
+                </property>
+                <property name="value">
+                 <double>180.000000000000000</double>
+                </property>
+               </widget>
+              </item>
+              <item row="2" column="2">
+               <widget class="QLabel" name="label_14">
+                <property name="text">
+                 <string>min</string>
+                </property>
+               </widget>
+              </item>
+              <item row="5" column="0" colspan="7">
+               <widget class="Line" name="line_above_snip">
+                <property name="orientation">
+                 <enum>Qt::Horizontal</enum>
+                </property>
+               </widget>
+              </item>
+              <item row="15" column="6">
+               <widget class="QComboBox" name="polar_x_axis_type">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select what will be displayed on the x-axis. By default, this is &lt;span style=&quot; font-family:'Times New Roman'; font-size:medium; color:#000000;&quot;&gt;2θ&lt;/span&gt; in degrees.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Other options include the Q scattering vector in &lt;span style=&quot; font-family:'Roboto','arial','sans-serif'; font-size:14px; color:#4d5156; background-color:#ffffff;&quot;&gt;Å⁻¹.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <item>
+                 <property name="text">
+                  <string>2θ</string>
+                 </property>
+                </item>
+                <item>
+                 <property name="text">
+                  <string>Q</string>
+                 </property>
+                </item>
+               </widget>
+              </item>
+              <item row="15" column="4" colspan="2">
+               <widget class="QLabel" name="polar_x_axis_type_label">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select what will be displayed on the x-axis. By default, this is &lt;span style=&quot; font-family:'Times New Roman'; font-size:medium; color:#000000;&quot;&gt;2θ&lt;/span&gt; in degrees.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Other options include the Q scattering vector in &lt;span style=&quot; font-family:'Roboto','arial','sans-serif'; font-size:14px; color:#4d5156; background-color:#ffffff;&quot;&gt;Å⁻¹.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
-                 <string>w:</string>
+                 <string>X Axis type:</string>
                 </property>
                 <property name="alignment">
                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -1,6 +1,10 @@
+from typing import Union
+
 import numpy as np
 
 from hexrd.transforms.xfcapi import mapAngle
+
+from hexrd.ui.constants import KEV_TO_WAVELENGTH
 
 from .stereo2angle import ij2ang as stereo_ij2ang, ang2ij as ang2stereo_ij
 
@@ -63,3 +67,20 @@ def angles_to_stereo(angs, instr, stereo_size):
         stereo_size=stereo_size,
         bvec=instr.beam_vector,
     )
+
+
+def tth_to_q(tth: Union[np.ndarray, float], beam_energy: float):
+    # Convert tth values in degrees to q-space in Angstrom^-1
+    # The formula is Q = 4 * pi * sin(theta)/lambda.
+    # lambda is the wavelength in Angstrom, and
+    # theta = current x-axis value/2 in radians.
+
+    tth = np.radians(tth)
+    # The input tth is in degrees, and the beam_energy is in keV
+    return 4 * np.pi * np.sin(tth / 2) * beam_energy / KEV_TO_WAVELENGTH
+
+
+def q_to_tth(q: Union[np.ndarray, float], beam_energy: float):
+    # Convert the q-space values (Angstrom^-1) to tth in degrees
+    tth = np.arcsin(q / 4 / np.pi * KEV_TO_WAVELENGTH / beam_energy) * 2
+    return np.degrees(tth)


### PR DESCRIPTION
This adds an option to change the polar x-axis type to the Q scattering vector. This also adds infrastructure so that we can more easily add more polar x-axis types in the future if needed.

This also adds `Q` to the mouse hover information in all views.

![image](https://user-images.githubusercontent.com/9558430/236517719-8eb9f022-7180-4393-a27c-ab3e8d043b6e.png)

Fixes: #1403