### PR TITLE
Hide all toolbars when clearing so none remain

### DIFF
--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -61,6 +61,11 @@ class ImageTabWidget(QTabWidget):
             canvas.mpl_disconnect(cid)
             canvas.deleteLater()
 
+        # Hide all toolbars
+        for tb in self.toolbars:
+            tb['tb'].setVisible(False)
+            tb['sb'].set_visible(False)
+
         del self.image_canvases[1:]
         del self.toolbars[1:]
         del self.mpl_connections[1:]


### PR DESCRIPTION
Even though extra toolbars were being deleted, they were not being hidden, and thus a reference to them were held and they remained visible.

Hide all toolbars when clearing so this does not happen.

Fixes: #1453