### PR TITLE
Change prerelease channel names to be "prerelease"

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -63,9 +63,9 @@ jobs:
           python packaging/github_action_version.py ${{ env.HEXRDGUI_GIT_DESCRIBE }} minor
           python packaging/github_action_version.py ${{ env.HEXRDGUI_GIT_DESCRIBE }} patch
 
-    - name: Set channel for HEXRD ( hexrd or hexrd-prerelease )
+    - name: Set channel for HEXRD ( hexrd or prerelease )
       run: |
-          $(${{ github.event_name == 'push' }} && ${{ startsWith(github.ref, 'refs/tags/') }}) && echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV || echo "HEXRD_PACKAGE_CHANNEL=HEXRD/label/hexrd-prerelease" >> $GITHUB_ENV
+          $(${{ github.event_name == 'push' }} && ${{ startsWith(github.ref, 'refs/tags/') }}) && echo "HEXRD_PACKAGE_CHANNEL=HEXRD" >> $GITHUB_ENV || echo "HEXRD_PACKAGE_CHANNEL=HEXRD/label/prerelease" >> $GITHUB_ENV
 
     - name: Create conda environment to build HEXRDGUI
       working-directory: hexrdgui
@@ -125,9 +125,9 @@ jobs:
         name: HEXRDGUI-${{ matrix.config.name }}-${{ env.HEXRDGUI_GIT_DESCRIBE }}.tar.bz2
         path: ${{ github.workspace }}/hexrdgui/packaging/output/**/*.tar.bz2
 
-    - name: Set label ( main or hexrdgui-prerelease )
+    - name: Set label ( main or prerelease )
       run: |
-          [[ ${{ github.event_name }} = 'push' && ${{ github.ref }} = 'refs/heads/master' ]] && echo "HEXRDGUI_PACKAGE_LABEL=hexrdgui-prerelease" >> $GITHUB_ENV || echo "HEXRDGUI_PACKAGE_LABEL=main" >> $GITHUB_ENV
+          [[ ${{ github.event_name }} = 'push' && ${{ github.ref }} = 'refs/heads/master' ]] && echo "HEXRDGUI_PACKAGE_LABEL=prerelease" >> $GITHUB_ENV || echo "HEXRDGUI_PACKAGE_LABEL=main" >> $GITHUB_ENV
 
     - name: Upload the package to anaconda channel (only on master)
       if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')

--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ Please see [here](https://hexrdgui.readthedocs.io/en/latest/issues/)
 
 ## PRs
 
-PRs are built using the [`hexrd-prerelease`](https://anaconda.org/hexrd/repo/files?type=any&label=hexrd-prerelease) label on the [HEXRD](https://anaconda.org/hexrd) conda channel
+PRs are built using the [`prerelease`](https://anaconda.org/hexrd/repo/files?type=any&label=prerelease) label on the [HEXRD](https://anaconda.org/hexrd) conda channel
 
 ## Merges to master
 
-When a PR is merged into master the conda package is uploaded to the [HEXRD](https://anaconda.org/hexrd) channel using the [`hexrdgui-prerelease`](https://anaconda.org/hexrd/repo/files?type=any&label=hexrdgui-prerelease) label.
+When a PR is merged into master the conda package is uploaded to the [HEXRD](https://anaconda.org/hexrd) channel using the [`prerelease`](https://anaconda.org/hexrd/repo/files?type=any&label=prerelease) label.
 
 ## Pushed tag
 


### PR DESCRIPTION
This simplifies the conda install instructions to be just this:

```bash
conda install -c hexrd/label/prerelease -c conda-forge hexrdgui
```