### PR TITLE
Make several fixes to polar masking

### DIFF
--- a/hexrd/ui/create_raw_mask.py
+++ b/hexrd/ui/create_raw_mask.py
@@ -59,7 +59,6 @@ def convert_polar_to_raw(line_data, reverse_tth_distortion=True):
             # Go ahead and get rid of nan coordinates. They cause trouble
             # with scikit image's polygon.
             raw = raw[~np.isnan(raw.min(axis=1))]
-
             raw_line_data.append((key, raw))
 
     return raw_line_data

--- a/hexrd/ui/hand_drawn_mask_dialog.py
+++ b/hexrd/ui/hand_drawn_mask_dialog.py
@@ -18,7 +18,7 @@ class HandDrawnMaskDialog(QObject):
     finished = Signal(list, list)
 
     def __init__(self, canvas, parent):
-        super(HandDrawnMaskDialog, self).__init__(parent)
+        super().__init__(parent)
 
         loader = UiLoader()
         self.ui = loader.load_file('hand_drawn_mask_dialog.ui', parent)

--- a/hexrd/ui/mask_regions_dialog.py
+++ b/hexrd/ui/mask_regions_dialog.py
@@ -179,16 +179,20 @@ class MaskRegionsDialog(QObject):
         any_changes = False
         tol = 0.01
         if abs(event.xdata - tth_min) / tth_range < tol:
-            event.xdata = tth_min
+            # Add a small buffer so it isn't out of bounds by accident
+            event.xdata = tth_min + 1e-15
             any_changes = True
         elif abs(event.xdata - tth_max) / tth_range < tol:
-            event.xdata = tth_max
+            # Subtract a small buffer so it isn't out of bounds by accident
+            event.xdata = tth_max - 1e-15
             any_changes = True
         if abs(event.ydata - eta_min) / eta_range < tol:
-            event.ydata = eta_min
+            # Add a small buffer so it doesn't wrap around by accident
+            event.ydata = eta_min + 1e-7
             any_changes = True
         elif abs(event.ydata - eta_max) / eta_range < tol:
-            event.ydata = eta_max
+            # Subtract a small buffer so it doesn't wrap around by accident
+            event.ydata = eta_max - 1e-7
             any_changes = True
 
         if any_changes:


### PR DESCRIPTION
This adds several fixes, including:

1. Slightly adjusting the "snap" values in the rectangular mask (so that they don't go out of bounds on conversion)
2. Increasing the required gap to assume the mask is split across eta
3. Adding logic to handle a single gap (there must be two gaps, so we then look for the second largest gap)