### PR TITLE
Do not load font from state files

### DIFF
--- a/hexrd/ui/hexrd_config.py
+++ b/hexrd/ui/hexrd_config.py
@@ -470,6 +470,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 'show_all_colormaps',
                 'limited_cmaps_list',
                 'default_cmap',
+                # Ignore the font size when loading from state
+                'font_size',
             ]
 
         try:


### PR DESCRIPTION
We only load the font size from QSettings, not from state files.