### PR TITLE
Add constant chi overlays

### DIFF
--- a/hexrdgui/const_chi_overlay_editor.py
+++ b/hexrdgui/const_chi_overlay_editor.py
@@ -1,0 +1,471 @@
+import re
+
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtGui import QCursor, QKeyEvent
+from PySide6.QtWidgets import (
+    QCheckBox, QComboBox, QDoubleSpinBox, QHBoxLayout, QMenu, QSpinBox,
+    QStyledItemDelegate, QTableWidgetItem, QWidget
+)
+
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.overlays.const_chi_overlay import ChiValue
+from hexrdgui.tree_views.dict_tree_view import DictTreeItemModel, DictTreeView
+from hexrdgui.ui_loader import UiLoader
+from hexrdgui.utils import (
+    block_signals, euler_angles_to_exp_map, exp_map_to_euler_angles
+)
+from hexrdgui.utils.const_chi import calc_angles_for_fiber
+
+COLUMNS = {
+    'value': 0,
+    'hkl': 1,
+    'visible': 2,
+}
+
+
+class ConstChiOverlayEditor(QObject):
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('const_chi_overlay_editor.ui', parent)
+
+        self.chi_table.setItemDelegate(CenterDelegate())
+
+        self.fiber_tree = FiberTreeView({}, parent=self.ui)
+        self.ui.fiber_tree_layout.addWidget(self.fiber_tree)
+
+        self.chi_table.installEventFilter(self)
+
+        # These are not used currently, so just hide them until they are used.
+        # FIXME: remove this once these are supported.
+        self.ui.tvec_label.hide()
+        for w in self.tvec_widgets:
+            w.hide()
+
+        self._overlay = None
+
+        self.visibility_boxes = []
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        for w in self.widgets:
+            if isinstance(w, (QDoubleSpinBox, QSpinBox)):
+                w.valueChanged.connect(self.update_config)
+            elif isinstance(w, QCheckBox):
+                w.toggled.connect(self.update_config)
+            elif isinstance(w, QComboBox):
+                w.currentIndexChanged.connect(self.update_config)
+
+        HexrdConfig().euler_angle_convention_changed.connect(
+            self.euler_angle_convention_changed)
+
+        self.ui.add_chi_value_row.clicked.connect(
+            self.add_chi_value)
+        self.chi_table.itemChanged.connect(self.update_config)
+        self.chi_table.itemSelectionChanged.connect(self.update_enable_states)
+
+        self.ui.delete_selected_chi_values.clicked.connect(
+            self.delete_selected_rows)
+
+        for w in self.fiber_widgets:
+            w.valueChanged.connect(self.update_fiber_tree)
+
+        self.fiber_tree.selection_changed.connect(self.update_enable_states)
+        self.fiber_tree.add_selected_chi_values.connect(
+            self.add_selected_chi_values)
+
+        self.ui.add_selected_chi_values.clicked.connect(
+            self.add_selected_chi_values)
+
+    def eventFilter(self, obj, event):
+        if obj is self.chi_table:
+            return self.chi_table_event_filter(obj, event)
+
+        return False
+
+    def chi_table_event_filter(self, obj, event):
+        if isinstance(event, QKeyEvent):
+            if event.key() == Qt.Key_Delete:
+                self.delete_selected_rows()
+                return True
+
+        return False
+
+    @property
+    def overlay(self):
+        return self._overlay
+
+    @overlay.setter
+    def overlay(self, v):
+        self._overlay = v
+        self.update_gui()
+
+    def update_enable_states(self):
+        num_selected = len(self.selected_chi_value_rows)
+        self.ui.delete_selected_chi_values.setEnabled(num_selected > 0)
+
+        num_selected = len(self.fiber_tree.selected_rows)
+        self.ui.add_selected_chi_values.setEnabled(num_selected > 0)
+
+    def create_visibility_checkbox(self, v):
+        cb = QCheckBox(self.chi_table)
+        cb.setChecked(v)
+        cb.toggled.connect(self.update_config)
+        self.visibility_boxes.append(cb)
+        return self.create_table_widget(cb)
+
+    def create_table_widget(self, w):
+        # These are required to center the widget...
+        tw = QWidget(self.chi_table)
+        layout = QHBoxLayout(tw)
+        layout.addWidget(w)
+        layout.setAlignment(Qt.AlignCenter)
+        layout.setContentsMargins(0, 0, 0, 0)
+        return tw
+
+    def update_gui(self):
+        if self.overlay is None:
+            return
+
+        with block_signals(*self.widgets):
+            self.tvec_gui = self.tvec_config
+            self.tilt_gui = self.tilt_config
+            self.chi_values_gui = self.chi_values_config
+
+        self.update_tilt_suffixes()
+        self.update_fiber_tree()
+        self.update_enable_states()
+
+    def update_config(self):
+        self.tvec_config = self.tvec_gui
+        self.tilt_config = self.tilt_gui
+        self.chi_values_config = self.chi_values_gui
+
+        self.overlay.update_needed = True
+        HexrdConfig().overlay_config_changed.emit()
+
+        # The ConstChiOverlay might sort or remove duplicate chi values.
+        # So we should update the GUI in case that happened.
+        self.update_gui()
+
+    def euler_angle_convention_changed(self):
+        self.update_gui()
+
+    def update_tilt_suffixes(self):
+        suffix = '' if HexrdConfig().euler_angle_convention is None else '°'
+        for w in self.tilt_widgets:
+            w.setSuffix(suffix)
+
+    @property
+    def tilt_config(self):
+        if self.overlay is None:
+            return
+
+        return self.overlay.sample_tilt
+
+    @tilt_config.setter
+    def tilt_config(self, v):
+        if self.overlay is None:
+            return
+
+        self.overlay.sample_tilt = v
+
+    @property
+    def tilt_gui(self):
+        angles = [w.value() for w in self.tilt_widgets]
+        return euler_angles_to_exp_map(angles)
+
+    @tilt_gui.setter
+    def tilt_gui(self, v):
+        if v is None:
+            return
+
+        angles = exp_map_to_euler_angles(v)
+        for w, v in zip(self.tilt_widgets, angles):
+            w.setValue(v)
+
+    @property
+    def tvec_config(self):
+        if self.overlay is None:
+            return
+
+        return self.overlay.tvec
+
+    @tvec_config.setter
+    def tvec_config(self, v):
+        if self.overlay is None:
+            return
+
+        self.overlay.tvec = v
+
+    @property
+    def tvec_gui(self):
+        return [w.value() for w in self.tvec_widgets]
+
+    @tvec_gui.setter
+    def tvec_gui(self, v):
+        if v is None:
+            return
+
+        for i, w in enumerate(self.tvec_widgets):
+            w.setValue(v[i])
+
+    @property
+    def chi_values_config(self):
+        if self.overlay is None:
+            return
+
+        return self.overlay.chi_values
+
+    @chi_values_config.setter
+    def chi_values_config(self, v):
+        if self.overlay is None:
+            return
+
+        self.overlay.chi_values = v
+
+    @property
+    def chi_table(self):
+        return self.ui.chi_values
+
+    def clear_table(self):
+        table = self.chi_table
+        table.clearContents()
+
+        self.visibility_boxes.clear()
+
+    @property
+    def chi_values_gui(self):
+        results = []
+        table = self.chi_table
+        for i in range(table.rowCount()):
+            results.append(ChiValue(**{
+                'value': float(table.item(i, COLUMNS['value']).text()),
+                'hkl': table.item(i, COLUMNS['hkl']).text(),
+                'visible': self.visibility_boxes[i].isChecked(),
+            }))
+
+        return results
+
+    @chi_values_gui.setter
+    def chi_values_gui(self, v):
+        table = self.chi_table
+
+        with block_signals(table):
+            self.clear_table()
+
+            table.setRowCount(len(v))
+            for i, chi_value in enumerate(v):
+                w = FloatTableItem(chi_value.value)
+                table.setItem(i, COLUMNS['value'], w)
+
+                w = QTableWidgetItem(chi_value.hkl)
+                w.setTextAlignment(Qt.AlignCenter)
+                table.setItem(i, COLUMNS['hkl'], w)
+
+                w = self.create_visibility_checkbox(chi_value.visible)
+                table.setCellWidget(i, COLUMNS['visible'], w)
+
+    def add_chi_value(self):
+        # Find a unique chi value and add it
+        all_values = [x.value for x in self.chi_values_config]
+        unique_value = None
+        for i in range(180):
+            if i not in all_values:
+                unique_value = i
+                break
+
+        if unique_value is None:
+            raise Exception('Unable to create a unique chi value')
+
+        self.add_chi_values([ChiValue(**{
+            'value': unique_value,
+            'hkl': 'None',
+            'visible': True,
+        })])
+
+    def add_chi_values(self, v):
+        self.chi_values_config = self.chi_values_config + v
+        self.update_gui()
+
+        self.overlay.update_needed = True
+        HexrdConfig().overlay_config_changed.emit()
+
+    @property
+    def selected_chi_value_rows(self):
+        selected_indexes = self.chi_table.selectionModel().selectedRows()
+        return sorted([x.row() for x in selected_indexes])
+
+    def delete_selected_rows(self):
+        selected_rows = self.selected_chi_value_rows
+        new_values = []
+        for i, chi_value in enumerate(self.chi_values_config):
+            if i not in selected_rows:
+                new_values.append(chi_value)
+
+        self.chi_values_config = new_values
+        self.update_gui()
+
+        self.overlay.update_needed = True
+        HexrdConfig().overlay_config_changed.emit()
+
+    @property
+    def fiber_gui(self):
+        return [w.value() for w in self.fiber_widgets]
+
+    @property
+    def tilt_widgets(self):
+        return [getattr(self.ui, f'tilt_{i}') for i in range(3)]
+
+    @property
+    def tvec_widgets(self):
+        return [getattr(self.ui, f'tvec_{i}') for i in range(3)]
+
+    @property
+    def fiber_widgets(self):
+        return [getattr(self.ui, f'fiber_{i}') for i in range(3)]
+
+    @property
+    def widgets(self):
+        return [
+            *self.tilt_widgets,
+            *self.tvec_widgets,
+        ]
+
+    def update_fiber_tree(self):
+        # First, clear it
+        self.fiber_tree.config = {}
+        if self.overlay is None:
+            return
+
+        material = self.overlay.material
+        fiber_values = self.fiber_gui
+
+        if fiber_values == [0, 0, 0]:
+            # All zeros is invalid. Just return.
+            return
+
+        result = calc_angles_for_fiber(material, fiber_values)
+        # Convert numpy arrays to lists
+        result = {k: v.tolist() for k, v in result.items()}
+
+        self.fiber_tree.config = result
+        self.fiber_tree.expand_rows(rows=[0, 1, 2])
+
+    def add_selected_chi_values(self):
+        self.add_chi_values([{
+            'value': x.data(1),
+            'hkl': x.parent_item.data(0),
+            'visible': True,
+        } for x in self.fiber_tree.selected_items])
+
+
+class FloatTableItem(QTableWidgetItem):
+    # Subclass to store the actual float value alongside string version
+    DATA_ROLE = Qt.UserRole
+
+    def __init__(self, data):
+        string = '{:.10g}'.format(data).replace('e+', 'e')
+        string = re.sub(r'e(-?)0*(\d+)', r'e\1\2', string)
+
+        super().__init__(string)
+
+        self.setTextAlignment(Qt.AlignCenter)
+        self.setData(self.DATA_ROLE, data)
+
+    @property
+    def value(self):
+        return self.data(self.DATA_ROLE)
+
+    def __lt__(self, other):
+        return self.value < other.value
+
+
+class CenterDelegate(QStyledItemDelegate):
+    # Use this so that the QTableWidget text editor is centered
+    def createEditor(self, parent, option, index):
+        editor = QStyledItemDelegate.createEditor(self, parent, option, index)
+        editor.setAlignment(Qt.AlignCenter)
+        return editor
+
+
+class FiberTreeModel(DictTreeItemModel):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Override these titles
+        self.root_item.set_data(0, 'HKL')
+        self.root_item.set_data(1, 'Chi Values')
+
+
+class FiberTreeView(DictTreeView):
+
+    add_selected_chi_values = Signal()
+
+    def __init__(self, *args, **kwargs):
+        kwargs = {
+            'model': FiberTreeModel,
+            **kwargs,
+        }
+        super().__init__(*args, **kwargs)
+
+        self.editable = False
+        self.lists_resizable = False
+        self.set_extended_selection_mode()
+
+    @property
+    def config(self):
+        return self.model().config
+
+    @config.setter
+    def config(self, v):
+        self.model().config = v
+        self.rebuild_tree()
+
+    def rebuild_tree(self):
+        return self.model().rebuild_tree()
+
+    def contextMenuEvent(self, event):
+        actions = {}
+
+        index = self.indexAt(event.pos())
+        model = self.model()
+        item = model.get_item(index)
+        selected_items = self.selected_items
+        path = tuple(model.path_to_value(item, index.column()))
+        parent_element = model.config_val(path[:-1]) if path else None  # noqa
+        menu = QMenu(self)
+
+        # Helper functions
+        def add_actions(d: dict):
+            actions.update({menu.addAction(k): v for k, v in d.items()})
+
+        def add_separator():
+            if not actions:
+                return
+            menu.addSeparator()
+
+        if len(path) == 2 and selected_items:
+            # Find the selected items
+            add_actions({
+                'Add Chi Values': self.add_selected_chi_values.emit,
+            })
+
+        if not actions:
+            # No context menu
+            return super().contextMenuEvent(event)
+
+        # Open up the context menu
+        action_chosen = menu.exec(QCursor.pos())
+
+        if action_chosen is None:
+            # No action chosen
+            return super().contextMenuEvent(event)
+
+        # Run the function for the action that was chosen
+        actions[action_chosen]()
+
+        return super().contextMenuEvent(event)

