### PR TITLE
Aggregate HKL powder lines in the polar lineout

### DIFF
--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -6,6 +6,7 @@ from hexrd import constants
 from hexrd.material import unitcell
 
 from hexrd.transforms import xfcapi
+from hexrd.utils.hkl import hkl_to_str
 
 from hexrdgui.constants import OverlayType, ViewType
 from hexrdgui.overlays.overlay import Overlay
@@ -39,6 +40,9 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         self.tth_distortion_type = tth_distortion_type
         self.tth_distortion_kwargs = tth_distortion_kwargs
         self.clip_with_panel_buffer = clip_with_panel_buffer
+
+        # Store hkl means if we are in the polar view (for azimuthal lineout)
+        self.hkl_means = {}
 
     @property
     def child_attributes_to_save(self):
@@ -184,6 +188,9 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         self.calibration_picks = picks
 
     def generate_overlay(self):
+        # Ensure hkl means is cleared
+        self.hkl_means.clear()
+
         instr = self.instrument
         plane_data = self.plane_data
         display_mode = self.display_mode
@@ -237,7 +244,79 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                 point_groups[det_key]['rbnds'] += upper_pts
                 point_groups[det_key]['rbnd_indices'] += upper_indices
 
+        if display_mode == ViewType.polar:
+            self.generate_hkl_means(point_groups)
+
         return point_groups
+
+    def generate_hkl_means(self, point_groups):
+        # Concatenate all hkl rings and rbnds together for the polar
+        # view azimuthal lineout.
+        hkl_data = {}
+
+        for det_key, data in point_groups.items():
+            for i, hkl in enumerate(data['hkls']):
+                hkl_str = hkl_to_str(hkl)
+                if hkl_str not in hkl_data:
+                    hkl_data[hkl_str] = {'rings': []}
+                    if 'rbnds' in data:
+                        hkl_data[hkl_str]['rbnds'] = {
+                            'lower': [],
+                            'upper': [],
+                            'merged': False,
+                        }
+
+                hkl_data[hkl_str]['rings'].append(data['rings'][i])
+
+                if 'rbnds' not in data:
+                    # Do not include ranges
+                    continue
+
+                # We should encounter two instances of this rbnd.
+                # The first index will be lower.
+                lower = True
+                for j, ind_list in enumerate(data['rbnd_indices']):
+                    # Only pay attention to one of the HKLs in the ind
+                    # list, so we don't duplicate data.
+                    if ind_list[0] == i:
+                        # This rbnd uses this hkl
+                        key = 'lower' if lower else 'upper'
+                        hkl_data[hkl_str]['rbnds'][key].append(
+                            data['rbnds'][j]
+                        )
+
+                        # Indicate whether this is a merged range or not
+                        hkl_data[hkl_str]['rbnds']['merged'] = (
+                            len(ind_list) > 1
+                        )
+
+                        # We found the lower. Next must be upper
+                        lower = False
+
+        # Now compute the means
+        means = {}
+        for hkl_str, data in hkl_data.items():
+            hkl_means = means.setdefault(hkl_str, {})
+
+            stacked = np.vstack(data['rings'])
+            hkl_means['rings'] = np.nanmean(stacked[:, 0])
+
+            if 'rbnds' not in data:
+                # No ranges
+                continue
+
+            hkl_rbnd_means = hkl_means.setdefault('rbnds', {})
+            for key in ('lower', 'upper'):
+                entry = data['rbnds'][key]
+                if not entry:
+                    hkl_rbnd_means[key] = np.nan
+                    continue
+
+                hkl_rbnd_means[key] = np.nanmean(np.vstack(entry)[:, 0])
+
+            hkl_rbnd_means['merged'] = data['rbnds']['merged']
+
+        self.hkl_means = means
 
     def generate_ring_points(self, instr, tths, etas, panel, display_mode):
         from hexrdgui.hexrd_config import HexrdConfig


### PR DESCRIPTION
Before this PR, each detector would draw the mean of its own powder line data in the polar view azimuthal lineout. This isn't noticeable when the powder lines are completely straight. However, when the powder lines are not completely straight, the duplicate lines would be visible as separate means.

To avoid this, concatenate all lines that belong to the same HKL from each detector, and take their mean together. Use this mean to draw a single line in the azimuthal lineout. Repeat this kind of thing for the ranges, too.

# Before
![before](https://github.com/HEXRD/hexrdgui/assets/9558430/3d5c3445-8001-45d9-8bc7-4f57efd7fc8e)

# After
![after](https://github.com/HEXRD/hexrdgui/assets/9558430/687995d1-bcac-4e97-8c1d-c2ac38b21f2b)

Fixes: #1432