### PR TITLE
Add option to lock ROI group detector transforms

### DIFF
--- a/hexrdgui/blit_manager.py
+++ b/hexrdgui/blit_manager.py
@@ -43,6 +43,10 @@ class BlitManager:
                 )
                 raise RuntimeError(msg)
 
+        if not cv.figure.axes:
+            # Ignore the request, as there are currently no axes
+            return
+
         self.bg = cv.copy_from_bbox(cv.figure.bbox)
         self.draw_all_artists()
 

--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -316,10 +316,10 @@ class InstrumentViewer:
                 self.dpanel_sizes[1] < new_panel_size[1]):
             # The panel size has increased. Let's re-create the display panel
             # We will only increase the panel size in this function.
-            # Also bump up the sizes by 5% as well for better interaction.
+            # Also bump up the sizes by 15% as well for better interaction.
             self.dpanel_sizes = (
-                int(max(self.dpanel_sizes[0], new_panel_size[0]) * 1.05),
-                int(max(self.dpanel_sizes[1], new_panel_size[1]) * 1.05),
+                int(max(self.dpanel_sizes[0], new_panel_size[0]) * 1.15),
+                int(max(self.dpanel_sizes[1], new_panel_size[1]) * 1.15),
             )
             self.make_dpanel()
             # Re-create all images

--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -296,7 +296,7 @@ class InstrumentViewer:
         if HexrdConfig().any_intensity_corrections:
             self.images_dict = HexrdConfig().images_dict
 
-    def update_detector(self, det):
+    def update_detectors(self, detectors):
         # If there are intensity corrections and the detector transform
         # has been modified, we need to update the images dict.
         self.update_images_dict()
@@ -304,9 +304,10 @@ class InstrumentViewer:
         # First, convert to the "None" angle convention
         iconfig = HexrdConfig().instrument_config_none_euler_convention
 
-        t_conf = iconfig['detectors'][det]['transform']
-        self.instr.detectors[det].tvec = t_conf['translation']
-        self.instr.detectors[det].tilt = t_conf['tilt']
+        for det in detectors:
+            t_conf = iconfig['detectors'][det]['transform']
+            self.instr.detectors[det].tvec = t_conf['translation']
+            self.instr.detectors[det].tilt = t_conf['tilt']
 
         # If the panel size has increased, re-create the display panel.
         # This is so that interactively moving detectors outside of the
@@ -325,8 +326,9 @@ class InstrumentViewer:
             # Re-create all images
             self.plot_dplane()
         else:
-            # Update the individual detector image
-            self.create_warped_image(det)
+            # Update the individual detector images
+            for det in detectors:
+                self.create_warped_image(det)
 
         # Generate the final image
         self.generate_image()

--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -82,8 +82,8 @@ class InstrumentViewer:
     def update_overlay_data(self):
         update_overlay_data(self.instr, self.type)
 
-    def update_detector(self, det):
-        self.pv.update_detector(det)
+    def update_detectors(self, detectors):
+        self.pv.update_detectors(detectors)
 
     def write_image(self, filename='polar_image.npz'):
         filename = Path(filename)

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -461,7 +461,7 @@ class PolarView:
         if HexrdConfig().any_intensity_corrections:
             self.images_dict = HexrdConfig().images_dict
 
-    def update_detector(self, det):
+    def update_detectors(self, detectors):
         self.reset_cached_distortion_fields()
 
         # If there are intensity corrections and the detector transform
@@ -471,12 +471,13 @@ class PolarView:
         # First, convert to the "None" angle convention
         iconfig = HexrdConfig().instrument_config_none_euler_convention
 
-        t_conf = iconfig['detectors'][det]['transform']
-        self.instr.detectors[det].tvec = t_conf['translation']
-        self.instr.detectors[det].tilt = t_conf['tilt']
+        for det in detectors:
+            t_conf = iconfig['detectors'][det]['transform']
+            self.instr.detectors[det].tvec = t_conf['translation']
+            self.instr.detectors[det].tilt = t_conf['tilt']
 
-        # Update the individual detector image
-        self.create_warp_image(det)
+            # Update the individual detector image
+            self.create_warp_image(det)
 
         # Generate the final image
         self.generate_image()

--- a/hexrdgui/calibration/raw_iviewer.py
+++ b/hexrdgui/calibration/raw_iviewer.py
@@ -24,13 +24,14 @@ class InstrumentViewer:
     def update_overlay_data(self):
         update_overlay_data(self.instr, self.type)
 
