### PR TITLE
Remove bin_frames option for eta omega maps

### DIFF
--- a/hexrd/ui/indexing/ome_maps_select_dialog.py
+++ b/hexrd/ui/indexing/ome_maps_select_dialog.py
@@ -110,10 +110,6 @@ class OmeMapsSelectDialog(QObject):
             self.ui.threshold.setValue(v)
 
     @property
-    def bin_frames(self):
-        return self.ui.bin_frames.value()
-
-    @property
     def material_options(self):
         w = self.ui.material
         return [w.itemText(i) for i in range(w.count())]
@@ -144,7 +140,6 @@ class OmeMapsSelectDialog(QObject):
         return [
             self.ui.file_name,
             self.ui.threshold,
-            self.ui.bin_frames
         ]
 
     def update_config(self):
@@ -154,7 +149,6 @@ class OmeMapsSelectDialog(QObject):
         maps_config['_select_method'] = self.method_name
         maps_config['file'] = self.file_name
         maps_config['threshold'] = self.threshold
-        maps_config['bin_frames'] = self.bin_frames
 
         indexing_config['_selected_material'] = self.selected_material
 
@@ -170,7 +164,6 @@ class OmeMapsSelectDialog(QObject):
 
             self.ui.file_name.setText(file_name)
             self.threshold = maps_config['threshold']
-            self.ui.bin_frames.setValue(maps_config['bin_frames'])
 
             self.selected_material = indexing_config.get('_selected_material')
 

--- a/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrd/ui/resources/ui/ome_maps_select_dialog.ui
@@ -51,13 +51,6 @@
        <string>Generate</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="5" column="0">
-        <widget class="QLabel" name="bin_frames_label">
-         <property name="text">
-          <string>Bin Frames:</string>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="0">
         <widget class="QCheckBox" name="apply_threshold">
          <property name="text">
@@ -78,16 +71,6 @@
          </property>
          <property name="value">
           <double>250.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="1">
-        <widget class="QSpinBox" name="bin_frames">
-         <property name="minimum">
-          <number>1</number>
-         </property>
-         <property name="maximum">
-          <number>1000</number>
          </property>
         </widget>
        </item>
@@ -168,7 +151,6 @@
   <tabstop>choose_hkls</tabstop>
   <tabstop>apply_threshold</tabstop>
   <tabstop>threshold</tabstop>
-  <tabstop>bin_frames</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This doesn't actually do anything right now. We should remove it until we decide to add it back into HEXRD.

Fixes: #1546