### PR TITLE
Add and integrate generic calibration dialog

### DIFF
--- a/hexrdgui/calibration/auto/__init__.py
+++ b/hexrdgui/calibration/auto/__init__.py
@@ -1,8 +1,7 @@
 from .powder_calibration_dialog import PowderCalibrationDialog
-from .powder_runner import PowderRunner, save_picks_to_overlay
+from .powder_runner import PowderRunner
 
 __all__ = [
     'PowderCalibrationDialog',
     'PowderRunner',
-    'save_picks_to_overlay',
 ]

--- a/hexrdgui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrdgui/calibration/auto/powder_calibration_dialog.py
@@ -1,4 +1,3 @@
-from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QMessageBox
 
 import numpy as np
@@ -44,10 +43,7 @@ class PowderCalibrationDialog:
         self.ui.tth_tolerance.setValue(self.tth_tol)
         self.ui.eta_tolerance.setValue(options['eta_tol'])
         self.ui.fit_tth_tol.setValue(options['fit_tth_tol'])
-        self.ui.max_iter.setValue(options['max_iter'])
         self.ui.int_cutoff.setValue(options['int_cutoff'])
-        self.ui.conv_tol.setValue(options['conv_tol'])
-        self.ui.robust.setChecked(options['use_robust_optimization'])
 
         self.auto_guess_initial_fwhm = options['auto_guess_initial_fwhm']
         self.initial_fwhm = options['initial_fwhm']
@@ -60,10 +56,7 @@ class PowderCalibrationDialog:
         self.tth_tol = self.ui.tth_tolerance.value()
         options['eta_tol'] = self.ui.eta_tolerance.value()
         options['fit_tth_tol'] = self.ui.fit_tth_tol.value()
-        options['max_iter'] = self.ui.max_iter.value()
         options['int_cutoff'] = self.ui.int_cutoff.value()
-        options['conv_tol'] = self.ui.conv_tol.value()
-        options['use_robust_optimization'] = self.ui.robust.isChecked()
 
         options['auto_guess_initial_fwhm'] = self.auto_guess_initial_fwhm
         options['initial_fwhm'] = self.initial_fwhm
@@ -144,12 +137,6 @@ class PowderCalibrationDialog:
 
         if not found:
             raise Exception(f'Unknown background type: {v}')
-
-    def show_optimization_parameters(self, b=True):
-        self.ui.optimization_parameters_group.setVisible(b)
-
-        # Resize later so that the dialog is the correct size
-        QTimer.singleShot(0, lambda: self.ui.resize(self.ui.sizeHint()))
 
 
 # If this gets added as a list to hexrd, we can import it from there

--- a/hexrdgui/calibration/calibration_dialog.py
+++ b/hexrdgui/calibration/calibration_dialog.py
@@ -2,6 +2,7 @@ import copy
 import yaml
 
 from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QComboBox, QDoubleSpinBox, QMessageBox, QSpinBox
 
 from hexrdgui import resource_loader
@@ -359,14 +360,8 @@ class CalibrationDialog(QObject):
             # It has already been initialized
             return
 
-        columns = {
-            'Value': '_value',
-            'Vary': '_vary',
-            'Minimum': '_min',
-            'Maximum': '_max',
-        }
         tree_dict = self.tree_view_dict_of_params
-        self.tree_view = MultiColumnDictTreeView(tree_dict, columns,
+        self.tree_view = MultiColumnDictTreeView(tree_dict, TREE_VIEW_COLUMNS,
                                                  parent=self.parent(),
                                                  model_class=TreeItemModel)
         self.tree_view.check_selection_index = 2
@@ -392,6 +387,24 @@ class CalibrationDialog(QObject):
                 )
                 QMessageBox.information(self.parent(), 'HEXRD', msg)
             editor.apply_to_polar_view = False
+
+
+TREE_VIEW_COLUMNS = {
+    'Value': '_value',
+    'Vary': '_vary',
+    'Minimum': '_min',
+    'Maximum': '_max',
+}
+TREE_VIEW_COLUMN_INDICES = {
+    'Key': 0,
+    **{
+        k: list(TREE_VIEW_COLUMNS).index(k) + 1 for k in TREE_VIEW_COLUMNS
+    }
+}
+VALUE_IDX = TREE_VIEW_COLUMN_INDICES['Value']
+MAX_IDX = TREE_VIEW_COLUMN_INDICES['Maximum']
+MIN_IDX = TREE_VIEW_COLUMN_INDICES['Minimum']
+BOUND_INDICES = (VALUE_IDX, MAX_IDX, MIN_IDX)
 
 
 class TreeItemModel(MultiColumnDictTreeItemModel):

--- a/hexrdgui/calibration/calibration_dialog.py
+++ b/hexrdgui/calibration/calibration_dialog.py
@@ -30,8 +30,9 @@ class CalibrationDialog(QObject):
     undo_run = Signal()
     finished = Signal()
 
-    def __init__(self, instr, params_dict, format_extra_params_func=None, parent=None,
-                 engineering_constraints=None, window_title='Calibration Dialog'):
+    def __init__(self, instr, params_dict, format_extra_params_func=None,
+                 parent=None, engineering_constraints=None,
+                 window_title='Calibration Dialog'):
         super().__init__(parent)
 
         loader = UiLoader()
@@ -338,7 +339,8 @@ class CalibrationDialog(QObject):
             recursively_format_det(det, this_config, this_template)
 
         if self.format_extra_params_func is not None:
-            self.format_extra_params_func(params_dict, tree_dict, create_param_item)
+            self.format_extra_params_func(params_dict, tree_dict,
+                                          create_param_item)
 
         # Now all keys should have been used. Verify this is true.
         if sorted(used_params) != sorted(list(params_dict)):