-    def update_detector(self, det):
+    def update_detectors(self, detectors):
         # First, convert to the "None" angle convention
         iconfig = HexrdConfig().instrument_config_none_euler_convention
 
-        t_conf = iconfig['detectors'][det]['transform']
-        self.instr.detectors[det].tvec = t_conf['translation']
-        self.instr.detectors[det].tilt = t_conf['tilt']
+        for det in detectors:
+            t_conf = iconfig['detectors'][det]['transform']
+            self.instr.detectors[det].tvec = t_conf['translation']
+            self.instr.detectors[det].tilt = t_conf['tilt']
 
         # Since these are just individual images, no further updates are needed
 

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -178,9 +178,9 @@ class InstrumentViewer:
     def update_overlay_data(self):
         update_overlay_data(self.instr, self.type)
 
-    def update_detector(self, det):
+    def update_detectors(self, detectors):
         if self.project_from_polar:
-            self.pv.update_detector(det)
+            self.pv.update_detectors(detectors)
 
         self.draw_stereo()
 

--- a/hexrdgui/calibration_slider_widget.py
+++ b/hexrdgui/calibration_slider_widget.py
@@ -282,8 +282,17 @@ class CalibrationSliderWidget(QObject):
                 # Apply rmat diff
                 new_rmat = rmat_diff @ rmat
 
-                # Convert back to tilt (using our convention) and set it
-                transform['tilt']['value'] = _rmat_to_tilt(new_rmat)
+                if detector is det:
+                    # This tilt is set from user interaction. Just keep it
+                    # that way, rather than re-computing it, to avoid issues
+                    # with non-uniqueness when converting to/from exponential
+                    # map parameters.
+                    tilt = new_tilt
+                else:
+                    # Convert back to tilt (using our convention) and set it
+                    tilt = _rmat_to_tilt(new_rmat)
+
+                transform['tilt']['value'] = tilt
 
                 # Compute change in translation
                 translation = np.asarray(transform['translation']['value'])

--- a/hexrdgui/calibration_slider_widget.py
+++ b/hexrdgui/calibration_slider_widget.py
@@ -2,8 +2,11 @@ from PySide6.QtCore import QObject
 
 import numpy as np
 
+from hexrd.rotations import angleAxisOfRotMat, rotMatOfExpMap
+
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.ui_loader import UiLoader
+from hexrdgui.utils import block_signals, convert_angle_convention
 
 
 class CalibrationSliderWidget(QObject):
@@ -25,7 +28,7 @@ class CalibrationSliderWidget(QObject):
     def setup_connections(self):
         self.ui.detector.currentIndexChanged.connect(
             self.update_gui_from_config)
-        for widget in self.config_widgets():
+        for widget in self.config_widgets:
             widget.valueChanged.connect(self.update_widget_counterpart)
             widget.valueChanged.connect(self.update_config_from_gui)
 
@@ -35,27 +38,30 @@ class CalibrationSliderWidget(QObject):
 
         self.ui.push_reset_config.pressed.connect(self.reset_config)
 
+        self.ui.roi_lock_group_transforms.toggled.connect(
+            HexrdConfig().set_roi_lock_group_transforms)
+
         HexrdConfig().euler_angle_convention_changed.connect(
             self.update_labels)
 
     def update_ranges(self):
         r = self.ui.sb_translation_range.value()
         slider_r = r * self.CONF_VAL_TO_SLIDER_VAL
-        for w in self.translation_widgets():
+        for w in self.translation_widgets:
             v = w.value()
             r_val = slider_r if w.objectName().startswith('slider') else r
             w.setRange(v - r_val / 2.0, v + r_val / 2.0)
 
         r = self.ui.sb_tilt_range.value()
         slider_r = r * self.CONF_VAL_TO_SLIDER_VAL
-        for w in self.tilt_widgets():
+        for w in self.tilt_widgets:
             v = w.value()
             r_val = slider_r if w.objectName().startswith('slider') else r
             w.setRange(v - r_val / 2.0, v + r_val / 2.0)
 
         r = self.ui.sb_beam_range.value()
         slider_r = r * self.CONF_VAL_TO_SLIDER_VAL
-        for w in self.beam_widgets():
+        for w in self.beam_widgets:
             v = w.value()
             r_val = slider_r if w.objectName().startswith('slider') else r
             w.setRange(v - r_val / 2.0, v + r_val / 2.0)
