### PR TITLE
Fill nan lineout columns with zero

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1116,7 +1116,7 @@ class ImageCanvas(FigureCanvas):
         # !!! NOTE: visible polar masks have already been applied
         #           in polarview.py
         masked = np.ma.masked_array(pimg, mask=np.isnan(pimg))
-        return masked.sum(axis=0) / np.sum(~masked.mask, axis=0)
+        return (masked.sum(axis=0) / np.sum(~masked.mask, axis=0)).filled(0)
 
     def clear_azimuthal_overlay_artists(self):
         while self.azimuthal_overlay_artists:


### PR DESCRIPTION
Otherwise, they produce gaps in the lineout plot

This was only an issue if you had all nans in a column (such as when you apply a powder overlay mask in the polar view).