--- a/hexrdgui/calibration/calibration_dialog_callbacks.py
+++ b/hexrdgui/calibration/calibration_dialog_callbacks.py
@@ -1,0 +1,305 @@
+from abc import abstractmethod
+import copy
+
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QFileDialog
+
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.utils import instr_to_internal_dict
+from hexrdgui.utils.abc_qobject import ABCQObject
+
+
+class CalibrationDialogCallbacks(ABCQObject):
+    """A class with default behavior for calibration dialog callbacks"""
+
+    instrument_updated = Signal()
+
+    def __init__(self, dialog, calibrator, instr, async_runner):
+        super().__init__(dialog.ui)
+        self.dialog = dialog
+        self.calibrator = calibrator
+        self.instr = instr
+        self.async_runner = async_runner
+
+        self.edit_picks_dictionary = None
+        self.edit_picks_dialog = None
+
+        self.drawing_picks = True
+
+        self.draw_picks_lines = []
+        self.undo_stack = []
+
+        self.round_param_numbers()
+        self.draw_picks()
+        self.setup_connections()
+
+    def setup_connections(self):
+        dialog = self.dialog
+
+        dialog.ui.draw_picks.setChecked(self.drawing_picks)
+        dialog.draw_picks_toggled.connect(self.draw_picks)
+        dialog.edit_picks_clicked.connect(self.on_edit_picks_clicked)
+        dialog.save_picks_clicked.connect(self.on_save_picks_clicked)
+        dialog.load_picks_clicked.connect(self.on_load_picks_clicked)
+        dialog.engineering_constraints_changed.connect(
+            self.on_engineering_constraints_changed)
+        dialog.run.connect(self.on_run_clicked)
+        dialog.undo_run.connect(self.on_undo_run_clicked)
+        dialog.finished.connect(self.on_finished)
+
+        HexrdConfig().image_view_loaded.connect(self.on_image_view_loaded)
+
+    @property
+    def canvas(self):
+        return HexrdConfig().active_canvas
+
+    @abstractmethod
+    def draw_picks_on_canvas(self):
+        pass
+
+    @abstractmethod
+    def on_edit_picks_clicked(self):
+        pass
+
+    @abstractmethod
+    def on_edit_picks_accepted(self):
+        pass
+
+    @abstractmethod
+    def save_picks_to_file(self):
+        pass
+
+    @abstractmethod
+    def load_picks_from_file(self):
+        pass
+
+    @abstractmethod
+    def validate_picks(self, picks):
+        pass
+
+    def set_focus_mode(self, b):
+        # This will disable some widgets in the GUI during focus mode
+        # Be very careful to make sure focus mode won't be set permanently
+        # if an exception occurs, or else this will ruin the user's session.
+        # Therefore, this should only be turned on during important moments,
+        # such as when a dialog is showing, and turned off during processing.
+        HexrdConfig().enable_canvas_focus_mode.emit(b)
+
+    def on_image_view_loaded(self, img_dict):
+        # If the image view is modified, it may have been because of
+        # edits to tth distortion, so we should redraw the picks.
+        self.redraw_picks()
+
+    def update_dialog_from_calibrator(self):
+        self.dialog.update_from_calibrator(self.calibrator)
+
+    def push_undo_stack(self):
+        stack_item = {
+            'engineering_constraints': self.calibrator.engineering_constraints,
+            'tth_distortion': self.calibrator.tth_distortion,
+            'params': self.calibrator.params,
+            'advanced_options': self.dialog.advanced_options,
+        }
+        # Make deep copies to ensure originals will not be edited
+        stack_item = {k: copy.deepcopy(v) for k, v in stack_item.items()}
+
+        self.undo_stack.append(stack_item)
+        self.update_undo_enable_state()
+
+    def pop_undo_stack(self):
+        stack_item = self.undo_stack.pop(-1)
+
+        calibrator_items = [
+            'engineering_constraints',
+            'tth_distortion',
+            # Put this last so it will get set last
+            'params',
+        ]
+
+        # Params should get set last
+        for k in calibrator_items:
+            v = stack_item[k]
+            setattr(self.calibrator, k, v)
+
+        self.instr.update_from_lmfit_parameter_list(self.calibrator.params)
+        self.update_config_from_instrument()
+        self.update_dialog_from_calibrator()
+        self.dialog.advanced_options = stack_item['advanced_options']
+
+        self.update_undo_enable_state()
+
+    def update_undo_enable_state(self):
+        self.dialog.undo_enabled = bool(self.undo_stack)
+
+    def on_engineering_constraints_changed(self, new_constraint):
+        self.calibrator.engineering_constraints = new_constraint
+
+        # Keep old settings in the dialog if they are present in the new params
+        # Remember everything except the name (should be the same) and
+        # the expression (which might be modified from the engineering
+        # constraints).
+        to_remember = [
+            'value',
+            'vary',
+            'min',
+            'max',
+            'brute_step',
+            'user_data',
+        ]
+
+        for param_key, param in self.dialog.params_dict.items():
+            if param_key in self.calibrator.params:
+                current = self.calibrator.params[param_key]
+                for attr in to_remember:
+                    setattr(current, attr, getattr(param, attr))
+
+        self.dialog.params_dict = self.calibrator.params
+
+    def on_run_clicked(self):
+        self.async_runner.progress_title = 'Running calibration...'
+        self.async_runner.success_callback = self.update_config_from_instrument
+        self.async_runner.run(self.run_calibration)
+
+    def on_undo_run_clicked(self):
+        print('Undo changes')
+        self.pop_undo_stack()
+
+    def clear_drawn_picks(self):
+        while self.draw_picks_lines:
+            self.draw_picks_lines.pop(0).remove()
+
+        self.canvas.draw_idle()
+
+    def redraw_picks(self):
+        self.draw_picks(self.drawing_picks)
+
+    def draw_picks(self, b=True):
+        self.drawing_picks = b
+        self.clear_drawn_picks()
+
+        if not b:
+            return
+
+        self.draw_picks_on_canvas()
+
+    def run_calibration(self):
+        # Update the tth distortion on the calibrator from the dialog
+        self.update_tth_distortion_from_dialog()
+
+        # Add the current parameters to the undo stack
+        self.push_undo_stack()
+
+        odict = copy.deepcopy(self.dialog.advanced_options)
+
+        x0 = self.calibrator.params.valuesdict()
+        result = self.calibrator.run_calibration(odict=odict)
+
+        # Round the calibrator numbers to 3 decimal places
+        self.round_param_numbers()
+
+        x1 = result.params.valuesdict()
+
+        results_message = 'Calibration Results:\n'
+        for name in x0:
+            if not result.params[name].vary:
+                continue
+
+            old = x0[name]
+            new = x1[name]
+            results_message += f'{name}: {old:6.3g} ---> {new:6.3g}\n'
+
+        print(results_message)
+
+        self.results_message = results_message
+
+    def update_config_from_instrument(self):
+        output_dict = instr_to_internal_dict(self.instr)
+
+        # Save the previous iconfig to restore the statuses
+        prev_iconfig = HexrdConfig().config['instrument']
+
+        # Update the config
+        HexrdConfig().config['instrument'] = output_dict
+
+        # This adds in any missing keys. In particular, it is going to
+        # add in any "None" detector distortions
+        HexrdConfig().set_detector_defaults_if_missing()
+
+        # Add status values
+        HexrdConfig().add_status(output_dict)
+
+        # Set the previous statuses to be the current statuses
+        HexrdConfig().set_statuses_from_prev_iconfig(prev_iconfig)
+
+        self.instrument_updated.emit()
+
+        # Update the tree_view in the GUI with the new refinements
+        self.update_refinements_tree_view()
+
+        # Update the drawn picks with their new locations
+        self.redraw_picks()
+
+    def update_refinements_tree_view(self):
+        self.dialog.params_dict = self.calibrator.params
+
+    def update_tth_distortion_from_dialog(self):
+        self.calibrator.tth_distortion = self.dialog.tth_distortion
+
+    def round_param_numbers(self, decimals=3):
+        params_dict = self.calibrator.params
+
+        attrs = [
+            'value',
+            'min',
+            'max',
+        ]
+        for param in params_dict.values():
+            for attr in attrs:
+                setattr(param, attr, round(getattr(param, attr), 3))
+
+    def on_edit_picks_finished(self):
+        # Show this again
+        self.dialog.show()
+        self.redraw_picks()
+
+    def on_save_picks_clicked(self):
+        title = 'Save Picks'
+
+        selected_file, selected_filter = QFileDialog.getSaveFileName(
+            self.dialog.ui, title, HexrdConfig().working_dir,
+            'HDF5 files (*.h5 *.hdf5)')
+
+        if not selected_file:
+            # The user canceled
+            return
+
+        self.save_picks_to_file(selected_file)
+
+    def on_load_picks_clicked(self):
+        title = 'Load Picks'
+
+        selected_file, selected_filter = QFileDialog.getOpenFileName(
+            self.dialog.ui, title, HexrdConfig().working_dir,
+            'HDF5 files (*.h5 *.hdf5)')
+
+        if not selected_file:
+            # The user canceled
+            return
+
+        picks = self.load_picks_from_file(selected_file)
+        self.set_picks(picks)
+
+    def set_picks(self, picks):
+        self.validate_picks(picks)
+        self.calibrator.data = picks
+
+        # Update the dialog
+        self.clear_drawn_picks()
+        self.dialog.params_dict = self.calibrator.params
+
+        self.redraw_picks()
+
+    def on_finished(self):
+        self.draw_picks(False)
+        # Ensure focus mode is off (even if it wasn't set)
+        self.set_focus_mode(False)

