### PR TITLE
Ensure tree view gets fully reset when clearing

### DIFF
--- a/hexrd/ui/tree_views/base_tree_item_model.py
+++ b/hexrd/ui/tree_views/base_tree_item_model.py
@@ -67,9 +67,16 @@ class BaseTreeItemModel(QAbstractItemModel):
     def clear(self):
         # Remove all of the root item children. That clears it.
         root = self.root_item
-        self.beginRemoveRows(QModelIndex(), KEY_COL, root.child_count() - 1)
+
+        # We need to do begin/endResetModel() rather than begin/endRemoveRows()
+        # because it was buggy when we were using the row version before.
+        # I think the issue was that some parts of the item model were not
+        # being notified that the data was modified (maybe a dataChanged() was
+        # needed). However, since we are deleting everything, it is simpler
+        # to just do a full ResetModel().
+        self.beginResetModel()
         root.clear_children()
-        self.endRemoveRows()
+        self.endResetModel()
 
     def add_tree_item(self, data, parent):
         return TreeItem(data, parent)


### PR DESCRIPTION
When we cleared the tree view before, we would call `beginRemoveRows()` and `endRemoveRows()`. However, some parts of the model were apparently not notified of the underlying data change, and they were not updating properly. Maybe a `dataChanged()` would have fixed this, but since we are deleting everything anyways, we should just do `beginResetModel()` and `endResetModel()` instead.

This appears to fix the issues.

Fixes: #1452