### PR TITLE
Apply masks before applying tth distortion

### DIFF
--- a/hexrd/ui/create_polar_mask.py
+++ b/hexrd/ui/create_polar_mask.py
@@ -128,10 +128,14 @@ def _interpolate_split_coords_1d(coords1, coords2):
     return coords1, coords2
 
 
+def create_polar_mask_from_raw(name, value):
+    line_data = []
+    for det, data in value:
+        line_data.extend(convert_raw_to_polar(det, data))
+    create_polar_mask(name, line_data)
+
+
 def rebuild_polar_masks():
     HexrdConfig().masks.clear()
     for name, value in HexrdConfig().raw_mask_coords.items():
-        line_data = []
-        for det, data in value:
-            line_data.extend(convert_raw_to_polar(det, data))
-        create_polar_mask(name, line_data)
+        create_polar_mask_from_raw(name, value)

--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -126,9 +126,9 @@ class HandDrawnMaskDialog(QObject):
 
         linebuilder.disconnect()
 
-        # Make sure there are at least 50 points, so that conversions
+        # Make sure there are at least 300 points, so that conversions
         # between raw/polar views come out okay.
-        ring_data = add_sample_points(ring_data, 50)
+        ring_data = add_sample_points(ring_data, 300)
 
         self.ring_data.append(ring_data)
         self.dets.append(self.ax.get_title())

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -37,7 +37,9 @@ from hexrd.ui.calibration.picks_tree_view_dialog import (
     PicksTreeViewDialog, overlays_to_tree_format, tree_format_to_picks,
 )
 from hexrd.ui.calibration.wppf_runner import WppfRunner
-from hexrd.ui.create_polar_mask import create_polar_mask, rebuild_polar_masks
+from hexrd.ui.create_polar_mask import (
+    create_polar_mask_from_raw, rebuild_polar_masks
+)
 from hexrd.ui.create_raw_mask import (
     convert_polar_to_raw, create_raw_mask, rebuild_raw_masks)
 from hexrd.ui.constants import ViewType, DOCUMENTATION_URL
@@ -680,7 +682,7 @@ class MainWindow(QObject):
                 raw_line = convert_polar_to_raw([line])
                 HexrdConfig().raw_mask_coords[name] = raw_line
                 HexrdConfig().visible_masks.append(name)
-                create_polar_mask(name, [line])
+                create_polar_mask_from_raw(name, raw_line)
             HexrdConfig().polar_masks_changed.emit()
         elif self.image_mode == ViewType.raw:
             for det, line in zip(dets, line_data):
@@ -717,9 +719,9 @@ class MainWindow(QObject):
             return
 
         name = unique_name(HexrdConfig().raw_mask_coords, 'laue_mask')
-        create_polar_mask(name, data)
         raw_data = convert_polar_to_raw(data)
         HexrdConfig().raw_mask_coords[name] = raw_data
+        create_polar_mask_from_raw(name, raw_data)
         HexrdConfig().visible_masks.append(name)
         self.new_mask_added.emit(self.image_mode)
         HexrdConfig().polar_masks_changed.emit()
@@ -753,9 +755,9 @@ class MainWindow(QObject):
             return
 
         name = unique_name(HexrdConfig().raw_mask_coords, 'powder_mask')
-        create_polar_mask(name, data)
         raw_data = convert_polar_to_raw(data)
         HexrdConfig().raw_mask_coords[name] = raw_data
+        create_polar_mask_from_raw(name, raw_data)
         HexrdConfig().visible_masks.append(name)
         self.new_mask_added.emit(self.image_mode)
         HexrdConfig().polar_masks_changed.emit()

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -1,7 +1,7 @@
-from hexrd.ui.create_polar_mask import create_polar_mask
 from PySide2.QtCore import QObject, Signal, Qt
 
 from hexrd.ui.create_raw_mask import convert_polar_to_raw, create_raw_mask
+from hexrd.ui.create_polar_mask import create_polar_mask_from_raw
 from hexrd.ui.utils import unique_name
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.constants import ViewType
@@ -214,7 +214,7 @@ class MaskRegionsDialog(QObject):
             elif self.image_mode == 'polar':
                 raw_coords = convert_polar_to_raw(data)
                 HexrdConfig().raw_mask_coords[name] = raw_coords