--- a/hexrdgui/calibration/material_calibration_dialog_callbacks.py
+++ b/hexrdgui/calibration/material_calibration_dialog_callbacks.py
@@ -1,0 +1,136 @@
+from hexrdgui.calibration.calibration_dialog_callbacks import (
+    CalibrationDialogCallbacks,
+)
+from hexrdgui.calibration.hkl_picks_tree_view_dialog import (
+    overlays_to_tree_format, HKLPicksTreeViewDialog,
+)
+from hexrdgui.constants import ViewType
+
+
+class MaterialCalibrationDialogCallbacks(CalibrationDialogCallbacks):
+
+    def __init__(self, overlays, dialog, calibrator, instr, async_runner):
+        self.overlays = overlays
+
+        if not hasattr(self, 'edit_picks_dialog'):
+            self.edit_picks_dialog = None
+
+        super().__init__(dialog, calibrator, instr, async_runner)
+
+    @property
+    def calibrators(self):
+        return self.calibrator.calibrators
+
+    def create_hkl_picks_tree_view_dialog(self):
+        kwargs = {
+            'dictionary': overlays_to_tree_format(self.overlays),
+            'coords_type': ViewType.polar,
+            'canvas': self.canvas,
+            'parent': self.canvas,
+        }
+        return HKLPicksTreeViewDialog(**kwargs)
+
+    def update_edit_picks_dictionary(self):
+        if self.edit_picks_dialog is None:
+            # Nothing to update
+            return
+
+        tree_format = overlays_to_tree_format(self.overlays)
+        self.edit_picks_dialog.dictionary = tree_format
+
+    @property
+    def edit_picks_dictionary(self):
+        if self.edit_picks_dialog is None:
+            return {}
+
+        return self.edit_picks_dialog.dictionary
+
+    def set_picks(self, picks):
+        self.validate_picks(picks)
+
+        overlays = {x.name: x for x in self.overlays}
+        for name, overlay_picks in picks.items():
+            overlays[name].calibration_picks_polar = overlay_picks
+
+        # Update the data on the calibrators
+        for calibrator, overlay in zip(self.calibrators, self.overlays):
+            calibrator.calibration_picks = overlay.calibration_picks
+
+        self.update_edit_picks_dictionary()
+
+        # Update the dialog
+        self.redraw_picks()
+
+    def on_edit_picks_accepted(self):
+        # Write the modified picks to the overlays
+        self.set_picks(self.edit_picks_dictionary)
+
+    def on_calibration_finished(self):
+        super().on_calibration_finished()
+
+        # Now make sure the overlays have updated instruments
+        for overlay in self.overlays:
+            overlay.instrument = self.instr
+
+    def validate_picks(self, picks):
+        if len(picks) != len(self.overlays):
+            msg = (
+                f'Number of picks ({len(picks)}) do not match number of '
+                f'overlays ({len(picks)}).'
+            )
+            raise Exception(msg)
+
+        instr_dets = sorted(list(self.instr.detectors))
+
+        overlay_names = [x.name for x in self.overlays]
+        for name, overlay_picks in picks.items():
+            if name not in overlay_names:
+                msg = (
+                    f'Picks names ({list(picks)}) do not match overlay names '
+                    f'({overlay_names})'
+                )
+                raise Exception(msg)
+
+            det_keys = sorted(list(overlay_picks))
+            if det_keys != instr_dets:
+                msg = (
+                    f'Detector keys ({det_keys}) for picks "{name}" do not '
+                    f'match instrument keys ({instr_dets})'
+                )
+                raise Exception(msg)
+
+
+def format_material_params_func(params_dict, tree_dict, create_param_item,
+                                overlays, calibrators):
+    tree_dict.setdefault('Materials', {})
+    for overlay, calibrator in zip(overlays, calibrators):
+        if not calibrator.param_names:
+            continue
+
+        d = tree_dict['Materials'].setdefault(overlay.name, {})
+        if calibrator.type == 'powder':
+            for name in calibrator.param_names:
+                # Assume this for now...
+                lat_param_name = name.split('_')[-1]
+                d[lat_param_name] = create_param_item(
+                    params_dict[name]
+                )
+        else:
+            # Assume grain parameters
+            d['Orientation'] = {}
+            labels = ['Z', "X'", "Z''"]
+            for i in range(3):
+                param = params_dict[calibrator.param_names[i]]
+                d['Orientation'][labels[i]] = create_param_item(param)
+
+            d['Position'] = {}
+            labels = ['X', 'Y', 'Z']
+            for i in range(3):
+                param = params_dict[calibrator.param_names[i + 3]]
+                d['Position'][labels[i]] = create_param_item(param)
+
+            d['Stretch'] = {}
+            labels = ['U_xx', 'U_yy', 'U_zz', 'U_yz', 'U_xz', 'U_xy']
+            for i in range(6):
+                param = params_dict[calibrator.param_names[i + 6]]
+                d['Stretch'][labels[i]] = create_param_item(param)

--- a/hexrdgui/calibration/pick_based_calibration.py
+++ b/hexrdgui/calibration/pick_based_calibration.py
@@ -1,123 +1,46 @@
-import numpy as np
-from scipy.optimize import leastsq
-
-from hexrd.fitting.calibration import CompositeCalibration
-
-
-def enrich_pick_data(picks, instr, materials):
-    # add plane_data, xy points from angles...
-    data_key = 'pick_xys'
-    for pick_data in picks:
-        # need plane data
-        material_name = pick_data['material']
-        plane_data = materials[material_name].planeData
-        pick_data['plane_data'] = plane_data
-
-        # now add additional data depending on pick type
-        pick_dict = pick_data['picks']
-        pick_type = pick_data['type']
-
-        # loop over detectors
-        pick_data[data_key] = dict.fromkeys(pick_dict)
-        for det_key, panel in instr.detectors.items():
-            if pick_type == 'laue':
-                # need grain parameters and stacked picks
-                grain_params = pick_data['options']['crystal_params']
-                tth_eta_picks = pick_dict[det_key]
-                if len(tth_eta_picks) == 0:
-                    tth_eta_picks = np.empty((0, 2))
-                    pick_data[data_key][det_key] = np.empty((0, 2))
-                else:
-                    # calculate cartesian coords
-                    tth_eta_picks = np.vstack(tth_eta_picks)
-                    xy_picks = panel.angles_to_cart(
-                        np.radians(tth_eta_picks),
-                        tvec_c=np.asarray(grain_params[3:6], dtype=float)
-                    )
-                    pick_data[data_key][det_key] = xy_picks
-            elif pick_type == 'powder':
-                # !!! need translation vector from overlay
-                tvec_c = np.asarray(
-                    pick_data['options']['tvec'], dtype=float
-                ).flatten()
-
-                # calculate cartesian coords
-                # !!! uses translation vector
-                pdl = []
-                for ring_picks in pick_dict[det_key]:
-                    if len(ring_picks) > 0:
-                        xy_picks = panel.angles_to_cart(
-                            np.atleast_2d(np.radians(ring_picks)),
-                            tvec_c=tvec_c
-                        )
-                    else:
-                        xy_picks = []
-                    pdl.append(xy_picks)
-                pick_data[data_key][det_key] = pdl
+from hexrd.fitting.calibration import (
+    InstrumentCalibrator,
+    LaueCalibrator,
+    PowderCalibrator,
+)
+from hexrdgui.utils.guess_instrument_type import guess_instrument_type
 
 
-def run_calibration(picks, instr, img_dict, materials):
-    enrich_pick_data(picks, instr, materials)
+def make_calibrators_from_picks(instr, processed_picks, materials, img_dict):
+    calibrators = []
+    for pick_data in processed_picks:
+        if pick_data['type'] == 'powder':
+            kwargs = {
+                'instr': instr,
+                'material': materials[pick_data['material']],
+                'img_dict': img_dict,
+                'default_refinements': pick_data['default_refinements'],
+                'tth_distortion': pick_data['tth_distortion'],
+                'calibration_picks': pick_data['picks'],
+            }
+            calibrators.append(PowderCalibrator(**kwargs))
 
-    # Run composite calibration
-    instr_calibrator = CompositeCalibration(instr, picks, img_dict)
-
-    x0_comp = instr_calibrator.reduced_params()
-
-    # Compute resd0, as hexrd does
-    resd0 = instr_calibrator.residual(x0_comp, picks)  # noqa: F841
-
-    x1, cox_x, infodict, mesg, ierr = leastsq(
-                        instr_calibrator.residual, x0_comp, args=(picks, ),
-                        full_output=True
-                )
-
-    # Evaluate new residual
-    # This will update the parameters
-    resd1 = instr_calibrator.residual(x1, picks)  # noqa: F841
-
-    return instr_calibrator
+        elif pick_data['type'] == 'laue':
+            # gpflags = [i[1] for i in pick_data['refinements']]
+            kwargs = {
+                'instr': instr,
+                'material': materials[pick_data['material']],
+                'grain_params': pick_data['options']['crystal_params'],
+                'default_refinements': pick_data['default_refinements'],
+                'min_energy': pick_data['options']['min_energy'],
+                'max_energy': pick_data['options']['max_energy'],
+                'calibration_picks': pick_data['picks'],
+            }
+            calibrators.append(LaueCalibrator(**kwargs))
+    return calibrators
 
 
-if __name__ == '__main__':
+def create_instrument_calibrator(picks, instr, img_dict, materials):
+    engineering_constraints = guess_instrument_type(instr.detectors)
+    calibrators = make_calibrators_from_picks(instr, picks, materials,
+                                              img_dict)
 
