### PR TITLE
Add an option to modify the font size of the app

### DIFF
--- a/hexrd/ui/config_dialog.py
+++ b/hexrd/ui/config_dialog.py
@@ -1,3 +1,5 @@
+from PySide2.QtWidgets import QMessageBox
+
 from hexrd.ui.hexrd_config import HexrdConfig
 from hexrd.ui.ui_loader import UiLoader
 
@@ -18,9 +20,11 @@ class ConfigDialog:
 
     def update_gui(self):
         self.max_cpus_ui = self.max_cpus_config
+        self.font_size_ui = self.font_size_config
 
     def update_config(self):
         self.max_cpus_config = self.max_cpus_ui
+        self.font_size_config = self.font_size_ui
 
     def on_accepted(self):
         self.update_config()
@@ -41,9 +45,40 @@ class ConfigDialog:
         self.ui.max_cpus.setValue(v)
 
     @property
+    def font_size_ui(self):
+        return self.ui.font_size.value()
+
+    @font_size_ui.setter
+    def font_size_ui(self, v):
+        self.ui.font_size.setValue(v)
+
+    @property
     def max_cpus_config(self):
         return HexrdConfig().max_cpus
 
     @max_cpus_config.setter
     def max_cpus_config(self, v):
         HexrdConfig().max_cpus = v
+
+    @property
+    def font_size_config(self):
+        return HexrdConfig().font_size
+
+    @font_size_config.setter
+    def font_size_config(self, v):
+        if self.font_size_config == v:
+            # Just return
+            return
+
+        # Warn the user that they must restart the application for all
+        # widgets to be updated properly.
+        msg = (
+            'Upon changing the font size, many (but not all) widgets '
+            'will update immediately.\n\nTo ensure all widgets are updated, '
+            'please close the application normally via the "X" button in the '
+            'top corner of the main window, and then start the application '
+            'again.'
+        )
+        QMessageBox.warning(self.ui, 'WARNING', msg)
+
+        HexrdConfig().font_size = v

--- a/hexrd/ui/resources/ui/config_dialog.ui
+++ b/hexrd/ui/resources/ui/config_dialog.ui
@@ -7,13 +7,30 @@
     <x>0</x>
     <y>0</y>
     <width>374</width>
-    <height>94</height>
+    <height>122</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>HEXRDGUI Configuration</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="limit_cpus">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the number of CPUs used for multiprocessing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Limit CPUs?</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="0" column="1">
     <widget class="QSpinBox" name="max_cpus">
      <property name="enabled">
@@ -27,17 +44,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QCheckBox" name="limit_cpus">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Limit the number of CPUs used for multiprocessing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Limit CPUs?</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="2">
+   <item row="2" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -50,10 +57,26 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="1" column="0">
+    <widget class="QLabel" name="font_size_label">
+     <property name="text">
+      <string>Font Size:</string>
+     </property>
+     <property name="buddy">
+      <cstring>font_size</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="font_size">
+     <property name="minimum">
+      <number>1</number>
+     </property>
+     <property name="maximum">
+      <number>10000</number>
+     </property>
+     <property name="value">
+      <number>11</number>
      </property>
     </widget>
    </item>
@@ -62,6 +85,7 @@
  <tabstops>
   <tabstop>limit_cpus</tabstop>
   <tabstop>max_cpus</tabstop>
+  <tabstop>font_size</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This option is present in the new "Edit"->"Configuration" dialog. This modifies the font size of both Qt and matplotlib.

When the user modifies the font size in the dialog, most (but not all) widgets in the application are updated immediately. It appears that any widgets with custom style sheets do not get updated. Perhaps some other types of widgets don't get updated either. But restarting the application normally appears to update everything to the new font size.

It would be nice to get all widgets to update immediately when the user modifies the font size. But for now, we can just present a warning that the user should restart the application normally in order to get all widgets to update.

Fixes: #1575