### PR TITLE
Use nansum for zoom box subplots

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -220,6 +220,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when material parameters are modified"""
     material_modified = Signal(str)
 
+    """Emitted when image mode widget should be enabled/disabled"""
+    enable_image_mode_widget = Signal(bool)
+
     def __init__(self):
         # Should this have a parent?
         super(HexrdConfig, self).__init__(None)

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -97,6 +97,9 @@ class ImageModeWidget(QObject):
         HexrdConfig().instrument_config_loaded.connect(
             self.auto_generate_polar_params)
 
+        HexrdConfig().enable_image_mode_widget.connect(
+            self.enable_image_mode_widget)
+
         self.ui.polar_show_snip1d.clicked.connect(self.polar_show_snip1d.emit)
 
         self.ui.tab_widget.currentChanged.connect(self.currentChanged)
@@ -126,6 +129,9 @@ class ImageModeWidget(QObject):
             HexrdConfig().set_stereo_show_border)
         self.ui.stereo_project_from_polar.toggled.connect(
             HexrdConfig().set_stereo_project_from_polar)
+
+    def enable_image_mode_widget(self, b):
+        self.ui.tab_widget.setEnabled(b)
 
     def currentChanged(self, index):
         modes = {

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -227,8 +227,8 @@ class ZoomCanvas(FigureCanvas):
         a3_y = np.degrees(pv.angular_grid[0][i_row[1]:i_row[2], 0])
         if self.display_sums_in_subplots:
             roi = rsimg[i_row[1]:i_row[2], j_col[0]:j_col[1]]
-            a2_y = np.sum(roi, axis=0)
-            a3_x = np.sum(roi, axis=1)
+            a2_y = np.nansum(roi, axis=0)
+            a3_x = np.nansum(roi, axis=1)
         else:
             if self.in_zoom_axis and self.vhlines:
                 x = self.vhlines[0].get_xdata()

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -240,8 +240,8 @@ class ZoomCanvas(FigureCanvas):
                 x, y = np.mean(xlims), np.mean(ylims)
 
             # Convert to pixels
-            x_pixel = pv.tth_to_pixel(np.radians(x))
-            y_pixel = pv.eta_to_pixel(np.radians(y))
+            x_pixel = pv.tth_to_pixel(np.radians(x)).item()
+            y_pixel = pv.eta_to_pixel(np.radians(y)).item()
 
             # Extract the points from the main image
             a2_y = rsimg[round(y_pixel), j_col[0]:j_col[1]]


### PR DESCRIPTION
This prevents points on the lines from disappearing entirely when there are nans in the row/column.

This PR also adds support for enabling/disabling the entire image mode widget, as well as fixing mouse hovering on the zoom canvas in unsummed mode.