### PR TITLE
Toggle mask boundaries

### DIFF
--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -284,7 +284,6 @@ class InstrumentViewer:
         self.warp_dict[detector_id] = res
         return res
 
-
     @property
     def display_img(self):
         return self.img

--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -29,6 +29,7 @@ class InstrumentViewer:
         self.type = ViewType.cartesian
         self.instr = create_hedm_instrument()
         self.images_dict = HexrdConfig().images_dict
+        self.img = None
 
         # Perform some checks before proceeding
         self.check_keys_match()
@@ -282,6 +283,11 @@ class InstrumentViewer:
                       preserve_range=True)
         self.warp_dict[detector_id] = res
         return res
+
+
+    @property
+    def display_img(self):
+        return self.img
 
     def generate_image(self):
         img = np.zeros((self.dpanel.rows, self.dpanel.cols))

--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -52,6 +52,10 @@ class InstrumentViewer:
         return self.pv.img
 
     @property
+    def display_img(self):
+        return self.pv.display_img
+
+    @property
     def snip_background(self):
         return self.pv.snip_background
 

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -384,6 +384,7 @@ class PolarView:
         # Both "visible" and "boundary" masks are applied to the
         # computational image
         comp_img = self.apply_boundary_masks(img)
+        comp_img = self.apply_tth_distortion(comp_img)
         self.computation_img = comp_img
 
     def apply_snip(self, img):
@@ -466,6 +467,7 @@ class PolarView:
         # Both "visible" and "boundary" masks are applied to the
         # computational image
         comp_img = self.apply_boundary_masks(img)
+        comp_img = self.apply_tth_distortion(comp_img)
         self.computation_img = comp_img
 
     @property

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -54,7 +54,8 @@ class PolarView:
 
         self.raw_img = None
         self.snipped_img = None
-        self.processed_img = None
+        self.computation_img = None
+        self.display_image = None
 
         self.snip_background = None
 
@@ -374,11 +375,16 @@ class PolarView:
 
         # Apply the masks before the polar_tth_distortion, because the
         # masks should also be distorted as well.
-        img = self.apply_masks(img)
 
-        img = self.apply_tth_distortion(img)
+        # We only apply "visible" masks to the display image
+        img = self.apply_visible_masks(img)
+        disp_img = self.apply_tth_distortion(img)
+        self.display_image = disp_img
 
-        self.processed_img = img
+        # Both "visible" and "boundary" masks are applied to the
+        # computational image
+        comp_img = self.apply_boundary_masks(img)
+        self.computation_img = comp_img
 
     def apply_snip(self, img):
         # do SNIP if requested
@@ -410,7 +416,7 @@ class PolarView:
 
         return img
 
-    def apply_masks(self, img):
+    def apply_visible_masks(self, img):
         # Apply user-specified masks if they are present
         from hexrdgui.masking.mask_manager import MaskManager
         img = img.copy()
@@ -430,6 +436,20 @@ class PolarView:
 
         return img
 
+    def apply_boundary_masks(self, img):
+        # Apply user-specified masks if they are present
+        from hexrdgui.masking.mask_manager import MaskManager
+        img = img.copy()
+        total_mask = self.raw_mask
+        for mask in MaskManager().masks.values():
+            if mask.type == MaskType.threshold or not mask.show_border:
+                continue
+            mask_arr = mask.get_masked_arrays(ViewType.polar)
+            total_mask = np.logical_or(total_mask, ~mask_arr)
+        img[total_mask] = np.nan
+
+        return img
+
     def reapply_masks(self):
         # This will only re-run the final steps of the processing...
         if self.snipped_img is None:
@@ -437,15 +457,24 @@ class PolarView:
 
         # Apply the masks before the polar_tth_distortion, because the
         # masks should also be distorted as well.
-        img = self.apply_masks(self.snipped_img)
 
-        img = self.apply_tth_distortion(img)
+        # We only apply "visible" masks to the display image
+        img = self.apply_visible_masks(self.snipped_img)
+        disp_img = self.apply_tth_distortion(img)
+        self.display_image = disp_img
 
-        self.processed_img = img
+        # Both "visible" and "boundary" masks are applied to the
+        # computational image
+        comp_img = self.apply_boundary_masks(img)
+        self.computation_img = comp_img
 
     @property
     def img(self):
-        return self.processed_img
+        return self.computation_img
+
+    @property
+    def display_img(self):
+        return self.display_image
 
     def warp_all_images(self):
         self.reset_cached_distortion_fields()

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -139,7 +139,7 @@ class InstrumentViewer:
             # Don't redraw the polar view unless we have to
             self.draw_polar()
 
