### PR TITLE
Add tooltips for QActions when they are disabled

### DIFF
--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -155,6 +155,8 @@ class MainWindow(QObject):
 
         ImageFileManager().load_dummy_images(True)
 
+        self.update_all_menu_item_tooltips()
+
         # In order to avoid both a not very nice looking black window,
         # and a bug with the tabbed view
         # (see https://github.com/HEXRD/hexrdgui/issues/261),
@@ -315,6 +317,11 @@ class MainWindow(QObject):
         self.ui.action_about.triggered.connect(self.on_action_about_triggered)
         self.ui.action_documentation.triggered.connect(
             self.on_action_documentation_triggered)
+
+        # Update menu item tooltips when their enable state changes
+        for widget_name in self._menu_item_tooltips:
+            w = getattr(self.ui, widget_name)
+            w.changed.connect(self._update_menu_item_tooltip_for_sender)
 
     def on_state_loaded(self):
         self.update_action_check_states()
@@ -1109,8 +1116,8 @@ class MainWindow(QObject):
         has_images = HexrdConfig().has_images
         num_images = HexrdConfig().imageseries_length
 
-        self.ui.action_image_calculator.setEnabled(
-            has_images and num_images == 1)
+        enable_image_calculator = has_images and num_images == 1
+        self.ui.action_image_calculator.setEnabled(enable_image_calculator)
 
         # Update the HEDM enable states
         self.update_hedm_enable_states()
@@ -1132,6 +1139,87 @@ class MainWindow(QObject):
         # If we made it here, they should be enabled.
         for action in actions:
             action.setEnabled(True)
+
+    @property
+    def _menu_item_tooltips(self):
+        # The keys here are QAction names. The value is a dict where the keys
+        # are the enable state, and the values are the tooltips for that
+        # enable state.
+        return {
+            'action_edit_apply_hand_drawn_mask': {
+                True: '',
+                False: 'Polar/raw view must be active with image data loaded',
+            },
+            'action_edit_apply_laue_mask_to_polar': {
+                True: '',
+                False: 'Polar view must be active',
+            },
+            'action_edit_apply_powder_mask_to_polar': {
+                True: '',
+                False: 'Polar view must be active',
+            },
+            'action_export_current_plot': {
+                True: '',
+                False: ('Cartesian/polar/stereo view must be active '
+                        'with image data loaded'),
+            },
+            'action_export_to_maud': {
+                True: '',
+                False: 'Polar view must be active with image data loaded',
+            },
+            'action_image_calculator': {
+                True: '',
+                False: ('Image data must be loaded (and must not be an image '
+                        'stack)'),
+            },
+            'action_run_laue_and_powder_calibration': {
+                True: '',
+                False: 'Polar view must be active with image data loaded',
+            },
+            'action_rerun_clustering': {
+                True: '',
+                False: 'Indexing must have been ran to re-run clustering',
+            },
+            'action_run_fit_grains': {
+                True: '',
+                False: 'An image stack with omega values is required',
+            },
+            'action_run_indexing': {
+                True: '',
+                False: 'An image stack with omega values is required',
+            },
+            'action_run_wppf': {
+                True: '',
+                False: 'The polar view must be active with image data loaded',
+            },
+            'action_transform_detectors': {
+                True: '',
+                False: 'Image data must be loaded',
+            },
+        }
+
+    def _update_menu_item_tooltip_for_sender(self):
+        # This function should be called automatically when the sending
+        # QAction is modified.
+        # The modification may have been its enable state.
+
+        w = self.sender()
+        enabled = w.isEnabled()
+        name = w.objectName()
+
+        tooltips = self._menu_item_tooltips
+        if name not in tooltips:
+            return
+
+        w.setToolTip(tooltips[name][enabled])
+
+    def update_all_menu_item_tooltips(self):
+        tooltips = self._menu_item_tooltips
+
+        for widget_name, tooltip_options in tooltips.items():
+            w = getattr(self.ui, widget_name)
+            enabled = w.isEnabled()
+            w.setToolTip(tooltip_options[enabled])
 
     def on_action_open_mask_manager_triggered(self):
         self.mask_manager_dialog.show()

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -48,9 +48,15 @@
     <property name="title">
      <string>File</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <widget class="QMenu" name="menu_open">
      <property name="title">
       <string>&amp;Open</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_open_images"/>
      <addaction name="action_open_state"/>
