### PR TITLE
Add ability to copy reflections table to clipboard

### DIFF
--- a/hexrdgui/resources/ui/reflections_table.ui
+++ b/hexrdgui/resources/ui/reflections_table.ui
@@ -42,6 +42,9 @@
    </item>
    <item row="0" column="0" colspan="4">
     <widget class="QTableWidget" name="table">
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;left click a row to activate the hkl&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>


### PR DESCRIPTION
If a user right-clicks a row in the reflections table, a context menu appears with a single option: "Copy to Clipboard".

If the user clicks "Copy to Clipboard", the selected rows in the reflections table will be copied to the clipboard in CSV format. This may then be pasted anywhere (including to Excel).

An example:

![image](https://github.com/HEXRD/hexrdgui/assets/9558430/d2da1b31-1349-447a-adf0-2db6c1a68030)

The copied CSV text:
```csv
ID,{hkl},d-spacing (Å),2θ (°),|F|²,Iₚ,Multiplicity
0,1 1 1,3.12,3.17,100.00,100.00,8
1,2 0 0,2.71,3.66,44.98,25.29,6
2,2 2 0,1.91,5.18,52.19,29.30,12
3,3 1 1,1.63,6.08,19.52,15.93,24
4,2 2 2,1.56,6.35,10.37,2.59,8
```

Fixes: #1617