-    import json
-    import pickle as pkl
-
-    # %% grab serialiazed objects
-    instr = pkl.load(open('instrument.pkl', 'rb'))
-
-    with open('calibration_picks.json', 'r') as f:
-        picks = json.load(f)
-
-    material_names = [x['material'] for x in picks]
-    materials = {x: pkl.load(open(f'{x}.pkl', 'rb')) for x in material_names}
-
-    # instrument parameter flags
-    # !!! these come from the GUI tree view
-    iflags = np.array(
-        [0,
-         1, 1,
-         0,
-         0, 0, 0,
-         0, 0, 1, 1, 1, 1,
-         0, 0, 0, 1, 1, 1],
-        dtype=bool
+    return InstrumentCalibrator(
+        *calibrators,
+        engineering_constraints=engineering_constraints,
     )
-    instr.calibration_flags = iflags  # update instrument
-
-    instr_calibrator = run_calibration(picks, instr, materials)
-    instr.write_config('new-instrument-comp.yml')
-
-    # %%
-    """
-    Now we just need to update the values in the GUI; the instrument class is
-    updated already, can just grab its parameter dict
-    The powder and laue parameters can be lifted from the corresp classes
-    """
-    for ical, cal_class in enumerate(instr_calibrator.calibrators):
-        pnames = ['{:>24s}'.format(i[0]) for i in picks[ical]['refinements']]
-        print("calibrator type: %s" % cal_class.calibrator_type)
-        print("refined parameters:")
-        for pname, param in zip(pnames, cal_class.params):
-            print("\t%s = %.7e" % (pname, param))

--- a/hexrdgui/calibration/structureless/runner.py
+++ b/hexrdgui/calibration/structureless/runner.py
@@ -1,4 +1,3 @@
-import copy
 from itertools import cycle
 import traceback
 
@@ -11,13 +10,15 @@ from PySide6.QtWidgets import QFileDialog, QMessageBox
 from hexrd.fitting.calibration import StructureLessCalibrator
 
 from hexrdgui.calibration.calibration_dialog import CalibrationDialog
+from hexrdgui.calibration.calibration_dialog_callbacks import (
+    CalibrationDialogCallbacks,
+)
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.line_picker_dialog import LinePickerDialog
 from hexrdgui.markers import igor_marker
 from hexrdgui.select_item_dialog import SelectItemDialog
 from hexrdgui.tree_views import GenericPicksTreeViewDialog
-from hexrdgui.utils import instr_to_internal_dict
 from hexrdgui.utils.conversions import angles_to_cart, cart_to_angles
 from hexrdgui.utils.dialog import add_help_url
 from hexrdgui.utils.guess_instrument_type import guess_instrument_type
@@ -36,18 +37,8 @@ class StructurelessCalibrationRunner(QObject):
         self.canvas = canvas
         self.async_runner = async_runner
         self.parent = parent
-        self.drawing_picks = False
 
         self._calibration_dialog = None
-        self._edit_picks_dialog = None
-
-        self.undo_stack = []
-        self.draw_picks_lines = []
-
-        self.setup_connections()
-
-    def setup_connections(self):
-        HexrdConfig().image_view_loaded.connect(self.on_image_view_loaded)
 
     def clear(self):
         pass
@@ -84,10 +75,6 @@ class StructurelessCalibrationRunner(QObject):
             )
             QMessageBox.information(self.parent, 'HEXRD', msg)
             HexrdConfig().polar_tth_distortion_object = None
-
-    def finished(self):
-        self.draw_picks(False)
-        self.set_focus_mode(False)
 
     def set_focus_mode(self, b):
         # This will disable some widgets in the GUI during focus mode
@@ -180,7 +167,7 @@ class StructurelessCalibrationRunner(QObject):
 
             try:
                 calibration_lines = load_picks_from_file(selected_file)
-                self._validate_picks(calibration_lines)
+                validate_picks(calibration_lines, self.instr)
             except Exception as e:
                 QMessageBox.critical(self.parent, 'HEXRD', f'Error: {e}')
                 traceback.print_exc()
@@ -212,7 +199,7 @@ class StructurelessCalibrationRunner(QObject):
     def show_calibration_dialog(self, calibrator_lines):
         self.previous_picks_data = calibrator_lines
 
-        engineering_constraints = self.guess_engineering_constraints
+        engineering_constraints = guess_instrument_type(self.instr.detectors)
 
         # Create the structureless calibrator with the data
         # FIXME: add the tth_distortion dict here, if present
@@ -223,10 +210,8 @@ class StructurelessCalibrationRunner(QObject):
         }
         self.calibrator = StructureLessCalibrator(**kwargs)
 
-        # Round the calibrator numbers to 3 decimal places
-        self.round_param_numbers(3)
-
-        def format_extra_params_func(params_dict, tree_dict, create_param_item):
+        def format_extra_params_func(params_dict, tree_dict,
+                                     create_param_item):
             # Make the debye scherrer ring means
             key = 'Debye-Scherrer ring means'
             template = 'DS_ring_{i}'
@@ -252,19 +237,11 @@ class StructurelessCalibrationRunner(QObject):
         }
         dialog = CalibrationDialog(**kwargs)
 
-        self.draw_picks(True)
-
         # Connect interactions to functions
-        dialog.ui.draw_picks.setChecked(self.drawing_picks)
-        dialog.draw_picks_toggled.connect(self.draw_picks)
-        dialog.edit_picks_clicked.connect(self._on_edit_picks_clicked)
-        dialog.save_picks_clicked.connect(self._on_save_picks_clicked)
-        dialog.load_picks_clicked.connect(self._on_load_picks_clicked)
-        dialog.engineering_constraints_changed.connect(
-            self._on_engineering_constraints_changed)
-        dialog.run.connect(self._on_dialog_run_clicked)
-        dialog.undo_run.connect(self._on_dialog_undo_run_clicked)
-        dialog.finished.connect(self._on_dialog_finished)
+        self._dialog_callback_handler = StructurelessCalibrationCallbacks(
+            dialog, self.calibrator, self.instr, self.async_runner)
+        self._dialog_callback_handler.instrument_updated.connect(
+            self.instrument_updated.emit)
         dialog.show()
 
         self._calibration_dialog = dialog
@@ -275,292 +252,6 @@ class StructurelessCalibrationRunner(QObject):
         self.set_focus_mode(True)
 
         return dialog
