### PR TITLE
Do not rerender when overwriting loaded state file

### DIFF
--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1417,14 +1417,13 @@ class MainWindow(QObject):
             # Re-load the imageseries
             # Keep the file open and let the imageseries close it...
             HexrdConfig().loading_state = True
+            self.color_map_editor.block_updates(True)
             try:
                 h5_file = h5py.File(selected_file, 'r')
                 state.load_imageseries_dict(h5_file)
             finally:
                 HexrdConfig().loading_state = False
-
-            # Perform a deep rerender so updates are reflected
-            HexrdConfig().deep_rerender_needed.emit()
+                self.color_map_editor.block_updates(False)
 
         HexrdConfig().working_dir = os.path.dirname(selected_file)
 


### PR DESCRIPTION
We were previously rerendering, because overwriting a loaded state file requires us to reload the imageseries from the new state file, and we wanted to make sure that any changes would be reflected in the UI.

However, there really shouldn't be any changes, and rerendering sometimes takes quite a while (for example, in high resolution polar view). So just skip rerendering, and do not allow the colormap ranges to reset either.

Fixes: #1694