-        polar_img = self.pv.img
+        polar_img = self.pv.display_img
 
         extent = np.degrees(self.pv.extent)
         tth_range = extent[:2]

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -135,7 +135,7 @@ class InstrumentViewer:
             # Don't redraw the polar view unless we have to
             self.draw_polar()
 
-        polar_img = self.pv.img
+        polar_img = self.pv.display_img
 
         extent = np.degrees(self.pv.extent)
         tth_range = extent[:2]

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -139,7 +139,7 @@ class InstrumentViewer:
             # Don't redraw the polar view unless we have to
             self.draw_polar()
 
-        polar_img = self.pv.display_img
+        polar_img = self.pv.img
 
         extent = np.degrees(self.pv.extent)
         tth_range = extent[:2]

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -56,6 +56,10 @@ class InstrumentViewer:
     def project_from_polar(self):
         return HexrdConfig().stereo_project_from_polar
 
+    @property
+    def display_img(self):
+        return self.img
+
     def detector_borders(self, det):
         panel = self.instr_pv.detectors[det]
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -223,7 +223,8 @@ class ImageCanvas(FigureCanvas):
     def create_image_dict(self, display=False):
         # Returns a dict of the unscaled computation images
         if self.mode == ViewType.raw:
-            return HexrdConfig().create_masked_images_dict(fill_value=np.nan)
+            return HexrdConfig().create_masked_images_dict(fill_value=np.nan,
+                                                           display=display)
         else:
             # Masks are already applied...
             img = self.iviewer.display_img if display else self.iviewer.img

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1109,6 +1109,8 @@ class ImageCanvas(FigureCanvas):
             self.axis.autoscale_view()
             self.figure.tight_layout()
 
+        self.update_mask_boundaries(self.axis)
+
         self.draw_stereo_border()
         self.update_auto_picked_data()
         self.draw_detector_borders()
@@ -1541,7 +1543,7 @@ class ImageCanvas(FigureCanvas):
             print('No instrument viewer! Cannot generate snip1d!')
             return
 
-        if self.iviewer.display_img is None:
+        if self.iviewer.img is None:
             print('No image! Cannot generate snip1d!')
             return
 
@@ -1572,6 +1574,15 @@ class ImageCanvas(FigureCanvas):
                 verts = [v for k, v in mask.data if k == det]
             elif self.mode == ViewType.polar or self.mode == ViewType.stereo:
                 verts = create_polar_line_data_from_raw(mask.data)