-
-    def _on_edit_picks_clicked(self):
-        # Convert to polar lines
-        data = cart_to_polar_lines(self.calibrator_lines, self.instr)
-
-        # Convert to lists
-        for i in range(len(data)):
-            data[i] = data[i].tolist()
-
-        # Now convert to a dictionary for the line labels
-        dictionary = {}
-        for ring_idx, v in enumerate(data):
-            name = f'DS ring {ring_idx + 1}'
-            dictionary[name] = data[ring_idx]
-
-        def new_line_name_generator():
-            nonlocal ring_idx
-            ring_idx += 1
-            return f'DS ring {ring_idx + 1}'
-
-        dialog = GenericPicksTreeViewDialog(dictionary, canvas=self.canvas,
-                                            parent=self.canvas)
-        dialog.tree_view.new_line_name_generator = new_line_name_generator
-        dialog.accepted.connect(self._on_edit_picks_accepted)
-        dialog.finished.connect(self._on_edit_picks_finished)
-        dialog.show()
-
-        self._edit_picks_dictionary = dictionary
-        self._edit_picks_dialog = dialog
-
-        self.clear_drawn_picks()
-        self._calibration_dialog.hide()
-
-    def _on_edit_picks_accepted(self):
-        lines = list(self._edit_picks_dictionary.values())
-        # Convert back to lines in cartesian coords
-        # lines = list(dictionary.values())
-        cart = polar_lines_to_cart(lines, self.instr)
-        self._set_picks(cart)
-
-    def _on_edit_picks_finished(self):
-        # Show this again
-        self._calibration_dialog.show()
-        self.redraw_picks()
-
-    def _on_save_picks_clicked(self):
-        title = 'Save Picks for Structureless Calibration'
-
-        selected_file, selected_filter = QFileDialog.getSaveFileName(
-            self.file_dialog_parent, title, HexrdConfig().working_dir,
-            'HDF5 files (*.h5 *.hdf5)')
-
-        if not selected_file:
-            # The user canceled
-            return
-
-        save_picks_to_file(self.calibrator_lines, selected_file)
-
-    def _on_load_picks_clicked(self):
-        title = 'Load Picks for Structureless Calibration'
-
-        selected_file, selected_filter = QFileDialog.getOpenFileName(
-            self.file_dialog_parent, title, HexrdConfig().working_dir,
-            'HDF5 files (*.h5 *.hdf5)')
-
-        if not selected_file:
-            # The user canceled
-            return
-
-        picks = load_picks_from_file(selected_file)
-        self._set_picks(picks)
-
-    def _set_picks(self, picks):
-        self._validate_picks(picks)
-        self.calibrator.data = picks
-
-        dialog = self._calibration_dialog
-        if dialog:
-            # Update the dialog
-            self.clear_drawn_picks()
-            dialog.params_dict = self.calibrator.params
-        else:
-            self.show_calibration_dialog(picks)
-
-        self.redraw_picks()
-
-    def _on_engineering_constraints_changed(self, new_constraint):
-        self.calibrator.engineering_constraints = new_constraint
-        dialog = self._calibration_dialog
-
-        # Keep old settings in the dialog if they are present in the new params
-        # Remember everything except the name (should be the same) and
-        # the expression (which might be modified from the engineering
-        # constraints).
-        to_remember = [
-            'value',
-            'vary',
-            'min',
-            'max',
-            'brute_step',
-            'user_data',
-        ]
-
-        for param_key, param in dialog.params_dict.items():
-            if param_key in self.calibrator.params:
-                current = self.calibrator.params[param_key]
-                for attr in to_remember:
-                    setattr(current, attr, getattr(param, attr))
-
-        dialog.params_dict = self.calibrator.params
-
-    def _validate_picks(self, picks):
-        # Verify that the detector keys match up
-        for det_lines in picks:
-            for det_key in det_lines:
-                if det_key not in self.instr.detectors:
-                    dets_str = ', '.join(self.instr.detectors)
-                    msg = (
-                        f'Detector "{det_key}" does not match current '
-                        f'detectors "{dets_str}"'
-                    )
-                    raise Exception(msg)
-
-    def _on_dialog_finished(self):
-        # This is called when the dialog finishes.
-        # Call any cleanup code.
-        self.finished()
-
-
-    def on_image_view_loaded(self, img_dict):
-        # If the image view is modified, it may have been because of
-        # edits to tth distortion, so we should redraw the picks.
-        self.redraw_picks()
-
-    def clear_drawn_picks(self):
-        while self.draw_picks_lines:
-            self.draw_picks_lines.pop(0).remove()
-
-        self.canvas.draw_idle()
-
-    def redraw_picks(self):
-        self.draw_picks(self.drawing_picks)
-
-    def draw_picks(self, b=True):
-        self.drawing_picks = b
-        self.clear_drawn_picks()
-
-        if not b:
-            return
-
-        line_settings = {
-            'marker': igor_marker,
-            'markeredgecolor': 'black',
-            'markersize': 16,
-            'linestyle': 'None',
-        }
-
-        prop_cycle = plt.rcParams['axes.prop_cycle']
-        color_cycler = cycle(prop_cycle.by_key()['color'])
-
-        polar_lines = cart_to_polar_lines(self.calibrator_lines, self.instr)
-        for points in polar_lines:
-            color = next(color_cycler)
-            artist, = self.canvas.axis.plot(points[:, 0], points[:, 1],
-                                            color=color, **line_settings)
-            self.draw_picks_lines.append(artist)
-
-        self.canvas.draw_idle()
-
-    def _on_dialog_run_clicked(self):
-        self.async_runner.progress_title = 'Running calibration...'
-        self.async_runner.success_callback = self.update_config_from_instrument
-        self.async_runner.run(self._run_calibration)
-
-    def _on_dialog_undo_run_clicked(self):
-        print('Undo changes')
-        self.pop_undo_stack()
-
-    def update_calibrator_tth_distortion(self):
-        dialog = self._calibration_dialog
-        if not dialog:
-            return
-
-        self.calibrator.tth_distortion = dialog.tth_distortion
-
-    def _run_calibration(self):
-        # Update the tth distortion on the calibrator from the dialog
-        self.update_calibrator_tth_distortion()
-
-        # Add the current parameters to the undo stack
-        self.push_undo_stack()
-
-        odict = self._calibration_dialog.advanced_options
-
-        x0 = self.calibrator.params.valuesdict()
-        result = self.calibrator.run_calibration(odict=odict)
-
-        # Round the calibrator numbers to 3 decimal places
-        self.round_param_numbers(3)
-
-        x1 = result.params.valuesdict()
-
-        results_message = 'Calibration Results:\n'
-        for name in x0:
-            if not result.params[name].vary:
-                continue
-
-            old = x0[name]
-            new = x1[name]
-            results_message += f'{name}: {old:6.3g} ---> {new:6.3g}\n'
-
-        print(results_message)
-
-        self.results_message = results_message
-
-    def update_config_from_instrument(self):
-        output_dict = instr_to_internal_dict(self.instr)
-
-        # Save the previous iconfig to restore the statuses
-        prev_iconfig = HexrdConfig().config['instrument']
-
-        # Update the config
-        HexrdConfig().config['instrument'] = output_dict
-
-        # This adds in any missing keys. In particular, it is going to
-        # add in any "None" detector distortions
-        HexrdConfig().set_detector_defaults_if_missing()
-
-        # Add status values
-        HexrdConfig().add_status(output_dict)
-
-        # Set the previous statuses to be the current statuses
-        HexrdConfig().set_statuses_from_prev_iconfig(prev_iconfig)
-
-        self.instrument_updated.emit()
-
-        # Update the tree_view in the GUI with the new refinements
-        self.update_refinements_tree_view()
-
-        # Update the drawn picks with their new locations
-        self.redraw_picks()
-
-    def update_refinements_tree_view(self):
-        dialog = self._calibration_dialog
-        dialog.params_dict = self.calibrator.params
-
-    def push_undo_stack(self):
-        dialog = self._calibration_dialog
-        calibrator = self.calibrator
-        stack_item = {
-            'engineering_constraints': calibrator.engineering_constraints,
-            'tth_distortion': copy.deepcopy(calibrator.tth_distortion),
-            'params': copy.deepcopy(calibrator.params),
-            'advanced_options': dialog.advanced_options,
-        }
-        self.undo_stack.append(stack_item)
-        self.update_undo_enable_state()
-
-    def pop_undo_stack(self):
-        stack_item = self.undo_stack.pop(-1)
-
-        calibrator_items = [
-            'engineering_constraints',
-            'tth_distortion',
-            # Put this last so it will get set last
-            'params',
-        ]
-
-        # Params should get set last
-        calibrator = self.calibrator
-        for k in calibrator_items:
-            v = stack_item[k]
-            setattr(calibrator, k, v)
-
-        self.instr.update_from_lmfit_parameter_list(calibrator.params)
-        self.update_config_from_instrument()
-
-        dialog = self._calibration_dialog
-        dialog.update_from_calibrator(calibrator)
-        dialog.advanced_options = stack_item['advanced_options']
-
-        self.update_undo_enable_state()
-
-    def update_undo_enable_state(self):
-        dialog = self._calibration_dialog
-        dialog.undo_enabled = bool(self.undo_stack)
 
     @property
     def previous_picks_data(self):
@@ -573,35 +264,11 @@ class StructurelessCalibrationRunner(QObject):
         setattr(HexrdConfig(), name, v)
 
     @property
-    def calibrator_lines(self):
-        return self.calibrator.data
-
-    @property
     def file_dialog_parent(self):
         # Use the calibration dialog as the parent if possible.
         # Otherwise, just use our parent.
         dialog = self._calibration_dialog
         return dialog.ui if dialog else self.canvas
-
-    def round_param_numbers(self, decimals=3):
-        params_dict = self.calibrator.params
-
-        attrs = [
-            'value',
-            'min',
-            'max',
-        ]
-        for param in params_dict.values():
-            for attr in attrs:
-                setattr(param, attr, round(getattr(param, attr), 3))
-
-    @property
-    def guess_engineering_constraints(self):
-        instr_type = guess_instrument_type(self.instr.detectors)
-        if instr_type == 'TARDIS':
-            return 'TARDIS'
-
-        return None
 
 
 def polar_lines_to_cart(data, instr):
@@ -660,3 +327,91 @@ def cart_to_polar_lines(calibrator_lines, instr):
         output.append(points)
 
     return output
