### PR TITLE
Fix polar mask when eta is split

### DIFF
--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -10,9 +10,9 @@ from hexrd.ui.utils.conversions import pixels_to_angles
 
 
 def convert_raw_to_polar(det, line):
-    # Make sure there at least 50 sample points so that the conversion
+    # Make sure there at least 300 sample points so that the conversion
     # looks correct.
-    line = add_sample_points(line, 50)
+    line = add_sample_points(line, 300)
 
     instr = create_hedm_instrument()
     kwargs = {
@@ -29,6 +29,13 @@ def create_polar_mask(name, line_data):
     # Calculate current image dimensions
     pv = PolarView(None)
     shape = pv.shape
+    num_pix_eta = shape[0]
+
+    # If any consecutive pixel coordinates for the mask are greater than this
+    # distance apart (in eta), then that means the mask is being split
+    # above/below the image, and we need to split the mask up.
+    eta_max_pix_diff = num_pix_eta / 2
+
     # Generate masks from line data
     final_mask = np.ones(shape, dtype=bool)
     for line in line_data:
@@ -38,11 +45,87 @@ def create_polar_mask(name, line_data):
         j_col = np.floor((tth - np.degrees(pv.tth_min)) / pv.tth_pixel_size)
         i_row = np.floor((eta - np.degrees(pv.eta_min)) / pv.eta_pixel_size)
 
-        rr, cc = polygon(i_row, j_col, shape=shape)
-        mask = np.ones(shape, dtype=bool)
-        mask[rr, cc] = False
-        final_mask = np.logical_and(final_mask, mask)
+        gaps, = np.nonzero(np.abs(np.diff(i_row)) > eta_max_pix_diff)
+        if gaps.size == 0:
+            # Just one mask
+            masks = [_pixel_perimeter_to_mask(i_row, j_col, shape)]
+        else:
+            # This mask is split between the top and bottom of the image.
+            # We need to split it up into two polygons.
+
+            # There should be exactly two gaps. Add one to these indices.
+            gaps += 1
+
+            # Now split them up into two polygons along with some buffering
+            i_row1, i_row2 = _split_coords_1d(i_row, gaps[0], gaps[1])
+            i_row1, i_row2 = _buffer_coords_1d(i_row1, i_row2, 0, shape[0] - 1)
+
+            j_col1, j_col2 = _split_coords_1d(j_col, gaps[0], gaps[1])
+            j_col1, j_col2 = _interpolate_split_coords_1d(j_col1, j_col2)
+
+            # Create the masks
+            masks = [
+                _pixel_perimeter_to_mask(i_row1, j_col1, shape),
+                _pixel_perimeter_to_mask(i_row2, j_col2, shape),
+            ]
+
+        for mask in masks:
+            final_mask = np.logical_and(final_mask, mask)
+
     HexrdConfig().masks[name] = final_mask
+
+
+def _pixel_perimeter_to_mask(r, c, shape):
+    # The arguments are all forwarded to skimage.draw.polygon
+    rr, cc = polygon(r, c, shape=shape)
+    mask = np.ones(shape, dtype=bool)
+    mask[rr, cc] = False
+    return mask
+
+
+def _split_coords_1d(x, gap1, gap2):
+    coords1 = np.hstack((x[gap2:], x[:gap1]))
+    coords2 = x[gap1:gap2]
+    return coords1, coords2
+
+
+def _buffer_coords_1d(coords1, coords2, min_val, max_val):
+    # Buffer the coords with whichever is closer on the sides,
+    # min_val or max_val
+    if max_val - coords1[0] < coords1[0] - min_val:
+        # coords1 is closer to the max, and coords2 is closer to the min
+        # If the coord is already greater than the max, just leave it alone.
+        border1 = max(max_val, coords1[0])
+        border2 = min_val
+    else:
+        # coords2 is closer to the max, and coords1 is closer to the min
+        # If the coord is already greater than the max, just leave it alone.
+        border1 = min_val
+        border2 = max(max_val, coords2[0])
+
+    coords1 = np.hstack((border1, coords1, border1))
+    coords2 = np.hstack((border2, coords2, border2))
+    return coords1, coords2
+
+
+def _interpolate_split_coords_1d(coords1, coords2):
+    # Buffer the coords with interpolation between values.
+    if abs(coords1[0] - coords2[-1]) < abs(coords1[0] - coords2[0]):
+        # coords1[0] and coords2[-1] are attached
+        coords1_first = (coords1[0] + coords2[-1]) / 2
+        coords1_last = (coords1[-1] + coords2[0]) / 2
+        coords2_first = coords1_last
+        coords2_last = coords1_first
+    else:
+        # coords1[0] and coords2[0] are attached
+        coords1_first = (coords1[0] + coords2[0]) / 2
+        coords1_last = (coords1[-1] + coords2[-1]) / 2
+        coords2_first = coords1_first
+        coords2_last = coords1_last
+
+    coords1 = np.hstack((coords1_first, coords1, coords1_last))
+    coords2 = np.hstack((coords2_first, coords2, coords2_last))
+    return coords1, coords2
 
 
 def rebuild_polar_masks():

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -38,9 +38,9 @@ def create_threshold_mask(img):
 def convert_polar_to_raw(line_data):
     raw_line_data = []
     for line in line_data:
-        # Make sure there are at least 50 sample points
+        # Make sure there are at least 300 sample points
         # so that the conversion will appear correct.
-        line = add_sample_points(line, 50)
+        line = add_sample_points(line, 300)
         for key, panel in create_hedm_instrument().detectors.items():
             raw = angles_to_pixels(line, panel)
             if all([np.isnan(x) for x in raw.flatten()]):

--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -45,7 +45,13 @@ def convert_polar_to_raw(line_data):
             raw = angles_to_pixels(line, panel)
             if all([np.isnan(x) for x in raw.flatten()]):
                 continue
+
+            # Go ahead and get rid of nan coordinates. They cause trouble
+            # with scikit image's polygon.
+            raw = raw[~np.isnan(raw.min(axis=1))]
+
             raw_line_data.append((key, raw))
+
     return raw_line_data
 
 

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -184,8 +184,8 @@ class MaskRegionsDialog(QObject):
             self.patch.get_path().vertices[:-1])
 
         # So that this gets converted between raw and polar correctly,
