### PR TITLE
Filter down engineering constraint types

### DIFF
--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -10,7 +10,10 @@ from hexrd.fitting.calibration import InstrumentCalibrator, PowderCalibrator
 
 from hexrdgui.async_runner import AsyncRunner
 from hexrdgui.calibration.auto import PowderCalibrationDialog
-from hexrdgui.calibration.calibration_dialog import CalibrationDialog
+from hexrdgui.calibration.calibration_dialog import (
+    CalibrationDialog,
+    guess_engineering_constraints,
+)
 from hexrdgui.calibration.material_calibration_dialog_callbacks import (
     format_material_params_func,
     MaterialCalibrationDialogCallbacks,
@@ -18,7 +21,6 @@ from hexrdgui.calibration.material_calibration_dialog_callbacks import (
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.utils import masks_applied_to_panel_buffers
-from hexrdgui.utils.guess_instrument_type import guess_instrument_type
 
 
 class PowderRunner(QObject):
@@ -67,7 +69,7 @@ class PowderRunner(QObject):
         else:
             fwhm_estimate = options['initial_fwhm']
 
-        engineering_constraints = guess_instrument_type(self.instr.detectors)
+        engineering_constraints = guess_engineering_constraints(self.instr)
 
         # Get an intensity-corrected masked dict of the images
         img_dict = HexrdConfig().masked_images_dict

--- a/hexrdgui/calibration/calibration_dialog.py
+++ b/hexrdgui/calibration/calibration_dialog.py
@@ -610,3 +610,17 @@ TILT_LABELS_EULER = {
     ('xyz', True): ('X', 'Y', 'Z'),
     ('zxz', False): ('Z', "X'", "Z''"),
 }
+
+
+def guess_engineering_constraints(instr) -> str | None:
+    # First guess the instrument type.
+    instr_type = guess_instrument_type(instr.detectors)
+
+    # If it matches one of our expected engineering constraints, use it.
+    expected_options = [
+        'TARDIS',
+    ]
+    if instr_type in expected_options:
+        return instr_type
+
+    return None

--- a/hexrdgui/calibration/pick_based_calibration.py
+++ b/hexrdgui/calibration/pick_based_calibration.py
@@ -3,8 +3,10 @@ from hexrd.fitting.calibration import (
     LaueCalibrator,
     PowderCalibrator,
 )
+from hexrdgui.calibration.calibration_dialog import (
+    guess_engineering_constraints,
+)
 from hexrdgui.hexrd_config import HexrdConfig
-from hexrdgui.utils.guess_instrument_type import guess_instrument_type
 
 
 def make_calibrators_from_picks(instr, processed_picks, materials, img_dict,
@@ -40,7 +42,7 @@ def make_calibrators_from_picks(instr, processed_picks, materials, img_dict,
 
 def create_instrument_calibrator(picks, instr, img_dict, materials):
     euler_convention = HexrdConfig().euler_angle_convention
-    engineering_constraints = guess_instrument_type(instr.detectors)
+    engineering_constraints = guess_engineering_constraints(instr)
     calibrators = make_calibrators_from_picks(instr, picks, materials,
                                               img_dict, euler_convention)
 

--- a/hexrdgui/calibration/structureless/runner.py
+++ b/hexrdgui/calibration/structureless/runner.py
@@ -9,7 +9,10 @@ from PySide6.QtWidgets import QFileDialog, QMessageBox
 
 from hexrd.fitting.calibration import StructurelessCalibrator
 
-from hexrdgui.calibration.calibration_dialog import CalibrationDialog
+from hexrdgui.calibration.calibration_dialog import (
+    CalibrationDialog,
+    guess_engineering_constraints,
+)
 from hexrdgui.calibration.calibration_dialog_callbacks import (
     CalibrationDialogCallbacks,
 )
@@ -21,7 +24,6 @@ from hexrdgui.select_item_dialog import SelectItemDialog
 from hexrdgui.tree_views import GenericPicksTreeViewDialog
 from hexrdgui.utils.conversions import angles_to_cart, cart_to_angles
 from hexrdgui.utils.dialog import add_help_url
-from hexrdgui.utils.guess_instrument_type import guess_instrument_type
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 from .picks_io import load_picks_from_file, save_picks_to_file
@@ -199,7 +201,7 @@ class StructurelessCalibrationRunner(QObject):
     def show_calibration_dialog(self, calibrator_lines):
         self.previous_picks_data = calibrator_lines
 
-        engineering_constraints = guess_instrument_type(self.instr.detectors)
+        engineering_constraints = guess_engineering_constraints(self.instr)
 
         # Create the structureless calibrator with the data
         # FIXME: add the tth_distortion dict here, if present


### PR DESCRIPTION
We are currently identifying TARDIS and PXRDIP both when `guess_instrument_type()` is used. However, only TARDIS has engineering constraints, and an exception is raised if we try to set engineering constraints using PXRDIP.

When guessing the engineering constraints, we should filter down (ignore) any instrument types for which we do not yet have engineering constraints defined. This prevents errors from occuring later.