+
+
+def validate_picks(picks, instr):
+    # Verify that the detector keys match up
+    for det_lines in picks:
+        for det_key in det_lines:
+            if det_key not in instr.detectors:
+                dets_str = ', '.join(instr.detectors)
+                msg = (
+                    f'Detector "{det_key}" does not match current '
+                    f'detectors "{dets_str}"'
+                )
+                raise Exception(msg)
+
+
+class StructurelessCalibrationCallbacks(CalibrationDialogCallbacks):
+
+    @property
+    def calibrator_lines(self):
+        return self.calibrator.data
+
+    def draw_picks_on_canvas(self):
+        line_settings = {
+            'marker': igor_marker,
+            'markeredgecolor': 'black',
+            'markersize': 16,
+            'linestyle': 'None',
+        }
+
+        prop_cycle = plt.rcParams['axes.prop_cycle']
+        color_cycler = cycle(prop_cycle.by_key()['color'])
+
+        polar_lines = cart_to_polar_lines(self.calibrator_lines, self.instr)
+        for points in polar_lines:
+            color = next(color_cycler)
+            artist, = self.canvas.axis.plot(points[:, 0], points[:, 1],
+                                            color=color, **line_settings)
+            self.draw_picks_lines.append(artist)
+
+        self.canvas.draw_idle()
+
+    def on_edit_picks_clicked(self):
+        # Convert to polar lines
+        data = cart_to_polar_lines(self.calibrator_lines, self.instr)
+
+        # Convert to lists
+        for i in range(len(data)):
+            data[i] = data[i].tolist()
+
+        # Now convert to a dictionary for the line labels
+        dictionary = {}
+        for ring_idx, v in enumerate(data):
+            name = f'DS ring {ring_idx + 1}'
+            dictionary[name] = data[ring_idx]
+
+        def new_line_name_generator():
+            nonlocal ring_idx
+            ring_idx += 1
+            return f'DS ring {ring_idx + 1}'
+
+        dialog = GenericPicksTreeViewDialog(dictionary, canvas=self.canvas,
+                                            parent=self.canvas)
+        dialog.tree_view.new_line_name_generator = new_line_name_generator
+        dialog.accepted.connect(self.on_edit_picks_accepted)
+        dialog.finished.connect(self.on_edit_picks_finished)
+        dialog.show()
+
+        self.edit_picks_dictionary = dictionary
+        self.edit_picks_dialog = dialog
+
+        self.clear_drawn_picks()
+        self.dialog.hide()
+
+    def on_edit_picks_accepted(self):
+        lines = list(self.edit_picks_dictionary.values())
+        # Convert back to lines in cartesian coords
+        # lines = list(dictionary.values())
+        cart = polar_lines_to_cart(lines, self.instr)
+        self.set_picks(cart)
+
+    def save_picks_to_file(self, selected_file):
+        save_picks_to_file(self.calibrator_lines, selected_file)
+
+    def load_picks_from_file(self, selected_file):
+        return load_picks_from_file(selected_file)
+
+    def validate_picks(self, picks):
+        return validate_picks(picks, self.instr)

--- a/hexrdgui/calibration/structureless/runner.py
+++ b/hexrdgui/calibration/structureless/runner.py
@@ -7,7 +7,7 @@ import numpy as np
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtWidgets import QFileDialog, QMessageBox
 
-from hexrd.fitting.calibration import StructureLessCalibrator
+from hexrd.fitting.calibration import StructurelessCalibrator
 
 from hexrdgui.calibration.calibration_dialog import CalibrationDialog
 from hexrdgui.calibration.calibration_dialog_callbacks import (
@@ -208,7 +208,7 @@ class StructurelessCalibrationRunner(QObject):
             'data': calibrator_lines,
             'engineering_constraints': engineering_constraints,
         }
-        self.calibrator = StructureLessCalibrator(**kwargs)
+        self.calibrator = StructurelessCalibrator(**kwargs)
 
         def format_extra_params_func(params_dict, tree_dict,
                                      create_param_item):
@@ -234,6 +234,7 @@ class StructurelessCalibrationRunner(QObject):
             'parent': self.parent,
             'engineering_constraints': engineering_constraints,
             'window_title': 'Structureless Calibration Dialog',
+            'help_url': 'calibration/structureless'
         }
         dialog = CalibrationDialog(**kwargs)
 
@@ -344,6 +345,12 @@ def validate_picks(picks, instr):
 
 class StructurelessCalibrationCallbacks(CalibrationDialogCallbacks):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.edit_picks_dialog = None
+        self.edit_picks_dictionary = None
+
     @property
     def calibrator_lines(self):
         return self.calibrator.data
@@ -412,6 +419,16 @@ class StructurelessCalibrationCallbacks(CalibrationDialogCallbacks):
 
     def load_picks_from_file(self, selected_file):
         return load_picks_from_file(selected_file)
+
+    def set_picks(self, picks):
+        self.validate_picks(picks)
+        self.calibrator.data = picks
+
+        # Update the dialog
+        self.clear_drawn_picks()
+        self.dialog.params_dict = self.calibrator.params
+
+        self.redraw_picks()
 
     def validate_picks(self, picks):
         return validate_picks(picks, self.instr)

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -220,6 +220,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when material parameters are modified"""
     material_modified = Signal(str)
 
+    """Emitted when the active canvas is changed"""
+    active_canvas_changed = Signal()
+
     """Emitted when image mode widget should be enabled/disabled"""
     enable_image_mode_widget = Signal(bool)
 
@@ -292,6 +295,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.default_cmap = constants.DEFAULT_CMAP
         self._previous_structureless_calibration_picks_data = None
         self.image_mode = constants.ViewType.raw
+        self._active_canvas = None
         self._sample_tilt = np.asarray([0, 0, 0], float)
         self.recent_state_files = []
 
@@ -757,6 +761,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
             if isinstance(default[key], dict):
                 self._recursive_set_defaults(current[key], default[key])
+
+    @property
+    def active_canvas(self):
+        return self._active_canvas
+
+    @active_canvas.setter
+    def active_canvas(self, v):
+        if v is self._active_canvas:
+            return
+
+        self._active_canvas = v
+        self.active_canvas_changed.emit()
 
     def image(self, name, idx):
         return self.imageseries(name)[idx]

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -232,6 +232,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when image mode widget needs to be in a certain mode"""
     set_image_mode_widget_tab = Signal(str)
 
