### PR TITLE
Add material name to HKL info for mouse hover

### DIFF
--- a/hexrd/ui/image_tab_widget.py
+++ b/hexrd/ui/image_tab_widget.py
@@ -365,7 +365,8 @@ class ImageTabWidget(QTabWidget):
                 eta = np.radians(info['y_data'])
 
             # We will only display the active material's hkls
-            plane_data = HexrdConfig().active_material.planeData
+            material = HexrdConfig().active_material
+            plane_data = material.planeData
             dsp = 0.5 * plane_data.wavelength / np.sin(0.5 * tth)
             hkl = str(plane_data.getHKLs(asStr=True, allHKLs=True,
                                          thisTTh=tth))
@@ -374,6 +375,7 @@ class ImageTabWidget(QTabWidget):
             info['eta'] = np.degrees(eta)
             info['dsp'] = dsp
             info['hkl'] = hkl
+            info['material_name'] = material.name
             info['Q'] = tth_to_q(info['tth'], iviewer.instr.beam_energy)
         elif mode == ViewType.polar:
             # No intensities in the polar view implies we are in the azimuthal

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1063,12 +1063,14 @@ class MainWindow(QObject):
 
         intensity = info['intensity']
         if intensity is not None:
+            material_name = info.get("material_name", "")
+
             labels.append(f'value = {info["intensity"]:8.3f}')
             labels.append(f'tth = {info["tth"]:8.3f}')
             labels.append(f'eta = {info["eta"]:8.3f}')
             labels.append(f'dsp = {info["dsp"]:8.3f}')
             labels.append(f'Q = {info["Q"]:8.3f}')
-            labels.append(f'hkl = {info["hkl"]}')
+            labels.append(f'hkl ({material_name}) = {info["hkl"]}')
 
         return labels
 
@@ -1084,11 +1086,13 @@ class MainWindow(QObject):
             labels.append(f'Q = {info["Q"]:8.3f}')
         else:
             # We are in the main polar canvas
+            material_name = info.get("material_name", "")
+
             labels.append(f'eta = {info["y_data"]:8.3f}')
             labels.append(f'value = {info["intensity"]:8.3f}')
             labels.append(f'dsp = {info["dsp"]:8.3f}')
             labels.append(f'Q = {info["Q"]:8.3f}')
-            labels.append(f'hkl = {info["hkl"]}')
+            labels.append(f'hkl ({material_name}) = {info["hkl"]}')
 
         return labels
 


### PR DESCRIPTION
The currently selected material in the materials panel is the one that is used for mouse hover info. However, this may not be explicit to users, who may expect whatever overlay is displayed to be the material that is used.

The material name makes it more explicit which material is being used to compute the HKL.

![image](https://github.com/HEXRD/hexrdgui/assets/9558430/87385048-e3b6-4798-afd7-f313264db0cf)
