### PR TITLE
Default to not display sums in subplots in zoom

### DIFF
--- a/hexrd/ui/line_picker_dialog.py
+++ b/hexrd/ui/line_picker_dialog.py
@@ -61,7 +61,9 @@ class LinePickerDialog(QObject):
 
         self.two_click_mode = self.ui.two_click_mode.isChecked()
 
-        self.zoom_canvas = ZoomCanvas(canvas)
+        display_sums_in_subplots = self.ui.display_sums_in_subplots.isChecked()
+
+        self.zoom_canvas = ZoomCanvas(canvas, True, display_sums_in_subplots)
         self.zoom_canvas.zoom_width = self.ui.zoom_tth_width.value()
         self.zoom_canvas.zoom_height = self.ui.zoom_eta_width.value()
         self.ui.zoom_canvas_layout.addWidget(self.zoom_canvas)

--- a/hexrd/ui/resources/ui/line_picker_dialog.ui
+++ b/hexrd/ui/resources/ui/line_picker_dialog.ui
@@ -152,9 +152,6 @@
        <property name="text">
         <string>Display sums in subplots</string>
        </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
       </widget>
      </item>
     </layout>

--- a/hexrd/ui/zoom_canvas.py
+++ b/hexrd/ui/zoom_canvas.py
@@ -15,7 +15,8 @@ class ZoomCanvas(FigureCanvas):
 
     point_picked = Signal(object)
 
-    def __init__(self, main_canvas, draw_crosshairs=True):
+    def __init__(self, main_canvas, draw_crosshairs=True,
+                 display_sums_in_subplots=False):
         self.figure = Figure()
         super().__init__(self.figure)
 
@@ -24,7 +25,7 @@ class ZoomCanvas(FigureCanvas):
         self.xdata = None
         self.ydata = None
         self.main_artists_visible = True
-        self._display_sums_in_subplots = True
+        self._display_sums_in_subplots = display_sums_in_subplots
 
         self.i_row = None
         self.j_col = None

--- a/hexrd/ui/zoom_canvas_dialog.py
+++ b/hexrd/ui/zoom_canvas_dialog.py
@@ -8,7 +8,10 @@ class ZoomCanvasDialog:
         loader = UiLoader()
         self.ui = loader.load_file('zoom_canvas_dialog.ui', parent)
 
-        self.zoom_canvas = ZoomCanvas(main_canvas, draw_crosshairs)
+        display_sums_in_subplots = self.ui.display_sums_in_subplots.isChecked()
+
+        self.zoom_canvas = ZoomCanvas(main_canvas, draw_crosshairs,
+                                      display_sums_in_subplots)
         self.ui.zoom_canvas_layout.addWidget(self.zoom_canvas)
         self.zoom_dimensions_changed(rerender=False)
 


### PR DESCRIPTION
For the Composite (Laue and Powder) calibration, default to not display sums in subplots. For this workflow, it is more helpful to not display the sums.

For the raw view zoom dialog, however, we are leaving it on for now.

Fixes: #1566