### PR TITLE
Add option to set eta_step size for eta omega maps

### DIFF
--- a/hexrdgui/indexing/ome_maps_select_dialog.py
+++ b/hexrdgui/indexing/ome_maps_select_dialog.py
@@ -114,6 +114,14 @@ class OmeMapsSelectDialog(QObject):
             self.ui.threshold.setValue(v)
 
     @property
+    def eta_step(self):
+        return self.ui.eta_step.value()
+
+    @eta_step.setter
+    def eta_step(self, v):
+        self.ui.eta_step.setValue(v)
+
+    @property
     def material_options(self):
         w = self.ui.material
         return [w.itemText(i) for i in range(w.count())]
@@ -153,6 +161,7 @@ class OmeMapsSelectDialog(QObject):
         maps_config['_select_method'] = self.method_name
         maps_config['file'] = self.file_name
         maps_config['threshold'] = self.threshold
+        maps_config['eta_step'] = self.eta_step
 
         indexing_config['_selected_material'] = self.selected_material
 
@@ -168,6 +177,8 @@ class OmeMapsSelectDialog(QObject):
 
             self.ui.file_name.setText(file_name)
             self.threshold = maps_config['threshold']
+
+            self.eta_step = maps_config['eta_step']
 
             self.selected_material = indexing_config.get('_selected_material')
 

--- a/hexrdgui/resources/indexing/default_indexing_config.yml
+++ b/hexrdgui/resources/indexing/default_indexing_config.yml
@@ -19,6 +19,9 @@ find_orientations:
 
     filter_maps: False
 
+    # The eta pixel size in the maps to be generated
+    eta_step: 0.25
+
     # "all", or a list of hkl orders used to find orientations
     # defaults to all orders listed in the material definition
     # *** These are set automatically by hexrdgui based on the materials table

--- a/hexrdgui/resources/ui/ome_maps_select_dialog.ui
+++ b/hexrdgui/resources/ui/ome_maps_select_dialog.ui
@@ -14,7 +14,7 @@
    <item row="2" column="0" colspan="2">
     <widget class="QTabWidget" name="tab_widget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="load_tab">
       <attribute name="title">
@@ -51,13 +51,6 @@
        <string>Generate</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="3" column="0">
-        <widget class="QCheckBox" name="apply_threshold">
-         <property name="text">
-          <string>Threshold data?</string>
-         </property>
-        </widget>
-       </item>
        <item row="3" column="1">
         <widget class="ScientificDoubleSpinBox" name="threshold">
          <property name="enabled">
@@ -81,10 +74,55 @@
          </property>
         </widget>
        </item>
+       <item row="3" column="0">
+        <widget class="QCheckBox" name="apply_threshold">
+         <property name="text">
+          <string>Threshold data?</string>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="1">
         <widget class="QPushButton" name="choose_hkls">
          <property name="text">
           <string>Choose HKLs</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="eta_step_label">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pixel resolution in &lt;span style=&quot; font-family:'sans-serif'; color:#202122; background-color:#f8f9fa;&quot;&gt;η&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; font-family:'sans-serif'; color:#202122; background-color:#f8f9fa;&quot;&gt;η&lt;/span&gt; Step:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="buddy">
+          <cstring>eta_step</cstring>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="ScientificDoubleSpinBox" name="eta_step">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Pixel resolution in &lt;span style=&quot; font-family:'sans-serif'; color:#202122; background-color:#f8f9fa;&quot;&gt;η&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="suffix">
+          <string>°</string>
+         </property>
+         <property name="decimals">
+          <number>8</number>
+         </property>
+         <property name="minimum">
+          <double>0.000100000000000</double>
+         </property>
+         <property name="maximum">
+          <double>360.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.050000000000000</double>
+         </property>
+         <property name="value">
+          <double>0.250000000000000</double>
          </property>
         </widget>
        </item>
@@ -151,6 +189,7 @@
   <tabstop>choose_hkls</tabstop>
   <tabstop>apply_threshold</tabstop>
   <tabstop>threshold</tabstop>
+  <tabstop>eta_step</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -161,8 +200,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>217</x>
-     <y>205</y>
+     <x>228</x>
+     <y>277</y>
     </hint>
     <hint type="destinationlabel">
      <x>217</x>
@@ -177,8 +216,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>217</x>
-     <y>205</y>
+     <x>228</x>
+     <y>277</y>
     </hint>
     <hint type="destinationlabel">
      <x>217</x>
@@ -193,12 +232,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>167</x>
-     <y>105</y>
+     <x>180</x>
+     <y>193</y>
     </hint>
     <hint type="destinationlabel">
-     <x>467</x>
-     <y>105</y>
+     <x>624</x>
+     <y>194</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
It was previously fixed to 0.25 degrees. However, the users may find it beneficial to change this.

Smaller eta_step sizes might lead to less overlap between neighboring peaks in the eta omega maps, for example.

Depends on: hexrd/hexrd#573