### PR TITLE
Add an option to load pre-configured instrument files

### DIFF
--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1590,12 +1590,20 @@ class MainWindow(QObject):
         self.load_state_file(path)
 
     def on_action_open_preconfigured_instrument_file_triggered(self):
+        # Should we put this in HEXRD?
+        aliases = {
+            'dual_dexelas.yml': 'Dual Dexelas',
+        }
+
         # Create a dict of options for loading an instrument, mapping file
         # name to instrument config
         options = {}
         for f in resource_loader.module_contents(instrument_templates):
             if f.endswith(('.yml', '.yaml', '.hexrd', '.h5', '.hdf5')):
                 name = Path(f).name
+                if name in aliases:
+                    name = aliases[name]
+
                 options[name] = f
 
         # Provide simple dialog for selecting instrument to import

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -13,7 +13,8 @@ from PySide6.QtCore import (
 )
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
-    QApplication, QDockWidget, QFileDialog, QMainWindow, QMessageBox
+    QApplication, QDockWidget, QFileDialog,
+    QInputDialog, QMainWindow, QMessageBox
 )
 
 from hexrdgui.about_dialog import AboutDialog
@@ -76,7 +77,8 @@ from hexrdgui.utils import block_signals, unique_name
 from hexrdgui.utils.dialog import add_help_url
 from hexrdgui.zoom_canvas_dialog import ZoomCanvasDialog
 from hexrdgui.rerun_clustering_dialog import RerunClusteringDialog
-from hexrdgui import state
+from hexrdgui import resource_loader, state
+from hexrd.resources import instrument_templates
 
 
 class MainWindow(QObject):
@@ -177,7 +179,7 @@ class MainWindow(QObject):
     def setup_connections(self):
         """This is to setup connections for non-gui objects"""
         self.ui.installEventFilter(self)
-        self.ui.action_open_config_file.triggered.connect(
+        self.ui.action_open_instrument_file.triggered.connect(
             self.on_action_open_config_file_triggered)
         self.ui.action_open_grain_fitting_results.triggered.connect(
             self.open_grain_fitting_results)
@@ -286,6 +288,8 @@ class MainWindow(QObject):
             self.active_canvas_changed)
         self.ui.action_edit_apply_threshold.triggered.connect(
             self.on_action_edit_apply_threshold_triggered)
+        self.ui.action_open_preconfigured_instrument_file.triggered.connect(
+            self.on_action_open_preconfigured_instrument_file_triggered)
 
         self.image_mode_widget.polar_show_snip1d.connect(
             self.ui.image_tab_widget.polar_show_snip1d)
@@ -1584,3 +1588,24 @@ class MainWindow(QObject):
             return
 
         self.load_state_file(path)
+
+    def on_action_open_preconfigured_instrument_file_triggered(self):
+        # Create a dict of options for loading an instrument, mapping file
+        # name to instrument config
+        options = {}
+        for f in resource_loader.module_contents(instrument_templates):
+            if f.endswith(('.yml', '.yaml', '.hexrd', '.h5', '.hdf5')):
+                name = Path(f).name
+                options[name] = f
+
+        # Provide simple dialog for selecting instrument to import
+        msg = 'Select pre-configured instrument to load'
+        instr_name, ok = QInputDialog.getItem(
+            self.ui, 'Load Instrument', msg, list(options), 0, False)
+
+        if not ok:
+            return
+
+        fname = options[instr_name]
+        with resource_loader.resource_path(instrument_templates, fname) as f:
+            HexrdConfig().load_instrument_config(Path(f))

--- a/hexrdgui/resources/ui/main_window.ui
+++ b/hexrdgui/resources/ui/main_window.ui
@@ -58,9 +58,16 @@
      <property name="toolTipsVisible">
       <bool>true</bool>
      </property>
+     <widget class="QMenu" name="menu_instrument">
+      <property name="title">
+       <string>Instrument</string>
+      </property>
+      <addaction name="action_open_instrument_file"/>
+      <addaction name="action_open_preconfigured_instrument_file"/>
+     </widget>
      <addaction name="action_open_images"/>
      <addaction name="action_open_state"/>
-     <addaction name="action_open_config_file"/>
+     <addaction name="menu_instrument"/>
      <addaction name="action_open_materials"/>
      <addaction name="separator"/>
      <addaction name="action_open_grain_fitting_results"/>
@@ -74,7 +81,7 @@
      </property>
      <widget class="QMenu" name="menu_save_config">
       <property name="title">
-       <string>&amp;Configuration</string>
+       <string>&amp;Instrument</string>
       </property>
       <property name="toolTipsVisible">
        <bool>true</bool>
@@ -629,11 +636,6 @@
     <string>Laue</string>
    </property>
   </action>
-  <action name="action_open_config_file">
-   <property name="text">
-    <string>Configuration</string>
-   </property>
-  </action>
   <action name="action_save_config_yaml">
    <property name="text">
     <string>YAML</string>
@@ -849,6 +851,16 @@
   <action name="action_edit_config">
    <property name="text">
     <string>Configuration</string>
+   </property>
+  </action>
+  <action name="action_open_instrument_file">
+   <property name="text">
+    <string>File</string>
+   </property>
+  </action>
+  <action name="action_open_preconfigured_instrument_file">
+   <property name="text">
+    <string>Preconfigured</string>
    </property>
   </action>
  </widget>

--- a/tests/test_hedm.py
+++ b/tests/test_hedm.py
@@ -13,7 +13,7 @@ def test_load_data(qtbot, main_window, default_config_path, default_data_path):
 
     # Load config file
     with select_files_when_asked(default_config_path):
-        main_window.ui.action_open_config_file.triggered.emit()
+        main_window.ui.action_open_instrument_file.triggered.emit()
 
     # Should have loaded the instrument config
     detectors = HexrdConfig().detectors


### PR DESCRIPTION
Also updates the naming from "Configuration" to "Instrument" in the "Open" and "Save" menus.

Relies on HEXRD/hexrd#602.

Fixes #1586 