### PR TITLE
Add an option to color invalid pixels

### DIFF
--- a/hexrdgui/resources/ui/color_map_editor.ui
+++ b/hexrdgui/resources/ui/color_map_editor.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>417</width>
-    <height>121</height>
+    <width>459</width>
+    <height>143</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -61,7 +61,7 @@
         <property name="spacing">
          <number>0</number>
         </property>
-        <item row="6" column="1">
+        <item row="7" column="1">
          <spacer name="verticalSpacer">
           <property name="orientation">
            <enum>Qt::Vertical</enum>
@@ -70,6 +70,36 @@
            <size>
             <width>20</width>
             <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>Maximum Value: </string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="4">
+         <widget class="QCheckBox" name="reverse">
+          <property name="text">
+           <string>reverse</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="5">
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
            </size>
           </property>
          </spacer>
@@ -100,39 +130,6 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="5">
-         <spacer name="horizontalSpacer">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>40</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="0" column="0">
-         <widget class="QLabel" name="label">
-          <property name="text">
-           <string>Color Map: </string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="4">
-         <widget class="QCheckBox" name="show_over">
-          <property name="toolTip">
-           <string>Color over values as red</string>
-          </property>
-          <property name="text">
-           <string>show over</string>
-          </property>
-         </widget>
-        </item>
         <item row="1" column="1">
          <widget class="ScientificDoubleSpinBox" name="minimum">
           <property name="keyboardTracking">
@@ -146,16 +143,6 @@
           </property>
           <property name="displayIntegerBase">
            <number>10</number>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="4">
-         <widget class="QCheckBox" name="show_under">
-          <property name="toolTip">
-           <string>Color under values as blue</string>
-          </property>
-          <property name="text">
-           <string>show under</string>
           </property>
          </widget>
         </item>
@@ -175,10 +162,26 @@
           </property>
          </widget>
         </item>
-        <item row="0" column="4">
-         <widget class="QCheckBox" name="reverse">
+        <item row="5" column="1">
+         <widget class="QPushButton" name="bc_editor_button">
+          <property name="enabled">
+           <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Brightness and Contrast editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
-           <string>reverse</string>
+           <string>B&amp;&amp;C</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>Color Map: </string>
+          </property>
+          <property name="alignment">
+           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
          </widget>
         </item>
@@ -192,38 +195,45 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="label_3">
-          <property name="text">
-           <string>Maximum Value: </string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QPushButton" name="bc_editor_button">
-          <property name="enabled">
-           <bool>false</bool>
-          </property>
+        <item row="3" column="4">
+         <widget class="QCheckBox" name="show_over">
           <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Brightness and Contrast editor&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           <string>Color over values as red</string>
           </property>
           <property name="text">
-           <string>B&amp;&amp;C</string>
+           <string>show over</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="3">
+        <item row="5" column="3">
          <widget class="QLabel" name="scaling_label">
           <property name="text">
            <string>Scaling:</string>
           </property>
          </widget>
         </item>
-        <item row="4" column="4">
+        <item row="5" column="4">
          <widget class="QComboBox" name="scaling"/>
+        </item>
+        <item row="1" column="4">
+         <widget class="QCheckBox" name="show_under">
+          <property name="toolTip">
+           <string>Color under values as blue</string>
+          </property>
+          <property name="text">
+           <string>show under</string>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="4">
+         <widget class="QCheckBox" name="show_invalid">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Display invalid (nan) pixels with a specified color.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>show invalid</string>
+          </property>
+         </widget>
         </item>
        </layout>
       </item>
@@ -246,6 +256,9 @@
   <tabstop>show_under</tabstop>
   <tabstop>maximum</tabstop>
   <tabstop>show_over</tabstop>
+  <tabstop>show_invalid</tabstop>
+  <tabstop>bc_editor_button</tabstop>
+  <tabstop>scaling</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
If checked, pixels that are `nan` are displayed with a specified color.

First, a QColorDialog appears asking the user to select a color. After a color is selected, `nan` pixels will be displayed with this color.