### PR TITLE
Change info group to be a QGridLayout

### DIFF
--- a/hexrdgui/resources/ui/simple_image_series_dialog.ui
+++ b/hexrdgui/resources/ui/simple_image_series_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>647</width>
-    <height>571</height>
+    <height>631</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -353,7 +353,7 @@
       <property name="title">
        <string>Information</string>
       </property>
-      <layout class="QFormLayout" name="formLayout_4">
+      <layout class="QGridLayout" name="gridLayout_2">
        <item row="0" column="0">
         <widget class="QLabel" name="image_directory_label">
          <property name="text">


### PR DESCRIPTION
The QFormLayout that it was before was causing some resizing issues on Mac.

Fixes: #1607