### PR TITLE
Forward arguments in Linux bash entrypoint script

### DIFF
--- a/packaging/linux/hexrdgui
+++ b/packaging/linux/hexrdgui
@@ -4,5 +4,4 @@ SCRIPT_DIR="$( cd "$(dirname "$0")" ; pwd -P )"
 export FONTCONFIG_PATH="${SCRIPT_DIR}/../etc/fonts"
 export FONTCONFIG_FILE="${SCRIPT_DIR}/../etc/fonts/fonts.conf"
 
-"${SCRIPT_DIR}/python" "${SCRIPT_DIR}/run-hexrdgui.py"
-
+"${SCRIPT_DIR}/python" "${SCRIPT_DIR}/run-hexrdgui.py" "$@"


### PR DESCRIPTION
This is so that users may do things like open state files by specifying a path after the entrypoint.