### PR TITLE
Block color map updates during detector changes

### DIFF
--- a/hexrd/ui/llnl_import_tool_dialog.py
+++ b/hexrd/ui/llnl_import_tool_dialog.py
@@ -199,14 +199,20 @@ class LLNLImportToolDialog(QObject):
         self.load_instrument_config()
 
     def detector_selected(self, selected):
-        self.ui.instrument.setDisabled(selected)
-        self.detector = self.ui.detectors.currentText()
-        self.add_template()
-        if self.instrument == 'TARDIS':
-            self.cancel_workflow.emit()
-            self.enable_widgets(self.ui.accept_template, enabled=False)
-        else:
-            self.enable_widgets(self.ui.accept_template, enabled=True)
+        # Don't allow the color map range to change while we are changing
+        # detectors. Otherwise, it gets reset to something like "1 - 6".
+        self.cmap.block_updates(True)
+        try:
+            self.ui.instrument.setDisabled(selected)
+            self.detector = self.ui.detectors.currentText()
+            self.add_template()
+            if self.instrument == 'TARDIS':
+                self.cancel_workflow.emit()
+                self.enable_widgets(self.ui.accept_template, enabled=False)
+            else:
+                self.enable_widgets(self.ui.accept_template, enabled=True)
+        finally:
+            self.cmap.block_updates(False)
 
     def update_bbox_height(self, val):
         y0, y1, *x = self.it.bounds

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -7,8 +7,8 @@ polar:
   eta_max: 180.0
   apply_snip1d: false
   snip1d_algorithm: 0
-  snip1d_width: 0.2
-  snip1d_numiter: 2
+  snip1d_width: 2.0
+  snip1d_numiter: 1
   apply_erosion: false
   x_axis_type: 'tth'
 cartesian:


### PR DESCRIPTION
Somewhere in that code, the color map range was being reset to be something
like 1 - 6, which was not a good range for the data. Prevent the color
map range from being reset.

Also, use better default values for SNIP.