### PR TITLE
Add options to use relative constraints

### DIFF
--- a/hexrdgui/resources/ui/calibration_dialog.ui
+++ b/hexrdgui/resources/ui/calibration_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>1020</width>
-    <height>940</height>
+    <height>923</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
       <string>Constraints</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
+      <item row="1" column="0">
        <widget class="QLabel" name="engineering_constraints_label">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -30,14 +30,14 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QCheckBox" name="delta_boundaries">
         <property name="text">
          <string>Use delta for boundaries</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item row="1" column="1">
        <widget class="QComboBox" name="engineering_constraints">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -54,13 +54,30 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0" colspan="2">
+      <item row="3" column="0" colspan="2">
        <widget class="QPushButton" name="mirror_constraints_from_first_detector">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If clicked, the &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; (if &amp;quot;Use delta for boundaries&amp;quot; is checked) settings of the first detector's tilt/translation parameters will be copied to all other detectors' tilt/translation parameters.&lt;/p&gt;&lt;p&gt;This is helpful if you have many detectors and want to modify all of their &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; settings in a similar way.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
          <string>Mirror Constraints from First Detector</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="relative_constraints_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Relative constraints:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="relative_constraints">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
@@ -466,6 +483,7 @@ See scipy.optimize.least_squares for more details.</string>
   <tabstop>draw_picks</tabstop>
   <tabstop>active_beam</tabstop>
   <tabstop>show_picks_from_all_xray_sources</tabstop>
+  <tabstop>relative_constraints</tabstop>
   <tabstop>engineering_constraints</tabstop>
   <tabstop>delta_boundaries</tabstop>
   <tabstop>mirror_constraints_from_first_detector</tabstop>
@@ -492,8 +510,8 @@ See scipy.optimize.least_squares for more details.</string>
    <slot>setVisible(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>258</x>
-     <y>618</y>
+     <x>269</x>
+     <y>592</y>
     </hint>
     <hint type="destinationlabel">
      <x>509</x>

--- a/hexrdgui/tree_views/base_dict_tree_item_model.py
+++ b/hexrdgui/tree_views/base_dict_tree_item_model.py
@@ -124,6 +124,23 @@ class BaseDictTreeItemModel(BaseTreeItemModel):
 
         return flags
 
+    def create_index(self, path, column=0):
+        # Create an index, given a path
+
+        def recurse(item, cur_path):
+            for i, child_item in enumerate(item.child_items):
+                if child_item.data(KEY_COL) == cur_path[0]:
+                    if len(cur_path) == 1:
+                        return self.createIndex(
+                            child_item.row(),
+                            column,
+                            child_item,
+                        )
+                    else:
+                        return recurse(child_item, cur_path[1:])
+
+        return recurse(self.root_item, path)
+
     def remove_items(self, items):
         for item in items:
             row = item.row()


### PR DESCRIPTION
This adds options to use relative constraints within the calibration workflows.

Depends on: hexrd/hexrd#723