+                if self.mode == ViewType.stereo:
+                    # Now convert from polar to stereo
+                    for i, vert in enumerate(verts):
+                        verts[i] = angles_to_stereo(
+                            np.radians(vert),
+                            self.iviewer.instr_pv,
+                            HexrdConfig().stereo_size,
+                        )
+
             for vert in verts:
                 kwargs = {
                     'fill': False,

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -221,7 +221,7 @@ class ImageCanvas(FigureCanvas):
             return HexrdConfig().create_masked_images_dict(fill_value=np.nan)
         else:
             # Masks are already applied...
-            return {'img': self.iviewer.img}
+            return {'img': self.iviewer.display_img}
 
     @property
     def unscaled_images(self):
@@ -229,7 +229,7 @@ class ImageCanvas(FigureCanvas):
         if self.mode == ViewType.raw:
             return list(self.unscaled_image_dict.values())
         else:
-            return [self.iviewer.img]
+            return [self.iviewer.display_img]
 
     @property
     def scaled_image_dict(self):
@@ -1516,7 +1516,7 @@ class ImageCanvas(FigureCanvas):
             print('No instrument viewer! Cannot generate snip1d!')
             return
 
-        if self.iviewer.img is None:
+        if self.iviewer.display_img is None:
             print('No image! Cannot generate snip1d!')
             return
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1548,7 +1548,12 @@ class ImageCanvas(FigureCanvas):
             elif self.mode == ViewType.polar or self.mode == ViewType.stereo:
                 verts = create_polar_line_data_from_raw(mask.data)
             for vert in verts:
-                kwargs = {'fill': False, 'lw': 1, 'linestyle': '--'}
+                kwargs = {
+                    'fill': False,
+                    'lw': 1,
+                    'linestyle': '--',
+                    'color': MaskManager().boundary_color
+                }
                 axis.add_patch(Polygon(vert, **kwargs))
 
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -214,59 +214,57 @@ class ImageCanvas(FigureCanvas):
         msg = 'Image view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
 
-    @property
-    def unscaled_image_dict(self):
+    def create_image_dict(self, display=False):
         # Returns a dict of the unscaled computation images
         if self.mode == ViewType.raw:
             return HexrdConfig().create_masked_images_dict(fill_value=np.nan)
         else:
             # Masks are already applied...
-            return {'img': self.iviewer.img}
+            img = self.iviewer.display_img if display else self.iviewer.img
+            return {'img': img}
+
+    @property
+    def unscaled_image_dict(self):
+        return self.create_image_dict(display=False)
 
     @property
     def unscaled_display_image_dict(self):
-        # Returns a dict of the unscaled display images
-        if self.mode == ViewType.raw:
-            return HexrdConfig().create_masked_images_dict(fill_value=np.nan)
-        else:
-            # Masks are already applied...
-            return {'img': self.iviewer.display_img}
+        return self.create_image_dict(display=True)
 
     @property
     def unscaled_images(self):
         # Returns a list of the unscaled computation images
-        if self.mode == ViewType.raw:
-            return list(self.unscaled_image_dict.values())
-        else:
-            return [self.iviewer.img]
+        return list(self.unscaled_image_dict.values())
 
     @property
     def unscaled_display_images(self):
         # Returns a list of the unscaled display images
-        if self.mode == ViewType.raw:
-            return list(self.unscaled_display_image_dict.values())
+        return list(self.unscaled_display_image_dict.values())
+
+    def create_scaled_image_dict(self, display=False):
+        if display:
+            unscaled = self.unscaled_display_image_dict
         else:
-            return [self.iviewer.display_img]
+            unscaled = self.unscaled_image_dict
+        return {k: self.transform(v) for k, v in unscaled.items()}
 
     @property
     def scaled_image_dict(self):
         # Returns a dict of the scaled computation images
-        unscaled = self.unscaled_image_dict
-        return {k: self.transform(v) for k, v in unscaled.items()}
+        return self.create_scaled_image_dict(display=False)
 
     @property
     def scaled_display_image_dict(self):
         # Returns a dict of the scaled display images
-        unscaled = self.unscaled_display_image_dict
-        return {k: self.transform(v) for k, v in unscaled.items()}
+        return self.create_scaled_image_dict(display=True)
 
     @property
     def scaled_images(self):
-        return [self.transform(x) for x in self.unscaled_images]
+        return list(self.scaled_image_dict.values())
 
     @property
     def scaled_display_images(self):
-        return [self.transform(x) for x in self.unscaled_display_image_dict]
+        return list(self.scaled_display_image_dict.values())
 
     @property
     def blit_artists(self):

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -735,7 +735,7 @@ class ImageCanvas(FigureCanvas):
             return
 
         # Use the unscaled image data to determine saturation
-        images_dict = self.unscaled_display_image_dict
+        images_dict = self.unscaled_image_dict
 
         def compute_saturation_and_size(detector_name):
             detector = HexrdConfig().detector(detector_name)

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -316,7 +316,7 @@ class ImageTabWidget(QTabWidget):
     def scaled_image_data(self):
         # Even for tabbed mode for a raw view, this function should
         # return the whole image data dict.
-        return self.image_canvases[0].scaled_image_dict
+        return self.image_canvases[0].scaled_display_image_dict
 
     def on_motion_notify_event(self, event):
         # Clear the info if the mouse leaves a plot

--- a/hexrdgui/masking/constants.py
+++ b/hexrdgui/masking/constants.py
@@ -7,3 +7,10 @@ class MaskType:
     pinhole = 'pinhole'
 
 CURRENT_MASK_VERSION = 2
+
+
+class MaskStatus:
+    none = 0
+    visible = 1
+    boundary = 2
+    all = 3

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -139,10 +139,15 @@ def _interpolate_split_coords_1d(coords1, coords2):
     return coords1, coords2
 
 
-def create_polar_mask_from_raw(value):
+def create_polar_line_data_from_raw(value):
     line_data = []
     for det, data in value:
         line_data.extend(convert_raw_to_polar(det, data))
+    return line_data
+
+
+def create_polar_mask_from_raw(value):
+    line_data = create_polar_line_data_from_raw(value)
     return create_polar_mask(line_data)
 
 

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -30,7 +30,6 @@ class Mask(ABC):
         self.show_border = show_border
         self.masked_arrays = None
         self.masked_arrays_view_mode = ViewType.raw
-        self.boundary_lines = None
 
     def get_masked_arrays(self):
         if self.masked_arrays is None:
@@ -204,6 +203,7 @@ class MaskManager(QObject, metaclass=QSingleton):
         super().__init__(None)
         self.masks = {}
         self.view_mode = ViewType.raw
+        self.boundary_color = '#000'  # Default to black
 
         self.setup_connections()
 

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -272,11 +272,14 @@ class MaskManager(QObject, metaclass=QSingleton):
         unwrap_dict_to_h5(h5py_group, data, asattr=False)
 
     def write_single_mask(self, name):
-        d = {name: self.masks[name].serialize()}
+        d = {
+            name: self.masks[name].serialize(),
+            'boundary_color': self.boundary_color
+        }
         self.export_masks_to_file.emit(d)
 
     def write_all_masks(self, h5py_group=None):
-        d = {}
+        d = {'boundary_color': self.boundary_color}
         for name, mask_info in self.masks.items():
             d[name] = mask_info.serialize()
         if h5py_group:
@@ -295,7 +298,10 @@ class MaskManager(QObject, metaclass=QSingleton):
         actual_view_mode = self.view_mode
         self.view_mode = ViewType.raw
         for key, data in items.items():
-            if data['mtype'] == MaskType.threshold:
+            if key == 'boundary_color':
+                self.boundary_color = data
+                continue
+            elif data['mtype'] == MaskType.threshold:
                 new_mask = ThresholdMask.deserialize(data)
             else:
                 new_mask = RegionMask.deserialize(data)

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -6,9 +6,9 @@ import h5py
 from PySide6.QtCore import QObject, Qt
 from PySide6.QtWidgets import (
     QComboBox, QDialog, QDialogButtonBox, QFileDialog, QMenu,
-    QMessageBox, QPushButton, QTableWidgetItem, QVBoxLayout
+    QMessageBox, QPushButton, QTableWidgetItem, QVBoxLayout, QColorDialog
 )
-from PySide6.QtGui import QCursor
+from PySide6.QtGui import QCursor, QColor
 
 
 from hexrdgui.utils import block_signals
@@ -56,6 +56,7 @@ class MaskManagerDialog(QObject):
         self.ui.show_all_boundaries.clicked.connect(self.show_all_boundaries)
         MaskManager().mask_mgr_dialog_update.connect(self.update_table)
         MaskManager().export_masks_to_file.connect(self.export_masks_to_file)
+        self.ui.border_color.clicked.connect(self.set_boundary_color)
 
     def update_table(self):
         with block_signals(self.ui.masks_table):
@@ -244,3 +245,9 @@ class MaskManagerDialog(QObject):
             MaskManager().update_border_visibility(name, True)
         self.update_presentation_selector()
         MaskManager().masks_changed()
+
+    def set_boundary_color(self):
+        dialog = QColorDialog(QColor(MaskManager().boundary_color), self.ui)
+        if dialog.exec():
+            MaskManager().boundary_color = dialog.selectedColor().name()
+            MaskManager().masks_changed()

--- a/hexrdgui/masking/mask_regions_dialog.py
+++ b/hexrdgui/masking/mask_regions_dialog.py
@@ -114,7 +114,7 @@ class MaskRegionsDialog(QObject):
         det = self.added_templates.pop()
         it = self.interactive_templates[det].pop()
         it.disconnect()
-        it.template.remove()
+        it.clear()
 
     def undo_selection(self):
         if not self.added_templates:

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -7,80 +7,28 @@
     <x>0</x>
     <y>0</y>
     <width>681</width>
-    <height>266</height>
+    <height>297</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Mask Management</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="1">
-    <widget class="QPushButton" name="import_masks">
-     <property name="text">
-      <string>Import Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
+   <item row="1" column="1" colspan="2">
     <widget class="QPushButton" name="export_masks">
      <property name="text">
       <string>Export Masks</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="panel_buffer">
-     <property name="text">
-      <string>Masks to Panel Buffer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QPushButton" name="view_masks">
-     <property name="text">
-      <string>View Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
+   <item row="4" column="1" colspan="2">
     <widget class="QPushButton" name="hide_all_masks">
      <property name="text">
       <string>Hide All Masks</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="show_all_masks">
-     <property name="text">
-      <string>Show All Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QPushButton" name="hide_all_boundaries">
-     <property name="text">
-      <string>Hide All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="QPushButton" name="show_all_boundaries">
-     <property name="text">
-      <string>Show All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::NoButton</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" rowspan="9">
+   <item row="0" column="0" rowspan="11">
     <widget class="QTableWidget" name="masks_table">
      <property name="minimumSize">
       <size>
@@ -133,6 +81,65 @@
        <string>Remove</string>
       </property>
      </column>
+    </widget>
+   </item>
+   <item row="7" column="1" colspan="2">
+    <widget class="QPushButton" name="show_all_boundaries">
+     <property name="text">
+      <string>Show All Boundaries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1" colspan="2">
+    <widget class="QPushButton" name="panel_buffer">
+     <property name="text">
+      <string>Masks to Panel Buffer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QPushButton" name="import_masks">
+     <property name="text">
+      <string>Import Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QPushButton" name="show_all_masks">
+     <property name="text">
+      <string>Show All Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1" colspan="2">
+    <widget class="QPushButton" name="view_masks">
+     <property name="text">
+      <string>View Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1" rowspan="2" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::NoButton</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QPushButton" name="hide_all_boundaries">
+     <property name="text">
+      <string>Hide All Boundaries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1" colspan="2">
+    <widget class="QPushButton" name="border_color">
+     <property name="text">
+      <string>Border Color</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -103,11 +103,14 @@
      <property name="sortingEnabled">
       <bool>false</bool>
      </property>
+     <attribute name="horizontalHeaderCascadingSectionResizes">
+      <bool>false</bool>
+     </attribute>
      <attribute name="horizontalHeaderMinimumSectionSize">
       <number>52</number>
      </attribute>
      <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>120</number>
+      <number>150</number>
      </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
@@ -119,15 +122,7 @@
      </column>
      <column>
       <property name="text">
-       <string>Apply Mask</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Show Boundary</string>
+       <string>Presentation</string>
       </property>
       <property name="textAlignment">
        <set>AlignCenter</set>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -6,35 +6,14 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>695</width>
-    <height>229</height>
+    <width>681</width>
+    <height>266</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Mask Management</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="1">
-    <widget class="QPushButton" name="view_masks">
-     <property name="text">
-      <string>View Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="panel_buffer">
-     <property name="text">
-      <string>Masks to Panel Buffer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="show_all_masks">
-     <property name="text">
-      <string>Show All Masks</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1">
     <widget class="QPushButton" name="import_masks">
      <property name="text">
@@ -49,6 +28,20 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="panel_buffer">
+     <property name="text">
+      <string>Masks to Panel Buffer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="view_masks">
+     <property name="text">
+      <string>View Masks</string>
+     </property>
+    </widget>
+   </item>
    <item row="4" column="1">
     <widget class="QPushButton" name="hide_all_masks">
      <property name="text">
@@ -56,7 +49,28 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="1">
+    <widget class="QPushButton" name="show_all_masks">
+     <property name="text">
+      <string>Show All Masks</string>
+     </property>
+    </widget>
+   </item>
    <item row="6" column="1">
+    <widget class="QPushButton" name="hide_all_boundaries">
+     <property name="text">
+      <string>Hide All Boundaries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="QPushButton" name="show_all_boundaries">
+     <property name="text">
+      <string>Show All Boundaries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::NoButton</set>
@@ -66,7 +80,7 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" rowspan="7">
+   <item row="0" column="0" rowspan="9">
     <widget class="QTableWidget" name="masks_table">
      <property name="minimumSize">
       <size>
@@ -89,6 +103,12 @@
      <property name="sortingEnabled">
       <bool>false</bool>
      </property>
+     <attribute name="horizontalHeaderMinimumSectionSize">
+      <number>52</number>
+     </attribute>
+     <attribute name="horizontalHeaderDefaultSectionSize">
+      <number>120</number>
+     </attribute>
      <attribute name="horizontalHeaderStretchLastSection">
       <bool>true</bool>
      </attribute>
@@ -99,7 +119,15 @@
      </column>
      <column>
       <property name="text">
-       <string>Visible</string>
+       <string>Apply Mask</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Show Boundary</string>
       </property>
       <property name="textAlignment">
        <set>AlignCenter</set>


### PR DESCRIPTION
This branch allows users to view a boundary of a masked region (polygon/rectangle/ellipse) instead of/in addition to masking the actual data.

Based on [previous discussion](https://github.com/HEXRD/hexrdgui/pull/1588#issuecomment-1766887043) and the open issue, the last remaining tasks for this branch are:

- [x] Add support for setting boundary styling
~- [ ] Do not use intensities in Azimuthal lineout if boundary is visible (even if image values are not being masked)([comment](https://github.com/HEXRD/hexrdgui/issues/1373#issuecomment-1486045904))~

Fixes #1373