### PR TITLE
Add the option to cancel fit grains

### DIFF
--- a/hexrd/ui/resources/ui/progress_dialog.ui
+++ b/hexrd/ui/resources/ui/progress_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>500</width>
-    <height>88</height>
+    <height>124</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -49,7 +49,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="4" column="0">
     <layout class="QVBoxLayout" name="messages_widget_layout">
      <item>
       <spacer name="verticalSpacer">
@@ -68,6 +68,16 @@
       </spacer>
      </item>
     </layout>
+   </item>
+   <item row="5" column="0">
+    <widget class="QDialogButtonBox" name="cancel_button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Sometimes, users realize after they start fit-grains that the options selected will take a *very* long time.

Rather than having to kill the application and start the HEDM workflow all over again, we now provide an option to cancel fit-grains. This stops running fit-grains and it goes back to the fit-grains options dialog.

![example1](https://github.com/HEXRD/hexrdgui/assets/9558430/8053f587-f83a-4fa4-a659-35aef108ba48)

Depends on hexrd/hexrd#543
Fixes part of #1515