@@ -66,6 +72,7 @@ class CalibrationSliderWidget(QObject):
     def current_detector_dict(self):
         return HexrdConfig().detector(self.current_detector())
 
+    @property
     def translation_widgets(self):
         # Let's take advantage of the naming scheme
         prefixes = ['sb', 'slider']
@@ -79,6 +86,7 @@ class CalibrationSliderWidget(QObject):
 
         return [getattr(self.ui, x) for x in widget_names]
 
+    @property
     def tilt_widgets(self):
         # Let's take advantage of the naming scheme
         prefixes = ['sb', 'slider']
@@ -92,9 +100,11 @@ class CalibrationSliderWidget(QObject):
 
         return [getattr(self.ui, x) for x in widget_names]
 
+    @property
     def transform_widgets(self):
-        return self.translation_widgets() + self.tilt_widgets()
+        return self.translation_widgets + self.tilt_widgets
 
+    @property
     def beam_widgets(self):
         # Let's take advantage of the naming scheme
         prefixes = ['sb', 'slider']
@@ -109,26 +119,13 @@ class CalibrationSliderWidget(QObject):
 
         return [getattr(self.ui, x) for x in widget_names]
 
+    @property
     def config_widgets(self):
-        return self.transform_widgets() + self.beam_widgets()
+        return self.transform_widgets + self.beam_widgets
 
+    @property
     def all_widgets(self):
-        return self.config_widgets() + [self.ui.detector]
-
-    def block_all_signals(self):
-        previously_blocked = []
-        all_widgets = self.all_widgets()
-
-        for widget in all_widgets:
-            previously_blocked.append(widget.blockSignals(True))
-
-        return previously_blocked
-
-    def unblock_all_signals(self, previously_blocked):
-        all_widgets = self.all_widgets()
-
-        for block, widget in zip(previously_blocked, all_widgets):
-            widget.blockSignals(block)
+        return self.config_widgets + [self.ui.detector]
 
     def on_detector_changed(self):
         self.update_gui_from_config()
@@ -159,16 +156,20 @@ class CalibrationSliderWidget(QObject):
     def update_gui_from_config(self):
         self.update_detectors_from_config()
 
-        previously_blocked = self.block_all_signals()
-        try:
-            for widget in self.config_widgets():
+        with block_signals(*self.config_widgets):
+            for widget in self.config_widgets:
                 self.update_widget_value(widget)
 
-        finally:
-            self.unblock_all_signals(previously_blocked)
+        self.ui.roi_lock_group_transforms.setChecked(
+            HexrdConfig().roi_lock_group_transforms)
 
         self.update_ranges()
         self.update_labels()
+        self.update_visibility_states()
+
+    def update_visibility_states(self):
+        self.ui.roi_lock_group_transforms.setVisible(
+            HexrdConfig().instrument_has_roi)
 
     def update_detectors_from_config(self):
         widget = self.ui.detector
@@ -211,14 +212,17 @@ class CalibrationSliderWidget(QObject):
                 # Convert to radians, and to the native python type before save
                 val = np.radians(val).item()
 
-            det['transform'][key]['value'][ind] = val
+            if HexrdConfig().roi_lock_group_transforms:
+                self._transform_locked_group(det, key, ind, val)
+            else:
+                det['transform'][key]['value'][ind] = val
 
-            # Since we modify the value directly instead of letting the
-            # HexrdConfig() do it, let's also emit the signal it would
-            # have emitted.
-            HexrdConfig().detector_transform_modified.emit(
-                self.current_detector()
-            )
+                # Since we modify the value directly instead of letting the
+                # HexrdConfig() do it, let's also emit the signal it would
+                # have emitted.
+                HexrdConfig().detector_transforms_modified.emit(
+                    [self.current_detector()]
+                )
         else:
             iconfig = HexrdConfig().config['instrument']
             if key == 'energy':
@@ -230,6 +234,73 @@ class CalibrationSliderWidget(QObject):
             else:
                 iconfig['beam']['vector'][key]['value'] = val
                 HexrdConfig().beam_vector_changed.emit()
