### PR TITLE
Use yaml.safe_dump or NumpyToNativeDumper

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -16,6 +16,7 @@ from hexrd.config.loader import NumPyIncludeLoader
 from hexrd.instrument import HEDMInstrument
 from hexrd.material import load_materials_hdf5, save_materials_hdf5, Material
 from hexrd.rotations import RotMatEuler
+from hexrd.utils.yaml import NumpyToNativeDumper
 from hexrd.valunits import valWUnit
 
 from hexrdgui import constants
@@ -1154,7 +1155,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         cfg['working_dir'] = '.'
 
         with open(output_file, 'w') as f:
-            yaml.dump(cfg, f)
+            yaml.dump(cfg, f, Dumper=NumpyToNativeDumper)
 
     def create_internal_config(self, cur_config):
         if not self.has_status(cur_config):

--- a/hexrdgui/image_file_manager.py
+++ b/hexrdgui/image_file_manager.py
@@ -99,7 +99,7 @@ class ImageFileManager(metaclass=Singleton):
             input_dict['meta'] = {}
             temp = tempfile.NamedTemporaryFile(delete=False)
             try:
-                data = yaml.dump(input_dict).encode('utf-8')
+                data = yaml.safe_dump(input_dict).encode('utf-8')
                 temp.write(data)
                 temp.close()
                 ims = imageseries.open(temp.name, 'image-files')
@@ -129,7 +129,7 @@ class ImageFileManager(metaclass=Singleton):
         input_dict['meta'] = {}
         temp = tempfile.NamedTemporaryFile(delete=False)
         try:
-            data = yaml.dump(input_dict).encode('utf-8')
+            data = yaml.safe_dump(input_dict).encode('utf-8')
             temp.write(data)
             temp.close()
             ims = imageseries.open(temp.name, 'image-files')


### PR DESCRIPTION
We want to make sure that we write out safe yaml files (that don't require an unsafe_load to load them). So always use `yaml.safe_dump()` or the `NumpyToNativeDumper` in HEXRD.

Fixes: #1629