### PR TITLE
Invalidate grains table for failed clustering

### DIFF
--- a/hexrdgui/indexing/run.py
+++ b/hexrdgui/indexing/run.py
@@ -380,6 +380,7 @@ class IndexingRunner(Runner):
         num_grains = self.qbar.shape[1]
         if num_grains == 0:
             print('No grains found')
+            self.grains_table = None
             return
 
         plural = 's' if num_grains != 1 else ''

--- a/hexrdgui/rerun_clustering_dialog.py
+++ b/hexrdgui/rerun_clustering_dialog.py
@@ -2,7 +2,7 @@ import numpy as np
 from pathlib import Path
 
 from PySide6.QtWidgets import QDialog, QFileDialog
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QTimer, Qt
 
 from hexrdgui.async_worker import AsyncWorker
 from hexrdgui.hexrd_config import HexrdConfig
@@ -88,6 +88,10 @@ class RerunClusteringDialog(QDialog):
             # Since this is a QueuedConnection, we need to accept progress here
             runner.accept_progress()
             runner.confirm_indexing_results()
+
+            if runner.grains_table is None:
+                # The previous step must have failed. Show again.
+                QTimer.singleShot(0, self.exec)
 
         def on_rejected():
             # Since this is a QueuedConnection, we need to accept progress here


### PR DESCRIPTION
Previously, if the user re-ran the clustering, and no grains were found, the grains table would not be invalidated, and some results would appear.

Invalidate the grains table so that this does not happen.

Fixes: #1715