### PR TITLE
Allow Euler convention setting for calibration

### DIFF
--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -86,7 +86,9 @@ class PowderRunner(QObject):
 
         self.pc = PowderCalibrator(**kwargs)
         self.ic = InstrumentCalibrator(
-            self.pc, engineering_constraints=engineering_constraints
+            self.pc,
+            engineering_constraints=engineering_constraints,
+            euler_convention=HexrdConfig().euler_angle_convention,
         )
         self.extract_powder_lines()
 

--- a/hexrdgui/calibration/calibration_dialog_callbacks.py
+++ b/hexrdgui/calibration/calibration_dialog_callbacks.py
@@ -4,6 +4,10 @@ import copy
 from PySide6.QtCore import Signal
 from PySide6.QtWidgets import QFileDialog
 
+from hexrd.fitting.calibration.lmfit_param_handling import (
+    update_instrument_from_params,
+)
+
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.utils import instr_to_internal_dict
 from hexrdgui.utils.abc_qobject import ABCQObject
@@ -54,6 +58,10 @@ class CalibrationDialogCallbacks(ABCQObject):
     @property
     def canvas(self):
         return HexrdConfig().active_canvas
+
+    @property
+    def euler_convention(self):
+        return HexrdConfig().euler_angle_convention
 
     @abstractmethod
     def draw_picks_on_canvas(self):
@@ -127,7 +135,11 @@ class CalibrationDialogCallbacks(ABCQObject):
             v = stack_item[k]
             setattr(self.calibrator, k, v)
 
-        self.instr.update_from_lmfit_parameter_list(self.calibrator.params)
+        update_instrument_from_params(
+            self.instr,
+            self.calibrator.params,
+            self.euler_convention,
+        )
         self.update_config_from_instrument()
         self.update_dialog_from_calibrator()
         self.dialog.advanced_options = stack_item['advanced_options']

--- a/hexrdgui/calibration/calibration_runner.py
+++ b/hexrdgui/calibration/calibration_runner.py
@@ -859,6 +859,7 @@ class CalibrationRunner(QObject):
             'grain_params': overlay.crystal_params,
             'min_energy': overlay.min_energy,
             'max_energy': overlay.max_energy,
+            'euler_convention': HexrdConfig().euler_angle_convention,
         }
 
         self.laue_auto_picker = LaueCalibrator(**init_kwargs)

--- a/hexrdgui/calibration/material_calibration_dialog_callbacks.py
+++ b/hexrdgui/calibration/material_calibration_dialog_callbacks.py
@@ -1,3 +1,8 @@
+from hexrd.fitting.calibration.lmfit_param_handling import (
+    normalize_euler_convention
+)
+
+from hexrdgui.calibration.calibration_dialog import TILT_LABELS_EULER
 from hexrdgui.calibration.calibration_dialog_callbacks import (
     CalibrationDialogCallbacks,
 )
@@ -5,6 +10,7 @@ from hexrdgui.calibration.hkl_picks_tree_view_dialog import (
     overlays_to_tree_format, HKLPicksTreeViewDialog,
 )
 from hexrdgui.constants import ViewType
+from hexrdgui.hexrd_config import HexrdConfig
 
 
 class MaterialCalibrationDialogCallbacks(CalibrationDialogCallbacks):
@@ -118,7 +124,9 @@ def format_material_params_func(params_dict, tree_dict, create_param_item,
         else:
             # Assume grain parameters
             d['Orientation'] = {}
-            labels = ['Z', "X'", "Z''"]
+            euler_convention = normalize_euler_convention(
+                HexrdConfig().euler_angle_convention)
+            labels = TILT_LABELS_EULER[euler_convention]
             for i in range(3):
                 param = params_dict[calibrator.param_names[i]]
                 d['Orientation'][labels[i]] = create_param_item(param)

--- a/hexrdgui/calibration/pick_based_calibration.py
+++ b/hexrdgui/calibration/pick_based_calibration.py
@@ -3,10 +3,12 @@ from hexrd.fitting.calibration import (
     LaueCalibrator,
     PowderCalibrator,
 )
+from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.utils.guess_instrument_type import guess_instrument_type
 
 
-def make_calibrators_from_picks(instr, processed_picks, materials, img_dict):
+def make_calibrators_from_picks(instr, processed_picks, materials, img_dict,
+                                euler_convention):
     calibrators = []
     for pick_data in processed_picks:
         if pick_data['type'] == 'powder':
@@ -30,17 +32,20 @@ def make_calibrators_from_picks(instr, processed_picks, materials, img_dict):
                 'min_energy': pick_data['options']['min_energy'],
                 'max_energy': pick_data['options']['max_energy'],
                 'calibration_picks': pick_data['picks'],
+                'euler_convention': euler_convention,
             }
             calibrators.append(LaueCalibrator(**kwargs))
     return calibrators
 
 
 def create_instrument_calibrator(picks, instr, img_dict, materials):
+    euler_convention = HexrdConfig().euler_angle_convention
     engineering_constraints = guess_instrument_type(instr.detectors)
     calibrators = make_calibrators_from_picks(instr, picks, materials,
-                                              img_dict)
+                                              img_dict, euler_convention)
 
     return InstrumentCalibrator(
         *calibrators,
         engineering_constraints=engineering_constraints,
+        euler_convention=euler_convention,
     )

--- a/hexrdgui/calibration/structureless/runner.py
+++ b/hexrdgui/calibration/structureless/runner.py
@@ -207,6 +207,7 @@ class StructurelessCalibrationRunner(QObject):
             'instr': self.instr,
             'data': calibrator_lines,
             'engineering_constraints': engineering_constraints,
+            'euler_convention': HexrdConfig().euler_angle_convention,
         }
         self.calibrator = StructurelessCalibrator(**kwargs)
 

--- a/hexrdgui/resources/calibration/calibration_params_tree_view.yml
+++ b/hexrdgui/resources/calibration/calibration_params_tree_view.yml
@@ -13,9 +13,6 @@ detectors:
   '{det}':
     transform:
       tilt:
-        Z: '{det}_euler_z'
-        "X'": '{det}_euler_xp'
-        "Z''": '{det}_euler_zpp'
       translation:
         X: '{det}_tvec_x'
         Y: '{det}_tvec_y'


### PR DESCRIPTION
Some users strongly prefer to use a different Euler convention for calibration, such as extrinsic XYZ. It is easy to convert angles from one Euler convention to another. However, it is difficult to convert boundary conditions (min/max ranges for each angle) from one convention to another.

So we add the ability to choose the Euler convention to use in calibration. This allows the min/max ranges to be specified in lmfit using that convention.

This Euler angle convention setting applies to detector tilt angles and grain parameter orientations.

Depends on hexrd/hexrd#637