### PR TITLE
Add ability to export grains from indexing results

### DIFF
--- a/hexrdgui/indexing/grains_table_model.py
+++ b/hexrdgui/indexing/grains_table_model.py
@@ -2,6 +2,8 @@ import numpy as np
 
 from PySide6.QtCore import QAbstractTableModel, QModelIndex, Qt, Signal
 
+from hexrdgui.indexing.utils import write_grains_txt
+
 
 class GrainsTableModel(QAbstractTableModel):
     """Model for viewing grains"""
@@ -103,33 +105,5 @@ class GrainsTableModel(QAbstractTableModel):
                 if i not in self.excluded_columns]
 
     def save(self, path):
-        with open(path, 'w') as fp:
-            header_items = self.full_headers.copy()
-            header_items[0] = f'# {self.full_headers[0]}'
-
-            # Formatting logic is copied from instrument GrainDataWriter
-            delim = '  '
-            header = delim.join(
-                [delim.join(
-                    np.tile('{:<12}', 3)
-                    ).format(*header_items[:3]), delim.join(
-                        np.tile('{:<23}', len(header_items) - 3)
-                    ).format(*header_items[3:])]
-            )
-            fp.write(header)
-            fp.write('\n')
-
-            for row in self.full_grains_table:
-                res = row.tolist()
-                res[0] = int(res[0])
-                output_str = delim.join(
-                    [delim.join(
-                        ['{:<12d}', '{:<12f}', '{:<12e}']
-                    ).format(*res[:3]), delim.join(
-                        np.tile('{:<23.16e}', len(res) - 3)
-                    ).format(*res[3:])]
-                )
-                fp.write(output_str)
-                fp.write('\n')
-
-            print('Wrote', path)
+        write_grains_txt(self.full_grains_table, path)
+        print('Wrote', path)

--- a/hexrdgui/indexing/utils.py
+++ b/hexrdgui/indexing/utils.py
@@ -20,6 +20,15 @@ def generate_grains_table(qbar):
     return grains_table
 
 
+def write_grains_txt(grains_table, filename):
+    gw = instrument.GrainDataWriter(filename=filename)
+    try:
+        for grain in grains_table:
+            gw.dump_grain(grain[0], grain[1], grain[2], grain[3:15])
+    finally:
+        gw.close()
+
+
 def hkl_in_list(hkl, hkl_list):
     def hkls_equal(hkl_a, hkl_b):
         return all(x == y for x, y in zip(hkl_a, hkl_b))

--- a/hexrdgui/resources/ui/indexing_results_dialog.ui
+++ b/hexrdgui/resources/ui/indexing_results_dialog.ui
@@ -14,7 +14,7 @@
    <string>Indexing Results</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="0" colspan="3">
+   <item row="7" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -23,6 +23,9 @@
       <bool>false</bool>
      </property>
     </widget>
+   </item>
+   <item row="3" column="1" rowspan="4">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
    </item>
    <item row="3" column="2" rowspan="2">
     <widget class="QWidget" name="widget" native="true">
@@ -38,33 +41,13 @@
       </item>
       <item>
        <layout class="QGridLayout" name="grid_layout">
-        <item row="6" column="2" colspan="2">
-         <spacer name="verticalSpacer_3">
-          <property name="orientation">
-           <enum>Qt::Vertical</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>20</width>
-            <height>40</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item row="2" column="2" colspan="2">
-         <widget class="QCheckBox" name="show_all_grains">
-          <property name="text">
-           <string>Show all grains?</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="2" column="1">
-         <widget class="QComboBox" name="grain_id">
+        <item row="3" column="0">
+         <widget class="QLabel" name="grain_id_label">
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="text">
+           <string>Grain ID:</string>
           </property>
          </widget>
         </item>
@@ -75,17 +58,24 @@
           </property>
          </widget>
         </item>
-        <item row="2" column="0">
-         <widget class="QLabel" name="grain_id_label">
+        <item row="3" column="1">
+         <widget class="QComboBox" name="grain_id">
           <property name="enabled">
            <bool>false</bool>
           </property>
+         </widget>
+        </item>
+        <item row="3" column="2" colspan="2">
+         <widget class="QCheckBox" name="show_all_grains">
           <property name="text">
-           <string>Grain ID:</string>
+           <string>Show all grains?</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
-        <item row="1" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="current_hkl_label">
           <property name="layoutDirection">
            <enum>Qt::LeftToRight</enum>
@@ -101,7 +91,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="2" column="1">
          <widget class="QComboBox" name="current_hkl">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -111,7 +101,7 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="2" colspan="2">
+        <item row="2" column="2" colspan="2">
          <widget class="QCheckBox" name="show_results">
           <property name="text">
            <string>Show results?</string>
@@ -121,15 +111,25 @@
           </property>
          </widget>
         </item>
+        <item row="7" column="2" colspan="2">
+         <spacer name="verticalSpacer_3">
+          <property name="orientation">
+           <enum>Qt::Vertical</enum>
+          </property>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>20</width>
+            <height>40</height>
+           </size>
+          </property>
+         </spacer>
+        </item>
        </layout>
       </item>
      </layout>
     </widget>
    </item>
-   <item row="3" column="1" rowspan="3">
-    <layout class="QVBoxLayout" name="canvas_layout"/>
-   </item>
-   <item row="5" column="2">
+   <item row="6" column="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -142,6 +142,13 @@
      </property>
     </spacer>
    </item>
+   <item row="5" column="2">
+    <widget class="QPushButton" name="export_grains">
+     <property name="text">
+      <string>Export Grains</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -150,6 +157,7 @@
   <tabstop>show_results</tabstop>
   <tabstop>grain_id</tabstop>
   <tabstop>show_all_grains</tabstop>
+  <tabstop>export_grains</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
This adds an "Export Grains" button to the indexing results dialog where the user can write out the unfit grains.

If the file is saved with a `.npz` extension, the new NPZ grains file format is used. Otherwise, the old `.out` format is used.

Fixes: #1716