### PR TITLE
Add the loaded file info to the toolbar

### DIFF
--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -45,7 +45,7 @@ class ImageSeriesToolbar(QWidget):
         self.omega_label.setVisible(False)
 
         data = resource_loader.load_resource(hexrd.ui.resources.icons,
-                                        'file.svg', binary=True)
+                                             'file.svg', binary=True)
         pixmap = QPixmap()
         pixmap.loadFromData(data, 'svg')
         self.file_label = QLabel(self.parent())
@@ -113,7 +113,7 @@ class ImageSeriesToolbar(QWidget):
         ome_range = HexrdConfig().omega_ranges
 
         enable = not is_aggregated and ome_range is not None
-        self.toggle_widget_visibility(enable)
+        self.omega_label.setVisible(enable)
         if not enable:
             return
 
@@ -125,6 +125,6 @@ class ImageSeriesToolbar(QWidget):
         for det, images in HexrdConfig().recent_images.items():
             fnames = [Path(img).name for img in images]
             tips.append(
-                f'{det}: {(", ").join(fnames)}'
+                f'{det}: {", ".join(fnames)}'
             )
-        self.file_label.setToolTip(('\n').join(tips))
+        self.file_label.setToolTip('\n'.join(tips))

--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -17,8 +17,6 @@ class ImageSeriesInfoToolbar(QWidget):
         self.widget = None
         self.file_label = None
 
-        self.show = False
-
         self.create_widget()
 
         self.setup_connections()

--- a/hexrd/ui/image_series_toolbar.py
+++ b/hexrd/ui/image_series_toolbar.py
@@ -39,6 +39,7 @@ class ImageSeriesToolbar(QWidget):
     def create_widget(self):
         self.slider = QSlider(Qt.Horizontal, self.parent())
         self.frame = QSpinBox(self.parent())
+        self.frame.setKeyboardTracking(False)
 
         self.widget = QWidget(self.parent())
         self.omega_label = QLabel(self.parent())
@@ -81,6 +82,8 @@ class ImageSeriesToolbar(QWidget):
             if not size == self.slider.maximum():
                 self.slider.setMaximum(size)
                 self.frame.setMaximum(size)
+                self.frame.setToolTip(f'Max: {size}')
+                self.slider.setToolTip(f'Max: {size}')
                 self.slider.setValue(0)
                 self.frame.setValue(self.slider.value())
         else:
@@ -118,7 +121,11 @@ class ImageSeriesToolbar(QWidget):
             return
 
         ome_min, ome_max = ome_range
-        self.omega_label.setText(f'  Omega range: [{ome_min}°, {ome_max}°]')
+        # We will display 6 digits at most, because omegas go up to 360
+        # degrees (so up to 3 digits before the decimal place), and we
+        # will always show at least 3 digits after the decimal place.
+        text = f'  Omega range: [{ome_min:.6g}°, {ome_max:.6g}°]'
+        self.omega_label.setText(text)
 
     def update_file_tooltip(self):
         tips = []

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -6,7 +6,7 @@ import numpy as np
 from hexrd.ui.constants import PAN, ViewType, ZOOM
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.image_canvas import ImageCanvas
-from hexrd.ui.image_series_toolbar import ImageSeriesToolbar
+from hexrd.ui.image_series_toolbar import ImageSeriesToolbar, ImageSeriesInfoToolbar
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.utils.conversions import stereo_to_angles, tth_to_q
 from hexrd.ui import utils
@@ -65,6 +65,7 @@ class ImageTabWidget(QTabWidget):
         for tb in self.toolbars:
             tb['tb'].setVisible(False)
             tb['sb'].set_visible(False)
+            tb['ib'].setVisible(False)
 
         del self.image_canvases[1:]
         del self.toolbars[1:]
@@ -155,6 +156,7 @@ class ImageTabWidget(QTabWidget):
 
         self.toolbars[self.current_index]['tb'].setVisible(b)
         self.toolbars[self.current_index]['sb'].set_visible(b)
+        self.toolbars[self.current_index]['ib'].set_visible(b)
 
     def allocate_toolbars(self):
         parent = self.parent()
@@ -165,14 +167,16 @@ class ImageTabWidget(QTabWidget):
             # Current detector
             name = self.image_names[idx]
             sb = ImageSeriesToolbar(name, self)
+            ib = ImageSeriesInfoToolbar(self)
 
             # This will put it at the bottom of the central widget
             toolbar = QHBoxLayout()
+            toolbar.addWidget(ib.widget)
             toolbar.addWidget(tb)
             toolbar.addWidget(sb.widget)
             parent.layout().addLayout(toolbar)
             parent.layout().setAlignment(toolbar, Qt.AlignCenter)