-                create_polar_mask(name, data)
+                create_polar_mask_from_raw(name, raw_coords)
             HexrdConfig().visible_masks.append(name)
 
         masks_changed_signal = {

--- a/hexrd/ui/overlays/laue_overlay.py
+++ b/hexrd/ui/overlays/laue_overlay.py
@@ -239,11 +239,12 @@ class LaueOverlay(Overlay):
                 angles_corr[:, 1], np.radians(self.eta_period), units='radians'
             )
             """
-
-            if display_mode == ViewType.polar:
+            if display_mode in (ViewType.polar, ViewType.stereo):
                 # If the polar view is being distorted, apply this tth
                 # distortion to the angles as well.
                 angles = apply_tth_distortion_if_needed(angles)
+
+            if display_mode == ViewType.polar:
                 # Save the Laue spots as a list instead of a numpy array,
                 # so that we can predictably get the id() of spots inside.
                 # Numpy arrays do fancy optimizations that break this.

--- a/hexrd/ui/overlays/laue_overlay.py
+++ b/hexrd/ui/overlays/laue_overlay.py
@@ -16,6 +16,7 @@ from hexrd.ui.overlays.overlay import Overlay
 from hexrd.ui.utils.conversions import (
     angles_to_cart, angles_to_stereo, cart_to_angles
 )
+from hexrd.ui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
 class LaueOverlay(Overlay):
@@ -240,6 +241,9 @@ class LaueOverlay(Overlay):
             """
 
             if display_mode == ViewType.polar:
+                # If the polar view is being distorted, apply this tth
+                # distortion to the angles as well.
+                angles = apply_tth_distortion_if_needed(angles)
                 # Save the Laue spots as a list instead of a numpy array,
                 # so that we can predictably get the id() of spots inside.
                 # Numpy arrays do fancy optimizations that break this.

--- a/hexrd/ui/overlays/powder_overlay.py
+++ b/hexrd/ui/overlays/powder_overlay.py
@@ -256,7 +256,7 @@ class PowderOverlay(Overlay):
         # 2. We are not distorting the polar image with the current overlay
         distortion_overlay = HexrdConfig().polar_tth_distortion_overlay
         polar_distortion_with_self = (
-            display_mode == ViewType.polar and
+            display_mode in (ViewType.polar, ViewType.stereo) and
             distortion_overlay is self
         )
         apply_distortion = (
@@ -272,7 +272,7 @@ class PowderOverlay(Overlay):
             polar_angular_grid = HexrdConfig().polar_angular_grid
 
             offset_distortion = (
-                display_mode == ViewType.polar and
+                display_mode in (ViewType.polar, ViewType.stereo) and
                 distortion_overlay is not None and
                 polar_corr_field is not None and
                 polar_angular_grid is not None

--- a/hexrd/ui/utils/tth_distortion.py
+++ b/hexrd/ui/utils/tth_distortion.py
@@ -1,0 +1,46 @@
+import numpy as np
+
+
+def apply_tth_distortion_if_needed(ang_crds, in_degrees=False, reverse=False):
+    from hexrd.ui.hexrd_config import HexrdConfig
+
+    # The ang_crds is a numpy array of angular coordinates
+    # in_degrees indicates whether the polar data is in degrees or not
+    # If reverse is true, then the distortion is applied in the opposite
+    # direction.
+    multiplier = -1 if reverse else 1
+
+    # First, check if we are actually applying tth distortion.
+    # If we are not, just skip and return.
+    distortion_overlay = HexrdConfig().polar_tth_distortion_overlay
+    polar_corr_field = HexrdConfig().polar_corr_field_polar
+    polar_angular_grid = HexrdConfig().polar_angular_grid
+
+    skip = (
+        distortion_overlay is None or
+        polar_corr_field is None or
+        polar_angular_grid is None
+    )
+    if skip:
+        # We are not applying tth distortion. Just return.
+        return ang_crds
+
+    # Set up the variables we need
+    polar_field = polar_corr_field.filled(np.nan)
+    eta_centers, tth_centers = polar_angular_grid
+    first_eta_col = eta_centers[:, 0]
+    first_tth_row = tth_centers[0]
+
+    # Compute and apply offset in reverse
+    if in_degrees:
+        ang_crds = np.radians(ang_crds)
+
+    for ic, ang_crd in enumerate(ang_crds):
+        i = np.argmin(np.abs(ang_crd[0] - first_tth_row))
+        j = np.argmin(np.abs(ang_crd[1] - first_eta_col))
+        ang_crds[ic, 0] += (polar_field[j, i] * multiplier)
+
+    if in_degrees:
+        ang_crds = np.degrees(ang_crds)
+
+    return ang_crds


### PR DESCRIPTION
We want the tth distortion to also move the masks, so make sure the masks are applied before applying the tth distortion.

This also fixes the `reapply_masks()` function to also apply the tth distortion again (otherwise, it would be lost).

Need to fix:

- [x] If tth distortion is applied, and then you draw a mask in the polar view, it acts as if you drew a mask in the non-distorted polar view (so the pixels get shifted a little bit compared to what you drew). We should fix this so drawing masks in a polar view with tth distortion applied is more intuitive.

Fixes: #1448
Fixes: #1481