### PR TITLE
Do not set detailed text in message box

### DIFF
--- a/hexrdgui/async_runner.py
+++ b/hexrdgui/async_runner.py
@@ -64,7 +64,6 @@ class AsyncRunner:
         exctype, value, traceback = t
         msg = f'An ERROR occurred: {exctype}: {value}.'
         msg_box = QMessageBox(QMessageBox.Critical, 'Error', msg)
-        msg_box.setDetailedText(traceback)
         msg_box.exec()
 
     @property

--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -195,7 +195,6 @@ class PowderRunner(QObject):
     def update_config(self):
         msg = 'Optimization successful!'
         msg_box = QMessageBox(QMessageBox.Information, 'HEXRD', msg)
-        msg_box.setDetailedText(self.results_message)
         msg_box.exec()
 
         output_dict = instr_to_internal_dict(self.instr)

--- a/hexrdgui/indexing/run.py
+++ b/hexrdgui/indexing/run.py
@@ -69,7 +69,6 @@ class Runner(QObject):
         exctype, value, traceback = t
         msg = f'An ERROR occurred: {exctype}: {value}.'
         msg_box = QMessageBox(QMessageBox.Critical, 'Error', msg)
-        msg_box.setDetailedText(traceback)
         msg_box.exec()
 
     def reset_cancel_tracker(self):


### PR DESCRIPTION
On Linux, the detailed text is hidden by default and can be shown via a button.

On Mac, however, the detailed text is always shown, and if it is too long, the buttons at the bottom of the dialog box will be unreachable on the user's monitor.

Don't put the detailed text in the message box. We already print it out in the messages widget, and that should be good enough. Only keep the abbreviated message in the message box.

Fixes: #1595 
Fixes: #1597