-            self.toolbars.append({'tb': tb, 'sb': sb})
+            self.toolbars.append({'tb': tb, 'sb': sb, 'ib': ib})
 
     def switch_toolbar(self, idx):
         if idx < 0:
@@ -185,6 +189,7 @@ class ImageTabWidget(QTabWidget):
             status = self.toolbar_visible if idx == i else False
             toolbar['tb'].setVisible(status)
             toolbar['sb'].set_visible(status)
+            toolbar['ib'].set_visible(status)
         self.update_ims_toolbar()
 
     def update_ims_toolbar(self):

--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -65,7 +65,7 @@ class ImageTabWidget(QTabWidget):
         for tb in self.toolbars:
             tb['tb'].setVisible(False)
             tb['sb'].set_visible(False)
-            tb['ib'].setVisible(False)
+            tb['ib'].set_visible(False)
 
         del self.image_canvases[1:]
         del self.toolbars[1:]

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -286,8 +286,6 @@ class MainWindow(QObject):
             self.on_detector_shape_changed)
         HexrdConfig().deep_rerender_needed.connect(self.deep_rerender)
         HexrdConfig().raw_masks_changed.connect(self.update_all)
-        HexrdConfig().recent_images_changed.connect(
-            self.update_view_recent_images_list)
 
         ImageLoadManager().update_needed.connect(self.update_all)
         ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)
@@ -416,7 +414,7 @@ class MainWindow(QObject):
         self.load_dummy_images()
         self.ui.image_tab_widget.switch_toolbar(0)
         self.simple_image_series_dialog.config_changed()
-        self.update_view_recent_images_list()
+        HexrdConfig().recent_images_changed.emit()
 
     def on_detector_shape_changed(self, det_key):
         # We need to load/reset the dummy images if a detector's shape changes.
@@ -1369,13 +1367,6 @@ class MainWindow(QObject):
     def on_action_about_triggered(self):
         dialog = AboutDialog(self.ui)
         dialog.ui.exec_()
-
-    def update_view_recent_images_list(self):
-        self.ui.view_recent_images.clear()
-        for det, images in HexrdConfig().recent_images.items():
-            self.ui.view_recent_images.addSection(det)
-            for image in images:
-                self.ui.view_recent_images.addAction(image)
 
     def on_action_documentation_triggered(self):
         QDesktopServices.openUrl(QUrl(DOCUMENTATION_URL))

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -414,7 +414,6 @@ class MainWindow(QObject):
         self.load_dummy_images()
         self.ui.image_tab_widget.switch_toolbar(0)
         self.simple_image_series_dialog.config_changed()
-        HexrdConfig().recent_images_changed.emit()
 
     def on_detector_shape_changed(self, det_key):
         # We need to load/reset the dummy images if a detector's shape changes.

--- a/hexrd/ui/resources/icons/file.svg
+++ b/hexrd/ui/resources/icons/file.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6m4 18H6V4h7v5h5v11Z"/></svg>

--- a/hexrd/ui/resources/icons/file.svg
+++ b/hexrd/ui/resources/icons/file.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6m4 18H6V4h7v5h5v11Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6m4 18H6V4h7v5h5v11Z"/></svg>

--- a/hexrd/ui/resources/icons/file.svg
+++ b/hexrd/ui/resources/icons/file.svg
@@ -1,1 +1,1 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6m4 18H6V4h7v5h5v11Z"/></svg>
+<svg xmlns="http://www.w3.org/2000/svg" width="26" height="26" viewBox="0 0 24 24"><path fill="currentColor" d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8l-6-6m4 18H6V4h7v5h5v11Z"/></svg>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>26</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -127,11 +127,6 @@
       <string>Dock Widgets</string>
      </property>
     </widget>
-    <widget class="QMenu" name="view_recent_images">
-     <property name="title">
-      <string>Loaded Images</string>
-     </property>
-    </widget>
     <widget class="QMenu" name="colormaps_menu">
      <property name="title">
       <string>Colormaps</string>
@@ -150,7 +145,6 @@
     <addaction name="action_view_indexing_config"/>
     <addaction name="action_view_fit_grains_config"/>
     <addaction name="action_view_overlay_picks"/>
-    <addaction name="view_recent_images"/>
     <addaction name="colormaps_menu"/>
    </widget>
    <widget class="QMenu" name="menu_edit">
@@ -302,7 +296,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>753</height>
+          <height>775</height>
          </rect>
         </property>
         <attribute name="label">
@@ -315,7 +309,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>753</height>
+          <height>775</height>
          </rect>
         </property>
         <attribute name="label">


### PR DESCRIPTION
Adds the list of file names to a tooltip in the toolbar at the bottom of the window. The full path is still available in the menu: `View>Loaded Images`

![files_tooltip](https://github.com/HEXRD/hexrdgui/assets/51238406/d13ab9b2-0209-485d-b85b-ec8576a6403a)

Fixes #1460
