### PR TITLE
Use average detector pixel size for cartesian view

### DIFF
--- a/hexrdgui/image_mode_widget.py
+++ b/hexrdgui/image_mode_widget.py
@@ -244,7 +244,7 @@ class ImageModeWidget(QObject):
         cart_config = HexrdConfig().config['image']['cartesian']
 
         # Round these to two for a nicer display
-        cart_config['pixel_size'] = round(average_size * 5, 2)
+        cart_config['pixel_size'] = round(average_size, 2)
         cart_config['virtual_plane_distance'] = round(abs(average_dist), 2)
 
         # Get the GUI to update with the new values


### PR DESCRIPTION
For some reason, we were using the average detector pixel size multiplied by 5. We should just not multiply by 5...

Fixes: #1603