### PR TITLE
Disable most of the app during hand picking

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -226,6 +226,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when image mode widget should be enabled/disabled"""
     enable_image_mode_widget = Signal(bool)
 
+    """Emitted with the navigation toolbar should be enabled/disabled"""
+    enable_canvas_toolbar = Signal(bool)
+
     """Emitted when image mode widget needs to be in a certain mode"""
     set_image_mode_widget_tab = Signal(str)
 

--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -152,7 +152,7 @@ class LLNLImportToolDialog(QObject):
         self.detector_defaults.clear()
 
         if self.instrument is None:
-            self.parent().action_show_toolbar.setChecked(True)
+            HexrdConfig().enable_canvas_toolbar.emit(True)
         else:
             self.import_in_progress = True
             HexrdConfig().set_image_mode_widget_tab.emit(ViewType.raw)
@@ -161,7 +161,7 @@ class LLNLImportToolDialog(QObject):
             self.enable_widgets(self.ui.raw_image, self.ui.config,
                                 self.ui.file_selection, self.ui.finalize,
                                 enabled=True)
-            self.parent().action_show_toolbar.setChecked(False)
+            HexrdConfig().enable_canvas_toolbar.emit(False)
             self.ui.config_file_label.setToolTip(
                 'Defaults to currently loaded configuration')
             self.update_config_selection(self.ui.config_selection.currentIndex())
@@ -524,8 +524,7 @@ class LLNLImportToolDialog(QObject):
 
         self.close_widget()
         self.ui.instrument.setDisabled(False)
-        self.parent().action_show_toolbar.setEnabled(True)
-        self.parent().action_show_toolbar.setChecked(True)
+        HexrdConfig().enable_canvas_toolbar.emit(True)
         self.cmap.block_updates(False)
 
     def show(self):

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -289,6 +289,8 @@ class MainWindow(QObject):
         HexrdConfig().deep_rerender_needed.connect(self.deep_rerender)
         HexrdConfig().rerender_needed.connect(self.on_rerender_needed)
         HexrdConfig().raw_masks_changed.connect(self.update_all)
+        HexrdConfig().enable_canvas_toolbar.connect(
+            self.on_enable_canvas_toolbar)
 
         ImageLoadManager().update_needed.connect(self.update_all)
         ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)
@@ -1017,6 +1019,17 @@ class MainWindow(QObject):
         # Only perform an update if we have live updates enabled
         if HexrdConfig().live_update:
             self.update_all()
+
+    def on_enable_canvas_toolbar(self, b):
+        prev_state_name = '_previous_action_show_toolbar_state'
+        w = self.ui.action_show_toolbar
+        w.setEnabled(b)
+        if not b:
+            setattr(self, prev_state_name, w.isChecked())
+            w.setChecked(False)
+        else:
+            checked = getattr(self, prev_state_name, True)
+            w.setChecked(checked)
 
     def show_beam_marker_toggled(self, b):
         HexrdConfig().show_beam_marker = b

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -1023,6 +1023,11 @@ class MainWindow(QObject):
     def on_enable_canvas_toolbar(self, b):
         prev_state_name = '_previous_action_show_toolbar_state'
         w = self.ui.action_show_toolbar
+
+        if b == w.isEnabled():
+            # It already matches, just ignore
+            return
+
         w.setEnabled(b)
         if not b:
             setattr(self, prev_state_name, w.isChecked())


### PR DESCRIPTION
If the user modifies certain settings while the hand picking is
being applied, the GUI can get into an unusable state.
    
Disable most of the app during hand picking, except what is relevant
and needed.
    
Fixes: #1497
