### PR TITLE
If recent images are not in state, clear them

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -511,6 +511,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # Thus, set the overlays later.
             QTimer.singleShot(0, set_overlays)
 
+        if '_recent_images' not in state:
+            self._recent_images.clear()
+
         self.recent_images_changed.emit()
 
     @property


### PR DESCRIPTION
This fixes an issue where the recent images would incorrectly display whatever they were before loading a state file, if an old state file was loaded where these were missing.