### PR TITLE
Change executable name in plist to match

### DIFF
--- a/packaging/darwin/Info.plist
+++ b/packaging/darwin/Info.plist
@@ -9,7 +9,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>English</string>
 	<key>CFBundleExecutable</key>
-	<string>HEXRDGUI</string>
+	<string>hexrdgui</string>
 	<key>CFBundleGetInfoString</key>
 	<string></string>
 	<key>CFBundleIconFile</key>


### PR DESCRIPTION
The name of the executable in the Info.plist file must exactly match the executable filename that is in `Contents/MacOS`. Otherwise, the code signing won't work.