### PR TITLE
Add option to stitch ROI images in raw view

### DIFF
--- a/hexrdgui/calibration/raw_iviewer.py
+++ b/hexrdgui/calibration/raw_iviewer.py
@@ -1,3 +1,7 @@
+from itertools import chain
+
+import numpy as np
+
 from hexrdgui.constants import ViewType
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
@@ -13,6 +17,9 @@ class InstrumentViewer:
     def __init__(self):
         self.type = ViewType.raw
         self.instr = create_hedm_instrument()
+        self.roi_info = {}
+
+        self.setup_roi_info()
 
     def update_overlay_data(self):
         update_overlay_data(self.instr, self.type)
@@ -26,3 +33,155 @@ class InstrumentViewer:
         self.instr.detectors[det].tilt = t_conf['tilt']
 
         # Since these are just individual images, no further updates are needed
+
+    @property
+    def has_roi(self):
+        # Assume it has ROI support if a single detector supports it
+        panel = next(iter(self.instr.detectors.values()))
+        return all(x is not None for x in (panel.roi, panel.group))
+
+    @property
+    def roi_groups(self):
+        return self.roi_info.get('groups', {})
+
+    @property
+    def roi_stitched_shapes(self):
+        return self.roi_info.get('stitched_shapes', {})
+
+    def setup_roi_info(self):
+        if not self.has_roi:
+            # Required info is missing
+            return
+
+        groups = {}
+        for det_key, panel in self.instr.detectors.items():
+            groups.setdefault(panel.group, []).append(det_key)
+
+        self.roi_info['groups'] = groups
+
+        # Find the ROI bounds for each group
+        stitched_shapes = {}
+        for group, det_keys in groups.items():
+            row_size = 0
+            col_size = 0
+            for det_key in det_keys:
+                panel = self.instr.detectors[det_key]
+                row_size = max(row_size, panel.roi[0][1])
+                col_size = max(col_size, panel.roi[1][1])
+
+            stitched_shapes[group] = (row_size, col_size)
+
+        self.roi_info['stitched_shapes'] = stitched_shapes
+
+    def raw_to_stitched(self, ij, det_key):
+        ij = np.array(ij)
+
+        panel = self.instr.detectors[det_key]
+
+        if ij.size != 0:
+            ij[:, 0] += panel.roi[0][0]
+            ij[:, 1] += panel.roi[1][0]
+
+        return ij, panel.group
+
+    def stitched_to_raw(self, ij, stitched_key):
+        ij = np.atleast_2d(ij)
+
+        ret = {}
+        for det_key in self.roi_groups[stitched_key]:
+            panel = self.instr.detectors[det_key]
+            on_panel_rows = (
+                in_range(ij[:, 0], panel.roi[0]) &
+                in_range(ij[:, 1], panel.roi[1])
+            )
+            if np.any(on_panel_rows):
+                new_ij = ij[on_panel_rows]
+                new_ij[:, 0] -= panel.roi[0][0]
+                new_ij[:, 1] -= panel.roi[1][0]
+                ret[det_key] = new_ij
+
+        return ret
+
+    def raw_images_to_stitched(self, group_names, images_dict):
+        shapes = self.roi_stitched_shapes
+        stitched = {}
+        for group in group_names:
+            for det_key in self.roi_groups[group]:
+                panel = self.instr.detectors[det_key]
+                if group not in stitched:
+                    stitched[group] = np.empty(shapes[group])
+                image = stitched[group]
+                roi = panel.roi
+                image[slice(*roi[0]), slice(*roi[1])] = images_dict[det_key]
+
+        return stitched
+
+    def create_overlay_data(self, overlay):
+        if HexrdConfig().stitch_raw_roi_images:
+            return self.create_roi_overlay_data(overlay)
+
+        return overlay.data
+
+    def create_roi_overlay_data(self, overlay):
+        ret = {}
+        for det_key, data in overlay.data.items():
+            panel = self.instr.detectors[det_key]
+
+            def raw_to_stitched(x):
+                # x is in "ji" coordinates
+                x[:, 0] += panel.roi[1][0]
+                x[:, 1] += panel.roi[0][0]
+
+            group = panel.group
+            ret.setdefault(group, {})
+            for data_key, entry in data.items():
+                if data_key == overlay.ranges_indices_key:
+                    # Need to adjust indices since we stack ranges
+                    if data_key not in ret[group]:
+                        ret[group][data_key] = entry
+                        continue
+
+                    # We need to adjust these rbnd_indices. Find the max.
+                    prev_max = max(chain(*ret[group][data_key]))
+                    for i, x in enumerate(entry):
+                        entry[i] = [j + prev_max + 1 for j in x]
+                    ret[group][data_key] += entry
+                    continue
+
+                if data_key not in overlay.plot_data_keys:
+                    # This is not for plotting. No conversions needed.
+                    ret[group][data_key] = entry
+                    continue
+
+                if len(entry) == 0:
+                    continue
+
+                # Points are 2D in shape, and lines are 3D in shape.
+                # Perorm the conversion regardless of the dimensions.
+                if isinstance(entry, list) or entry.ndim == 3:
+                    for x in entry:
+                        # This will convert in-place since `x` is a view
+                        raw_to_stitched(x)
+                else:
+                    raw_to_stitched(entry)
+
+                if data_key in ret[group]:
+                    # Stack it with previous entries
+                    if isinstance(ret[group][data_key], list):
+                        entry = ret[group][data_key] + entry
+                    else:
+                        entry = np.vstack((ret[group][data_key], entry))
+
+                ret[group][data_key] = entry
+
+        # If data was missing for a whole group, set it to an empty list.
+        for group in ret:
+            for data_key in overlay.plot_data_keys:
+                if data_key not in ret[group]:
+                    ret[group][data_key] = []
+
+        return ret
+
+
+def in_range(x, range):
+    return (range[0] <= x) & (x < range[1])

