### PR TITLE
Fix the LLNL import of the rind detector

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -290,12 +290,12 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
                 frames = frames[::-1]
             ims_dict[key] = imageseries.process.ProcessedImageSeries(
                 ims_dict[key], ops, frame_list=frames)
-            HexrdConfig().set_instrument_config_val(
-                ['detectors', key, 'pixels', 'columns', 'value'],
-                ims_dict[key].shape[1])
-            HexrdConfig().set_instrument_config_val(
-                ['detectors', key, 'pixels', 'rows', 'value'],
-                ims_dict[key].shape[0])
+
+            # Set these directly so no signals get emitted
+            det_conf = HexrdConfig().config['instrument']['detectors'][key]
+            det_conf['pixels']['columns']['value'] = ims_dict[key].shape[1]
+            det_conf['pixels']['rows']['value'] = ims_dict[key].shape[0]
+
         self.images_transformed.emit()
 
     def display_aggregation(self, ims_dict):


### PR DESCRIPTION
Previous updates to reload dummy images when pixel sizes change introduced an issue when loading the rind via the LLNL import tool.

This update fixes the code so that dummy images are not reloaded for the rind.

Fixes: #1472