### PR TITLE
Preserve the value range for the cartesian view

### DIFF
--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -278,7 +278,8 @@ class InstrumentViewer:
         tform3.estimate(src, dst)
 
         res = tf.warp(img, tform3,
-                      output_shape=(self.dpanel.rows, self.dpanel.cols))
+                      output_shape=(self.dpanel.rows, self.dpanel.cols),
+                      preserve_range=True)
         self.warp_dict[detector_id] = res
         return res
 


### PR DESCRIPTION
If the `img` provided is a non-float image, then the values get normalized to a range from 0 to 1 as part of the transform operation. Preserve the original range so that the color map doesn't get messed up.