### PR TITLE
Make sure threshold masks are appended to existing masks

### DIFF
--- a/hexrd/ui/calibration/polarview.py
+++ b/hexrd/ui/calibration/polarview.py
@@ -421,7 +421,8 @@ class PolarView:
             lt_val, gt_val = HexrdConfig().threshold_values
             lt_mask = img < lt_val
             gt_mask = img > gt_val
-            total_mask = np.logical_or(lt_mask, gt_mask)
+            mask = np.logical_or(lt_mask, gt_mask)
+            total_mask = np.logical_or(total_mask, mask)
         img[total_mask] = np.nan
 
         return img


### PR DESCRIPTION
Previously threshold masks were overwriting any other masks in the polar view.

Fixes #1560 