### PR TITLE
Fix infinite recursion

### DIFF
--- a/hexrdgui/polar_distortion_object.py
+++ b/hexrdgui/polar_distortion_object.py
@@ -143,16 +143,4 @@ class PolarDistortionObject:
 
     @classmethod
     def deserialize(cls, d):
-        from hexrdgui.hexrd_config import HexrdConfig
-
-        if HexrdConfig().physics_package is None:
-            # This requires a physics package to deserialize
-            HexrdConfig().create_default_physics_package()
-
-        if d.get('pinhole_distortion_type') == 'SampleLayerDistortion':
-            # We added pinhole_radius later. Set a default if it is missing.
-            if 'pinhole_radius' not in d['pinhole_distortion_kwargs']:
-                radius = HexrdConfig().physics_package.pinhole_radius
-                d['pinhole_distortion_kwargs']['pinhole_radius'] = radius * 1e-3
-
         return cls(**d)


### PR DESCRIPTION
We need to move the logic for fixing the deserialization of a polar distortion object into HexrdConfig, which might not be fully constructed yet, to avoid an infinite recursion.