@@ -63,9 +69,15 @@
      <property name="title">
       <string>&amp;Save</string>
      </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
+     </property>
      <widget class="QMenu" name="menu_save_config">
       <property name="title">
        <string>&amp;Configuration</string>
+      </property>
+      <property name="toolTipsVisible">
+       <bool>true</bool>
       </property>
       <addaction name="action_save_config_hexrd"/>
       <addaction name="action_save_config_yaml"/>
@@ -79,12 +91,18 @@
      <property name="title">
       <string>Export</string>
      </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
+     </property>
      <addaction name="action_export_current_plot"/>
      <addaction name="action_export_to_maud"/>
     </widget>
     <widget class="QMenu" name="menu_import">
      <property name="title">
       <string>Import</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_hedm_import_tool"/>
      <addaction name="action_image_stack"/>
@@ -101,6 +119,9 @@
     <property name="title">
      <string>View</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <widget class="QMenu" name="view_dock_widgets">
      <property name="title">
       <string>Dock Widgets</string>
@@ -114,6 +135,9 @@
     <widget class="QMenu" name="colormaps_menu">
      <property name="title">
       <string>Colormaps</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_show_all_colormaps"/>
      <addaction name="action_edit_defaults"/>
@@ -133,9 +157,15 @@
     <property name="title">
      <string>E&amp;dit</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <widget class="QMenu" name="menu_masks">
      <property name="title">
       <string>Masks</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_edit_apply_hand_drawn_mask"/>
      <addaction name="action_edit_apply_laue_mask_to_polar"/>
@@ -147,6 +177,9 @@
     <widget class="QMenu" name="menu_intensity_corrections">
      <property name="title">
       <string>Intensity Corrections</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_apply_pixel_solid_angle_correction"/>
      <addaction name="action_apply_lorentz_correction"/>
@@ -165,9 +198,15 @@
     <property name="title">
      <string>R&amp;un</string>
     </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
+    </property>
     <widget class="QMenu" name="menu_hedm">
      <property name="title">
       <string>HEDM</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_run_indexing"/>
      <addaction name="action_rerun_clustering"/>
@@ -176,6 +215,9 @@
     <widget class="QMenu" name="menu_calibration">
      <property name="title">
       <string>Calibration</string>
+     </property>
+     <property name="toolTipsVisible">
+      <bool>true</bool>
      </property>
      <addaction name="action_run_fast_powder_calibration"/>
      <addaction name="action_run_laue_and_powder_calibration"/>
@@ -189,6 +231,9 @@
    <widget class="QMenu" name="menuHelp">
     <property name="title">
      <string>H&amp;elp</string>
+    </property>
+    <property name="toolTipsVisible">
+     <bool>true</bool>
     </property>
     <addaction name="action_documentation"/>
     <addaction name="action_about"/>
@@ -311,14 +356,6 @@
          </item>
          <item>
           <widget class="QDialogButtonBox" name="config_button_box">
-           <property name="geometry">
-            <rect>
-             <x>180</x>
-             <y>630</y>
-             <width>175</width>
-             <height>28</height>
-            </rect>
-           </property>
            <property name="standardButtons">
             <set>QDialogButtonBox::Help</set>
            </property>


### PR DESCRIPTION
This provides info as to why they are disabled.

![disabled_qaction_tooltips](https://github.com/HEXRD/hexrdgui/assets/9558430/d0a5d4a5-c1b0-4de4-b3d5-33e0079cae5b)

Fixes: #1449