--- a/hexrdgui/image_load_manager.py
+++ b/hexrdgui/image_load_manager.py
@@ -47,7 +47,7 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
     @property
     def naming_options(self):
         dets = HexrdConfig().detector_names
-        if HexrdConfig().is_roi_instrument_config:
+        if HexrdConfig().instrument_has_roi:
             groups = [HexrdConfig().detector_group(d) for d in dets]
             dets.extend([g for g in groups if g is not None])
         return dets

--- a/hexrdgui/image_series_toolbar.py
+++ b/hexrdgui/image_series_toolbar.py
@@ -56,17 +56,16 @@ class ImageSeriesInfoToolbar(QWidget):
 
 class ImageSeriesToolbar(QWidget):
 
-    def __init__(self, name, parent=None):
+    def __init__(self, ims, parent=None):
         super().__init__(parent)
 
-        self.ims = HexrdConfig().imageseries(name)
+        self.ims = ims
         self.slider = None
         self.frame = None
         self.layout = None
         self.widget = None
 
         self.show = False
-        self.name = name
 
         self.create_widget()
         self.set_range()
@@ -132,15 +131,13 @@ class ImageSeriesToolbar(QWidget):
         self.update_omega_label_text()
 
     def update_range(self, current_tab):
-        self.ims = HexrdConfig().imageseries(self.name)
         self.set_range(current_tab)
 
         if self.slider.value() != HexrdConfig().current_imageseries_idx:
             self.val_changed(self.slider.value())
 
-    def update_name(self, name):
-        if not name == self.name:
-            self.name = name
+    def update_ims(self, ims):
+        self.ims = ims
 
     def set_visible(self, b=False):
         self.widget.setVisible(b and len(self.ims)>1)

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -369,9 +369,17 @@ class ImageTabWidget(QTabWidget):
             # Image was created with imshow()
             artist = event.inaxes.get_images()[0]
 
-            i, j = utils.coords2index(artist, *raw_xy_data)
+            # Compute i and j
+            i, j = utils.coords2index(artist, info['x_data'], info['y_data'])
+            if stitched:
+                # For the intensity, use raw xy data for i and j
+                raw_i, raw_j = utils.coords2index(artist, *raw_xy_data)
+            else:
+                # They should be the same
+                raw_i, raw_j = i, j
+
             try:
-                intensity = artist.get_array().data[i, j]
+                intensity = artist.get_array().data[raw_i, raw_j]
             except IndexError:
                 # Most likely, this means we are slightly out of bounds,
                 # and the index is too big. Just clear the status bar in

--- a/hexrdgui/load_images_dialog.py
+++ b/hexrdgui/load_images_dialog.py
@@ -18,7 +18,7 @@ class LoadImagesDialog:
         loader = UiLoader()
         self.ui = loader.load_file('load_images_dialog.ui', parent)
         self.manual_assign = manual_assign