+
+    def _transform_locked_group(self, det, key, ind, val):
+        group = det.get('group', {}).get('value')
+        if not group:
+            raise Exception(f'Detector does not have a group: {det}')
+
+        group_dets = {}
+        for name in HexrdConfig().detector_names:
+            if HexrdConfig().detector_group(name) == group:
+                group_dets[name] = HexrdConfig().detector(name)
+
+        if key == 'translation':
+            # Compute the diff
+            previous = det['transform']['translation']['value'][ind]
+            diff = val - previous
+
+            # Translate all detectors in the same group by the same difference
+            for detector in group_dets.values():
+                detector['transform']['translation']['value'][ind] += diff
+        else:
+            # It is tilt. Compute the center of rotation first.
+            detector_centers = np.array([x['transform']['translation']['value']
+                                        for x in group_dets.values()])
+            center_of_rotation = detector_centers.mean(axis=0)
+
+            # Gather the old tilt and the new tilt to compute a difference.
+            old_tilt = det['transform']['tilt']['value']
+            new_tilt = old_tilt.copy()
+            # Apply the changed value
+            new_tilt[ind] = val
+
+            # Convert them to rotation matrices and compute the diff
+            old_rmat = _tilt_to_rmat(old_tilt)
+            new_rmat = _tilt_to_rmat(new_tilt)
+
+            # Compute the rmat used to convert from old to new
+            rmat_diff = new_rmat @ old_rmat.T
+
+            # Rotate each detector using the rmat_diff
+            for det_key, detector in group_dets.items():
+                transform = detector['transform']
+
+                # Compute current rmat
+                rmat = _tilt_to_rmat(transform['tilt']['value'])
+
+                # Apply rmat diff
+                new_rmat = rmat_diff @ rmat
+
+                # Convert back to tilt (using our convention) and set it
+                transform['tilt']['value'] = _rmat_to_tilt(new_rmat)
+
+                # Compute change in translation
+                translation = np.asarray(transform['translation']['value'])
+
+                # Translate to center and apply rmat diff
+                translation -= center_of_rotation
+                translation = rmat_diff @ translation + center_of_rotation
+
+                transform['translation']['value'] = translation.tolist()
+
+        HexrdConfig().detector_transforms_modified.emit(list(group_dets))
+
+        # Since we modified potentially all translations and tilts, we
+        # must update the GUI too.
+        with block_signals(*self.transform_widgets):
+            for w in self.transform_widgets:
+                self.update_widget_value(w)
 
     def update_widget_value(self, widget):
         name = widget.objectName()
@@ -285,3 +356,25 @@ class CalibrationSliderWidget(QObject):
         self.ui.label_tilt_2.setText(str.upper(a + ':'))
         self.ui.label_tilt_0.setText(str.upper(b + ':'))
         self.ui.label_tilt_1.setText(str.upper(c + ':'))
+
+
+def _tilt_to_rmat(tilt):
+    # Convert the tilt to exponential map parameters, and then
+    # to the rotation matrix, and return.
+    convention = HexrdConfig().euler_angle_convention
+    return rotMatOfExpMap(np.asarray(
+        convert_angle_convention(tilt, convention, None)
+    ))
+
+
+def _rmat_to_tilt(rmat):
+    # Convert the rotation matrix to exponential map parameters,
+    # and then to the tilt, and return.
+    convention = HexrdConfig().euler_angle_convention
+
+    # Compute tilt
+    phi, n = angleAxisOfRotMat(rmat)
+    tilt = phi * n.flatten()
+
+    # Convert back to convention
+    return convert_angle_convention(tilt, None, convention)

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -75,8 +75,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when the option to tab images is changed"""
     tab_images_changed = Signal()
 
-    """Emitted when a detector's transform is modified"""
-    detector_transform_modified = Signal(str)
+    """Emitted when a detector transforms are modified
+
+    The list is a list of detectors which were modified.
+    """
+    detector_transforms_modified = Signal(list)
 
     """Emitted when detector borders need to be re-rendered"""
     rerender_detector_borders = Signal()
@@ -253,6 +256,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.live_update = True
         self._show_saturation_level = False
         self._stitch_raw_roi_images = False
+        self._roi_lock_group_transforms = False
         self._tab_images = False
         self.previous_active_material = None
         self.collapsed_state = []
@@ -369,6 +373,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('config_indexing', None),
             ('config_image', None),
             ('_stitch_raw_roi_images', False),
+            ('_roi_lock_group_transforms', False),
             ('font_size', 11),
             ('images_dir', None),
             ('working_dir', '.'),
@@ -1452,7 +1457,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # If a detector transform was modified, send a signal
             # indicating so
             det = path[1]
-            self.detector_transform_modified.emit(det)
+            self.detector_transforms_modified.emit([det])
             return
 
         if (path[0] == 'detectors' and path[2] == 'pixels'
@@ -2398,7 +2403,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                                      set_show_saturation_level)
 
     def get_stitch_raw_roi_images(self):
