### PR TITLE
Add reflections table column for HEDM intensity

### DIFF
--- a/hexrdgui/reflections_table.py
+++ b/hexrdgui/reflections_table.py
@@ -24,8 +24,9 @@ class COLUMNS:
     D_SPACING = 2
     TTH = 3
     SF = 4
-    POWDER_INTENSITY = 5
-    MULTIPLICITY = 6
+    HEDM_INTENSITY = 5
+    POWDER_INTENSITY = 6
+    MULTIPLICITY = 7
 
 
 class ReflectionsTable:
@@ -307,6 +308,7 @@ class ReflectionsTable:
                     d_spacings = plane_data.getPlaneSpacings()
                     tth = plane_data.getTTh()
                     powder_intensity = plane_data.powder_intensity
+                    hedm_intensity = plane_data.hedm_intensity
                     multiplicity = plane_data.getMultiplicity()
 
                     # Since structure factors use arbitrary scaling, re-scale
@@ -347,6 +349,9 @@ class ReflectionsTable:
 
                     table_item = FloatTableItem(sf[i])
                     table.setItem(i, COLUMNS.SF, table_item)
+
+                    table_item = FloatTableItem(hedm_intensity[i])
+                    table.setItem(i, COLUMNS.HEDM_INTENSITY, table_item)
 
                     table_item = FloatTableItem(powder_intensity[i])
                     table.setItem(i, COLUMNS.POWDER_INTENSITY, table_item)

--- a/hexrdgui/resources/ui/reflections_table.ui
+++ b/hexrdgui/resources/ui/reflections_table.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>650</width>
+    <width>700</width>
     <height>349</height>
    </rect>
   </property>
@@ -70,7 +70,7 @@
       <number>5</number>
      </property>
      <property name="columnCount">
-      <number>7</number>
+      <number>8</number>
      </property>
      <attribute name="horizontalHeaderCascadingSectionResizes">
       <bool>true</bool>
@@ -115,6 +115,11 @@
      <column>
       <property name="text">
        <string>|F|²</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Iₛ</string>
       </property>
      </column>
      <column>


### PR DESCRIPTION
This is computed nearly the same way as the powder intensity, except that it does not include multiplicity. It is particularly useful for rotation series data.

It is `Iₛ` in this table:

![image](https://github.com/HEXRD/hexrdgui/assets/9558430/828cbef5-ea03-453e-9abc-e14b789a1def)

Fixes: #1664
Depends on: hexrd/hexrd#619