### PR TITLE
Prevent overflow from use of np.uint32

### DIFF
--- a/hexrdgui/image_load_manager.py
+++ b/hexrdgui/image_load_manager.py
@@ -372,7 +372,10 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
             # frames via the ProcessedImageSeries 'frame_list' arg to slice
             # the frame list
             start = self.data.get('empty_frames', 0)
-        return np.arange(start, len(ims))
+
+        # np.arange() would produce a list of np.uint32, which can overflow.
+        # Convert to a list of python integers, which cannot overflow.
+        return np.arange(start, len(ims)).tolist()
 
     def get_flip_op(self, oplist, idx):
         if self.data:


### PR DESCRIPTION
For larger datasets, we were encountering an integer overflow issue within fabio, since uint32 wasn't large enough to compute the byte offset.

Use a list of python integers instead to avoid this issue.