### PR TITLE
Ensure update of selected material in grains table

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -347,10 +347,16 @@ class FitGrainsOptionsDialog(QObject):
 
     @selected_material.setter
     def selected_material(self, name):
-        if name is None or name not in self.material_options:
+        if (
+            name is None or
+            name not in self.material_options or
+            name == self.selected_material
+        ):
             return
 
         self.ui.material.setCurrentText(name)
+        # Make sure these things get updated
+        self.selected_material_changed()
 
     @property
     def material(self):


### PR DESCRIPTION
These were sometimes getting out-of-sync and this was causing `pull_spots()` to run with the wrong material when visualizing the spots.

This issue is now fixed by adding this extra synchronization.