### PR TITLE
Remove tth max options from Fit Grains Options

### DIFF
--- a/hexrd/ui/indexing/fit_grains_options_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_options_dialog.py
@@ -14,6 +14,7 @@ from hexrd.ui.plot_grains import plot_grains
 from hexrd.ui.reflections_table import ReflectionsTable
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
+from hexrd.ui.utils.dialog import add_help_url
 
 from hexrd.ui.indexing.fit_grains_tolerances_model import (
     FitGrainsToleranceModel)
@@ -40,6 +41,9 @@ class FitGrainsOptionsDialog(QObject):
         self.ui = loader.load_file('fit_grains_options_dialog.ui', parent)
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
+
+        url = 'hedm/fit_grains/#fit-grains-options'
+        add_help_url(self.ui.button_box, url)
 
         self.update_materials()
 

--- a/hexrd/ui/indexing/fit_grains_results_dialog.py
+++ b/hexrd/ui/indexing/fit_grains_results_dialog.py
@@ -25,6 +25,7 @@ from hexrd.ui.indexing.grains_table_model import GrainsTableModel
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
+from hexrd.ui.utils.dialog import add_help_url
 
 
 COORDS_SLICE = slice(6, 9)
@@ -67,6 +68,9 @@ class FitGrainsResultsDialog(QObject):
 
         loader = UiLoader()
         self.ui = loader.load_file('fit_grains_results_dialog.ui', parent)
+
+        url = 'hedm/fit_grains/#fit-grains-results'
+        add_help_url(self.ui.button_box, url)
 
         self.ui.splitter.setStretchFactor(0, 1)
         self.ui.splitter.setStretchFactor(1, 10)

