### PR TITLE
Pin qt-main temporarily

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,6 +27,9 @@ requirements:
     - Pillow
     - pyhdf
     - pyside6
+    # FIXME: the latest qt6-main isn't compatible with PySide6, so we are pinning
+    # the version. Remove this pin when this is fixed.
+    - qt6-main==6.6.0
     - pyyaml
     - silx-base
 


### PR DESCRIPTION
The latest PySide6 doesn't appear to be compatible with qt6-main==6.6.1, so downgrade to 6.6.0 until it is fixed.