### PR TITLE
Use masked images for color map settings

### DIFF
--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -695,7 +695,7 @@ class MainWindow(QObject):
             raise
 
     def update_color_map_bounds(self):
-        self.color_map_editor.update_bounds(HexrdConfig().images_dict)
+        self.color_map_editor.update_bounds(HexrdConfig().masked_images_dict)
 
     def on_action_edit_euler_angle_convention(self):
         allowed_conventions = [


### PR DESCRIPTION
For Eiger, invalid pixels have a value of 4294967295. This really messes up the color map percentile defaults.

Instead of using the raw data for creating the default color map settings, we should use masked data instead, so that these invalid pixels are not included in the percentile setup.