-        self.using_roi = HexrdConfig().is_roi_instrument_config
+        self.using_roi = HexrdConfig().instrument_has_roi
         self.orignal_file_names = [f for i in image_files for f in i]
 
         self.setup_connections()

--- a/hexrdgui/masking/hand_drawn_mask_dialog.py
+++ b/hexrdgui/masking/hand_drawn_mask_dialog.py
@@ -7,6 +7,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from matplotlib.widgets import Cursor
 
+from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import add_sample_points
 from hexrdgui.utils.dialog import add_help_url
@@ -222,6 +223,12 @@ class LineBuilder(QObject):
         """
         Picker callback
         """
+        if HexrdConfig().stitch_raw_roi_images:
+            print('Polygon masks do not yet support drawing on a stitched '
+                  'raw view. Please switch to an unstitched view to draw the '
+                  'masks.')
+            return
+
         print('%s click: button=%d, x=%d, y=%d, xdata=%f, ydata=%f' %
               ('double' if event.dblclick else 'single', event.button,
                event.x, event.y, event.xdata, event.ydata))

--- a/hexrdgui/masking/mask_regions_dialog.py
+++ b/hexrdgui/masking/mask_regions_dialog.py
@@ -206,6 +206,12 @@ class MaskRegionsDialog(QObject):
             print('Masking must be done in raw or polar view')
             return
 
+        if HexrdConfig().stitch_raw_roi_images:
+            print('Ellipse/rectangle masks do not yet support drawing on a '
+                  'stitched raw view. Please switch to an unstitched view to '
+                  'draw the masks.')
+            return
+
         if not self.axes:
             return
 

