### PR TITLE
Masking fixes

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-13,
+            os: macos-12,
             package: 'dmg'
           }
         - {

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-latest,
+            os: macos-13,
             package: 'dmg'
           }
         - {
@@ -41,7 +41,7 @@ jobs:
         path: hexrdgui
 
     - name: Install conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: '3.11'

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -407,7 +407,7 @@ class PolarView:
 
         # Both "visible" and "boundary" masks are applied to the
         # computational image
-        comp_img = self.apply_boundary_masks(img)
+        comp_img = self.apply_boundary_masks(disp_img)
         self.computation_img = comp_img
 
     def apply_snip(self, img):
@@ -489,7 +489,7 @@ class PolarView:
 
         # Both "visible" and "boundary" masks are applied to the
         # computational image
-        comp_img = self.apply_boundary_masks(img)
+        comp_img = self.apply_boundary_masks(disp_img)
         self.computation_img = comp_img
 
     @property

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -401,14 +401,13 @@ class PolarView:
         # masks should also be distorted as well.
 
         # We only apply "visible" masks to the display image
-        img = self.apply_visible_masks(img)
-        disp_img = self.apply_tth_distortion(img)
+        img = self.apply_tth_distortion(img)
+        disp_img = self.apply_visible_masks(img)
         self.display_image = disp_img
 
         # Both "visible" and "boundary" masks are applied to the
         # computational image
         comp_img = self.apply_boundary_masks(img)
-        comp_img = self.apply_tth_distortion(comp_img)
         self.computation_img = comp_img
 
     def apply_snip(self, img):
@@ -484,14 +483,13 @@ class PolarView:
         # masks should also be distorted as well.
 
         # We only apply "visible" masks to the display image
-        img = self.apply_visible_masks(self.snipped_img)
-        disp_img = self.apply_tth_distortion(img)
+        img = self.apply_tth_distortion(self.snipped_img)
+        disp_img = self.apply_visible_masks(img)
         self.display_image = disp_img
 
         # Both "visible" and "boundary" masks are applied to the
         # computational image
         comp_img = self.apply_boundary_masks(img)
-        comp_img = self.apply_tth_distortion(comp_img)
         self.computation_img = comp_img
 
     @property

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1642,6 +1642,18 @@ class ImageCanvas(FigureCanvas):
                     verts = [v for k, v in mask.data if k == det]
             elif self.mode == ViewType.polar or self.mode == ViewType.stereo:
                 verts = create_polar_line_data_from_raw(instr, mask.data)
+                if self.mode == ViewType.polar:
+                    # Check for any major jumps in eta. That probably means
+                    # the border is wrapping around.
+                    for i, vert in enumerate(verts):
+                        # If there are two points far away, assume there
+                        # is a gap in the eta range.
+                        eta_diff = np.abs(np.diff(vert[:, 1]))
+                        delta_eta_est = np.nanmedian(eta_diff)
+                        tolerance = delta_eta_est * 10
+                        big_gaps, = np.nonzero(eta_diff > tolerance)
+                        verts[i] = np.insert(vert, big_gaps + 1, np.nan, axis=0)
+
                 if self.mode == ViewType.stereo:
                     # Now convert from polar to stereo
                     for i, vert in enumerate(verts):

--- a/hexrdgui/interactive_template.py
+++ b/hexrdgui/interactive_template.py
@@ -4,13 +4,12 @@ from matplotlib import patches
 from matplotlib.path import Path
 from matplotlib.transforms import Affine2D
 
-from skimage.draw import polygon
-
 from hexrdgui.constants import (
     KEY_ROTATE_ANGLE_FINE, KEY_TRANSLATE_DELTA, ViewType
 )
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.utils import has_nan
+from hexrdgui.utils.polygon import polygon_to_mask
 
 
 class InteractiveTemplate:
@@ -223,9 +222,7 @@ class InteractiveTemplate:
         for c, r in zip(cols, rows):
             c = c[~np.isnan(c)]
             r = r[~np.isnan(r)]
-            rr, cc = polygon(r, c, shape=self.img.shape)
-            mask = np.zeros(self.img.shape, dtype=bool)
-            mask[rr, cc] = True
+            mask = ~polygon_to_mask(np.vstack([c, r]).T, self.img.shape)
             master_mask = np.logical_xor(master_mask, mask)
         self.img[~master_mask] = 0
         return master_mask

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -93,10 +93,11 @@ def create_polar_mask(line_data):
 
 
 def _pixel_perimeter_to_mask(r, c, shape):
-    # The arguments are all forwarded to skimage.draw.polygon
-    rr, cc = polygon(r, c, shape=shape)
     mask = np.ones(shape, dtype=bool)
-    mask[rr, cc] = False
+    if len(r) and len(c):
+        # The arguments are all forwarded to skimage.draw.polygon
+        rr, cc = polygon(r, c, shape=shape)
+        mask[rr, cc] = False
     return mask
 
 

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -9,6 +9,7 @@ from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.utils import add_sample_points
 from hexrdgui.utils.conversions import pixels_to_angles
+from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
 def convert_raw_to_polar(instr, det, line):
@@ -25,7 +26,9 @@ def convert_raw_to_polar(instr, det, line):
         'tvec_s': instr.tvec,
     }
 
