### PR TITLE
Refactor overlay drawing to use fewer artists

### DIFF
--- a/hexrdgui/create_raw_mask.py
+++ b/hexrdgui/create_raw_mask.py
@@ -47,9 +47,10 @@ def convert_polar_to_raw(line_data, reverse_tth_distortion=True):
         line_data[i] = line
 
     raw_line_data = []
+    instr = create_hedm_instrument()
     for line in line_data:
-        for key, panel in create_hedm_instrument().detectors.items():
-            raw = angles_to_pixels(line, panel)
+        for key, panel in instr.detectors.items():
+            raw = angles_to_pixels(line, panel, tvec_s=instr.tvec)
             if all([np.isnan(x) for x in raw.flatten()]):
                 continue
 

--- a/hexrdgui/overlays/laue_overlay.py
+++ b/hexrdgui/overlays/laue_overlay.py
@@ -329,7 +329,13 @@ class LaueOverlay(Overlay):
         if self.width_shape not in range_func:
             raise Exception(f'Unknown range shape: {self.width_shape}')
 
-        return range_func[self.width_shape](spots, display_mode, panel)
+        data = range_func[self.width_shape](spots, display_mode, panel)
+
+        # Add a nans row at the end of each range
+        # This makes it easier to vstack them for plotting
+        data = [np.append(x, nans_row, axis=0) for x in data]
+
+        return data
 
     def rectangular_range_data(self, spots, display_mode, panel):
         range_corners = self.range_corners(spots)
@@ -456,3 +462,6 @@ class LaueRangeShape(str, Enum):
 class LaueLabelType(str, Enum):
     hkls = 'hkls'
     energy = 'energy'
+
+# Constants
+nans_row = np.nan * np.ones((1, 2))

--- a/hexrdgui/overlays/laue_overlay.py
+++ b/hexrdgui/overlays/laue_overlay.py
@@ -463,5 +463,6 @@ class LaueLabelType(str, Enum):
     hkls = 'hkls'
     energy = 'energy'
 
+
 # Constants
 nans_row = np.nan * np.ones((1, 2))

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -223,16 +223,22 @@ class PowderOverlay(Overlay, PolarDistortionObject):
 
             if plane_data.tThWidth is not None:
                 # Generate the ranges too
-                lower_pts, _ = self.generate_ring_points(
+                lower_pts, lower_skipped = self.generate_ring_points(
                     instr, r_lower, etas, panel, display_mode
                 )
-                upper_pts, _ = self.generate_ring_points(
+                upper_pts, upper_skipped = self.generate_ring_points(
                     instr, r_upper, etas, panel, display_mode
                 )
-                for lpts, upts in zip(lower_pts, upper_pts):
-                    point_groups[det_key]['rbnds'] += [lpts, upts]
-                for ind in indices:
-                    point_groups[det_key]['rbnd_indices'] += [ind, ind]
+                lower_indices = [x for i, x in enumerate(indices)
+                                 if i not in lower_skipped]
+                upper_indices = [x for i, x in enumerate(indices)
+                                 if i not in upper_skipped]
+
+                point_groups[det_key]['rbnds'] += lower_pts
+                point_groups[det_key]['rbnd_indices'] += lower_indices
+
+                point_groups[det_key]['rbnds'] += upper_pts
+                point_groups[det_key]['rbnd_indices'] += upper_indices
 
         return point_groups
 

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -282,7 +282,13 @@ class RotationSeriesOverlay(Overlay):
         return ranges
 
     def range_data(self, spots, display_mode, panel):
-        return self.rectangular_range_data(spots, display_mode, panel)
+        data = self.rectangular_range_data(spots, display_mode, panel)
+
+        # Add a nans row at the end of each range
+        # This makes it easier to vstack them for plotting
+        data = [np.append(x, nans_row, axis=0) for x in data]
+
+        return data
 
     def rectangular_range_data(self, spots, display_mode, panel):
         from hexrdgui.hexrd_config import HexrdConfig
@@ -371,3 +377,6 @@ class RotationSeriesOverlay(Overlay):
         if self.update_needed:
             HexrdConfig().overlay_config_changed.emit()
             HexrdConfig().update_overlay_editor.emit()
+
+# Constants
+nans_row = np.nan * np.ones((1, 2))

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -378,5 +378,6 @@ class RotationSeriesOverlay(Overlay):
             HexrdConfig().overlay_config_changed.emit()
             HexrdConfig().update_overlay_editor.emit()
 
+
 # Constants
 nans_row = np.nan * np.ones((1, 2))

--- a/hexrdgui/utils/array.py
+++ b/hexrdgui/utils/array.py
@@ -1,0 +1,17 @@
+import numpy as np
+
+
+def split_array(x, indices, axis=0):
+    # Split an array into two subarrays:
+    # the first containing the values at the indices,
+    # and the second containing the values *not* at the indices.
+    try:
+        # This is faster than the list version
+        taken = np.take(x, indices, axis=axis)
+        deleted = np.delete(x, indices, axis=axis)
+    except ValueError:
+        # The list version might take longer
+        taken = [x for i, x in enumerate(x) if i in indices]
+        deleted = [x for i, x in enumerate(x) if i not in indices]
+
+    return taken, deleted

--- a/hexrdgui/utils/conversions.py
+++ b/hexrdgui/utils/conversions.py
@@ -46,8 +46,10 @@ def angles_to_cart(angles, panel, tvec_s=None, tvec_c=None,
     return panel.angles_to_cart(**kwargs)
 
 
-def angles_to_pixels(angles, panel):
-    xys = angles_to_cart(angles, panel)
+def angles_to_pixels(angles, panel, tvec_s=None, tvec_c=None,
+                     apply_distortion=True):
+    xys = angles_to_cart(angles, panel, tvec_s=tvec_s, tvec_c=tvec_c,
+                         apply_distortion=apply_distortion)
     return cart_to_pixels(xys, panel)
 
 


### PR DESCRIPTION
For all overlay types, we were using more artists than we needed to. For powder overlays, for instance, we would have one artist per line. For Laue and rotation series overlays, we would have one artist per spot and one artist per range! This could easily result in hundreds of artists.

However, if everything about the artists (including the style) are identical, except for the data, we are able to merge them together into a single artist. This can make matplotlib run much faster.

For line artists, we can have a single artist draw every powder overlay line - we just insert a `[nan, nan]` row in between lines in the data. Different artists are used for different styles (i. e., merged ranges are red instead of green, so they get a different artist, and highlighted data/ranges are a different color too, so they get a different artist). But we end up using only about 5 line artists in total for the main canvas, per overlay and per detector (each detector is currently rendered separately).

For scatter (path) artists, we ought to just pass every single spot to a single call to `scatter()`.

These changes speed up rendering of the overlays significantly, especially when there were many lines or spots being drawn. This is a great step toward better interactivity.