-        return self.instrument_has_roi and self._stitch_raw_roi_images
+        return self._stitch_raw_roi_images and self.instrument_has_roi
 
     def set_stitch_raw_roi_images(self, v):
         if self._stitch_raw_roi_images != v:
@@ -2407,6 +2412,15 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     stitch_raw_roi_images = property(get_stitch_raw_roi_images,
                                      set_stitch_raw_roi_images)
+
+    def get_roi_lock_group_transforms(self):
+        return self._roi_lock_group_transforms and self.instrument_has_roi
+
+    def set_roi_lock_group_transforms(self, v):
+        self._roi_lock_group_transforms = v
+
+    roi_lock_group_transforms = property(get_roi_lock_group_transforms,
+                                         set_roi_lock_group_transforms)
 
     def tab_images(self):
         return self._tab_images

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -83,8 +83,8 @@ class ImageCanvas(FigureCanvas):
             self.show_saturation)
         HexrdConfig().show_stereo_border_changed.connect(
             self.draw_stereo_border)
-        HexrdConfig().detector_transform_modified.connect(
-            self.on_detector_transform_modified)
+        HexrdConfig().detector_transforms_modified.connect(
+            self.on_detector_transforms_modified)
         HexrdConfig().rerender_detector_borders.connect(
             self.draw_detector_borders)
         HexrdConfig().rerender_wppf.connect(self.draw_wppf)
@@ -1405,7 +1405,7 @@ class ImageCanvas(FigureCanvas):
             artist, = axis.plot(rijs[:, 0], rijs[:, 1], 'm+')
             self.auto_picked_data_artists.append(artist)
 
-    def on_detector_transform_modified(self, det):
+    def on_detector_transforms_modified(self, detectors):
         if HexrdConfig().loading_state:
             # Skip the request if we are loading state
             return
@@ -1413,7 +1413,8 @@ class ImageCanvas(FigureCanvas):
         if self.mode is None:
             return
 
-        self.iviewer.update_detector(det)
+        self.iviewer.update_detectors(detectors)
+
         if self.mode == ViewType.raw:
             # Only overlays need to be updated
             HexrdConfig().flag_overlay_updates_for_all_materials()

--- a/hexrdgui/resources/ui/calibration_slider_widget.ui
+++ b/hexrdgui/resources/ui/calibration_slider_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>618</height>
+    <height>673</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -24,176 +24,6 @@
     <number>0</number>
    </property>
    <item row="3" column="0" colspan="2">
-    <widget class="QGroupBox" name="tilt_group">
-     <property name="title">
-      <string>Tilt</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="2" column="0">
-       <widget class="QLabel" name="label_tilt_0">
-        <property name="text">
-         <string>Y:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="ScientificDoubleSpinBox" name="sb_tilt_0">
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="suffix">
-         <string>°</string>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="minimum">
-         <double>-1000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="0">
-       <widget class="QLabel" name="label_tilt_1">
-        <property name="text">
-         <string>Z:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QSlider" name="slider_tilt_1">
-        <property name="minimum">
-         <number>-100000</number>
-        </property>
-        <property name="maximum">
-         <number>100000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="2">
-       <widget class="ScientificDoubleSpinBox" name="sb_tilt_2">
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="suffix">
-         <string>°</string>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="minimum">
-         <double>-1000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSlider" name="slider_tilt_0">
-        <property name="minimum">
-         <number>-100000</number>
-        </property>
-        <property name="maximum">
-         <number>100000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="2">
-       <widget class="ScientificDoubleSpinBox" name="sb_tilt_1">
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="suffix">
-         <string>°</string>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="minimum">
-         <double>-1000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_tilt_2">
-        <property name="text">
-         <string>X:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="3" column="1">
-       <widget class="QSlider" name="slider_tilt_2">
-        <property name="minimum">
-         <number>-100000</number>
-        </property>
-        <property name="maximum">
-         <number>100000</number>
-        </property>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="ScientificDoubleSpinBox" name="sb_tilt_range">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify the sensitivity of the sliders by setting the ranges that the sliders cover.&lt;/p&gt;&lt;p&gt;When the ranges are modified, the current slider values will be centered, and the min and max will be set to &amp;quot;current_value - range / 2&amp;quot; and &amp;quot;current_value + range / 2&amp;quot;, respectively.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="keyboardTracking">
-         <bool>false</bool>
-        </property>
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="minimum">
-         <double>-1000000.000000000000000</double>
-        </property>
-        <property name="maximum">
-         <double>1000000.000000000000000</double>
-        </property>
-        <property name="singleStep">
-         <double>0.100000000000000</double>
-        </property>
-        <property name="value">
-         <double>30.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_tilt_range">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify the sensitivity of the sliders by setting the ranges that the sliders cover.&lt;/p&gt;&lt;p&gt;When the ranges are modified, the current slider values will be centered, and the min and max will be set to &amp;quot;current_value - range / 2&amp;quot; and &amp;quot;current_value + range / 2&amp;quot;, respectively.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Slider Range:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="translation_group">
      <property name="title">
       <string>Translation</string>
