### PR TITLE
Do not rescale the cartesian and polar views

### DIFF
--- a/hexrd/ui/calibration/cartesian_plot.py
+++ b/hexrd/ui/calibration/cartesian_plot.py
@@ -289,15 +289,6 @@ class InstrumentViewer:
 
         # In case there were any nans...
         nan_mask = np.isnan(img)
-        img = np.ma.masked_array(img, mask=nan_mask, fill_value=0.)
-
-        # Rescale the data to match the scale of the original dataset
-        # TODO: try to get create_calibration_image to not rescale the
-        # result to be between 0 and 1 in the first place so this will
-        # not be necessary.
-        img = np.interp(img, (img.min(), img.max()), (self.min, self.max))
-
-        # Re-mask...
         self.img = np.ma.masked_array(img, mask=nan_mask, fill_value=0.)
 
     def update_images_dict(self):

--- a/hexrd/ui/calibration/polar_plot.py
+++ b/hexrd/ui/calibration/polar_plot.py
@@ -33,10 +33,6 @@ class InstrumentViewer:
         return self.pv.angular_grid
 
     @property
-    def raw_rescaled_img(self):
-        return self.pv.raw_rescaled_img
-
-    @property
     def raw_img(self):
         return self.pv.raw_img
 
@@ -111,7 +107,7 @@ class InstrumentViewer:
             np.savetxt(filename, azimuthal_integration, delimiter=delimiter)
             return
 
-        intensities = self.raw_rescaled_img
+        intensities = self.raw_img.data
         intensities[self.raw_mask] = np.nan
 
         # Prepare the data to write out

--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from skimage.exposure import rescale_intensity
 from skimage.filters.edges import binary_erosion
 from skimage.morphology import rectangle
 from skimage.transform import warp
@@ -347,7 +346,6 @@ class PolarView:
         # mask_warp = warp(pimg.mask, displ_field, mode='edge')
         image1_warp = warp(pimg, displ_field, mode='edge')
 
-        # image1_warp = rescale_intensity(image1_warp, out_range=np.uint32)
         return np.ma.array(image1_warp)  # , mask=mask_warp)
 
     def generate_image(self):
@@ -363,15 +361,11 @@ class PolarView:
         self.apply_image_processing()
 
     @property
-    def raw_rescaled_img(self):
-        return self.apply_rescale(self.raw_img.data)
-
-    @property
     def raw_mask(self):
         return self.raw_img.mask
 
     def apply_image_processing(self):
-        img = self.raw_rescaled_img
+        img = self.raw_img.data
         img = self.apply_snip(img)
         # cache this step so we can just re-apply masks if needed
         self.snipped_img = img
@@ -383,15 +377,6 @@ class PolarView:
         img = self.apply_tth_distortion(img)
 
         self.processed_img = img
-
-    def apply_rescale(self, img):
-        # Rescale the data to match the scale of the original dataset
-        kwargs = {
-            'image': img,
-            'in_range': (np.nanmin(img), np.nanmax(img)),
-            'out_range': (self.min, self.max),
-        }
-        return rescale_intensity(**kwargs)
 
     def apply_snip(self, img):
         # do SNIP if requested

--- a/hexrd/ui/image_canvas.py
+++ b/hexrd/ui/image_canvas.py
@@ -1391,7 +1391,7 @@ class ImageCanvas(FigureCanvas):
             background = self.iviewer.snip_background
         else:
             # We have to run it ourselves...
-            img = self.iviewer.raw_rescaled_img
+            img = self.iviewer.raw_img.data
 
             no_nan_methods = [utils.SnipAlgorithmType.Fast_SNIP_1D]
             if HexrdConfig().polar_snip1d_algorithm not in no_nan_methods:


### PR DESCRIPTION
We have been rescaling the cartesian and polar views for quite a while, but it does not actually appear to be necessary.

The pixel values from the raw view seem to be maintained when they are transformed to the cartesian/polar view. Rescaling the values in the cartesian/polar view is sometimes causing problems when there are, for instance, very high and low values.