### PR TITLE
Performance improvements to raw view loading

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -888,13 +888,13 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @property
     def raw_masks_dict(self):
-        return self.create_raw_masks_dict(display=False)
+        return self.create_raw_masks_dict(self.images_dict, display=False)
 
-    def create_raw_masks_dict(self, display=False):
+    def create_raw_masks_dict(self, images_dict, display=False):
         """Get a masks dict"""
         from hexrdgui.masking.mask_manager import MaskManager
         masks_dict = {}
-        for name, img in self.images_dict.items():
+        for name, img in images_dict.items():
             final_mask = np.ones(img.shape, dtype=bool)
             for mask in MaskManager().masks.values():
                 if display and not mask.visible:
@@ -940,22 +940,23 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # and no panel buffers.
             fill_value = 0
 
-        raw_masks_dict = self.create_raw_masks_dict(display=display)
+        raw_masks_dict = self.create_raw_masks_dict(images_dict,
+                                                    display=display)
         for det, mask in raw_masks_dict.items():
+            img = images_dict[det]
             if has_panel_buffers:
                 panel = instr.detectors[det]
                 utils.convert_panel_buffer_to_2d_array(panel)
 
-            for name, img in images_dict.items():
-                if (np.issubdtype(type(fill_value), np.floating) and
-                        not np.issubdtype(img.dtype, np.floating)):
-                    img = img.astype(float)
-                    images_dict[name] = img
-                if det == name:
-                    img[~mask] = fill_value
+            if (np.issubdtype(type(fill_value), np.floating) and
+                    not np.issubdtype(img.dtype, np.floating)):
+                img = img.astype(float)
+                images_dict[det] = img
 
-                    if has_panel_buffers:
-                        img[~panel.panel_buffer] = fill_value
+            img[~mask] = fill_value
+
+            if has_panel_buffers:
+                img[~panel.panel_buffer] = fill_value
 
         return images_dict
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -196,11 +196,16 @@ class ImageCanvas(FigureCanvas):
                 img = images_dict[name]
                 self.axes_images[i].set_data(img)
 
-        # Create a computed version for the images dict
-        computed_images_dict = self.scaled_image_dict
-        if HexrdConfig().stitch_raw_roi_images:
-            computed_images_dict = self.iviewer.raw_images_to_stitched(
-                image_names, computed_images_dict)
+        if MaskManager().contains_border_only_masks:
+            # Create a computed version for the images dict
+            computed_images_dict = self.scaled_image_dict
+            if HexrdConfig().stitch_raw_roi_images:
+                computed_images_dict = self.iviewer.raw_images_to_stitched(
+                    image_names, computed_images_dict)
+        else:
+            # The computed image is the same as the display image.
+            # Save some computation time for faster rendering.
+            computed_images_dict = images_dict
 
         self.raw_view_images_dict = computed_images_dict
         for name, axis in self.raw_axes.items():

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -642,7 +642,9 @@ class ImageCanvas(FigureCanvas):
             return
 
         self.remove_all_overlay_artists()
-        if not HexrdConfig().show_overlays:
+        if not HexrdConfig().show_overlays or not HexrdConfig().overlays:
+            # Avoid proceeding if possible, as updating the blit manager
+            # can be time consuming.
             self.remove_all_overlay_artists()
             self.draw_idle()
             return

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -329,6 +329,14 @@ class MaskManager(QObject, metaclass=QSingleton):
     def update_border_visibility(self, name, visibility):
         self.masks[name].update_border_visibility(visibility)
 
+    @property
+    def contains_border_only_masks(self):
+        # If we have any border-only masks, that means the display images
+        # are different from computed images, and require extra computation.
+        # If this returns False, we can skip that extra computation and
+        # set display images and computed images to be the same.
+        return any(x.show_border and not x.visible for x in self.masks)
+
     def threshold_toggled(self):
         if self.threshold_mask:
             self.remove_mask(self.threshold_mask.name)


### PR DESCRIPTION
In order to make scrolling through images in the raw view faster, this PR provides several speed improvements to raw view loading. On my computer, it is now about 3.2x faster if there are no display masks and no overlays. Here are the performance improvements:

1. The images dict was accidentally being created twice, which caused a performance hit. It is now only being created once.
2. If there are no masks with a border-only setting, we avoid creating separate dictionaries for display images and computed images (we can re-use the display images *as* the computed images).
3. If there are no overlays, we don't update the blit manager, which can be time-consuming.