--- a/hexrdgui/const_chi_overlay_editor.py
+++ b/hexrdgui/const_chi_overlay_editor.py
@@ -1,6 +1,6 @@
 import re
 
-from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtCore import QObject, QTimer, Qt, Signal
 from PySide6.QtGui import QCursor, QKeyEvent
 from PySide6.QtWidgets import (
     QCheckBox, QComboBox, QDoubleSpinBox, QHBoxLayout, QMenu, QSpinBox,
@@ -149,7 +149,11 @@ class ConstChiOverlayEditor(QObject):
 
         # The ConstChiOverlay might sort or remove duplicate chi values.
         # So we should update the GUI in case that happened.
-        self.update_gui()
+        # We need to do this on the next iteration of the event loop
+        # to avoid the following error message:
+        # QAbstractItemView::closeEditor called with an editor that does
+        # not belong to this view
+        QTimer.singleShot(0, self.update_gui)
 
     def euler_angle_convention_changed(self):
         self.update_gui()

--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -45,6 +45,7 @@ class OverlayType(Enum):
     powder = 'powder'
     laue = 'laue'
     rotation_series = 'rotation_series'
+    const_chi = 'const_chi'
 
 
 class PolarXAxisType:

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -213,6 +213,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when overlays were added, removed, or upon type change"""
     overlay_list_modified = Signal()
 
+    """Emitted when the sample tilt is modified"""
+    sample_tilt_modified = Signal()
+
     """Emitted when the loaded images change"""
     recent_images_changed = Signal()
 
@@ -297,6 +300,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.default_cmap = constants.DEFAULT_CMAP
         self._previous_structureless_calibration_picks_data = None
         self.image_mode = constants.ViewType.raw
+        self._sample_tilt = np.asarray([0, 0, 0], float)
 
         # Make sure that the matplotlib font size matches the application
         self.font_size = self.font_size
@@ -397,6 +401,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('default_cmap', constants.DEFAULT_CMAP),
             ('custom_polar_tth_distortion_object_serialized', None),
             ('_previous_structureless_calibration_picks_data', None),
+            ('sample_tilt', [0, 0, 0]),
         ]
 
     # Provide a mapping from attribute names to the keys used in our state
@@ -1951,6 +1956,19 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def flag_overlay_updates_for_all_materials(self):
         for name in self.materials:
             self.flag_overlay_updates_for_material(name)
+
+    @property
+    def sample_tilt(self):
+        return self._sample_tilt
+
+    @sample_tilt.setter
+    def sample_tilt(self, v):
+        v = np.asarray(v, float)
+        if np.array_equal(v, self.sample_tilt):
+            return
+
+        self._sample_tilt = v
+        self.sample_tilt_modified.emit()
 
     def _polar_pixel_size_tth(self):
         return self.config['image']['polar']['pixel_size_tth']

--- a/hexrdgui/laue_overlay_editor.py
+++ b/hexrdgui/laue_overlay_editor.py
@@ -3,13 +3,13 @@ import numpy as np
 
 from PySide6.QtWidgets import QCheckBox, QComboBox, QDoubleSpinBox
 
-from hexrd.rotations import angles_from_rmat_xyz, rotMatOfExpMap
-
 from hexrdgui.calibration_crystal_editor import CalibrationCrystalEditor
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.overlays.laue_overlay import LaueLabelType, LaueRangeShape
 from hexrdgui.ui_loader import UiLoader
-from hexrdgui.utils import block_signals, convert_angle_convention
+from hexrdgui.utils import (
+    block_signals, euler_angles_to_rmat, rmat_to_euler_angles
+)
 
 
 class LaueOverlayEditor:
@@ -183,27 +183,11 @@ class LaueOverlayEditor:
     def sample_rmat(self):
         # Convert to rotation matrix
         angles = [w.value() for w in self.sample_orientation_widgets]
-        old_convention = HexrdConfig().euler_angle_convention
-        if old_convention is not None:
-            angles = np.radians(angles)
-            new_convention = None
-            angles = convert_angle_convention(angles, old_convention,
-                                              new_convention)
-        return rotMatOfExpMap(np.asarray(angles))
+        return euler_angles_to_rmat(angles)
 
     @sample_rmat.setter
     def sample_rmat(self, v):
-        # Convert from rotation matrix
-        xyz = angles_from_rmat_xyz(v)
-        old_convention = {
-            'axes_order': 'xyz',
-            'extrinsic': True,
-        }
-        new_convention = HexrdConfig().euler_angle_convention
-        angles = convert_angle_convention(xyz, old_convention, new_convention)
-        if new_convention is not None:
-            angles = np.degrees(angles)
-
+        angles = rmat_to_euler_angles(v)
         for w, v in zip(self.sample_orientation_widgets, angles):
             w.setValue(v)
 

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1205,6 +1205,7 @@ class MainWindow(QObject):
             labels.append(f'tth = {info["tth"]:8.3f}')
             labels.append(f'eta = {info["eta"]:8.3f}')
             labels.append(f'dsp = {info["dsp"]:8.3f}')
+            labels.append(f'chi = {info["chi"]:8.3f}')
             labels.append(f'Q = {info["Q"]:8.3f}')
             labels.append(f'hkl ({material_name}) = {info["hkl"]}')
 
@@ -1230,6 +1231,7 @@ class MainWindow(QObject):
             labels.append(f'eta = {info["y_data"]:8.3f}')
             labels.append(f'value = {info["intensity"]:8.3f}')
             labels.append(f'dsp = {info["dsp"]:8.3f}')
+            labels.append(f'chi = {info["chi"]:8.3f}')
             labels.append(f'Q = {info["Q"]:8.3f}')
             labels.append(f'hkl ({material_name}) = {info["hkl"]}')
 

--- a/hexrdgui/overlay_editor.py
+++ b/hexrdgui/overlay_editor.py
@@ -1,3 +1,4 @@
+from hexrdgui.const_chi_overlay_editor import ConstChiOverlayEditor
 from hexrdgui.laue_overlay_editor import LaueOverlayEditor
 from hexrdgui.powder_overlay_editor import PowderOverlayEditor
 from hexrdgui.rotation_series_overlay_editor import RotationSeriesOverlayEditor
@@ -22,6 +23,10 @@ class OverlayEditor:
             RotationSeriesOverlayEditor(self.ui))
         self.ui.rotation_series_overlay_editor_layout.addWidget(
             self.rotation_series_overlay_editor.ui)
+
+        self.const_chi_overlay_editor = ConstChiOverlayEditor(self.ui)
+        self.ui.const_chi_overlay_editor_layout.addWidget(
+            self.const_chi_overlay_editor.ui)
 
         self.ui.tab_widget.tabBar().hide()
 
@@ -59,6 +64,7 @@ class OverlayEditor:
             'powder': self.powder_overlay_editor,
             'laue': self.laue_overlay_editor,
             'rotation_series': self.rotation_series_overlay_editor,
+            'const_chi': self.const_chi_overlay_editor,
         }
 
         if self.type is None or self.type.value not in widgets:

--- a/hexrdgui/overlay_manager.py
+++ b/hexrdgui/overlay_manager.py
@@ -61,6 +61,7 @@ class OverlayManager:
     @staticmethod
     def format_type(type):
         types = {
+            OverlayType.const_chi: 'Constant Chi',
             OverlayType.powder: 'Powder',
             OverlayType.laue: 'Laue',
             OverlayType.rotation_series: 'Rotation Series',

--- a/hexrdgui/overlay_style_picker.py
+++ b/hexrdgui/overlay_style_picker.py
@@ -24,6 +24,7 @@ class OverlayStylePicker(QObject):
         self.overlay = overlay
         self.ui.material_name.setText(overlay.material_name)
 
+        self.ui.range_style_group.setVisible(self.include_ranges)
         self.ui.label_group.setVisible(self.include_labels)
 
         self.setup_labels()
@@ -120,16 +121,18 @@ class OverlayStylePicker(QObject):
 
     def update_gui(self):
         data = self.style['data']
-        ranges = self.style['ranges']
         keys = self.keys
 
         with block_signals(*self.all_widgets):
             self.ui.data_color.setText(data[keys['data_color']])
             self.ui.data_style.setCurrentText(data[keys['data_style']])
             self.ui.data_size.setValue(data[keys['data_size']])
-            self.ui.range_color.setText(ranges[keys['range_color']])
-            self.ui.range_style.setCurrentText(ranges[keys['range_style']])
-            self.ui.range_size.setValue(ranges[keys['range_size']])
+
+            if self.include_ranges:
+                ranges = self.style['ranges']
+                self.ui.range_color.setText(ranges[keys['range_color']])
+                self.ui.range_style.setCurrentText(ranges[keys['range_style']])
+                self.ui.range_size.setValue(ranges[keys['range_size']])
 
             if self.include_labels:
                 labels = self.style['labels']
@@ -142,15 +145,17 @@ class OverlayStylePicker(QObject):
 
     def update_config(self):
         data = self.style['data']
-        ranges = self.style['ranges']
         keys = self.keys
 
         data[keys['data_color']] = self.ui.data_color.text()
         data[keys['data_style']] = self.ui.data_style.currentData()
         data[keys['data_size']] = self.ui.data_size.value()
-        ranges[keys['range_color']] = self.ui.range_color.text()
-        ranges[keys['range_style']] = self.ui.range_style.currentData()
-        ranges[keys['range_size']] = self.ui.range_size.value()
+
+        if self.include_ranges:
+            ranges = self.style['ranges']
+            ranges[keys['range_color']] = self.ui.range_color.text()
+            ranges[keys['range_style']] = self.ui.range_style.currentData()
+            ranges[keys['range_size']] = self.ui.range_size.value()
 
         if self.include_labels:
             labels = self.style['labels']
@@ -189,6 +194,7 @@ class OverlayStylePicker(QObject):
                 OverlayType.powder: self.powder_keys,
                 OverlayType.laue: self.laue_keys,
                 OverlayType.rotation_series: self.rotation_series_keys,
+                OverlayType.const_chi: self.const_chi_keys,
             }
 
         type = self.overlay.type
@@ -228,12 +234,21 @@ class OverlayStylePicker(QObject):
         return self.laue_keys
 
     @property
+    def const_chi_keys(self):
+        return {
+            'data_color': 'c',
+            'data_style': 'ls',
+            'data_size': 'lw',
+        }
+
+    @property
     def labels(self):
         if not hasattr(self, '_labels'):
             self._labels = {
                 OverlayType.powder: self.powder_labels,
                 OverlayType.laue: self.laue_labels,
                 OverlayType.rotation_series: self.rotation_series_labels,
+                OverlayType.const_chi: self.const_chi_labels,
             }
 
         type = self.overlay.type
@@ -258,6 +273,15 @@ class OverlayStylePicker(QObject):
     def rotation_series_labels(self):
         # Same as Laue
         return self.laue_labels
+
+    @property
+    def const_chi_labels(self):
+        # No labels to override
+        return {}
+
+    @property
+    def include_ranges(self):
+        return not self.overlay.is_const_chi
 
     @property
     def include_labels(self):

--- a/hexrdgui/overlays/__init__.py
+++ b/hexrdgui/overlays/__init__.py
@@ -1,12 +1,14 @@
 from hexrdgui.constants import OverlayType
 
 from . import compatibility
+from .const_chi_overlay import ConstChiOverlay
 from .laue_overlay import LaueOverlay
 from .overlay import Overlay
 from .powder_overlay import PowderOverlay
 from .rotation_series_overlay import RotationSeriesOverlay
 
 type_dict = {
+    OverlayType.const_chi: ConstChiOverlay,
     OverlayType.laue: LaueOverlay,
     OverlayType.powder: PowderOverlay,
     OverlayType.rotation_series: RotationSeriesOverlay,
@@ -66,6 +68,7 @@ def update_overlay_data(instr, display_mode):
 
 
 __all__ = [
+    'ConstChiOverlay',
     'LaueOverlay',
     'Overlay',
     'PowderOverlay',

--- a/hexrdgui/overlays/const_chi_overlay.py
+++ b/hexrdgui/overlays/const_chi_overlay.py
@@ -1,0 +1,239 @@
+from dataclasses import asdict, dataclass
+
+import numpy as np
+
+from hexrd import constants
+
+from hexrdgui.constants import OverlayType, ViewType
+from hexrdgui.overlays.overlay import Overlay
+from hexrdgui.utils.const_chi import generate_ring_points_chi
+from hexrdgui.utils.conversions import (
+    angles_to_stereo, cart_to_angles, cart_to_pixels
+)
+
+
+class ConstChiOverlay(Overlay):
+
+    type = OverlayType.const_chi
+    hkl_data_key = 'data'
+
+    def __init__(self, material_name, chi_values=None, tvec=None,
+                 **overlay_kwargs):
+        Overlay.__init__(self, material_name, **overlay_kwargs)
+
+        if chi_values is None:
+            chi_values = []
+
+        if tvec is None:
+            tvec = constants.zeros_3.copy()
+
+        self.chi_values = chi_values
+        self.tvec = tvec
+
+        self.setup_connections()
+
+    def setup_connections(self):
+        from hexrdgui.hexrd_config import HexrdConfig
+        HexrdConfig().sample_tilt_modified.connect(
+            self.on_sample_tilt_modified)
+
+    @property
+    def child_attributes_to_save(self):
+        # These names must be identical here, as attributes, and as
+        # arguments to the __init__ method.
+        return [
+            'chi_values_serialized',
+            'tvec',
+        ]
+
+    @property
+    def chi_values(self):
+        return self._chi_values
+
+    @chi_values.setter
+    def chi_values(self, v):
+        values = []
+        for x in v:
+            if isinstance(x, dict):
+                x = ChiValue(**x)
+            elif not isinstance(x, ChiValue):
+                x = ChiValue(x)
+
+            values.append(x)
+
+        # If there are any duplicate values, only keep the first
+        raw_values = [x.value for x in values]
+        keep_indices = np.unique(raw_values, return_index=True)[1]
+        values = [x for i, x in enumerate(values) if i in keep_indices]
+
+        self._chi_values = sorted(values)
+
+    @property
+    def chi_values_serialized(self):
+        return [asdict(x) for x in self.chi_values]
+
+    @chi_values_serialized.setter
+    def chi_values_serialized(self, v):
+        # The regular setter can already handle this
+        self.chi_values = v
+
+    @property
+    def tvec(self):
+        return self._tvec
+
+    @tvec.setter
+    def tvec(self, v):
+        self._tvec = np.asarray(v, float)
+
+    @property
+    def sample_tilt(self):
+        from hexrdgui.hexrd_config import HexrdConfig
+        return HexrdConfig().sample_tilt
+
+    @sample_tilt.setter
+    def sample_tilt(self, v):
+        from hexrdgui.hexrd_config import HexrdConfig
+        HexrdConfig().sample_tilt = v
+
+    def on_sample_tilt_modified(self):
+        self.update_needed = True
+
+    def generate_overlay(self):
+        instr = self.instrument
+
+        data = {}
+        for chi_value in self.chi_values:
+            if not chi_value.visible:
+                continue
+
+            chi = chi_value.value
+            result = generate_ring_points_chi(chi, self.sample_tilt, instr)
+
+            for det_key, xys in result.items():
+                data.setdefault(det_key, [])
+                if len(xys) == 0:
+                    continue
+
+                # Convert to the display mode
+                pts = self.cart_to_display_mode(xys, instr, det_key)
+
+                data[det_key].append({
+                    'chi': chi,
+                    # Add a nans row so they can be combined easier for drawing
+                    'data': np.vstack([pts, nans_row]),
+                })
+
+        return data
+
+    def cart_to_display_mode(self, xys, instr, det_key):
+        panel = instr.detectors[det_key]
+        if self.display_mode in (ViewType.raw, ViewType.cartesian):
+            # Find the distances between all points, and insert nans between
+            # any points that are very far apart (10x the median)
+            distances = np.sqrt(np.sum(np.diff(xys, axis=0)**2, axis=1))
+            tolerance = np.nanmedian(distances) * 10
+            gaps, = np.nonzero(np.abs(distances) > np.abs(tolerance))
+            xys = np.insert(xys, gaps + 1, np.nan, axis=0)
+
+            if self.display_mode == ViewType.cartesian:
+                # Already correct
+                return xys
+            else:
+                return cart_to_pixels(xys, panel)
+
+        # Must be polar or stereo
+        from hexrdgui.hexrd_config import HexrdConfig
+        kwargs = {
+            'xys': xys,
+            'panel': panel,
+            'eta_period': HexrdConfig().polar_res_eta_period,
+            'tvec_s': instr.tvec,
+        }
+        angs = cart_to_angles(**kwargs)
+
+        diff = np.diff(angs[:, 1])
+        # # Some detectors, such as cylindrical, can easily end up
+        # # with points that are connected far apart, and run across
+        # # other detectors. Thus, we should insert nans at any gaps.
+        # # FIXME: is this a reasonable tolerance?
+        delta_eta_est = np.nanmedian(diff)
+        tolerance = delta_eta_est * 2
+        gaps, = np.nonzero(np.abs(diff) > np.abs(tolerance))
+        angs = np.insert(angs, gaps + 1, np.nan, axis=0)
+
+        if self.display_mode == ViewType.polar:
+            # We are done!
+            return angs
+
+        # We are in stereo
+        return angles_to_stereo(
+            np.radians(angs),
+            instr,
+            HexrdConfig().stereo_size,
+        )
+
+    @property
+    def default_style(self):
+        return {
+            'data': {
+                'c': '#e01b24',  # Red
+                'ls': 'dashdot',
+                'lw': 1.0,
+            }
+        }
+
+    @property
+    def default_highlight_style(self):
+        return {
+            'data': {
+                'c': '#ff00ff',  # Magenta
+                'ls': 'dashdot',
+                'lw': 3.0,
+            }
+        }
+
+    @property
+    def refinement_labels(self):
+        return []
+
+    @property
+    def default_refinements(self):
+        return []
+
+    def pad_picks_data(self):
+        # Const chi overlays do not currently support picks data
+        pass
+
+    @property
+    def has_picks_data(self):
+        # Const chi overlays do not currently support picks data
+        return False
+
+    @property
+    def calibration_picks_polar(self):
+        # Const chi overlays do not currently support picks data
+        return []
+
+    @calibration_picks_polar.setter
+    def calibration_picks_polar(self, picks):
+        # Const chi overlays do not currently support picks data
+        pass
+
+    @property
+    def has_widths(self):
+        # Const chi overlays do not currently support widths
+        return False
+
+
+@dataclass
+class ChiValue:
+    value: float
+    hkl: str = 'None'
+    visible: bool = True
+
+    def __lt__(self, other):
+        return self.value < other.value
+
+
+# Constants
+nans_row = np.nan * np.ones((1, 2))

--- a/hexrdgui/overlays/const_chi_overlay.py
+++ b/hexrdgui/overlays/const_chi_overlay.py
@@ -18,11 +18,16 @@ class ConstChiOverlay(Overlay):
     hkl_data_key = 'data'
 
     def __init__(self, material_name, chi_values=None, tvec=None,
-                 **overlay_kwargs):
+                 chi_values_serialized=None, **overlay_kwargs):
+        # chi_values_serialized is only used if chi_values is None.
+        # It is used for state loading.
         Overlay.__init__(self, material_name, **overlay_kwargs)
 
         if chi_values is None:
-            chi_values = []
+            if chi_values_serialized is not None:
+                chi_values = chi_values_serialized
+            else:
+                chi_values = []
 
         if tvec is None:
             tvec = constants.zeros_3.copy()

--- a/hexrdgui/overlays/laue_overlay.py
+++ b/hexrdgui/overlays/laue_overlay.py
@@ -22,7 +22,7 @@ from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 class LaueOverlay(Overlay):
 
     type = OverlayType.laue
-    hkl_data_key = 'spots'
+    hkl_data_key = None
 
     def __init__(self, material_name, crystal_params=None, sample_rmat=None,
                  min_energy=5, max_energy=35, tth_width=None, eta_width=None,

--- a/hexrdgui/overlays/laue_overlay.py
+++ b/hexrdgui/overlays/laue_overlay.py
@@ -22,7 +22,7 @@ from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 class LaueOverlay(Overlay):
 
     type = OverlayType.laue
-    hkl_data_key = None
+    hkl_data_key = 'spots'
 
     def __init__(self, material_name, crystal_params=None, sample_rmat=None,
                  min_energy=5, max_energy=35, tth_width=None, eta_width=None,

--- a/hexrdgui/overlays/overlay.py
+++ b/hexrdgui/overlays/overlay.py
@@ -332,6 +332,10 @@ class Overlay(ABC):
     def is_rotation_series(self):
         return self.type == OverlayType.rotation_series
 
+    @property
+    def is_const_chi(self):
+        return self.type == OverlayType.const_chi
+
     def on_new_images_loaded(self):
         # Do nothing by default. Subclasses can re-implement.
         pass

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -149,10 +149,6 @@ class PowderOverlay(Overlay, PolarDistortionObject):
     @property
     def calibration_picks_polar(self):
         # Convert from cartesian to polar
-        from hexrdgui.hexrd_config import HexrdConfig
-
-        eta_period = HexrdConfig().polar_res_eta_period
-
         instr = self.instrument
         picks = copy.deepcopy(self.calibration_picks)
         for det_key, det_picks in picks.items():
@@ -164,7 +160,7 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                 det_picks[i] = cart_to_angles(
                     det_picks[i],
                     panel,
-                    eta_period,
+                    self.eta_period,
                 ).tolist()
 
         return picks

--- a/hexrdgui/resources/ui/const_chi_overlay_editor.ui
+++ b/hexrdgui/resources/ui/const_chi_overlay_editor.ui
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>const_chi_overlay_editor</class>
+ <widget class="QWidget" name="const_chi_overlay_editor">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>815</width>
+    <height>590</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>0</width>
+    <height>590</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Edit Overlay</string>
+  </property>
+  <property name="styleSheet">
+   <string notr="true">QDoubleSpinBox:disabled {background-color: LightGray;}
+</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="1" colspan="2">
+    <widget class="QLabel" name="chi_values_label">
+     <property name="text">
+      <string>Chi Values</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="3">
+    <widget class="ScientificDoubleSpinBox" name="tilt_0">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="minimum">
+      <double>-1000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="4">
+    <widget class="ScientificDoubleSpinBox" name="tvec_1">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="suffix">
+      <string> mm</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="minimum">
+      <double>-100000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="4">
+    <widget class="ScientificDoubleSpinBox" name="tilt_1">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="minimum">
+      <double>-1000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QLabel" name="tilt_label">
+     <property name="text">
+      <string>Sample Tilt:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" colspan="2">
+    <widget class="QLabel" name="tvec_label">
+     <property name="text">
+      <string>Offset:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1" colspan="5">
+    <widget class="QGroupBox" name="suggested_chi_values">
+     <property name="title">
+      <string>Suggested Chi Values</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="2">
+       <widget class="QSpinBox" name="fiber_1">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="minimum">
+         <number>-1000000</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QSpinBox" name="fiber_0">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="minimum">
+         <number>-1000000</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="fiber_label">
+        <property name="text">
+         <string>Fiber:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QSpinBox" name="fiber_2">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="minimum">
+         <number>-1000000</number>
+        </property>
+        <property name="maximum">
+         <number>1000000</number>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="4">
+       <layout class="QVBoxLayout" name="fiber_tree_layout"/>
+      </item>
+      <item row="3" column="0" colspan="4">
+       <widget class="QPushButton" name="add_selected_chi_values">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Add Selected</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="5">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="5">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="5">
+    <widget class="QTableWidget" name="chi_values">
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="columnCount">
+      <number>3</number>
+     </property>
+     <attribute name="horizontalHeaderVisible">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>200</number>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>200</number>
+     </attribute>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Chi</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>HKL</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Visible</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item row="1" column="5">
+    <widget class="ScientificDoubleSpinBox" name="tvec_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="suffix">
+      <string> mm</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="minimum">
+      <double>-100000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="3">
+    <widget class="ScientificDoubleSpinBox" name="tvec_0">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>30</height>
+      </size>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="suffix">
+      <string> mm</string>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="minimum">
+      <double>-100000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="5">
+    <widget class="ScientificDoubleSpinBox" name="tilt_2">
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="decimals">
+      <number>8</number>
+     </property>
+     <property name="minimum">
+      <double>-1000000.000000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>10000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="5">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QPushButton" name="add_chi_value_row">
+       <property name="text">
+        <string>Add Row</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="delete_selected_chi_values">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Delete Selected</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.py</header>
+  </customwidget>
+ </customwidgets>
+ <tabstops>
+  <tabstop>tilt_0</tabstop>
+  <tabstop>tilt_1</tabstop>
+  <tabstop>tilt_2</tabstop>
+  <tabstop>tvec_0</tabstop>
+  <tabstop>tvec_1</tabstop>
+  <tabstop>tvec_2</tabstop>
+  <tabstop>chi_values</tabstop>
+  <tabstop>add_chi_value_row</tabstop>
+  <tabstop>delete_selected_chi_values</tabstop>
+  <tabstop>fiber_0</tabstop>
+  <tabstop>fiber_1</tabstop>
+  <tabstop>fiber_2</tabstop>
+  <tabstop>add_selected_chi_values</tabstop>
+ </tabstops>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrdgui/resources/ui/overlay_editor.ui
+++ b/hexrdgui/resources/ui/overlay_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>548</width>
-    <height>200</height>
+    <height>449</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -62,6 +62,16 @@
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">
         <layout class="QVBoxLayout" name="rotation_series_overlay_editor_layout"/>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="const_chi_tab">
+      <attribute name="title">
+       <string>Const Chi</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="0">
+        <layout class="QVBoxLayout" name="const_chi_overlay_editor_layout"/>
        </item>
       </layout>
      </widget>

--- a/hexrdgui/resources/ui/overlay_style_picker.ui
+++ b/hexrdgui/resources/ui/overlay_style_picker.ui
@@ -10,6 +10,9 @@
     <height>336</height>
    </rect>
   </property>
+  <property name="windowTitle">
+   <string>Overlay Style</string>
+  </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
     <number>6</number>

--- a/hexrdgui/tree_views/base_dict_tree_item_model.py
+++ b/hexrdgui/tree_views/base_dict_tree_item_model.py
@@ -6,7 +6,6 @@ from PySide6.QtWidgets import QMenu, QMessageBox, QTreeView
 
 from hexrdgui.tree_views.base_tree_item_model import BaseTreeItemModel
 from hexrdgui.tree_views.tree_item import TreeItem
-from hexrdgui.utils import is_int
 
 
 # Global constants
@@ -162,7 +161,6 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
         cur_tree_item = tree_item
         while cur_tree_item is not self.root_item:
             text = cur_tree_item.data(KEY_COL)
-            text = int(text) if is_int(text) else text
             path.insert(0, text)
             cur_tree_item = cur_tree_item.parent_item
 
@@ -176,6 +174,7 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
                 cur_val = cur_val[val]
         except KeyError:
             msg = f'Path: {path}\nwas not found in dict: {self.config}'
+            breakpoint()
             raise Exception(msg)
 
         return cur_val
@@ -242,9 +241,18 @@ class BaseDictTreeView(QTreeView):
     def rebuild_tree(self):
         self.model().rebuild_tree()
 
-    def expand_rows(self, parent=QModelIndex()):
-        # Recursively expands all rows
-        for i in range(self.model().rowCount(parent)):
+    def expand_rows(self, parent=QModelIndex(), rows=None):
+        row_count = self.model().rowCount(parent)
+
+        if rows is None:
+            # Default to all rows
+            rows = list(range(row_count))
+
+        # Recursively expands rows
+        for i in rows:
+            if i >= row_count:
+                continue
+
             index = self.model().index(i, KEY_COL, parent)
             self.expand(index)
             self.expand_rows(index)
@@ -252,6 +260,10 @@ class BaseDictTreeView(QTreeView):
     @property
     def lists_resizable(self):
         return self.model().lists_resizable
+
+    @lists_resizable.setter
+    def lists_resizable(self, v):
+        self.model().lists_resizable = v
 
     @property
     def blacklisted_paths(self):

--- a/hexrdgui/tree_views/dict_tree_view.py
+++ b/hexrdgui/tree_views/dict_tree_view.py
@@ -45,10 +45,10 @@ class DictTreeItemModel(BaseDictTreeItemModel):
 
 class DictTreeView(BaseDictTreeView):
 
-    def __init__(self, dictionary, parent=None):
+    def __init__(self, dictionary, model=DictTreeItemModel, parent=None):
         super().__init__(parent)
 
-        self.setModel(DictTreeItemModel(dictionary, parent=self))
+        self.setModel(model(dictionary, parent=self))
         self.setItemDelegateForColumn(
             VALUE_COL, ValueColumnDelegate(self))
 
@@ -66,7 +66,7 @@ class DictTreeViewDialog(QDialog):
 
         self.setLayout(QVBoxLayout(self))
 
-        self.tree_view = DictTreeView(dictionary, self)
+        self.tree_view = DictTreeView(dictionary, parent=self)
         self.layout().addWidget(self.tree_view)
 
         self.resize(500, 500)

--- a/hexrdgui/utils/const_chi.py
+++ b/hexrdgui/utils/const_chi.py
@@ -1,0 +1,267 @@
+import numpy as np
+
+from hexrd import constants
+from hexrd.rotations import make_rmat_euler
+from hexrd.transforms.xfcapi import (
+    angles_to_gvec, angles_to_dvec, gvecToDetectorXY
+)
+from hexrd.xrdutil.utils import _project_on_detector_cylinder, _dvec_to_angs
+
+
+def calc_chi(sample_tilt,
+             panel,
+             instr_tilt=0,
+             origin=constants.zeros_3):
+
+    rmat = make_rmat_euler(sample_tilt,
+                           'xyz',
+                           extrinsic=True)
+
+    nhat = np.dot(rmat, constants.lab_z)
+
+    gvecs = get_panel_gvec(panel,
+                           chi=instr_tilt,
+                           origin=origin)
+
+    dp = np.dot(gvecs, nhat)
+
+    mask = np.abs(dp) > 1
+    dp[mask] = np.sign(dp[mask])
+    chi = np.degrees(np.arccos(dp))
+
+    return chi.reshape(panel.shape)
+
+
+def get_panel_gvec(panel,
+                   chi=0.,
+                   origin=constants.zeros_3):
+
+    ang = panel.pixel_angles(origin=origin)
+    angs = np.vstack((ang[0].flatten(),
+                     ang[1].flatten(),
+                     np.zeros(ang[0].flatten().shape))).T
+
+    g_vec = angles_to_gvec(angs,
+                           beam_vec=panel.bvec,
+                           eta_vec=panel.evec,
+                           chi=chi,
+                           rmat_c=None)
+
+    return g_vec
+
+
+def angles_to_chi_vecs(const_chi,
+                       sample_tilt,
+                       panel):
+
+    eta = np.linspace(-np.pi, np.pi, 720)
+    chi = np.array([np.radians(const_chi)]*eta.shape[0])
+    omg = np.zeros(eta.shape)
+    angs = np.vstack((chi, eta, omg)).T
+
+    chivec = angles_to_dvec(angs,
+                            beam_vec=constants.lab_z,
+                            eta_vec=constants.lab_x)
+
+    return chivec
+
+
+def chi_vecs_to_gvecs(chivec,
+                      sample_tilt,
+                      origin=constants.zeros_3):
+    rmat = make_rmat_euler(sample_tilt,
+                           'xyz',
+                           extrinsic=True)
+    gvec = np.dot(rmat, chivec.T).T
+    return gvec
+
+
+def gvec_to_ang(gvec, panel, wavelength, origin=constants.zeros_3):
+
+    bvec = panel.bvec
+    sth = -np.dot(bvec, gvec.T)
+
+    dvecs = (np.tile(panel.bvec/wavelength, [sth.shape[0], 1]) +
+             gvec * np.tile((2*sth)/wavelength, [3, 1]).T)
+
+    dvecs = dvecs / np.tile(np.linalg.norm(dvecs, axis=1), [3, 1]).T
+    tth, eta = _dvec_to_angs(dvecs,
+                             panel.bvec,
+                             panel.evec)
+
+    omg = np.zeros([tth.shape[0], ])
+
+    return np.vstack((tth, eta, omg)).T
+
+
+def chi_to_angs(const_chi,
+                sample_tilt,
+                panel,
+                wavelength,
+                origin=constants.zeros_3):
+
+    chivecs = angles_to_chi_vecs(const_chi,
+                                 sample_tilt,
+                                 panel)
+
+    gvecs = chi_vecs_to_gvecs(chivecs,
+                              sample_tilt,
+                              origin=origin)
+
+    angs = gvec_to_ang(gvecs,
+                       panel,
+                       wavelength,
+                       origin=origin)
+
+    return angs
+
+
+def calc_chi_map(sample_tilt, instr):
+
+    chi = {}
+    for det_name, panel in instr.detectors.items():
+        chi[det_name] = calc_chi(sample_tilt,
+                                 panel,
+                                 instr_tilt=instr.chi,
+                                 origin=instr.tvec)
+
+    return chi
+
+
+def generate_ring_points_chi(const_chi,
+                             sample_tilt,
+                             instr):
+
+    xys = dict.fromkeys(instr.detectors)
+
+    for det_name, panel in instr.detectors.items():
+
+        if panel.detector_type == 'planar':
+
+            chivecs = angles_to_chi_vecs(const_chi,
+                                         sample_tilt,
+                                         panel)
+
+            gvecs = chi_vecs_to_gvecs(chivecs,
+                                      sample_tilt)
+
+            xy_det = gvecToDetectorXY(gvecs,
+                                      rMat_d=panel.rmat,
+                                      rMat_s=constants.identity_3x3,
+                                      rMat_c=constants.identity_3x3,
+                                      tVec_d=panel.tvec,
+                                      tVec_s=instr.tvec,
+                                      tVec_c=constants.zeros_3,
+                                      beamVec=panel.bvec)
+
+        elif panel.detector_type == 'cylindrical':
+
+            angs = chi_to_angs(const_chi,
+                               sample_tilt,
+                               panel,
+                               instr.beam_wavelength)
+
+            xy_det, rMat_ss, valid_mask = _project_on_detector_cylinder(
+                angs,
+                0,
+                panel.tvec,
+                panel.caxis,
+                panel.paxis,
+                panel.radius,
+                panel.physical_size,
+                panel.angle_extent,
+                panel.distortion,
+                beamVec=panel.bvec,
+                etaVec=panel.evec,
+                tVec_s=instr.tvec,
+                rmat_s=constants.identity_3x3,
+                tVec_c=constants.zeros_3x1)
+
+        xy_det, mask = panel.clip_to_panel(xy_det, buffer_edges=False)
+
+        xys[det_name] = xy_det
+
+    return xys
+
+
+def calc_angles_for_fiber(mat, fiber_direction):
+    sym_fib_dir = mat.unitcell.CalcStar(fiber_direction, 'r')
+    nsym = sym_fib_dir.shape[0]
+    hkls = mat.planeData.getHKLs()
+    n = hkls.shape[0]
+    n = np.min([n, 7])
+    hkls = hkls[0:n, :]
+
+    angles = np.zeros([nsym, ])
+    angle_dict = {}
+    for j in range(n):
+        v = np.squeeze(hkls[j, :])
+        vstr = str(v).strip('[]').replace(' ', '')
+        for i in range(nsym):
+            u = np.squeeze(sym_fib_dir[i, :])
+            angles[i] = np.round(np.degrees(mat.unitcell.CalcAngle(u, v, 'r')),
+                                 2)
+        angle_dict[vstr] = np.unique(angles)
+    return angle_dict
+
+
+if __name__ == '__main__':
+
+    import cProfile
+    from importlib.resources import read_text
+    import pstats
+
+    import matplotlib.pyplot as plt
+    import yaml
+
+    from hexrd import resources
+    from hexrd.instrument import HEDMInstrument
+    from hexrd.material import Material
+
+    text = read_text(resources, 'tardis_reference_config.yml')
+    conf = yaml.safe_load(text)
+
+    instr = HEDMInstrument(instrument_config=conf)
+
+    m = Material()
+    angles = calc_angles_for_fiber(m, [1, 1, 0])
+
+    const_chi = 45
+    sample_tilt = np.array([0, 0, 0])
+
+    profiler = cProfile.Profile()
+    profiler.enable()
+
+    xy = generate_ring_points_chi(const_chi,
+                                  sample_tilt,
+                                  instr)
+
+    chi = calc_chi_map(sample_tilt, instr)
+
+    profiler.disable()
+
+    pstats.Stats(profiler).sort_stats('tottime').print_stats(3)
+    pstats.Stats(profiler).sort_stats('cumtime').print_stats(3)
+
+    '''
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    DEBUGGING CODE
+    %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+    '''
+
+    for det_name, panel in instr.detectors.items():
+        pix = panel.cartToPixel(xy[det_name], pixels=True)
+        chi[det_name][pix[:, 0], pix[:, 1]] = np.nan
+
+        mask = np.abs(chi[det_name] - const_chi) < 0.05
+        chi[det_name][mask] = 0
+
+    fig, ax = plt.subplots(nrows=len(instr.detectors), ncols=1)
+
+    for ii, det_name in enumerate(instr.detectors):
+        if len(instr.detectors) > 1:
+            ax[ii].imshow(chi[det_name])
+        else:
+            ax.imshow(chi[det_name])
+
+    plt.show()


### PR DESCRIPTION
These overlays help the user to visualize constant chi values.

The material associated with a constant chi overlay is used to generate the suggested chi values (after the user selects a fiber).

The chi value information also now appears on mouse hover.

To do:

- [x] I need to verify that the tree view editor in a few different places is not broken by any of these changes.