### PR TITLE
Don't reset unaggregated images until "OK" clicked

### DIFF
--- a/hexrd/ui/image_load_manager.py
+++ b/hexrd/ui/image_load_manager.py
@@ -197,6 +197,8 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
             self.add_omega_metadata(HexrdConfig().imageseries_dict)
             if 'agg' in self.state and self.state['agg']:
                 self.display_aggregation(HexrdConfig().imageseries_dict)
+            else:
+                HexrdConfig().reset_unagg_imgs()
 
         self.update_progress(100)
 

--- a/hexrd/ui/simple_image_series_dialog.py
+++ b/hexrd/ui/simple_image_series_dialog.py
@@ -158,8 +158,6 @@ class SimpleImageSeriesDialog(QObject):
 
     def agg_changed(self):
         self.state['agg'] = self.ui.aggregation.currentIndex()
-        if self.ui.aggregation.currentIndex() == UI_AGG_INDEX_NONE:
-            HexrdConfig().reset_unagg_imgs()
         self.enable_read()
 
     def trans_changed(self):


### PR DESCRIPTION
I believe I ran into an issue where, when I was switching between the aggregations, something got reset in the config, and I believe this was the issue.

We should make sure we don't reset the aggregations on HexrdConfig() unless the "OK" button is clicked.

Does this look good to you, @bnmajor?