### PR TITLE
Add a dialog where config settings can be changed

### DIFF
--- a/hexrd/ui/config_dialog.py
+++ b/hexrd/ui/config_dialog.py
@@ -1,0 +1,49 @@
+from hexrd.ui.hexrd_config import HexrdConfig
+from hexrd.ui.ui_loader import UiLoader
+
+
+class ConfigDialog:
+    def __init__(self, parent=None):
+        self.ui = UiLoader().load_file('config_dialog.ui', parent)
+
+        self.update_gui()
+        self.setup_connections()
+
+    def setup_connections(self):
+        self.ui.accepted.connect(self.on_accepted)
+
+    def exec_(self):
+        self.update_gui()
+        self.ui.exec_()
+
+    def update_gui(self):
+        self.max_cpus_ui = self.max_cpus_config
+
+    def update_config(self):
+        self.max_cpus_config = self.max_cpus_ui
+
+    def on_accepted(self):
+        self.update_config()
+
+    @property
+    def max_cpus_ui(self):
+        if not self.ui.limit_cpus.isChecked():
+            return None
+
+        return self.ui.max_cpus.value()
+
+    @max_cpus_ui.setter
+    def max_cpus_ui(self, v):
+        self.ui.limit_cpus.setChecked(v is not None)
+        if v is None:
+            return
+
+        self.ui.max_cpus.setValue(v)
+
+    @property
+    def max_cpus_config(self):
+        return HexrdConfig().max_cpus
+
+    @max_cpus_config.setter
+    def max_cpus_config(self, v):
+        HexrdConfig().max_cpus = v

--- a/hexrd/ui/main_window.py
+++ b/hexrd/ui/main_window.py
@@ -22,6 +22,7 @@ from hexrd.ui.beam_marker_style_editor import BeamMarkerStyleEditor
 from hexrd.ui.calibration_slider_widget import CalibrationSliderWidget
 from hexrd.ui.create_hedm_instrument import create_hedm_instrument
 from hexrd.ui.color_map_editor import ColorMapEditor
+from hexrd.ui.config_dialog import ConfigDialog
 from hexrd.ui.progress_dialog import ProgressDialog
 from hexrd.ui.cal_tree_view import CalTreeView
 from hexrd.ui.hand_drawn_mask_dialog import HandDrawnMaskDialog
@@ -219,6 +220,8 @@ class MainWindow(QObject):
             self.on_action_transform_detectors_triggered)
         self.ui.action_image_calculator.triggered.connect(
             self.open_image_calculator)
+        self.ui.action_edit_config.triggered.connect(
+            self.on_action_edit_config_triggered)
         self.ui.action_open_mask_manager.triggered.connect(
             self.on_action_open_mask_manager_triggered)
         self.ui.action_show_live_updates.toggled.connect(
@@ -1237,6 +1240,9 @@ class MainWindow(QObject):
             self.update_all()
 
         dialog.accepted.connect(on_accepted)
+
+    def on_action_edit_config_triggered(self):
+        ConfigDialog(self.ui).exec_()
 
     def update_enable_states(self):
         has_images = HexrdConfig().has_images

--- a/hexrd/ui/resources/ui/config_dialog.ui
+++ b/hexrd/ui/resources/ui/config_dialog.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>config_dialog</class>
+ <widget class="QDialog" name="config_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>374</width>
+    <height>94</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>HEXRDGUI Configuration</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="1">
+    <widget class="QSpinBox" name="max_cpus">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="limit_cpus">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the number of CPUs used for multiprocessing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Limit CPUs?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>limit_cpus</tabstop>
+  <tabstop>max_cpus</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>limit_cpus</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>max_cpus</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>97</x>
+     <y>25</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>276</x>
+     <y>25</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>config_dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>68</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>186</x>
+     <y>46</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>config_dialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>186</x>
+     <y>68</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>186</x>
+     <y>46</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrd/ui/resources/ui/main_window.ui
+++ b/hexrd/ui/resources/ui/main_window.ui
@@ -41,7 +41,7 @@
      <x>0</x>
      <y>0</y>
      <width>1600</width>
-     <height>22</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_file">
@@ -206,6 +206,7 @@
     <addaction name="action_transform_detectors"/>
     <addaction name="action_edit_refinements"/>
     <addaction name="action_image_calculator"/>
+    <addaction name="action_edit_config"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -316,7 +317,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>775</height>
+          <height>753</height>
          </rect>
         </property>
         <attribute name="label">
@@ -329,7 +330,7 @@
           <x>0</x>
           <y>0</y>
           <width>550</width>
-          <height>775</height>
+          <height>753</height>
          </rect>
         </property>
         <attribute name="label">
@@ -837,6 +838,11 @@
   <action name="action_edit_apply_threshold">
    <property name="text">
     <string>Threshold</string>
+   </property>
+  </action>
+  <action name="action_edit_config">
+   <property name="text">
+    <string>Configuration</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This adds a dialog where the user can modify HEXRDGUI configuration settings.

Right now, the only option is to modify the number of processes used for multiprocessing.

The new menu item is under `Edit->Configuration`, and the dialog appears as the following:

![image](https://github.com/HEXRD/hexrdgui/assets/9558430/06a29273-308a-4241-b870-a297a43d2d08)

We can likely add more configuration settings to this in the future, as needed.

Fixes: #1578