--- a/hexrdgui/overlays/const_chi_overlay.py
+++ b/hexrdgui/overlays/const_chi_overlay.py
@@ -15,7 +15,8 @@ from hexrdgui.utils.conversions import (
 class ConstChiOverlay(Overlay):
 
     type = OverlayType.const_chi
-    hkl_data_key = 'data'
+    data_key = 'data'
+    ranges_key = None
 
     def __init__(self, material_name, chi_values=None, tvec=None,
                  chi_values_serialized=None, **overlay_kwargs):
@@ -106,7 +107,10 @@ class ConstChiOverlay(Overlay):
     def generate_overlay(self):
         instr = self.instrument
 
-        data = {}
+        data = {
+            det_key: {'data': [], 'chi': []}
+            for det_key in instr.detectors
+        }
         for chi_value in self.chi_values:
             if not chi_value.visible:
                 continue
@@ -115,18 +119,15 @@ class ConstChiOverlay(Overlay):
             result = generate_ring_points_chi(chi, self.sample_tilt, instr)
 
             for det_key, xys in result.items():
-                data.setdefault(det_key, [])
                 if len(xys) == 0:
                     continue
 
                 # Convert to the display mode
                 pts = self.cart_to_display_mode(xys, instr, det_key)
 
-                data[det_key].append({
-                    'chi': chi,
-                    # Add a nans row so they can be combined easier for drawing
-                    'data': np.vstack([pts, nans_row]),
-                })
+                data[det_key]['chi'].append(chi)
+                # Add a nans row so they can be combined easier for drawing
+                data[det_key]['data'].append(np.vstack([pts, nans_row]))
 
         return data
 

--- a/hexrdgui/overlays/laue_overlay.py
+++ b/hexrdgui/overlays/laue_overlay.py
@@ -22,7 +22,8 @@ from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 class LaueOverlay(Overlay):
 
     type = OverlayType.laue
-    hkl_data_key = 'spots'
+    data_key = 'spots'
+    ranges_key = 'ranges'
 
     def __init__(self, material_name, crystal_params=None, sample_rmat=None,
                  min_energy=5, max_energy=35, tth_width=None, eta_width=None,

--- a/hexrdgui/overlays/overlay.py
+++ b/hexrdgui/overlays/overlay.py
@@ -26,11 +26,6 @@ class Overlay(ABC):
 
     @property
     @abstractmethod
-    def hkl_data_key(self):
-        pass
-
-    @property
-    @abstractmethod
     def has_widths(self):
         pass
 
@@ -73,7 +68,21 @@ class Overlay(ABC):
     def calibration_picks_polar(self, picks):
         pass
 
+    @property
+    @abstractmethod
+    def data_key(self):
+        pass
+
+    @property
+    @abstractmethod
+    def ranges_key(self):
+        pass
+
     # Concrete methods
+    data_key = None
+    ranges_key = None
+    ranges_indices_key = None
+
     def __init__(self, material_name, name=None, refinements=None,
                  calibration_picks=None, style=None, highlight_style=None,
                  visible=True):
@@ -113,6 +122,17 @@ class Overlay(ABC):
         from hexrdgui.image_load_manager import ImageLoadManager
 
         ImageLoadManager().new_images_loaded.connect(self.on_new_images_loaded)
+
+    @property
+    def plot_data_keys(self):
+        # These are the data keys that are intended to be plotted.
+        # This will be used to perform any needed transforms (such as
+        # converting to/from stitched coordinates for ROI instruments).
+        keys = (
+            self.data_key,
+            self.ranges_key,
+        )
+        return tuple(x for x in keys if x is not None)
 
     def to_dict(self):
         d = {k: getattr(self, k) for k in self.attributes_to_save}
@@ -308,7 +328,7 @@ class Overlay(ABC):
         self._highlights.clear()
 
     def path_to_hkl_data(self, detector_key, hkl):
-        data_key = self.hkl_data_key
+        data_key = self.data_key
         detector_data = self.data[detector_key]
         ind = array_index_in_list(hkl, detector_data['hkls'])
         if ind == -1:

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -18,7 +18,9 @@ from hexrdgui.utils.conversions import (
 class PowderOverlay(Overlay, PolarDistortionObject):
 
     type = OverlayType.powder
-    hkl_data_key = 'rings'
+    data_key = 'rings'
+    ranges_key = 'rbnds'
+    ranges_indices_key = 'rbnd_indices'
 
     def __init__(self, material_name, tvec=None, eta_steps=360,
                  tth_distortion_type=None, tth_distortion_kwargs=None,

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -15,7 +15,8 @@ from hexrdgui.utils.conversions import angles_to_stereo
 class RotationSeriesOverlay(Overlay):
 
     type = OverlayType.rotation_series
-    hkl_data_key = 'data'
+    data_key = 'data'
+    ranges_key = 'ranges'
 
     def __init__(self, material_name, crystal_params=None, eta_ranges=None,
                  ome_ranges=None, ome_period=None, aggregated=True,

--- a/hexrdgui/resources/ui/image_mode_widget.ui
+++ b/hexrdgui/resources/ui/image_mode_widget.ui
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>0</number>
      </property>
      <property name="iconSize">
       <size>
@@ -73,6 +73,16 @@
           <widget class="QCheckBox" name="raw_show_saturation">
            <property name="text">
             <string>Show Saturation</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QCheckBox" name="raw_stitch_roi_images">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If checked, ROI images will be stitched together according to their &amp;quot;group&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Stitch ROI Images</string>
            </property>
           </widget>
          </item>

--- a/hexrdgui/simple_image_series_dialog.py
+++ b/hexrdgui/simple_image_series_dialog.py
@@ -346,7 +346,7 @@ class SimpleImageSeriesDialog(QObject):
         # We will not have an ROI most of the time. Perform
         # a quick check for an ROI, and if we have one, proceed
         # to add the rectangle info.
-        has_roi = HexrdConfig().is_roi_instrument_config
+        has_roi = HexrdConfig().instrument_has_roi
 
         if not has_roi:
             # No need to proceed further
@@ -384,7 +384,7 @@ class SimpleImageSeriesDialog(QObject):
 
     def find_images(self, fnames):
         self.files, manual = ImageLoadManager().load_images(fnames)
-        using_roi = HexrdConfig().is_roi_instrument_config
+        using_roi = HexrdConfig().instrument_has_roi
 
         if (not using_roi and
                 len(self.files) % len(HexrdConfig().detector_names) != 0):

--- a/hexrdgui/zoom_canvas.py
+++ b/hexrdgui/zoom_canvas.py
@@ -587,7 +587,7 @@ class ZoomCanvas(FigureCanvas):
             return self.main_canvas.scaled_images[0]
         elif self.canvas_is_raw:
             name = self.main_axis.get_title()
-            return self.main_canvas.scaled_image_dict[name]
+            return self.main_canvas.raw_view_images_dict[name]
 
     @property
     def disabled(self):


### PR DESCRIPTION
If the instrument config contains both the `roi` and `group` key in each detector, an additional checkbox now appears in the raw view settings that allows users to stitch the ROI images together.

Each subpanel is still treated separately. Overlays are also generated separately for each subpanel. However, the final images are stitched together into one large panel.

Fixes: #1627