### PR TITLE
Increase qfib warning threshold to 1e8

### DIFF
--- a/hexrdgui/color_map_editor.py
+++ b/hexrdgui/color_map_editor.py
@@ -3,7 +3,7 @@ import copy
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QColorDialog
 
-from matplotlib import cm
+from matplotlib import colormaps as cm
 import matplotlib.colors
 
 import numpy as np

--- a/hexrdgui/indexing/fit_grains_results_dialog.py
+++ b/hexrdgui/indexing/fit_grains_results_dialog.py
@@ -677,7 +677,8 @@ class FitGrainsResultsDialog(QObject):
 
     def update_cmap(self):
         # Get the Colormap object from the name
-        self.cmap = matplotlib.cm.get_cmap(self.ui.color_maps.currentText())
+        self.cmap = matplotlib.colormaps.get_cmap(
+            self.ui.color_maps.currentText())
         self.update_plot()
 
     def reset_glyph_size(self, update_plot=True):

--- a/hexrdgui/indexing/run.py
+++ b/hexrdgui/indexing/run.py
@@ -250,7 +250,7 @@ class IndexingRunner(Runner):
 
     def orientation_fibers_generated(self):
         # Perform some validation
-        qfib_warning_threshold = 5e7
+        qfib_warning_threshold = 1e8
         if self.qfib.shape[1] > qfib_warning_threshold:
             formatted = format_big_int(self.qfib.shape[1])
             msg = (f'Over {formatted} test orientations were '

--- a/packaging/package.py
+++ b/packaging/package.py
@@ -13,6 +13,7 @@ import zipfile
 import click
 import coloredlogs
 
+import conda
 import conda.cli.python_api as Conda
 from conda_build import api as CondaBuild
 from conda_build.config import Config
@@ -105,16 +106,18 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     # First build the hexrdgui package
     recipe_path = str(base_path / '..' / 'conda.recipe')
     config = Config()
-    config.channel = ['conda-forge']
+    channels = ['conda-forge']
     config.channel_urls = ['conda-forge']
-    config.override_channels = True
 
     if hexrdgui_output_folder is not None:
         config.output_folder = hexrdgui_output_folder
 
     if hexrd_package_channel is not None:
-        config.channel.insert(0, 'hexrd-channel')
+        channels.insert(0, 'hexrd-channel')
         config.channel_urls.insert(0, hexrd_package_channel)
+
+    # Set the channels on the conda context
+    conda.base.context.context.channels = channels
 
     # Determine the latest hexrd version in the hexrd_package_channel
     # (release or pre-release), and force that hexrd version to be used.

--- a/packaging/package.py
+++ b/packaging/package.py
@@ -106,18 +106,13 @@ def build_conda_pack(base_path, tmp, hexrd_package_channel, hexrdgui_output_fold
     # First build the hexrdgui package
     recipe_path = str(base_path / '..' / 'conda.recipe')
     config = Config()
-    channels = ['conda-forge']
     config.channel_urls = ['conda-forge']
 
     if hexrdgui_output_folder is not None:
         config.output_folder = hexrdgui_output_folder
 
     if hexrd_package_channel is not None:
-        channels.insert(0, 'hexrd-channel')
         config.channel_urls.insert(0, hexrd_package_channel)
-
-    # Set the channels on the conda context
-    conda.base.context.context.channels = channels
 
     # Determine the latest hexrd version in the hexrd_package_channel
     # (release or pre-release), and force that hexrd version to be used.


### PR DESCRIPTION
Our users have commonly been hitting the threshold limit that produced the warning, even though they are using far from their memory limit.

This should make the warning appear when it is actually needed.