### PR TITLE
Reload dummy images if detector shape changes

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -1332,6 +1332,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             for val in path[:-1]:
                 cur_val = cur_val[val]
 
+            old_val = cur_val[path[-1]]
             cur_val[path[-1]] = value
         except KeyError:
             msg = ('Path: ' + str(path) + '\nwas not found in dict: ' +
@@ -1340,6 +1341,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         if 'status' in path[-2:]:
             # If we are just modifying a status, we are done
+            return
+
+        if old_val == value:
+            # If we didn't modify anything, just return
             return
 
         # If the beam energy was modified, update the visible materials

--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -101,6 +101,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when detectors have been added or removed"""
     detectors_changed = Signal()
 
+    """Emitted when a detector's shape changes
+
+    The argument is the name of the detector whose shape changed.
+    """
+    detector_shape_changed = Signal(str)
+
     """Emitted when an instrument config has been loaded
 
     Warning: this will cause cartesian and polar parameters to be
@@ -1351,6 +1357,17 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # indicating so
             det = path[1]
             self.detector_transform_modified.emit(det)
+            return
+
+        if (path[0] == 'detectors' and path[2] == 'pixels'
+                and path[3] in ('columns', 'rows')):
+            # If the detector shape changes, we need to indicate so.
+            # Whatever images that were previously loaded need to be removed,
+            # since the shapes will no longer match, and new dummy
+            # images loaded with the correct pixel sizes.
+            det = path[1]
+            self.detector_shape_changed.emit(det)
+            self.rerender_needed.emit()
             return
 
         if path[0] == 'oscillation_stage':

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -280,6 +280,8 @@ class MainWindow(QObject):
             self.ui.status_bar.showMessage)
         HexrdConfig().detectors_changed.connect(
             self.on_detectors_changed)
+        HexrdConfig().detector_shape_changed.connect(
+            self.on_detector_shape_changed)
         HexrdConfig().deep_rerender_needed.connect(self.deep_rerender)
         HexrdConfig().raw_masks_changed.connect(self.update_all)
         HexrdConfig().recent_images_changed.connect(
@@ -411,6 +413,12 @@ class MainWindow(QObject):
         self.ui.image_tab_widget.switch_toolbar(0)
         self.simple_image_series_dialog.config_changed()
         self.update_view_recent_images_list()
+
+    def on_detector_shape_changed(self, det_key):
+        # We need to load/reset the dummy images if a detector's shape changes.
+        # Otherwise, the HexrdConfig().images_dict object will not have images
+        # with the correct shape.
+        self.load_dummy_images()
 
     def load_dummy_images(self):
         if HexrdConfig().loading_state:


### PR DESCRIPTION
If the detector shape changes, the images stored internally will not match the new shape. We must reset them. Otherwise, there are errors in the polar view.

Fixes: #1451