### PR TITLE
Fix a few issues due to the flipped overlay data

### DIFF
--- a/hexrdgui/calibration/calibration_runner.py
+++ b/hexrdgui/calibration/calibration_runner.py
@@ -518,7 +518,7 @@ class CalibrationRunner(QObject):
                     if hkl_index == -1:
                         continue
 
-                    tth_values = data[key][data_key][hkl_index][:, 1]
+                    tth_values = data[key][data_key][hkl_index][:, 0]
                     min_value = min(min_value, np.nanmin(tth_values))
 
                 min_tth_values.append(min_value)
@@ -542,7 +542,7 @@ class CalibrationRunner(QObject):
                     rings = data[key][data_key]
 
                     keys.append(key)
-                    min_eta_values[key] = np.nanmin(rings[hkl_index][:, 0])
+                    min_eta_values[key] = np.nanmin(rings[hkl_index][:, 1])
                     hkl_indices[key] = hkl_index
 
                 keys.sort(key=lambda x: min_eta_values[x])

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -817,8 +817,7 @@ class MainWindow(QObject):
             for _, val in overlay.data.items():
                 a = iter(val['rbnds'])
                 for start, end in zip(a, a):
-                    ranges = np.array(np.flip(start, axis=1))
-                    ranges = np.append(ranges, np.flip(end), axis=0)
+                    ranges = np.append(start, np.flip(end, axis=0), axis=0)
                     ranges = np.append(ranges, [ranges[0]], axis=0)
                     data.append(ranges[~np.isnan(ranges).any(axis=1)])
 


### PR DESCRIPTION
This fixes a couple of issues due to the flipped overlay data. Namely:

1. The sorting of HKL lines in the composite calibration
2. The masking by powder lines

I believe these should be the only two issues produced by #1612