### PR TITLE
Allow going back a line while hand-picking points

### DIFF
--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -627,8 +627,8 @@ class CalibrationRunner(QObject):
             self.current_data_list[ind] = data
             self.increment_overlay_data_index()
 
-            # In case a point was over-written, force an update of
-            # the line artists.
+            # The line builder doesn't accurately update the lines
+            # during Laue picking, so we force it here.
             self.update_lines_from_picks()
 
     def line_completed(self):
@@ -649,6 +649,10 @@ class CalibrationRunner(QObject):
             _, _, ind = self.current_data_path
             if 0 <= ind < len(self.current_data_list):
                 self.current_data_list[ind] = (np.nan, np.nan)
+
+            # The line builder doesn't accurately update the lines
+            # during Laue picking, so we force it here.
+            self.update_lines_from_picks()
 
     def last_line_restored(self):
         # This should only be called for powder overlays, because

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -185,6 +185,7 @@ class CalibrationRunner(QObject):
         picker.point_picked.connect(self.point_picked)
         picker.line_completed.connect(self.line_completed)
         picker.last_point_removed.connect(self.last_point_removed)
+        picker.last_line_restored.connect(self.last_line_restored)
         picker.finished.connect(self.calibration_line_picker_finished)
         picker.view_picks.connect(self.on_view_picks_clicked)
         picker.accepted.connect(self.finish_line)
@@ -642,12 +643,21 @@ class CalibrationRunner(QObject):
                 # Still nothing to do
                 return
             # Remove the last point of data
-            self.current_data_list.pop(-1)
+            self.current_data_list.pop()
         elif self.active_overlay.is_laue:
             self.decrement_overlay_data_index()
             _, _, ind = self.current_data_path
             if 0 <= ind < len(self.current_data_list):
                 self.current_data_list[ind] = (np.nan, np.nan)
+
+    def last_line_restored(self):
+        # This should only be called for powder overlays, because
+        # Laue overlays are single-line
+        while self.current_data_list:
+            self.current_data_list.pop()
+
+        # Go back one line
+        self.decrement_overlay_data_index()
 
     def disable_line_picker(self, b=True):
         if self.line_picker:

--- a/hexrd/ui/calibration/calibration_runner.py
+++ b/hexrd/ui/calibration/calibration_runner.py
@@ -1,5 +1,6 @@
 import copy
 from functools import partial
+import itertools
 from pathlib import Path
 
 import h5py
@@ -700,23 +701,29 @@ class CalibrationRunner(QObject):
         if not self.line_picker:
             return
 
-        # Save the previous index
-        prev_data_index = self.overlay_data_index
-
         picker = self.line_picker
-        for i, line in enumerate(picker.lines):
-            self.overlay_data_index = i
-            if not self.current_data_path:
-                break
+        if self.active_overlay.is_powder:
+            # Save the previous index
+            prev_data_index = self.overlay_data_index
+            for i, line in enumerate(picker.lines):
+                self.overlay_data_index = i
+                if not self.current_data_path:
+                    break
 
-            if self.current_data_list:
-                data = list(zip(*self.current_data_list))
-            else:
-                data = [(), ()]
+                if self.current_data_list:
+                    data = list(zip(*self.current_data_list))
+                else:
+                    data = [(), ()]
 
-            line.set_data(data)
+                line.set_data(data)
 
-        self.overlay_data_index = prev_data_index
+            self.overlay_data_index = prev_data_index
+        else:
+            # For Laue, there should be just one line that contains
+            # all of the points.
+            data = list(zip(*itertools.chain(*self.overlay_picks.values())))
+            picker.lines[0].set_data(data)
+
         picker.canvas.draw_idle()
 
     def auto_pick_points(self):

--- a/hexrd/ui/calibration/structureless/runner.py
+++ b/hexrd/ui/calibration/structureless/runner.py
@@ -601,7 +601,7 @@ def polar_lines_to_cart(data, instr):
         calibrator_line = {}
         panel_found = np.zeros(line.shape[0], dtype=bool)
         for det_key, panel in instr.detectors.items():
-            points = angles_to_cart(line, panel)
+            points = angles_to_cart(line, panel, tvec_c=instr.tvec)
             _, on_panel = panel.clip_to_panel(points)
             points[~on_panel] = np.nan
             valid_points = ~np.any(np.isnan(points), axis=1)

--- a/hexrd/ui/utils/conversions.py
+++ b/hexrd/ui/utils/conversions.py
@@ -35,9 +35,15 @@ def cart_to_angles(xys, panel, eta_period=None, tvec_s=None, tvec_c=None,
     return ang_crds
 
 
-def angles_to_cart(angles, panel, apply_distortion=True):
-    angles = np.radians(angles)
-    return panel.angles_to_cart(angles, apply_distortion=apply_distortion)
+def angles_to_cart(angles, panel, tvec_s=None, tvec_c=None,
+                   apply_distortion=True):
+    kwargs = {
+        'tth_eta': np.radians(angles),
+        'tvec_s': tvec_s,
+        'tvec_c': tvec_c,
+        'apply_distortion': apply_distortion,
+    }
+    return panel.angles_to_cart(**kwargs)
 
 
 def angles_to_pixels(angles, panel):


### PR DESCRIPTION
Previously, if the user accidentally right-clicked, we would move on
to the next line, and there would be no way to go back to the previous
line. This would mess up their hand-picking.
    
Now, the "Back" button is enabled, even when the current line has no
points, and clicking "Back" when the current line has no points results
in going back a line instead.

This PR also adds a couple of extra fixes where Laue spots were not
always being drawn correctly on the canvas while hand-picking
(they were not properly updated when the back button was pressed,
and they were not drawn on the detector after the first one).
    
Fixes: #1567