### PR TITLE
Simplify powder overlay generation

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -335,13 +335,13 @@ class ImageCanvas(FigureCanvas):
                 # Override with highlight style
                 current_style = highlight_style['data']
 
-            x, y = self.extract_ring_coords(pr)
+            x, y = pr.T
             artist, = axis.plot(x, y, **current_style)
             artists.append(artist)
 
         # Add the rbnds too
         for ind, pr in zip(rbnd_indices, rbnds):
-            x, y = self.extract_ring_coords(pr)
+            x, y = pr.T
             current_style = copy.deepcopy(ranges_style)
             if any(x in highlight_indices for x in ind):
                 # Override with highlight style
@@ -355,7 +355,7 @@ class ImageCanvas(FigureCanvas):
         if self.azimuthal_integral_axis is not None:
             az_axis = self.azimuthal_integral_axis
             for pr in rings:
-                x, _ = self.extract_ring_coords(pr)
+                x = pr[:, 0]
                 if len(x) == 0:
                     # Skip over rings that are out of bounds
                     continue
@@ -367,7 +367,7 @@ class ImageCanvas(FigureCanvas):
 
             # Add the rbnds too
             for ind, pr in zip(rbnd_indices, rbnds):
-                x, _ = self.extract_ring_coords(pr)
+                x = pr[:, 0]
                 if len(x) == 0:
                     # Skip over rbnds that are out of bounds
                     continue
@@ -569,13 +569,6 @@ class ImageCanvas(FigureCanvas):
     def draw_auto_picked_data(self):
         self.update_auto_picked_data()
         self.draw_idle()
-
-    def extract_ring_coords(self, data):
-        if self.mode == ViewType.cartesian:
-            # These are in x, y coordinates. Do not swap them.
-            return data[:, 0], data[:, 1]
-
-        return data[:, 1], data[:, 0]
 
     def clear_saturation(self):
         for t in self.saturation_texts:

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -344,19 +344,19 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                     skipped_tth.append(i)
                     continue
 
-                # Swap columns, convert to degrees
-                ang_crds[:, [0, 1]] = np.degrees(ang_crds[:, [1, 0]])
+                # Convert to degrees
+                ang_crds = np.degrees(ang_crds)
 
                 # fix eta period
-                ang_crds[:, 0] = xfcapi.mapAngle(
-                    ang_crds[:, 0], self.eta_period, units='degrees'
+                ang_crds[:, 1] = xfcapi.mapAngle(
+                    ang_crds[:, 1], self.eta_period, units='degrees'
                 )
 
                 # sort points for monotonic eta
-                eidx = np.argsort(ang_crds[:, 0])
+                eidx = np.argsort(ang_crds[:, 1])
                 ang_crds = ang_crds[eidx, :]
 
-                diff = np.diff(ang_crds[:, 0])
+                diff = np.diff(ang_crds[:, 1])
                 if len(diff) == 0:
                     skipped_tth.append(i)
                     continue
@@ -374,8 +374,8 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                     # append to list with nan padding
                     ring_pts.append(np.vstack([ang_crds, nans_row]))
                 elif display_mode == ViewType.stereo:
-                    # Swap back, convert to radians
-                    ang_crds[:, [0, 1]] = np.radians(ang_crds[:, [1, 0]])
+                    # Convert back to radians
+                    ang_crds = np.radians(ang_crds)
 
                     # Convert the ang_crds to stereo ij
                     stereo_ij = angles_to_stereo(
@@ -383,10 +383,6 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                         instr,
                         HexrdConfig().stereo_size,
                     )
-
-                    # FIXME: why??
-                    # swap i and j
-                    stereo_ij[:, [0, 1]] = stereo_ij[:, [1, 0]]
 
                     # append to list with nan padding
                     ring_pts.append(np.vstack([stereo_ij, nans_row]))
@@ -398,9 +394,8 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                     if panel.distortion is not None:
                         xys = panel.distortion.apply_inverse(xys)
 
-                    # Convert to pixel coordinates
-                    # ??? keep in pixels?
-                    xys = panel.cartToPixel(xys)
+                    # Convert to pixel coordinates and swap columns
+                    xys = panel.cartToPixel(xys)[:, [1, 0]]
 
                 diff_tol = np.radians(self.delta_eta) + 1e-4
                 ring_breaks = np.where(


### PR DESCRIPTION
This skips swapping columns in the powder overlay generation so that we do not have to swap columns again when we are drawing. This simplifies the logic and speeds it up a little bit.