### PR TITLE
Use the libmamba solver for packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -76,6 +76,10 @@ jobs:
       run: |
           conda activate hexrdgui-package
           mkdir output
+
+          # Use libmamba as the solver for all future conda commands
+          export CONDA_SOLVER=libmamba
+
           HEXRD_PACKAGE_CHANNEL=${HEXRD_PACKAGE_CHANNEL} HEXRDGUI_OUTPUT_FOLDER=output/ cpack
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.

--- a/packaging/environment.yml
+++ b/packaging/environment.yml
@@ -10,3 +10,4 @@ dependencies:
   - conda-build
   - conda-pack
   - click
+  - conda-libmamba-solver

--- a/packaging/package.py
+++ b/packaging/package.py
@@ -128,6 +128,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     config.variant['hexrd_version'] = hexrd_version
 
     config.CONDA_PY = '38'
+    config.CONDA_SOLVER = 'libmamba'
     logger.info('Building hexrdgui conda package.')
     CondaBuild.build(recipe_path, config=config)
 
@@ -155,6 +156,7 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     params = [
         Conda.Commands.INSTALL,
         '--prefix', env_prefix,
+        '--solver', 'libmamba',
         '--override-channels',
         '--channel', hexrdgui_output_folder_uri,
         '--channel', hexrd_package_channel,


### PR DESCRIPTION
This will potentially run significantly faster, as also demonstrated in HEXRD/hexrd#562.

The last merged packaging CI for HEXRDGUI took this long:

* Windows - 87 minutes
* Mac - 43 minutes
* Linux - 26 minutes

We'll see if we get any big speed improvements on the packaging.