### PR TITLE
Support varied file names when using 'image-files' adapter

### DIFF
--- a/hexrd/ui/image_file_manager.py
+++ b/hexrd/ui/image_file_manager.py
@@ -1,3 +1,4 @@
+import glob
 import os
 import numpy as np
 import tempfile
@@ -93,7 +94,7 @@ class ImageFileManager(metaclass=Singleton):
                 'image-files': {}
             }
             input_dict['image-files']['directory'] = os.path.dirname(f)
-            input_dict['image-files']['files'] = os.path.basename(f)
+            input_dict['image-files']['files'] = glob.escape(os.path.basename(f))
             input_dict['options'] = {} if options is None else options
             input_dict['meta'] = {}
             temp = tempfile.NamedTemporaryFile(delete=False)


### PR DESCRIPTION
Fixes a bug revealed in testing HEXRD/hexrd#523. Files loaded with the `image-files` Image Series Adapter are passed to `glob` but will fail if they contain special characters. Use `glob.escape` to parse the string and prevent errors loading files.