-    return [pixels_to_angles(**kwargs)]
+    line = pixels_to_angles(**kwargs)
+    line = apply_tth_distortion_if_needed(line, in_degrees=True)
+    return [line]
 
 
 def create_polar_mask(line_data):

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -1,14 +1,12 @@
 import numpy as np
 
 from skimage.draw import polygon
-from hexrdgui.constants import ViewType
 
-from hexrdgui.create_hedm_instrument import create_view_hedm_instrument
 from hexrdgui.calibration.polarview import PolarView
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.utils import add_sample_points
-from hexrdgui.utils.conversions import pixels_to_angles
+from hexrdgui.utils.conversions import cart_to_angles, pixels_to_cart
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
@@ -19,16 +17,17 @@ def convert_raw_to_polar(instr, det, line):
     # looks correct.
     line = add_sample_points(line, 300)
 
-    kwargs = {
-        'ij': line,
-        'panel': instr.detectors[det],
-        'eta_period': HexrdConfig().polar_res_eta_period,
-        'tvec_s': instr.tvec,
-    }
+    panel = instr.detectors[det]
+    cart = pixels_to_cart(line, panel)
+    xys, _ = panel.clip_to_panel(cart, buffer_edges=False)
 
-    line = pixels_to_angles(**kwargs)
+    kwargs = {
+        'eta_period': HexrdConfig().polar_res_eta_period,
+        'tvec_s': instr.tvec
+    }
+    line = cart_to_angles(xys, panel, **kwargs)
     line = apply_tth_distortion_if_needed(line, in_degrees=True)
-    return [line]
+    return [line] if line.size else None
 
 
 def create_polar_mask(line_data):
@@ -148,7 +147,8 @@ def create_polar_line_data_from_raw(instr, value):
     # This accepts an instrument rather than creating one for performance
     line_data = []
     for det, data in value:
-        line_data.extend(convert_raw_to_polar(instr, det, data))
+        if polar := convert_raw_to_polar(instr, det, data):
+            line_data.extend(polar)
     return line_data
 
 

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -13,9 +13,11 @@ from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 def convert_raw_to_polar(instr, det, line):
     # This accepts an instrument rather than creating one for performance
 
-    # Make sure there at least 300 sample points so that the conversion
+    # Make sure there at least 500 sample points so that the conversion
     # looks correct.
-    line = add_sample_points(line, 300)
+    # This needs to be greater than the number of sample points when going
+    # from polar to raw, so we can ensure that points along borders get added.
+    line = add_sample_points(line, 500)
 
     panel = instr.detectors[det]
     cart = pixels_to_cart(line, panel)

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -1,12 +1,11 @@
 import numpy as np
 
-from skimage.draw import polygon
-
 from hexrdgui.calibration.polarview import PolarView
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.utils import add_sample_points
 from hexrdgui.utils.conversions import cart_to_angles, pixels_to_cart
+from hexrdgui.utils.polygon import polygon_to_mask
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
@@ -93,12 +92,7 @@ def create_polar_mask(line_data):
 
 
 def _pixel_perimeter_to_mask(r, c, shape):
-    mask = np.ones(shape, dtype=bool)
-    if len(r) and len(c):
-        # The arguments are all forwarded to skimage.draw.polygon
-        rr, cc = polygon(r, c, shape=shape)
-        mask[rr, cc] = False
-    return mask
+    return polygon_to_mask(np.vstack([c, r]).T, shape)
 
 
 def _split_coords_1d(x, gap1, gap2):

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -92,7 +92,11 @@ def create_polar_mask(line_data):
 
 
 def _pixel_perimeter_to_mask(r, c, shape):
-    return polygon_to_mask(np.vstack([c, r]).T, shape)
+    polygon = np.vstack([c, r]).T
+    if polygon.size < 2:
+        return np.ones(shape, dtype=bool)
+
+    return polygon_to_mask(polygon, shape)
 
 
 def _split_coords_1d(x, gap1, gap2):

--- a/hexrdgui/masking/create_raw_mask.py
+++ b/hexrdgui/masking/create_raw_mask.py
@@ -1,13 +1,11 @@
 import numpy as np
 
 from skimage.draw import polygon