--- a/hexrd/ui/indexing/view_spots_dialog.py
+++ b/hexrd/ui/indexing/view_spots_dialog.py
@@ -13,12 +13,16 @@ from hexrd.ui.indexing.spot_montage import (
 from hexrd.ui.navigation_toolbar import NavigationToolbar
 from hexrd.ui.ui_loader import UiLoader
 from hexrd.ui.utils import block_signals
+from hexrd.ui.utils.dialog import add_help_url
 
 
 class ViewSpotsDialog:
     def __init__(self, spots, parent=None):
         loader = UiLoader()
         self.ui = loader.load_file('view_spots_dialog.ui', parent)
+
+        url = 'hedm/fit_grains/#visualize-spots'
+        add_help_url(self.ui.button_box, url)
 
         self.setup_canvas()
 

--- a/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
@@ -40,6 +40,20 @@
    </item>
    <item>
     <layout class="QGridLayout" name="gridLayout">
+     <item row="6" column="1" colspan="2">
+      <widget class="QLabel" name="refit_ome_label">
+       <property name="text">
+        <string>Refit ome step scale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1" colspan="2">
+      <widget class="QLabel" name="refit_pixel_labe">
+       <property name="text">
+        <string>Refit pixel scale</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="1" colspan="2">
       <widget class="QLabel" name="num_hkls_selected">
        <property name="text">
@@ -54,46 +68,16 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QLabel" name="material_label">
-       <property name="text">
-        <string>Selected Material:</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="3">
-      <widget class="ScientificDoubleSpinBox" name="min_sfac_value">
+     <item row="4" column="3" colspan="3">
+      <widget class="ScientificDoubleSpinBox" name="threshold">
        <property name="decimals">
         <number>8</number>
        </property>
        <property name="maximum">
-        <double>100.000000000000000</double>
+        <double>1000000.000000000000000</double>
        </property>
        <property name="value">
-        <double>5.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="5">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="2" column="1" colspan="2">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Select HKLs by min |F|² ?</string>
+        <double>25.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -104,71 +88,36 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="1" colspan="2">
-      <widget class="QLabel" name="threshold_label">
-       <property name="text">
-        <string>Threshold</string>
+     <item row="5" column="3" colspan="3">
+      <widget class="ScientificDoubleSpinBox" name="refit_pixel_scale">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <double>1000000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>2.000000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="5" column="1" colspan="2">
-      <widget class="QLabel" name="refit_pixel_labe">
+     <item row="1" column="3" colspan="3">
+      <widget class="QPushButton" name="choose_hkls">
        <property name="text">
-        <string>Refit pixel scale</string>
+        <string>Choose HKLs</string>
        </property>
       </widget>
      </item>
-     <item row="6" column="1" colspan="2">
-      <widget class="QLabel" name="refit_ome_label">
+     <item row="0" column="1" colspan="2">
+      <widget class="QLabel" name="material_label">
        <property name="text">
-        <string>Refit ome step scale</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1" colspan="2">
-      <widget class="QCheckBox" name="tth_max_enable">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enabling this will cause the HKLs to be modified again during fit-grains so that no HKLs above this tth max will be enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>override tth max</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="1" colspan="2">
-      <widget class="QRadioButton" name="tth_max_instrument">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">padding-left: 20px;
-</string>
-       </property>
-       <property name="text">
-        <string>Instrument</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1" colspan="2">
-      <widget class="QRadioButton" name="tth_max_specify">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">padding-left: 20px;</string>
-       </property>
-       <property name="text">
-        <string>Specify</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1" colspan="2">
-      <widget class="QCheckBox" name="write_out_spots">
-       <property name="text">
-        <string>Write out spots files</string>
+        <string>Selected Material:</string>
        </property>
       </widget>
      </item>
@@ -194,45 +143,60 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3" colspan="3">
-      <widget class="QComboBox" name="material"/>
-     </item>
-     <item row="1" column="3" colspan="3">
-      <widget class="QPushButton" name="choose_hkls">
+     <item row="4" column="1" colspan="2">
+      <widget class="QLabel" name="threshold_label">
        <property name="text">
-        <string>Choose HKLs</string>
+        <string>Threshold</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="3" colspan="3">
-      <widget class="ScientificDoubleSpinBox" name="threshold">
+     <item row="2" column="1" colspan="2">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Select HKLs by min |F|² ?</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="5">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="2" column="3">
+      <widget class="ScientificDoubleSpinBox" name="min_sfac_value">
        <property name="decimals">
         <number>8</number>
        </property>
        <property name="maximum">
-        <double>1000000.000000000000000</double>
+        <double>100.000000000000000</double>
        </property>
        <property name="value">
-        <double>25.000000000000000</double>
+        <double>5.000000000000000</double>
        </property>
       </widget>
      </item>
-     <item row="5" column="3" colspan="3">
-      <widget class="ScientificDoubleSpinBox" name="refit_pixel_scale">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
+     <item row="7" column="1" colspan="2">
+      <widget class="QCheckBox" name="write_out_spots">
+       <property name="text">
+        <string>Write out spots files</string>
        </property>
-       <property name="decimals">
-        <number>8</number>
-       </property>
-       <property name="maximum">
-        <double>1000000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>2.000000000000000</double>
+      </widget>
+     </item>
+     <item row="7" column="3" colspan="3">
+      <widget class="QPushButton" name="set_spots_directory">
+       <property name="text">
+        <string>Select Directory</string>
        </property>
       </widget>
      </item>
@@ -249,28 +213,8 @@
        </property>
       </widget>
      </item>
-     <item row="9" column="3" colspan="3">
-      <widget class="ScientificDoubleSpinBox" name="tth_max_value">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="decimals">
-        <number>8</number>
-       </property>
-       <property name="maximum">
-        <double>1000000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>20.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="3" colspan="3">
-      <widget class="QPushButton" name="set_spots_directory">
-       <property name="text">
-        <string>Select Directory</string>
-       </property>
-      </widget>
+     <item row="0" column="3" colspan="3">
+      <widget class="QComboBox" name="material"/>
      </item>
     </layout>
    </item>
@@ -419,10 +363,6 @@
   <tabstop>threshold</tabstop>
   <tabstop>refit_pixel_scale</tabstop>
   <tabstop>refit_ome_step_scale</tabstop>
-  <tabstop>tth_max_enable</tabstop>
-  <tabstop>tth_max_instrument</tabstop>
-  <tabstop>tth_max_specify</tabstop>
-  <tabstop>tth_max_value</tabstop>
   <tabstop>write_out_spots</tabstop>
   <tabstop>set_spots_directory</tabstop>
   <tabstop>tolerances_view</tabstop>

--- a/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_options_dialog.ui
@@ -334,7 +334,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>

--- a/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
+++ b/hexrd/ui/resources/ui/fit_grains_results_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1200</width>
-    <height>830</height>
+    <height>865</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -556,16 +556,29 @@
       </widget>
      </item>
      <item>
-      <widget class="QDialogButtonBox" name="button_box">
+      <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
-       <property name="standardButtons">
-        <set>QDialogButtonBox::Close</set>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
        </property>
-      </widget>
+      </spacer>
      </item>
     </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/hexrd/ui/resources/ui/view_spots_dialog.ui
+++ b/hexrd/ui/resources/ui/view_spots_dialog.ui
@@ -23,8 +23,8 @@
    <string notr="true"/>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1">
-    <widget class="QComboBox" name="grain_id">
+   <item row="1" column="3">
+    <widget class="QComboBox" name="detector">
      <property name="styleSheet">
       <string notr="true">combobox-popup: 0;</string>
      </property>
@@ -33,50 +33,20 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="grain_id_label">
+   <item row="1" column="10">
+    <widget class="QLabel" name="tolerances_label">
      <property name="text">
-      <string>Grain ID:</string>
+      <string>Tolerances:</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="9">
-    <spacer name="horizontal_spacer">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="grain_id">
+     <property name="styleSheet">
+      <string notr="true">combobox-popup: 0;</string>
      </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>40</width>
-       <height>20</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="1" column="2">
-    <widget class="QLabel" name="detector_label">
-     <property name="text">
-      <string>Detector:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="6">
-    <widget class="QLabel" name="peak_id_label">
-     <property name="text">
-      <string>Peak ID:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="4">
-    <widget class="QLabel" name="hkl_label">
-     <property name="text">
-      <string>HKL:</string>
-     </property>
-     <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     <property name="sizeAdjustPolicy">
+      <enum>QComboBox::AdjustToContents</enum>
      </property>
     </widget>
    </item>
@@ -90,10 +60,23 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="10">
-    <widget class="QLabel" name="tolerances_label">
+   <item row="3" column="0" colspan="13">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+   <item row="1" column="6">
+    <widget class="QLabel" name="peak_id_label">
      <property name="text">
-      <string>Tolerances:</string>
+      <string>Peak ID:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="grain_id_label">
+     <property name="text">
+      <string>Grain ID:</string>
      </property>
     </widget>
    </item>
@@ -114,16 +97,17 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0" colspan="13">
-    <layout class="QVBoxLayout" name="canvas_layout"/>
-   </item>
-   <item row="1" column="3">
-    <widget class="QComboBox" name="detector">
-     <property name="styleSheet">
-      <string notr="true">combobox-popup: 0;</string>
+   <item row="2" column="5" colspan="3">
+    <widget class="QCheckBox" name="show_frame_indices">
+     <property name="text">
+      <string>Show Frame Indices</string>
      </property>
-     <property name="sizeAdjustPolicy">
-      <enum>QComboBox::AdjustToContents</enum>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QLabel" name="detector_label">
+     <property name="text">
+      <string>Detector:</string>
      </property>
     </widget>
    </item>
@@ -134,10 +118,33 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="5" colspan="3">
-    <widget class="QCheckBox" name="show_frame_indices">
+   <item row="1" column="9">
+    <spacer name="horizontal_spacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="1" column="4">
+    <widget class="QLabel" name="hkl_label">
      <property name="text">
-      <string>Show Frame Indices</string>
+      <string>HKL:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="12">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Help</set>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
These options were actually not doing anything before. The reason is that the user is actually selecting these manually via the "Choose HKLs" button. That also provides the option to filter HKLs by their tth max value.

So the tth max options in the Fit Grains Options dialog were not doing anything, and their functionality is already available in the "Choose HKLs" button. Thus, they are removed.