+    """Emitted when the image mode changed"""
+    image_mode_changed = Signal(str)
+
     """Emitted when canvas focus mode should be started/stopped
 
     In canvas focus mode, the following widgets in the main window are
@@ -294,7 +297,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.limited_cmaps_list = constants.DEFAULT_LIMITED_CMAPS
         self.default_cmap = constants.DEFAULT_CMAP
         self._previous_structureless_calibration_picks_data = None
-        self.image_mode = constants.ViewType.raw
+        self._image_mode = constants.ViewType.raw
         self._active_canvas = None
         self._sample_tilt = np.asarray([0, 0, 0], float)
         self.recent_state_files = []
@@ -761,6 +764,18 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
             if isinstance(default[key], dict):
                 self._recursive_set_defaults(current[key], default[key])
+
+    @property
+    def image_mode(self):
+        return self._image_mode
+
+    @image_mode.setter
+    def image_mode(self, v):
+        if v == self._image_mode:
+            return
+
+        self._image_mode = v
+        self.image_mode_changed.emit(v)
 
     @property
     def active_canvas(self):

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1441,7 +1441,7 @@ class ImageCanvas(FigureCanvas):
         self.clear_auto_picked_data_artists()
 
         xys = HexrdConfig().auto_picked_data
-        if xys is None:
+        if xys is None or self.iviewer is None:
             return
 
         for det_key, panel in self.iviewer.instr.detectors.items():

--- a/hexrdgui/line_picker_dialog.py
+++ b/hexrdgui/line_picker_dialog.py
@@ -39,7 +39,8 @@ class LinePickerDialog(QObject):
     view_picks = Signal()
 
     def __init__(self, canvas, parent, single_line_mode=False,
-                 single_pick_mode=False, cycle_cursor_colors=False):
+                 single_pick_mode=False, cycle_cursor_colors=False,
+                 line_settings=None):
         super().__init__(parent)
 
         self.canvas = canvas
@@ -55,6 +56,16 @@ class LinePickerDialog(QObject):
         self.single_pick_mode = single_pick_mode
         self.cycle_cursor_colors = cycle_cursor_colors
         self.update_visible_states()
+
+        if line_settings is None:
+            line_settings = {
+                'marker': igor_marker,
+                'markeredgecolor': 'black',
+                'markersize': 16,
+                'linestyle': 'None',
+            }
+
+        self.line_settings = line_settings
 
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)
@@ -77,13 +88,6 @@ class LinePickerDialog(QObject):
         self.color_cycler = cycle(prop_cycle.by_key()['color'])
 
         self.move_dialog_to_left()
-
-        self.line_settings = {
-            'marker': igor_marker,
-            'markeredgecolor': 'black',
-            'markersize': 16,
-            'linestyle': 'None',
-        }
 
         self.setup_connections()
 

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -609,7 +609,7 @@ class MainWindow(QObject):
         canvas = self.ui.image_tab_widget.image_canvases[0]
         runner = CalibrationRunner(canvas, async_runner)
         self._calibration_runner = runner
-        runner.finished.connect(self.calibration_finished)
+        runner.calibration_finished.connect(self.calibration_finished)
 
         try:
             runner.run()
@@ -618,8 +618,6 @@ class MainWindow(QObject):
             raise
 
     def calibration_finished(self):
-        print('Calibration finished')
-        print('Updating the GUI')
         self.update_config_gui()
         self.deep_rerender()
 
@@ -998,13 +996,9 @@ class MainWindow(QObject):
         if hasattr(self, '_powder_runner'):
             self._powder_runner.clear()
 
-        self._powder_runner = PowderRunner(self.ui)
-        self._powder_runner.finished.connect(self.finish_powder_calibration)
-        self._powder_runner.run()
-
-    def finish_powder_calibration(self):
-        self.update_config_gui()
-        self.deep_rerender()
+        self._powder_runner = runner = PowderRunner(self.ui)
+        runner.calibration_finished.connect(self.calibration_finished)
+        runner.run()
 
     def update_config_gui(self):
         current_widget = self.ui.calibration_tab_widget.currentWidget()
@@ -1149,10 +1143,6 @@ class MainWindow(QObject):
         canvas = self.ui.image_tab_widget.image_canvases[0]
 
         overlays = HexrdConfig().overlays
-
-        # Pad all of the overlays to make sure their data is updated
-        for overlay in overlays:
-            overlay.pad_picks_data()
 
         kwargs = {
             'dictionary': overlays_to_tree_format(overlays),

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -99,6 +99,8 @@ class MainWindow(QObject):
         self.ui = loader.load_file('main_window.ui', parent)
         self.confirm_application_close = True
 
+        HexrdConfig().active_canvas = self.active_canvas
+
         self.progress_dialog = ProgressDialog(self.ui)
         self.progress_dialog.setWindowTitle('Calibration Running')
 
@@ -733,21 +735,26 @@ class MainWindow(QObject):
         self.update_all()
         self.update_config_gui()
 
+    @property
+    def active_canvas(self):
+        return self.ui.image_tab_widget.active_canvas
+
     def active_canvas_changed(self):
+        # Update the active canvas on HexrdConfig()
+        HexrdConfig().active_canvas = self.active_canvas
         self.update_drawn_mask_line_picker_canvas()
         self.update_mask_region_canvas()
 
     def update_drawn_mask_line_picker_canvas(self):
         if hasattr(self, '_apply_drawn_mask_line_picker'):
             self._apply_drawn_mask_line_picker.canvas_changed(
-                self.ui.image_tab_widget.active_canvas
+                self.active_canvas
             )
 
     def on_action_edit_apply_hand_drawn_mask_triggered(self):
         # Make the dialog
-        canvas = self.ui.image_tab_widget.active_canvas
         self._apply_drawn_mask_line_picker = (
-            HandDrawnMaskDialog(canvas, self.ui))
+            HandDrawnMaskDialog(self.active_canvas, self.ui))
         self._apply_drawn_mask_line_picker.start()
         self._apply_drawn_mask_line_picker.finished.connect(
             self.run_apply_hand_drawn_mask)
@@ -854,9 +861,7 @@ class MainWindow(QObject):
 
     def update_mask_region_canvas(self):
         if hasattr(self, '_masks_regions_dialog'):
-            self._masks_regions_dialog.canvas_changed(
-                self.ui.image_tab_widget.active_canvas
-            )
+            self._masks_regions_dialog.canvas_changed(self.active_canvas)
 
     def on_action_edit_apply_region_mask_triggered(self):
         self._masks_regions_dialog = MaskRegionsDialog(self.ui)
@@ -939,8 +944,7 @@ class MainWindow(QObject):
             self.deep_rerender()
 
     def on_show_raw_zoom_dialog(self):
-        canvas = self.ui.image_tab_widget.active_canvas
-        dialog = ZoomCanvasDialog(canvas, parent=self.ui)
+        dialog = ZoomCanvasDialog(self.active_canvas, parent=self.ui)
         self._zoom_dialog = dialog
         dialog.show()
 

--- a/hexrdgui/overlays/compatibility.py
+++ b/hexrdgui/overlays/compatibility.py
@@ -34,6 +34,14 @@ def from_dict(cls, d):
         type_str = cls.type.value
         d = CONVERSION_DICT[(version, CURRENT_DICT_VERSION)](d, type_str)
 
+    if d.get('calibration_picks'):
+        first_picks = next(iter(d['calibration_picks'].values()))
+        if not isinstance(first_picks, dict):
+            # It is not an HKL dict as we expect.
+            # We need to forget these because they are buggy and incompatible
+            # with the newer versions.
+            del d['calibration_picks']
+
     return cls(**d)
 
 

--- a/hexrdgui/overlays/const_chi_overlay.py
+++ b/hexrdgui/overlays/const_chi_overlay.py
@@ -206,10 +206,6 @@ class ConstChiOverlay(Overlay):
     def default_refinements(self):
         return []
 
-    def pad_picks_data(self):
-        # Const chi overlays do not currently support picks data
-        pass
-
     @property
     def has_picks_data(self):
         # Const chi overlays do not currently support picks data

--- a/hexrdgui/overlays/overlay.py
+++ b/hexrdgui/overlays/overlay.py
@@ -54,10 +54,6 @@ class Overlay(ABC):
     def has_picks_data(self):
         pass
 
-    @abstractmethod
-    def pad_picks_data(self):
-        pass
-
     @property
     @abstractmethod
     def calibration_picks_polar(self):
@@ -386,5 +382,15 @@ class Overlay(ABC):
     def reset_calibration_picks(self):
         # Make an empty list for each detector
         self._calibration_picks.clear()
-        self._calibration_picks |= {k: [] for k in self.data}
+
+        if self.display_mode != ViewType.cartesian:
+            # Cartesian uses a fake detector, so we don't want to
+            # use that for the calibration picks.
+            # But all other display modes should work.
+            self._calibration_picks |= {k: {} for k in self.data}
+
         self.pad_picks_data()
+
+    def pad_picks_data(self):
+        # Subclasses only need to override this if they actually need it
+        pass

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -159,10 +159,6 @@ class RotationSeriesOverlay(Overlay):
     def default_refinements(self):
         return default_crystal_refinements()
 
-    def pad_picks_data(self):
-        # Rotation series overlays do not currently support picks data
-        pass
-
     @property
     def has_picks_data(self):
         # Rotation series overlays do not currently support picks data

--- a/hexrdgui/pt_slider_dialog.py
+++ b/hexrdgui/pt_slider_dialog.py
@@ -178,11 +178,7 @@ class PTSliderDialog:
         if np.any(np.isnan(lparms)):
             raise Exception(f'lparms contains nan: {lparms}')
 
-        mat.latticeParameters = np.array([
-            # Convert to angstroms
-            *(lparms[:3] * 10),
-            *lparms[3:],
-        ])
+        mat.lparms = lparms
         mat.pressure = self.pressure
         mat.temperature = self.temperature
 

--- a/hexrdgui/reflections_table.py
+++ b/hexrdgui/reflections_table.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import Qt, QItemSelectionModel
 from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import QApplication, QMenu, QTableWidgetItem
 
-from hexrd.material.crystallography import hklToStr
+from hexrd.utils.hkl import hkl_to_str
 
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.reflections_selection_helper import ReflectionsSelectionHelper
@@ -319,7 +319,7 @@ class ReflectionsTable:
             hkl_ids = [-1] * len(hkls)
             for hkl_data in plane_data.hklDataList:
                 try:
-                    idx = hkls.index(hklToStr(hkl_data['hkl']))
+                    idx = hkls.index(hkl_to_str(hkl_data['hkl']))
                 except ValueError:
                     continue
                 else:

--- a/hexrdgui/resources/calibration/calibration_params_tree_view.yml
+++ b/hexrdgui/resources/calibration/calibration_params_tree_view.yml
@@ -22,6 +22,5 @@ detectors:
         Z: '{det}_tvec_z'
     radius: '{det}_radius'
     distortion parameters:
-Debye-Scherrer ring means:
 engineering constraints:
   distance between plates: tardis_distance_between_plates

--- a/hexrdgui/resources/calibration/default_calibration_config.yml
+++ b/hexrdgui/resources/calibration/default_calibration_config.yml
@@ -1,12 +1,9 @@
 powder:
   eta_tol: 5.0
   fit_tth_tol: 0.1
-  max_iter: 2
   int_cutoff: 0.0001
-  conv_tol: 0.0001
   pk_type: 'gaussian'
   bg_type: 'linear'
-  use_robust_optimization: true
   auto_guess_initial_fwhm: true
   initial_fwhm: 1.0
 laue_auto_picker:

--- a/hexrdgui/resources/ui/calibration_dialog.ui
+++ b/hexrdgui/resources/ui/calibration_dialog.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>structureless_calibration_dialog</class>
- <widget class="QDialog" name="structureless_calibration_dialog">
+ <class>calibration_dialog</class>
+ <widget class="QDialog" name="calibration_dialog">
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Structureless Calibration Dialog</string>
+   <string>Calibration Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="2" column="1">
@@ -148,7 +148,7 @@
       <item row="0" column="2">
        <widget class="QPushButton" name="load_picks_button">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load picks from a structureless calibration HDF5 file.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This HDF5 file is special to structureless calibration. Other HDF5 files will not work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Load picks from a calibration HDF5 file.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This HDF5 file is special to calibration. Other HDF5 files will not work.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Load Picks</string>
@@ -158,7 +158,7 @@
       <item row="0" column="1">
        <widget class="QPushButton" name="save_picks_button">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save picks to a structureless calibration HDF5 file.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This HDF5 file is special to structureless calibration.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Picks are saved as detector Cartesian coordinates (not as polar coordinates).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Save picks to a calibration HDF5 file.&lt;br/&gt;&lt;/p&gt;&lt;p&gt;This HDF5 file is special to calibration.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Picks are saved as detector Cartesian coordinates (not as polar coordinates).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Save Picks</string>

--- a/hexrdgui/resources/ui/laue_auto_picker_dialog.ui
+++ b/hexrdgui/resources/ui/laue_auto_picker_dialog.ui
@@ -10,6 +10,9 @@
     <height>284</height>
    </rect>
   </property>
+  <property name="windowTitle">
+   <string>Laue Auto Picker</string>
+  </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="3" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="button_box">

--- a/hexrdgui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrdgui/resources/ui/powder_calibration_dialog.ui
@@ -7,67 +7,21 @@
     <x>0</x>
     <y>0</y>
     <width>750</width>
-    <height>479</height>
+    <height>395</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Fast Powder Calibration</string>
+   <string>Auto Pick Powder Points</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="3" column="0" colspan="3">
-    <widget class="QGroupBox" name="optimization_parameters_group">
-     <property name="title">
-      <string>Optimization Parameters:</string>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
-     <layout class="QGridLayout" name="gridLayout_5">
-      <item row="0" column="0">
-       <widget class="QLabel" name="conv_tol_label">
-        <property name="text">
-         <string>Convergence Tolerance (Δr):</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QSpinBox" name="max_iter">
-        <property name="minimum">
-         <number>1</number>
-        </property>
-        <property name="maximum">
-         <number>10000000</number>
-        </property>
-        <property name="value">
-         <number>1</number>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="ScientificDoubleSpinBox" name="conv_tol">
-        <property name="decimals">
-         <number>8</number>
-        </property>
-        <property name="maximum">
-         <double>1000000.000000000000000</double>
-        </property>
-        <property name="value">
-         <double>0.000100000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="max_iter_label">
-        <property name="text">
-         <string>Max iterations:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="robust">
-        <property name="text">
-         <string>Use robust optimization?</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
     </widget>
    </item>
    <item row="0" column="1" rowspan="2" colspan="2">
@@ -199,16 +153,6 @@
      </layout>
     </widget>
    </item>
-   <item row="4" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0" rowspan="2">
     <widget class="QGroupBox" name="annular_sector_widths_group">
      <property name="title">
@@ -294,9 +238,6 @@
   <tabstop>background_type</tabstop>
   <tabstop>auto_guess_initial_fwhm</tabstop>
   <tabstop>initial_fwhm</tabstop>
-  <tabstop>conv_tol</tabstop>
-  <tabstop>max_iter</tabstop>
-  <tabstop>robust</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/hexrdgui/tree_views/base_dict_tree_item_model.py
+++ b/hexrdgui/tree_views/base_dict_tree_item_model.py
@@ -174,7 +174,6 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
                 cur_val = cur_val[val]
         except KeyError:
             msg = f'Path: {path}\nwas not found in dict: {self.config}'
-            breakpoint()
             raise Exception(msg)
 
         return cur_val
@@ -325,6 +324,9 @@ class BaseDictTreeView(QTreeView):
     @property
     def selected_items(self):
         return [self.model().get_item(x) for x in self.selected_rows]
+
+    def clear_selection(self):
+        self.selectionModel().clearSelection()
 
     def contextMenuEvent(self, event):
         # Generate the actions

--- a/hexrdgui/tree_views/hkl_picks_tree_view.py
+++ b/hexrdgui/tree_views/hkl_picks_tree_view.py
@@ -19,6 +19,22 @@ Y_COL = X_COL + 1
 
 class HKLPicksTreeView(GenericPicksTreeView):
 
+    def item_type(self, tree_item):
+        root_item = self.model().root_item
+
+        parents_to_root = 1
+        parent = tree_item.parent_item
+        while parent is not root_item:
+            parent = parent.parent_item
+            parents_to_root += 1
+
+        if parents_to_root == 3:
+            return 'spot'
+        elif parents_to_root == 4:
+            return 'line'
+
+        raise Exception(f'Unknown parents_to_root: {parents_to_root}')
+
     def clear_highlights(self):
         for overlay in HexrdConfig().overlays:
             overlay.clear_highlights()

--- a/hexrdgui/utils/__init__.py
+++ b/hexrdgui/utils/__init__.py
@@ -20,6 +20,7 @@ from hexrd.rotations import (
 )
 from hexrd.transforms.xfcapi import makeRotMatOfExpMap
 from hexrd.utils.decorators import memoize
+from hexrd.utils.hkl import str_to_hkl
 
 
 class SnipAlgorithmType(IntEnum):
@@ -429,7 +430,7 @@ def apply_symmetric_constraint(x):
 
 def hkl_str_to_array(hkl):
     # For instance: '1 -1 10' => np.array((1, -1, 10))
-    return np.array(list(map(int, hkl.split())))
+    return np.array(str_to_hkl(hkl))
 
 
 def is_omega_imageseries(ims):

--- a/hexrdgui/utils/abc_qobject.py
+++ b/hexrdgui/utils/abc_qobject.py
@@ -1,0 +1,13 @@
+from abc import ABC, ABCMeta
+
+from PySide6.QtCore import QObject
+
+QObjectMeta = type(QObject)
+
+
+class _ABCQObjectMeta(QObjectMeta, ABCMeta):
+    pass
+
+
+class ABCQObject(QObject, ABC, metaclass=_ABCQObjectMeta):
+    pass


### PR DESCRIPTION
A generic calibration dialog was added that re-uses the same dialog
for various calibration workflows. This allows users to utilize
the new lmfit parameters (from hexrd/hexrd#628) as well as more
generally control the calibration procedure (including "undo", or
changing refinable parameters and running again), after points have
been picked.

The "Fast Powder" and "Composite (Laue and Powder)" have been updated
to utilize this generic calibration dialog.

Depends on: hexrd/hexrd#628
