### PR TITLE
Unpin qt6-main

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -27,9 +27,6 @@ requirements:
     - Pillow
     - pyhdf
     - pyside6
-    # FIXME: the latest qt6-main isn't compatible with PySide6, so we are pinning
-    # the version. Remove this pin when this is fixed.
-    - qt6-main==6.6.0
     - pyyaml
     - silx-base
 


### PR DESCRIPTION
We should merge this when we verify that qt6-main no longer needs to be pinned.

This is to undo #1633