### PR TITLE
Add option to set lmfit boundaries as a delta

### DIFF
--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -107,6 +107,13 @@ KNOWN_DETECTOR_NAMES = {
         'IMAGE-PLATE-3',
         'IMAGE-PLATE-4',
     ],
+    'PXRDIP': [
+        'IMAGE-PLATE-B',
+        'IMAGE-PLATE-D',
+        'IMAGE-PLATE-L',
+        'IMAGE-PLATE-R',
+        'IMAGE-PLATE-U',
+    ],
 }
 
 KEY_ROTATE_ANGLE_FINE = 0.00175

--- a/hexrdgui/resources/ui/calibration_dialog.ui
+++ b/hexrdgui/resources/ui/calibration_dialog.ui
@@ -47,6 +47,13 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="delta_boundaries">
+        <property name="text">
+         <string>Use delta for boundaries</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -431,6 +438,7 @@ See scipy.optimize.least_squares for more details.</string>
  <tabstops>
   <tabstop>draw_picks</tabstop>
   <tabstop>engineering_constraints</tabstop>
+  <tabstop>delta_boundaries</tabstop>
   <tabstop>edit_picks_button</tabstop>
   <tabstop>save_picks_button</tabstop>
   <tabstop>load_picks_button</tabstop>
@@ -442,6 +450,7 @@ See scipy.optimize.least_squares for more details.</string>
   <tabstop>max_nfev</tabstop>
   <tabstop>jac</tabstop>
   <tabstop>method</tabstop>
+  <tabstop>undo_run_button</tabstop>
   <tabstop>run_button</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
lmfit does not allow a delta to be used, but instead a min/max must be specified. We can, however, allow a delta to be used in the GUI, and then set the min/max on the lmfit parameters based upon this delta. That is what is being done in this PR.

Using delta for boundaries is more intuitive for some workflows.