### PR TITLE
Improve performance of generating polar masks

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -48,12 +48,16 @@ class PolarView:
 
         self.distortion_instr = distortion_instrument
 
-        # Use an image dict with the panel buffers applied.
-        # This keeps invalid pixels from bleeding out in the polar view
-        self.images_dict = HexrdConfig().images_dict
-        # 0 is a better fill value because it results in fewer nans in
-        # the final image.
-        HexrdConfig().apply_panel_buffer_to_images(self.images_dict, 0)
+        if instrument is None:
+            # This is a dummy polar view
+            self._images_dict = None
+        else:
+            # Use an image dict with the panel buffers applied.
+            # This keeps invalid pixels from bleeding out in the polar view
+            self.images_dict = HexrdConfig().images_dict
+            # 0 is a better fill value because it results in fewer nans in
+            # the final image.
+            HexrdConfig().apply_panel_buffer_to_images(self.images_dict, 0)
 
         self.warp_dict = {}
 
@@ -445,7 +449,7 @@ class PolarView:
         for mask in MaskManager().masks.values():
             if mask.type == MaskType.threshold or not mask.visible:
                 continue
-            mask_arr = mask.get_masked_arrays(ViewType.polar)
+            mask_arr = mask.get_masked_arrays(ViewType.polar, self.instr)
             total_mask = np.logical_or(total_mask, ~mask_arr)
         if (tm := MaskManager().threshold_mask) and tm.visible:
             lt_val, gt_val = tm.data
@@ -465,7 +469,7 @@ class PolarView:
         for mask in MaskManager().masks.values():
             if mask.type == MaskType.threshold or not mask.show_border:
                 continue
-            mask_arr = mask.get_masked_arrays(ViewType.polar)
+            mask_arr = mask.get_masked_arrays(ViewType.polar, self.instr)
             total_mask = np.logical_or(total_mask, ~mask_arr)
         img[total_mask] = np.nan
 

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -30,6 +30,7 @@ def convert_raw_to_polar(instr, det, line):
 
 def create_polar_mask(line_data):
     # Calculate current image dimensions
+    # If we pass `None` to the polar view, it is a dummy polar view
     pv = PolarView(None)
     shape = pv.shape
     num_pix_eta = shape[0]
@@ -148,8 +149,12 @@ def create_polar_line_data_from_raw(instr, value):
     return line_data
 
 
-def create_polar_mask_from_raw(value):
-    instr = create_view_hedm_instrument()
+def create_polar_mask_from_raw(value, instr=None):
+    if instr is None:
+        # An instrument can be passed for improved performance.
+        # If one wasn't passed, create one.
+        instr = create_hedm_instrument()
+
     line_data = create_polar_line_data_from_raw(instr, value)
     return create_polar_mask(line_data)
 

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -86,16 +86,16 @@ class RegionMask(Mask):
         self._raw = values
         self.invalidate_masked_arrays()
 
-    def update_masked_arrays(self, view=ViewType.raw):
+    def update_masked_arrays(self, view=ViewType.raw, instr=None):
         self.masked_arrays_view_mode = view
         if view == ViewType.raw:
             self.masked_arrays = create_raw_mask(self._raw)
         else:
-            self.masked_arrays = create_polar_mask_from_raw(self._raw)
+            self.masked_arrays = create_polar_mask_from_raw(self._raw, instr)
 
-    def get_masked_arrays(self, image_mode=ViewType.raw):
+    def get_masked_arrays(self, image_mode=ViewType.raw, instr=None):
         if self.masked_arrays is None or self.masked_arrays_view_mode != image_mode:
-            self.update_masked_arrays(image_mode)
+            self.update_masked_arrays(image_mode, instr)
 
         return self.masked_arrays
 


### PR DESCRIPTION
For a large number of polar masks, `create_hedm_instrument()` was taking a lot of cumulative time, since it was being called repeatedly. Provide the option to pass it in as an argument for performance.

Also, an intensity-corrected images dict was being repeatedly created. Now, we skip that step if the PolarView is initialized with an instrument that is `None`.

This resulted in a ~50% performance improvement for generating the polar view with an example that had 42 masks.