-from hexrdgui.constants import ViewType
 
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
-from hexrdgui.masking.constants import MaskType
 from hexrdgui.utils import add_sample_points
-from hexrdgui.utils.conversions import angles_to_pixels
+from hexrdgui.utils.conversions import angles_to_cart, cart_to_pixels
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
@@ -55,7 +53,9 @@ def convert_polar_to_raw(line_data, reverse_tth_distortion=True):
     instr = create_hedm_instrument()
     for line in line_data:
         for key, panel in instr.detectors.items():
-            raw = angles_to_pixels(line, panel, tvec_s=instr.tvec)
+            cart = angles_to_cart(line, panel, tvec_s=instr.tvec)
+            clipped_cart, _ = panel.clip_to_panel(cart, buffer_edges=False)
+            raw = cart_to_pixels(clipped_cart, panel)
             if all([np.isnan(x) for x in raw.flatten()]):
                 continue
 

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -351,7 +351,7 @@ class MaskManager(QObject, metaclass=QSingleton):
         mask.name = new_name
         self.masks[new_name] = mask
 
-    def masks_to_panel_buffer(self, selection, buff_val):
+    def masks_to_panel_buffer(self, selection):
         # Set the visible masks as the panel buffer(s)
         # We must ensure that we are using raw masks
         for det, mask in HexrdConfig().raw_masks_dict.items():
@@ -359,11 +359,13 @@ class MaskManager(QObject, metaclass=QSingleton):
             buffer_default = {'status': 0}
             buffer = detector_config.setdefault('buffer', buffer_default)
             buffer_value = detector_config['buffer'].get('value', None)
-            if isinstance(buffer_value, np.ndarray) and buff_val.ndim == 2:
+            if isinstance(buffer_value, np.ndarray) and buffer_value.ndim == 2:
                 if selection == 'Logical AND with buffer':
-                    mask = np.logical_and(mask, buffer_value)
+                    # Need to invert so True is invalid
+                    mask = ~np.logical_and(~mask, ~buffer_value)
                 elif selection == 'Logical OR with buffer':
-                    mask = np.logical_or(mask, buffer_value)
+                    # Need to invert so True is invalid
+                    mask = ~np.logical_or(~mask, ~buffer_value)
             buffer['value'] = mask
 
     def clear_all(self):

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -192,7 +192,7 @@ class MaskManagerDialog(QObject):
 
             selection = options.currentText()
 
-        MaskManager().masks_to_panel_buffer(selection, buff_val)
+        MaskManager().masks_to_panel_buffer(selection)
         msg = 'Masks set as panel buffers.'
         QMessageBox.information(self.parent, 'HEXRD', msg)
 

--- a/hexrdgui/utils/__init__.py
+++ b/hexrdgui/utils/__init__.py
@@ -459,6 +459,14 @@ def set_combobox_enabled_items(cb, enable_list):
     cb.setCurrentIndex(new_index)
 
 
+def remove_duplicate_neighbors(points):
+    # Remove any points from this 2D array that are duplicates with
+    # their next neighbor.
+    rolled = np.roll(points, -1, axis=0)
+    delete_indices = np.all(np.isclose(rolled - points, 0), axis=1)
+    return np.delete(points, delete_indices, axis=0)
+
+
 def add_sample_points(points, min_output_length):
     """Add extra sample points to a 2D array of points
 
@@ -480,7 +488,8 @@ def add_sample_points(points, min_output_length):
     rolled = np.roll(points, -1, axis=0)
 
     # Generate the extra points between each point and its neighbor
-    output = np.linspace(points, rolled, num=num_reps)
+    # Adding endpoint=False significantly reduces our number of duplicates.
+    output = np.linspace(points, rolled, num=num_reps, endpoint=False)
 
     # Transform back into the correct shape and return
     return output.T.reshape(2, -1).T

--- a/hexrdgui/utils/polygon.py
+++ b/hexrdgui/utils/polygon.py
@@ -1,0 +1,12 @@
+from PIL import Image, ImageDraw
+import numpy as np
+
+
+def polygon_to_mask(coords, mask_shape):
+    # This comes out very slightly different than scikit-image's polygon
+    # method, with the only differences being along the edges (plus or minus
+    # a pixel).
+    img = Image.fromarray(np.ones(mask_shape, dtype=bool))
+    ImageDraw.Draw(img).polygon(coords.flatten().tolist(), outline=0, fill=0)
+
+    return np.array(img)


### PR DESCRIPTION
- Make sure cartesian coordinates are clipped before converting to/from raw coords
- Apply tth distortion (if needed) to mask coords when converted from raw to polar

Fixes: #1690