### PR TITLE
Fix fast powder calibration with subpanels

### DIFF
--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -198,7 +198,13 @@ class CalibrationCallbacks(MaterialCalibrationDialogCallbacks):
     def data_xys(self):
         ret = {}
         for k, v in self.overlays[0].calibration_picks.items():
-            ret[k] = np.vstack(list(v.values()))
+            points = list(v.values())
+            if not points:
+                # No points on this detector
+                ret[k] = []
+                continue
+
+            ret[k] = np.vstack(points)
         return ret
 
     def draw_picks_on_canvas(self):


### PR DESCRIPTION
The pick points didn't take into account subpanels... and the beam stop didn't either.

Also, we needed to add a check to verify that a detector actually has points. Instruments with many subpanels sometimes do not have points...

Fixes: #1699