### PR TITLE
Set panel buffer values to 0 before polar view

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -48,7 +48,12 @@ class PolarView:
 
         self.distortion_instr = distortion_instrument
 
+        # Use an image dict with the panel buffers applied.
+        # This keeps invalid pixels from bleeding out in the polar view
         self.images_dict = HexrdConfig().images_dict
+        # 0 is a better fill value because it results in fewer nans in
+        # the final image.
+        HexrdConfig().apply_panel_buffer_to_images(self.images_dict, 0)
 
         self.warp_dict = {}
 


### PR DESCRIPTION
For Eiger, the invalid pixels have a value of 4294967295. This high value bleeds into neighboring pixels when we warp to the polar view and makes them artificially high.

To prevent this bleeding over, we should set panel buffer values to 0 before generating the polar view.

0 seemed to be better than nan because nan would result in more polar view pixels being nan. Maybe an even better setup, however, would be to make the invalid pixels be the average value of their neighbors, so that they do not bring down the neighboring values in the final image. Something to think about in the future...

Note that masks in hexrdgui are not set to zero before generating the polar view, so the masked content may still bleed into neighboring pixels.

Fixes: #1684