### PR TITLE
Add pinhole radius to sample layer distortion

### DIFF
--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -42,6 +42,8 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         self.tth_distortion_kwargs = tth_distortion_kwargs
         self.clip_with_panel_buffer = clip_with_panel_buffer
 
+        self.validate_tth_distortion_kwargs()
+
         # Store hkl means if we are in the polar view (for azimuthal lineout)
         self.hkl_means = {}
 
@@ -56,6 +58,13 @@ class PowderOverlay(Overlay, PolarDistortionObject):
             'tth_distortion_kwargs',
             'clip_with_panel_buffer',
         ]
+
+    def validate_tth_distortion_kwargs(self):
+        if self.tth_distortion_type == 'SampleLayerDistortion':
+            # We added pinhole_radius later. Set a default if it is missing.
+            if 'pinhole_radius' not in self.tth_distortion_kwargs:
+                # Set to 0.15 mm for default
+                self.tth_distortion_kwargs['pinhole_radius'] = 0.15
 
     @property
     def has_widths(self):

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -115,6 +115,8 @@ class PinholeCorrectionEditor(QObject):
                     self.ui.sample_layer_thickness.value() * 1e-3),
                 'pinhole_thickness': (
                     self.ui.sample_pinhole_thickness.value() * 1e-3),
+                'pinhole_radius': (
+                    self.ui.sample_pinhole_radius.value() * 1e-3),
             }
         elif dtype == 'JHEPinholeDistortion':
             return {
@@ -144,6 +146,7 @@ class PinholeCorrectionEditor(QObject):
             'sample_layer_standoff': ('layer_standoff', 0.15),
             'sample_layer_thickness': ('layer_thickness', 0.005),
             'sample_pinhole_thickness': ('pinhole_thickness', 0.1),
+            'sample_pinhole_radius': ('pinhole_radius', 0.15),
             'rygg_radius': ('pinhole_radius', 0.2),
             'rygg_thickness': ('pinhole_thickness', 0.1),
             'rygg_num_phi_elements': ('num_phi_elements', 60),
@@ -188,6 +191,7 @@ class PinholeCorrectionEditor(QObject):
             self.ui.sample_layer_standoff,
             self.ui.sample_layer_thickness,
             self.ui.sample_pinhole_thickness,
+            self.ui.sample_pinhole_radius,
         ]
 
     @property

--- a/hexrdgui/polar_distortion_object.py
+++ b/hexrdgui/polar_distortion_object.py
@@ -143,4 +143,10 @@ class PolarDistortionObject:
 
     @classmethod
     def deserialize(cls, d):
+        if d.get('pinhole_distortion_type') == 'SampleLayerDistortion':
+            # We added pinhole_radius later. Set a default if it is missing.
+            if 'pinhole_radius' not in d['pinhole_distortion_kwargs']:
+                # Set to 0.15 mm for default
+                d['pinhole_distortion_kwargs']['pinhole_radius'] = 0.15
+
         return cls(**d)

--- a/hexrdgui/resources/ui/pinhole_correction_editor.ui
+++ b/hexrdgui/resources/ui/pinhole_correction_editor.ui
@@ -58,48 +58,10 @@
        <string>Sample Layer</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0">
-        <widget class="QLabel" name="sample_layer_standoff_label">
+       <item row="2" column="2">
+        <widget class="QLabel" name="label">
          <property name="text">
-          <string>Layer Standoff</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="sample_pinhole_thickness_label">
-         <property name="text">
-          <string>Pinhole Thickness</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="ScientificDoubleSpinBox" name="sample_pinhole_thickness">
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>30</height>
-          </size>
-         </property>
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="suffix">
-          <string> μm</string>
-         </property>
-         <property name="decimals">
-          <number>8</number>
-         </property>
-         <property name="minimum">
-          <double>0.100000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>10000000.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.010000000000000</double>
-         </property>
-         <property name="value">
-          <double>100.000000000000000</double>
+          <string>Pinhole Radius</string>
          </property>
         </widget>
        </item>
@@ -134,6 +96,37 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="2">
+        <widget class="ScientificDoubleSpinBox" name="sample_pinhole_thickness">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
+         <property name="suffix">
+          <string> μm</string>
+         </property>
+         <property name="decimals">
+          <number>8</number>
+         </property>
+         <property name="minimum">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>10000000.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>100.000000000000000</double>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="1">
         <widget class="ScientificDoubleSpinBox" name="sample_layer_thickness">
          <property name="minimumSize">
@@ -165,6 +158,13 @@
          </property>
         </widget>
        </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="sample_layer_standoff_label">
+         <property name="text">
+          <string>Layer Standoff</string>
+         </property>
+        </widget>
+       </item>
        <item row="0" column="1">
         <widget class="QLabel" name="sample_layer_thickness_label">
          <property name="text">
@@ -172,7 +172,42 @@
          </property>
         </widget>
        </item>
-       <item row="2" column="1">
+       <item row="0" column="2">
+        <widget class="QLabel" name="sample_pinhole_thickness_label">
+         <property name="text">
+          <string>Pinhole Thickness</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="2">
+        <widget class="ScientificDoubleSpinBox" name="sample_pinhole_radius">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
+         <property name="suffix">
+          <string> μm</string>
+         </property>
+         <property name="decimals">
+          <number>8</number>
+         </property>
+         <property name="maximum">
+          <double>100000000.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>200.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0" colspan="3">
         <spacer name="verticalSpacer_3">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -536,6 +571,7 @@ This will override any overlays that are currently being used for polar distorti
   <tabstop>sample_layer_standoff</tabstop>
   <tabstop>sample_layer_thickness</tabstop>
   <tabstop>sample_pinhole_thickness</tabstop>
+  <tabstop>sample_pinhole_radius</tabstop>
   <tabstop>rygg_radius</tabstop>
   <tabstop>rygg_thickness</tabstop>
   <tabstop>rygg_num_phi_elements</tabstop>
@@ -545,6 +581,7 @@ This will override any overlays that are currently being used for polar distorti
   <tabstop>jhe_radius</tabstop>
   <tabstop>jhe_thickness</tabstop>
   <tabstop>jhe_apply_panel_buffers</tabstop>
+  <tabstop>apply_to_polar_view</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This is now an option for sample layer distortion. It is used to compute the critical beta angle, and invalidate points outside of that angle.

Depends on: hexrd/hexrd#635