### PR TITLE
Update "qt5agg" to "qtagg"

### DIFF
--- a/hexrdgui/brightness_contrast_editor.py
+++ b/hexrdgui/brightness_contrast_editor.py
@@ -6,7 +6,7 @@ from PySide6.QtWidgets import (
     QDialog, QDialogButtonBox, QMessageBox, QVBoxLayout
 )
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 
 from hexrdgui.range_widget import RangeWidget

--- a/hexrdgui/calibration/hedm/calibration_results_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_results_dialog.py
@@ -1,7 +1,7 @@
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QSizePolicy
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 import numpy as np
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -4,7 +4,7 @@ import math
 from PySide6.QtCore import QThreadPool, QTimer, Signal, Qt
 from PySide6.QtWidgets import QFileDialog, QMessageBox
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
 from matplotlib.patches import Circle

--- a/hexrdgui/indexing/fit_grains_results_dialog.py
+++ b/hexrdgui/indexing/fit_grains_results_dialog.py
@@ -9,7 +9,7 @@ import numpy as np
 from mpl_toolkits.mplot3d import Axes3D, proj3d  # noqa: F401 unused import
 import matplotlib
 import matplotlib.ticker as ticker
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 
 from PySide6.QtCore import QObject, QTimer, Qt, Signal

--- a/hexrdgui/indexing/indexing_results_dialog.py
+++ b/hexrdgui/indexing/indexing_results_dialog.py
@@ -1,6 +1,6 @@
 import copy
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 import numpy as np
 

--- a/hexrdgui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrdgui/indexing/ome_maps_viewer_dialog.py
@@ -1,7 +1,7 @@
 import copy
 from pathlib import Path
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 import numpy as np
 import yaml

--- a/hexrdgui/indexing/view_spots_dialog.py
+++ b/hexrdgui/indexing/view_spots_dialog.py
@@ -1,7 +1,7 @@
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QSizePolicy
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 import numpy as np
 

--- a/hexrdgui/navigation_toolbar.py
+++ b/hexrdgui/navigation_toolbar.py
@@ -1,5 +1,5 @@
 from matplotlib import rc_context
-from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
+from matplotlib.backends.backend_qtagg import NavigationToolbar2QT
 
 from hexrdgui.utils import wrap_with_callbacks
 

--- a/hexrdgui/snip_viewer_dialog.py
+++ b/hexrdgui/snip_viewer_dialog.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import h5py
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 import numpy as np
 

--- a/hexrdgui/zoom_canvas.py
+++ b/hexrdgui/zoom_canvas.py
@@ -1,7 +1,7 @@
 from PySide6.QtCore import Signal, QTimer
 from PySide6.QtWidgets import QSizePolicy
 
-from matplotlib.backends.backend_qt5agg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvas
 
 from matplotlib.figure import Figure
 from matplotlib.widgets import Cursor


### PR DESCRIPTION
In matplotlib, "qt5agg" is just a reference to "qtagg" now.

Let's update ours to "qtagg" so that it doesn't appear that we are using a qt5-specific import.