@@ -354,30 +184,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Detector:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="detector"/>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0" colspan="2">
+   <item row="5" column="0" colspan="2">
     <widget class="QGroupBox" name="beam_group">
      <property name="title">
       <string>Beam</string>
@@ -547,13 +354,216 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="tilt_group">
+     <property name="title">
+      <string>Tilt</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_tilt_0">
+        <property name="text">
+         <string>Y:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="ScientificDoubleSpinBox" name="sb_tilt_0">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="label_tilt_1">
+        <property name="text">
+         <string>Z:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QSlider" name="slider_tilt_1">
+        <property name="minimum">
+         <number>-100000</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="2">
+       <widget class="ScientificDoubleSpinBox" name="sb_tilt_2">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="slider_tilt_0">
+        <property name="minimum">
+         <number>-100000</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2">
+       <widget class="ScientificDoubleSpinBox" name="sb_tilt_1">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string>°</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_tilt_2">
+        <property name="text">
+         <string>X:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QSlider" name="slider_tilt_2">
+        <property name="minimum">
+         <number>-100000</number>
+        </property>
+        <property name="maximum">
+         <number>100000</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="ScientificDoubleSpinBox" name="sb_tilt_range">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify the sensitivity of the sliders by setting the ranges that the sliders cover.&lt;/p&gt;&lt;p&gt;When the ranges are modified, the current slider values will be centered, and the min and max will be set to &amp;quot;current_value - range / 2&amp;quot; and &amp;quot;current_value + range / 2&amp;quot;, respectively.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>30.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_tilt_range">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Modify the sensitivity of the sliders by setting the ranges that the sliders cover.&lt;/p&gt;&lt;p&gt;When the ranges are modified, the current slider values will be centered, and the min and max will be set to &amp;quot;current_value - range / 2&amp;quot; and &amp;quot;current_value + range / 2&amp;quot;, respectively.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Slider Range:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Detector:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
     <widget class="QPushButton" name="push_reset_config">
      <property name="toolTip">
       <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the instrument configuration to the state when the most recent instrument file was loaded, or when the program started.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
       <string>Reset Configuration</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QComboBox" name="detector"/>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QCheckBox" name="roi_lock_group_transforms">
+     <property name="toolTip">
+      <string>If checked, when a detector is transformed (translation or tilt), all other detectors in the same group will be transformed in a similar way. For translation, all detectors will be translated by the same amount, and in the same direction. For tilt, all detectors in the same group will be rotated about the mean of the detector centers.</string>
+     </property>
+     <property name="text">
+      <string>Lock ROI Group Transformations</string>
      </property>
     </widget>
    </item>
@@ -568,6 +578,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>detector</tabstop>
+  <tabstop>roi_lock_group_transforms</tabstop>
   <tabstop>sb_translation_range</tabstop>
   <tabstop>slider_translation_0</tabstop>
   <tabstop>sb_translation_0</tabstop>
@@ -589,6 +600,7 @@
   <tabstop>sb_azimuth_0</tabstop>
   <tabstop>slider_polar_0</tabstop>
   <tabstop>sb_polar_0</tabstop>
+  <tabstop>push_reset_config</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
If an ROI instrument config is loaded, a new checkbox appears in the 
instrument slider view with the label "Lock ROI Group Transformations".

If checked, then when a detector is transformed (via translation or tilt),
all other detectors in the same group are transformed similarly.

For translation, all other detectors in the same group are translated by
the same amount, and in the same direction.

For tilt, all detectors in the group are rotated about the mean of their
centers by the tilt amount (which means their translation is affected too).

See below video as an example.

https://github.com/HEXRD/hexrdgui/assets/9558430/b90e2774-c5e9-49da-9427-3119f243fcfe

Fixes: #1628