### PR TITLE
Do not set a parent for OverlayStylePicker

### DIFF
--- a/hexrdgui/overlay_manager.py
+++ b/hexrdgui/overlay_manager.py
@@ -292,5 +292,5 @@ class OverlayManager:
         self.update_table()
 
     def edit_style(self):
-        self._style_picker = OverlayStylePicker(self.active_overlay, self.ui)
+        self._style_picker = OverlayStylePicker(self.active_overlay)
         self._style_picker.exec()


### PR DESCRIPTION
Calling `exec()` on the overlay style picker appears to be hiding its parent dialog, which we don't want.

It's okay (arguably preferable) for this picker to be application-modal, so remove the parent.