### PR TITLE
Make polar lineout scaling optional

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -2122,6 +2122,21 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.polar_tth_distortion_overlay_changed.emit()
 
     @property
+    def polar_apply_scaling_to_lineout(self):
+        return self.config['image']['polar']['apply_scaling_to_lineout']
+
+    @polar_apply_scaling_to_lineout.setter
+    def polar_apply_scaling_to_lineout(self, b):
+        if b == self.polar_apply_scaling_to_lineout:
+            return
+
+        self.config['image']['polar']['apply_scaling_to_lineout'] = b
+        self.rerender_needed.emit()
+
+    def set_polar_apply_scaling_to_lineout(self, b):
+        self.polar_apply_scaling_to_lineout = b
+
+    @property
     def polar_x_axis_type(self):
         return self.config['image']['polar']['x_axis_type']
 

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1113,7 +1113,7 @@ class ImageCanvas(FigureCanvas):
     def compute_azimuthal_integral_sum(self, scaled=True):
         # grab the polar image
         # !!! NOTE: currently not a masked image; just nans
-        if scaled:
+        if scaled and HexrdConfig().polar_apply_scaling_to_lineout:
             pimg = self.scaled_images[0]
         else:
             pimg = self.unscaled_images[0]

--- a/hexrd/ui/image_mode_widget.py
+++ b/hexrd/ui/image_mode_widget.py
@@ -101,6 +101,8 @@ class ImageModeWidget(QObject):
             HexrdConfig().set_polar_snip1d_numiter)
         self.ui.polar_apply_erosion.toggled.connect(
             HexrdConfig().set_polar_apply_erosion)
+        self.ui.polar_apply_scaling_to_lineout.toggled.connect(
+            HexrdConfig().set_polar_apply_scaling_to_lineout)
         self.ui.polar_x_axis_type.currentTextChanged.connect(
             self.on_polar_x_axis_type_changed)
         HexrdConfig().instrument_config_loaded.connect(
@@ -182,6 +184,7 @@ class ImageModeWidget(QObject):
             self.ui.polar_apply_erosion,
             self.ui.polar_apply_tth_distortion,
             self.ui.polar_tth_distortion_overlay,
+            self.ui.polar_apply_scaling_to_lineout,
             self.ui.polar_x_axis_type,
             self.ui.stereo_size,
             self.ui.stereo_show_border,
@@ -228,6 +231,8 @@ class ImageModeWidget(QObject):
                 HexrdConfig().polar_snip1d_numiter)
             self.ui.polar_apply_erosion.setChecked(
                 HexrdConfig().polar_apply_erosion)
+            self.ui.polar_apply_scaling_to_lineout.setChecked(
+                HexrdConfig().polar_apply_scaling_to_lineout)
             self.polar_x_axis_type = HexrdConfig().polar_x_axis_type
             self.ui.stereo_size.setValue(HexrdConfig().stereo_size)
             self.ui.stereo_show_border.setChecked(

--- a/hexrd/ui/resources/calibration/default_image_config.yml
+++ b/hexrd/ui/resources/calibration/default_image_config.yml
@@ -10,6 +10,7 @@ polar:
   snip1d_width: 2.0
   snip1d_numiter: 1
   apply_erosion: false
+  apply_scaling_to_lineout: false
   x_axis_type: 'tth'
 cartesian:
   pixel_size: 0.5

--- a/hexrd/ui/resources/ui/image_mode_widget.ui
+++ b/hexrd/ui/resources/ui/image_mode_widget.ui
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>2</number>
      </property>
      <property name="iconSize">
       <size>
@@ -865,6 +865,16 @@
                 </property>
                </widget>
               </item>
+              <item row="15" column="0" colspan="2">
+               <widget class="QCheckBox" name="polar_apply_scaling_to_lineout">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, the scaling from the color map will also be applied to the lineout.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the scaling is applied to the lineout, note that the lineout is generated as follows: &lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-style:italic;&quot;&gt;mean(sum(scale(img - min(img)), axis=0))&lt;/span&gt;&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The minimum of the image is subtracted before scaling. The sum is performed after scaling. And the mean is performed at the end so that masked values are not treated as zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Apply scaling to lineout?</string>
+                </property>
+               </widget>
+              </item>
              </layout>
             </item>
            </layout>
@@ -1026,10 +1036,12 @@
   <tabstop>polar_apply_tth_distortion</tabstop>
   <tabstop>polar_tth_distortion_overlay</tabstop>
   <tabstop>polar_azimuthal_overlays</tabstop>
+  <tabstop>polar_apply_scaling_to_lineout</tabstop>
   <tabstop>polar_x_axis_type</tabstop>
   <tabstop>stereo_size</tabstop>
   <tabstop>stereo_show_border</tabstop>
   <tabstop>stereo_project_from_polar</tabstop>
+  <tabstop>raw_show_zoom_dialog</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
It now also defaults to `False`.

Addresses part of #1437