-        # make sure there are at least 50 points.
-        data_coords = add_sample_points(data_coords, 50)
+        # make sure there are at least 300 points.
+        data_coords = add_sample_points(data_coords, 300)
 
         if self.image_mode == ViewType.raw:
             self.raw_mask_coords.append((self.det, data_coords))

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -17,8 +17,10 @@ def pixels_to_cart(ij, panel):
     return panel.pixelToCart(ij[:, [1, 0]])
 
 
-def cart_to_angles(xys, panel, eta_period, tvec_s=None, tvec_c=None,
+def cart_to_angles(xys, panel, eta_period=None, tvec_s=None, tvec_c=None,
                    apply_distortion=True):
+    # If the eta period is specified, the eta angles will be mapped to be
+    # within this period.
     kwargs = {
         'tvec_s': tvec_s,
         'tvec_c': tvec_c,
@@ -26,7 +28,10 @@ def cart_to_angles(xys, panel, eta_period, tvec_s=None, tvec_c=None,
     }
     ang_crds, _ = panel.cart_to_angles(xys, **kwargs)
     ang_crds = np.degrees(ang_crds)
-    ang_crds[:, 1] = mapAngle(ang_crds[:, 1], eta_period, units='degrees')
+
+    if eta_period is not None:
+        ang_crds[:, 1] = mapAngle(ang_crds[:, 1], eta_period, units='degrees')
+
     return ang_crds
 
 
@@ -40,7 +45,7 @@ def angles_to_pixels(angles, panel):
     return cart_to_pixels(xys, panel)
 
 
-def pixels_to_angles(ij, panel, eta_period, tvec_s=None, tvec_c=None):
+def pixels_to_angles(ij, panel, eta_period=None, tvec_s=None, tvec_c=None):
     xys = pixels_to_cart(ij, panel)
 
     kwargs = {


### PR DESCRIPTION
If a polar mask is split in eta so that part of it is at the top and
part of it is at the bottom, it is now split into two polygons. These
polygons get some extra padding (so they cover all pixels to the eta
border) and some interpolation is done in the two theta pixel to
ensure the padding runs in the correct direction.

This PR also fixes #1458, where masks would disappear if any nan coordinates were present.
    
Fixes: #1369
Fixes: #1458