### PR TITLE
Do not reset material exclusions for export HEDM

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -986,6 +986,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         recursive_key_check(self.indexing_config, cfg)
 
+        # Make sure the exclusions do not get reset in fit-grains
+        cfg['fit_grains']['reset_exclusions'] = False
+
         current_material = self.indexing_config['_selected_material']
         selected_material = self.material(current_material)
         plane_data = selected_material.planeData
@@ -1001,7 +1004,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'active': current_material,
             'dmin': selected_material.dmin.getVal('angstrom'),
             'tth_width': tth_width,
-            'min_sfac_ratio': None
+            'reset_exclusions': False,
         }
 
         data = []

--- a/hexrd/ui/indexing/create_config.py
+++ b/hexrd/ui/indexing/create_config.py
@@ -34,9 +34,14 @@ def create_indexing_config():
         # Set the max number of CPUs
         indexing_config['multiprocessing'] = HexrdConfig().max_cpus
 
+    # Make sure exclusions are not reset
+    fit_grains_config = indexing_config.setdefault('fit_grains', {})
+    disable_exclusions_reset(fit_grains_config)
+
     # Set the active material on the config
-    tmp = indexing_config.setdefault('material', {})
-    tmp['active'] = material.name
+    material_config = indexing_config.setdefault('material', {})
+    material_config['active'] = material.name
+    disable_exclusions_reset(material_config)
 
     # Create the root config from the indexing config dict
     config = RootConfig(indexing_config)
@@ -84,3 +89,24 @@ def validate_config(config):
 
 class OmegasNotFoundError(Exception):
     pass
+
+
+def disable_exclusions_reset(config):
+    # Disable exclusions reset for the provided config
+    config['reset_exclusions'] = False
+
+    # Set these to None so we don't get a warning message
+    set_to_none = [
+        'min_sfac_ratio',
+        'dmin',
+        'dmax',
+        'tthmin',
+        'tthmax',
+        'sfacmin',
+        'sfacmax',
+        'pintmin',
+        'pintmax',
+    ]
+
+    for key in set_to_none:
+        config[key] = None


### PR DESCRIPTION
As of hexrd/hexrd#513, the material exclusions are now reset by default when running fit-grains.

In hexrd/hexrd#520, they are now reset in the materials as well. However, that PR also introduces the option to not reset exclusions, both in fit-grains and in the material config.

Set that option when we export the config so that we keep the exclusions that we saved on the materials. This is so that we are able to reproduce what was set in the GUI when running the HEDM workflow from the command line.

Depends on: hexrd/hexrd#520