### PR TITLE
Fix exception that occurs when buffer is None

### DIFF
--- a/hexrd/ui/calibration/panel_buffer_dialog.py
+++ b/hexrd/ui/calibration/panel_buffer_dialog.py
@@ -168,6 +168,9 @@ class PanelBufferDialog(QObject):
 
                 if buffer.size in (1, 2):
                     self.mode = CONFIG_MODE_BORDER
+                    if buffer == None:
+                        buffer = np.asarray([0])
+
                     if buffer.size == 1:
                         buffer = [buffer.item()] * 2
 


### PR DESCRIPTION
This adds a check for when the buffer is `None`. If it is `None`, then we should just display zeros for the panel buffer border.