### PR TITLE
Refactor HEDM calibration for short-term changes

### DIFF
--- a/hexrdgui/calibration/hedm/calibration_options_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_options_dialog.py
@@ -1,9 +1,20 @@
-from PySide6.QtCore import QObject, Signal
+import numpy as np
 
+from PySide6.QtCore import QObject, Qt, Signal
+from PySide6.QtWidgets import QMessageBox, QTableWidget, QTableWidgetItem
+
+from hexrd import constants as cnst
+
+from hexrdgui.constants import OverlayType
 from hexrdgui.hexrd_config import HexrdConfig
-from hexrdgui.grains_viewer_dialog import GrainsViewerDialog
+from hexrdgui.indexing.create_config import (
+    create_indexing_config, OmegasNotFoundError
+)
+from hexrdgui.refinements_editor import RefinementsEditor
 from hexrdgui.reflections_table import ReflectionsTable
+from hexrdgui.select_grains_dialog import SelectGrainsDialog
 from hexrdgui.ui_loader import UiLoader
+from hexrdgui.utils import block_signals
 
 
 class HEDMCalibrationOptionsDialog(QObject):
@@ -11,25 +22,43 @@ class HEDMCalibrationOptionsDialog(QObject):
     accepted = Signal()
     rejected = Signal()
 
-    def __init__(self, material, grains_table, parent=None):
+    def __init__(self, material, parent=None):
         super().__init__(parent)
 
         loader = UiLoader()
         self.ui = loader.load_file('hedm_calibration_options_dialog.ui',
                                    parent)
+        self.refinements_editor = RefinementsEditor(self.ui)
+        self.refinements_editor.hide_bottom_buttons = True
 
         self.material = material
-        self.grains_table = grains_table
         self.parent = parent
 
+        self.setup_refinement_options()
+        self.setup_table()
+        self.update_materials()
         self.update_gui()
+        self.apply_refinement_selections()
         self.setup_connections()
 
     def setup_connections(self):
-        self.ui.view_grains_table.clicked.connect(self.show_grains_table)
+        self.ui.view_grains_table.clicked.connect(self.edit_grains_table)
+        self.ui.view_refinements.clicked.connect(self.view_refinements)
+
+        self.ui.material.currentIndexChanged.connect(self.material_changed)
         self.ui.choose_hkls.pressed.connect(self.choose_hkls)
 
         HexrdConfig().overlay_config_changed.connect(self.update_num_hkls)
+
+        self.ui.tolerances_selected_grain.currentIndexChanged.connect(
+            self.update_tolerances_table)
+        self.ui.tolerances_table.itemChanged.connect(
+            self.on_tolerances_changed)
+        self.refinements_editor.tree_view.dict_modified.connect(
+            self.on_refinements_editor_modified)
+        self.ui.fix_strain.toggled.connect(self.apply_refinement_selections)
+        self.ui.refinement_choice.currentIndexChanged.connect(
+            self.apply_refinement_selections)
 
         self.ui.accepted.connect(self.on_accepted)
         self.ui.rejected.connect(self.on_rejected)
@@ -43,11 +72,14 @@ class HEDMCalibrationOptionsDialog(QObject):
 
         calibration_config = indexing_config['_hedm_calibration']
         self.do_refit = calibration_config['do_refit']
-        self.clobber_strain = calibration_config['clobber_strain']
-        self.clobber_centroid = calibration_config['clobber_centroid']
-        self.clobber_grain_Y = calibration_config['clobber_grain_Y']
 
+        indexing_config = HexrdConfig().indexing_config
+        self.npdiv = indexing_config['fit_grains']['npdiv']
+        self.threshold = indexing_config['fit_grains']['threshold']
+
+        self.update_tolerances_grain_options()
         self.update_num_hkls()
+        self.update_num_grains_selected()
 
     def update_config(self):
         config = HexrdConfig().indexing_config['fit_grains']
@@ -57,19 +89,225 @@ class HEDMCalibrationOptionsDialog(QObject):
         indexing_config = HexrdConfig().indexing_config
         calibration_config = indexing_config['_hedm_calibration']
         calibration_config['do_refit'] = self.do_refit
-        calibration_config['clobber_strain'] = self.clobber_strain
-        calibration_config['clobber_centroid'] = self.clobber_centroid
-        calibration_config['clobber_grain_Y'] = self.clobber_grain_Y
+
+        indexing_config = HexrdConfig().indexing_config
+        indexing_config['fit_grains']['npdiv'] = self.npdiv
+        indexing_config['fit_grains']['threshold'] = self.threshold
+
+    def setup_refinement_options(self):
+        w = self.ui.refinement_choice
+        w.clear()
+
+        for key, label in REFINEMENT_OPTIONS.items():
+            w.addItem(label, key)
 
     def show(self):
         self.ui.show()
 
     def on_accepted(self):
+        self.apply_refinement_selections()
+
+        try:
+            self.validate()
+        except Exception as e:
+            QMessageBox.critical(self.parent, 'HEXRD', f'Error: {e}')
+            self.show()
+            return
+
+        self.refinements_editor.update_config()
+        self.refinements_editor.ui.accept()
+
         self.update_config()
         self.accepted.emit()
 
     def on_rejected(self):
         self.rejected.emit()
+
+    def validate(self):
+        # Validation to perform before we do anything else
+        if not self.active_overlays:
+            msg = 'At least one grain must be selected'
+            raise Exception(msg)
+
+        ome_periods = []
+        for overlay in self.active_overlays:
+            if not overlay.has_widths:
+                msg = (
+                    'All visible rotation series overlays must have widths '
+                    'enabled'
+                )
+                raise Exception(msg)
+
+            ome_periods.append(overlay.ome_period)
+
+        for i in range(1, len(ome_periods)):
+            if not np.allclose(ome_periods[0], ome_periods[i]):
+                msg = (
+                    'All visible rotation series overlays must have '
+                    'identical omega periods'
+                )
+                raise Exception(msg)
+
+        materials = [overlay.material_name for overlay in self.active_overlays]
+        if not all(x == materials[0] for x in materials):
+            msg = (
+                'All visible rotation series overlays must have the same '
+                'material'
+            )
+            raise Exception(msg)
+
+        # Make sure the material is updated in the indexing config
+        self.synchronize_material()
+
+        # Ensure we have omega metadata
+        try:
+            create_indexing_config()
+        except OmegasNotFoundError:
+            msg = (
+                'No omega metadata found. Be sure to import the image '
+                'series using the "Simple Image Series" import tool.'
+            )
+            raise Exception(msg)
+
+    def synchronize_material(self):
+        # This material is used for creating the indexing config.
+        # Make sure it matches the material we are using.
+        cfg = HexrdConfig().indexing_config
+        cfg['_selected_material'] = self.material.name
+
+    def update_materials(self):
+        prev = self.selected_material
+        material_names = list(HexrdConfig().materials)
+
+        self.ui.material.clear()
+        self.ui.material.addItems(material_names)
+
+        if prev in material_names:
+            self.ui.material.setCurrentText(prev)
+        else:
+            self.ui.material.setCurrentText(self.material.name)
+
+    def material_changed(self):
+        # First, update the material on self.material
+        self.material = HexrdConfig().material(self.selected_material)
+
+        # Deselect all grains
+        self.deselect_all_grains()
+
+    def deselect_all_grains(self):
+        for overlay in self.overlays:
+            overlay.visible = False
+
+        self.update_tolerances_grain_options()
+        self.update_num_grains_selected()
+        HexrdConfig().overlay_config_changed.emit()
+        HexrdConfig().update_overlay_manager.emit()
+        self.update_refinements_editor()
+
+    def update_tolerances_grain_options(self):
+        w = self.ui.tolerances_selected_grain
+        if w.count() > 0:
+            prev = int(w.currentText())
+        else:
+            prev = None
+
+        with block_signals(w):
+            w.clear()
+            items = [str(i) for i in range(len(self.active_overlays))]
+            w.addItems(items)
+            if prev is not None and prev < len(items):
+                w.setCurrentIndex(prev)
+
+        self.update_tolerances_table()
+
+    def setup_table(self):
+        w = self.ui.tolerances_table
+        for i in range(3):
+            item = QTableWidgetItem()
+            item.setTextAlignment(Qt.AlignCenter)
+            w.setItem(0, i, item)
+
+        content_height = calc_table_height(w)
+        w.setMaximumHeight(content_height)
+
+    def update_tolerances_table(self):
+        w = self.ui.tolerances_table
+        if len(self.active_overlays) == 0:
+            # Cannot update
+            with block_signals(w):
+                for i in range(3):
+                    w.item(0, i).setText('')
+            return
+
+        grain_w = self.ui.tolerances_selected_grain
+        idx = int(grain_w.currentText())
+
+        overlay = self.active_overlays[idx]
+
+        values = [
+            overlay.tth_width,
+            overlay.eta_width,
+            overlay.ome_width,
+        ]
+        for col, val in enumerate(values):
+            item = w.item(0, col)
+            item.setText(f'{np.round(np.degrees(val), 10)}')
+
+    def on_tolerances_changed(self):
+        if len(self.active_overlays) == 0:
+            # Can't do anything. Just return
+            return
+
+        grain_w = self.ui.tolerances_selected_grain
+        idx = int(grain_w.currentText())
+
+        overlay = self.active_overlays[idx]
+
+        w = self.ui.tolerances_table
+        columns = [
+            'tth_width',
+            'eta_width',
+            'ome_width',
+        ]
+        for col, attr in enumerate(columns):
+            item = w.item(0, col)
+            try:
+                val = float(item.text())
+            except ValueError:
+                # Invalid. Continue.
+                val = getattr(overlay, attr)
+                item.setText(f'{np.round(np.degrees(val), 10)}')
+                continue
+
+            setattr(overlay, attr, np.radians(val))
+
+        overlay.update_needed = True
+
+        HexrdConfig().overlay_config_changed.emit()
+        HexrdConfig().update_overlay_editor.emit()
+
+    def on_refinements_editor_modified(self):
+        # Set it to "custom"
+        idx = list(REFINEMENT_OPTIONS).index('custom')
+
+        w = self.ui.refinement_choice
+        fix_strain_w = self.ui.fix_strain
+        with block_signals(w, fix_strain_w):
+            w.setCurrentIndex(idx)
+
+            # Also disable fixing the strain
+            fix_strain_w.setChecked(False)
+
+        # Trigger an update to the config
+        self.refinements_editor.update_config()
+
+    @property
+    def selected_material(self) -> str:
+        return self.ui.material.currentText()
+
+    @selected_material.setter
+    def selected_material(self, v: str):
+        self.ui.material.setCurrentText(v)
 
     @property
     def do_refit(self):
@@ -96,28 +334,20 @@ class HEDMCalibrationOptionsDialog(QObject):
         self.ui.refit_ome_step_scale.setValue(v)
 
     @property
-    def clobber_strain(self):
-        return self.ui.clobber_strain.isChecked()
+    def npdiv(self):
+        return self.ui.npdiv.value()
 
-    @clobber_strain.setter
-    def clobber_strain(self, b):
-        self.ui.clobber_strain.setChecked(b)
-
-    @property
-    def clobber_centroid(self):
-        return self.ui.clobber_centroid.isChecked()
-
-    @clobber_centroid.setter
-    def clobber_centroid(self, b):
-        self.ui.clobber_centroid.setChecked(b)
+    @npdiv.setter
+    def npdiv(self, v):
+        self.ui.npdiv.setValue(v)
 
     @property
-    def clobber_grain_Y(self):
-        return self.ui.clobber_grain_Y.isChecked()
+    def threshold(self):
+        return self.ui.threshold.value()
 
-    @clobber_grain_Y.setter
-    def clobber_grain_Y(self, b):
-        self.ui.clobber_grain_Y.setChecked(b)
+    @threshold.setter
+    def threshold(self, v):
+        self.ui.threshold.setValue(v)
 
     def choose_hkls(self):
         kwargs = {
@@ -137,8 +367,198 @@ class HEDMCalibrationOptionsDialog(QObject):
         text = f'Number of hkls selected:  {num_hkls}'
         self.ui.num_hkls_selected.setText(text)
 
-    def show_grains_table(self):
-        if not hasattr(self, '_grains_viewer_dialog'):
-            self._grains_viewer_dialog = GrainsViewerDialog(self.grains_table)
+    def update_num_grains_selected(self):
+        num_grains = len(self.active_overlays)
+        text = f'Number of grains selected: {num_grains}'
+        self.ui.num_grains_selected.setText(text)
 
-        self._grains_viewer_dialog.show()
+    def edit_grains_table(self):
+        dialog = SelectGrainsDialog(None, self.ui)
+        if not dialog.exec():
+            return
+
+        selected_grains = dialog.selected_grains
+
+        # Hide any grains that were not selected.
+        # Show any grains that were selected.
+        # And add any new grains that don't have overlays.
+        new_overlays_needed = list(range(len(selected_grains)))
+        for overlay in self.overlays:
+            if not overlay.is_rotation_series:
+                overlay.visible = False
+                continue
+
+            match_idx = -1
+            for i in new_overlays_needed:
+                grain_params = selected_grains[i][3:15]
+                if np.allclose(overlay.crystal_params, grain_params):
+                    match_idx = i
+                    break
+
+            overlay.visible = match_idx != -1
+            if match_idx != -1:
+                new_overlays_needed.remove(match_idx)
+
+        # Now create new overlays for any missing selected grains
+        for i in new_overlays_needed:
+            HexrdConfig().append_overlay(
+                self.material.name,
+                OverlayType.rotation_series,
+            )
+
+            # Grab that overlay we just made, and set the grain params
+            overlay = HexrdConfig().overlays[-1]
+            overlay.crystal_params = selected_grains[i][3:15]
+            overlay.update_needed = True
+            overlay.visible = True
+
+        HexrdConfig().overlay_config_changed.emit()
+
+        self.update_tolerances_grain_options()
+        self.update_num_grains_selected()
+        self.apply_refinement_selections()
+        self.update_refinements_editor()
+        HexrdConfig().update_overlay_manager.emit()
+
+    @property
+    def fix_strain(self):
+        return self.ui.fix_strain.isChecked()
+
+    @fix_strain.setter
+    def fix_strain(self, b):
+        self.ui.fix_strain.setChecked(b)
+
+    @property
+    def fix_det_y(self):
+        return self.ui.refinement_choice.currentData() == 'fix_det_y'
+
+    @property
+    def fix_grain_centroid(self):
+        return self.ui.refinement_choice.currentData() == 'fix_grain_centroid'
+
+    @property
+    def fix_grain_y(self):
+        return self.ui.refinement_choice.currentData() == 'fix_grain_y'
+
+    @property
+    def custom_refinements(self):
+        return self.ui.refinement_choice.currentData() == 'custom'
+
+    def apply_refinement_selections(self):
+        def perform_updates():
+            self.update_refinements_editor()
+            HexrdConfig().overlay_config_changed.emit()
+            HexrdConfig().update_overlay_editor.emit()
+            HexrdConfig().update_instrument_toolbox.emit()
+
+        # First, apply strain settings
+        for overlay in self.active_overlays:
+            refinements = overlay.refinements
+            crystal_params = overlay.crystal_params
+            if self.fix_strain:
+                crystal_params[6:] = cnst.identity_6x1
+                for i in range(6, len(refinements)):
+                    refinements[i] = False
+            elif not self.custom_refinements:
+                # Make all strain parameters refinable, but only
+                # if we are not doing custom refinements.
+                for i in range(6, len(refinements)):
+                    refinements[i] = True
+
+        # If we are doing custom refinements, don't make any more changes
+        if self.custom_refinements:
+            perform_updates()
+            return
+
+        # Set all rotation series orientation/position refinement params
+        for idx, overlay in enumerate(self.active_overlays):
+            refinements = overlay.refinements
+            crystal_params = overlay.crystal_params
+
+            # The position and orientation will be refinable by default
+            for i in range(6):
+                refinements[i] = True
+
+            if idx == 0:
+                # First grain may be affected by refinement choices
+                if self.fix_grain_centroid:
+                    crystal_params[3:6] = cnst.zeros_3
+                    for i in range(3, 6):
+                        refinements[i] = False
+                elif self.fix_grain_y:
+                    crystal_params[4] = 0
+                    refinements[4] = False
+
+        def recursive_set_refinable(cur, b):
+            if 'status' not in cur:
+                for key, value in cur.items():
+                    recursive_set_refinable(value, b)
+                return
+
+            if isinstance(cur['status'], list):
+                for i in range(len(cur['status'])):
+                    cur['status'][i] = b
+            else:
+                cur['status'] = b
+
+        # Now make all detector parameters refinable by default.
+        iconfig = HexrdConfig().config['instrument']
+
+        # Mark everything under "beam" and "oscillation stage" as not refinable
+        recursive_set_refinable(iconfig['beam'], False)
+        recursive_set_refinable(iconfig['oscillation_stage'], False)
+
+        # Mark everything under detectors as refinable
+        recursive_set_refinable(iconfig['detectors'], True)
+
+        if self.fix_det_y:
+            # Fix the detector y translation values
+            for det_key, conf in iconfig['detectors'].items():
+                conf['transform']['translation']['status'][1] = False
+
+        # Now trigger updates everywhere
+        perform_updates()
+
+    def view_refinements(self):
+        self.update_refinements_editor()
+        self.refinements_editor.ui.show()
+
+    def update_refinements_editor(self):
+        self.refinements_editor.reset_dict()
+
+    @property
+    def overlays(self):
+        return HexrdConfig().overlays
+
+    @property
+    def visible_overlays(self):
+        return [x for x in self.overlays if x.visible]
+
+    @property
+    def visible_rotation_series_overlays(self):
+        return [x for x in self.visible_overlays if x.is_rotation_series]
+
+    @property
+    def active_overlays(self):
+        return self.visible_rotation_series_overlays
+
+
+def calc_table_height(table: QTableWidget) -> int:
+    """Calculate table height."""
+    res = 0
+    for i in range(table.verticalHeader().count()):
+        if not table.verticalHeader().isSectionHidden(i):
+            res += table.verticalHeader().sectionSize(i)
+    if table.horizontalScrollBar().isHidden():
+        res += table.horizontalScrollBar().height()
+    if not table.horizontalHeader().isHidden():
+        res += table.horizontalHeader().height()
+    return res
+
+
+REFINEMENT_OPTIONS = {
+    'fix_det_y': 'Fix origin based on current sample/detector position',
+    'fix_grain_centroid': 'Reset origin to grain centroid position',
+    'fix_grain_y': 'Reset Y axis origin to grain\'s Y position',
+    'custom': 'Custom refinement parameters',
+}

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -194,8 +194,14 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Indicate that the state was loaded..."""
     state_loaded = Signal()
 
+    """Indicate that the overlay manager should update its table"""
+    update_overlay_manager = Signal()
+
     """Indicate that the overlay editor should update its GUI"""
     update_overlay_editor = Signal()
+
+    """Indicate that the main window should update it's instrument toolbox"""
+    update_instrument_toolbox = Signal()
 
     """Indicate that the beam marker has been modified"""
     beam_marker_modified = Signal()

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -894,7 +894,7 @@ class ImageCanvas(FigureCanvas):
             # Right now, hexrd doesn't want this to be inf.
             # Maybe that will change in the future...
             self.iviewer.instr.source_distance = (
-                beam_config['source_distance']['value'],
+                beam_config['source_distance']['value']
             )
 
         self.update_overlays()

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -332,6 +332,8 @@ class MainWindow(QObject):
             self.update_drawn_mask_line_picker_canvas)
         HexrdConfig().tab_images_changed.connect(
             self.update_mask_region_canvas)
+        HexrdConfig().update_instrument_toolbox.connect(
+            self.update_config_gui)
 
         ImageLoadManager().update_needed.connect(self.update_all)
         ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)

--- a/hexrdgui/overlay_manager.py
+++ b/hexrdgui/overlay_manager.py
@@ -47,6 +47,7 @@ class OverlayManager:
         self.ui.add_button.pressed.connect(self.add)
         self.ui.remove_button.pressed.connect(self.remove)
         self.ui.edit_style_button.pressed.connect(self.edit_style)
+        HexrdConfig().update_overlay_manager.connect(self.update_table)
         HexrdConfig().update_overlay_editor.connect(self.update_overlay_editor)
         HexrdConfig().materials_added.connect(self.update_table)
         HexrdConfig().material_renamed.connect(self.on_material_renamed)

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -20,9 +20,10 @@ class RotationSeriesOverlay(Overlay):
 
     def __init__(self, material_name, crystal_params=None, eta_ranges=None,
                  ome_ranges=None, ome_period=None, aggregated=True,
-                 ome_width=np.radians(5.0).item(), tth_width=None,
-                 eta_width=None, sync_ome_period=True, sync_ome_ranges=True,
-                 **overlay_kwargs):
+                 ome_width=np.radians(1.5).item(),
+                 tth_width=np.radians(0.25).item(),
+                 eta_width=np.radians(1.0).item(),
+                 sync_ome_period=True, sync_ome_ranges=True, **overlay_kwargs):
         super().__init__(material_name, **overlay_kwargs)
 
         if crystal_params is None:

--- a/hexrdgui/resources/indexing/default_indexing_config.yml
+++ b/hexrdgui/resources/indexing/default_indexing_config.yml
@@ -147,7 +147,7 @@ fit_grains:
 
 # Some custom ones we have added for the GUI
 _hedm_calibration:
-  do_refit: false
-  clobber_strain: false
+  do_refit: true
+  clobber_strain: true
+  clobber_grain_Y: true
   clobber_centroid: false
-  clobber_grain_Y: false

--- a/hexrdgui/resources/ui/hedm_calibration_options_dialog.ui
+++ b/hexrdgui/resources/ui/hedm_calibration_options_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>479</width>
-    <height>558</height>
+    <width>606</width>
+    <height>850</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,7 +17,14 @@
    <item>
     <widget class="QPushButton" name="view_grains_table">
      <property name="text">
-      <string>View Grains Table</string>
+      <string>Select Grains for Calibration Refinement</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPushButton" name="view_refinements">
+     <property name="text">
+      <string>View Refinements</string>
      </property>
     </widget>
    </item>
@@ -40,52 +47,20 @@
    <item>
     <layout class="QGridLayout" name="grid_layout">
      <item row="4" column="1" colspan="2">
-      <widget class="QGroupBox" name="clobbering_group">
-       <property name="title">
-        <string>Clobbering</string>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>η and ω ranges can be edited within the &quot;Overlay Manager&quot;</string>
        </property>
-       <layout class="QVBoxLayout" name="verticalLayout_2">
-        <item>
-         <widget class="QCheckBox" name="clobber_strain">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the stretch matrix to identity.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Clobber strain?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="clobber_centroid">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain position to the origin: (0, 0, 0).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Clobber centroid?</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="clobber_grain_Y">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets and fixes the grain Y to zero.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Clobber grain Y?</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QLabel" name="num_hkls_selected">
        <property name="text">
         <string>Number of hkls selected:</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1" colspan="2">
+     <item row="7" column="1" colspan="2">
       <widget class="QGroupBox" name="refitting_group">
        <property name="title">
         <string>Refitting</string>
@@ -96,6 +71,9 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is not checked: The grain and instrument parameters will be refined once.&lt;/p&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is checked: The grain and instrument parameters will first be refined. Afterwards, a filtering step will filter out reflections that are too far away in x, y, or omega from the predicted values, and then the grain and instrument parameters will be refined again.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit pixel scale&amp;quot; is the maximum distance (in pixels) in x or y before the reflection is filtered out.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit omega step scale&amp;quot; is the maximum distance in omega steps before the reflection is filtered out. For example, if the omega step size is 0.25 degrees, and the &amp;quot;Refit omega step scale&amp;quot; is 2, then the maximum allowable difference in omega is 2 * 0.25 degrees = 0.5 degrees.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
            <string>Refit pixel scale</string>
           </property>
@@ -103,8 +81,14 @@
         </item>
         <item row="0" column="0">
          <widget class="QCheckBox" name="do_refit">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is not checked: The grain and instrument parameters will be refined once.&lt;/p&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is checked: The grain and instrument parameters will first be refined. Afterwards, a filtering step will filter out reflections that are too far away in x, y, or omega from the predicted values, and then the grain and instrument parameters will be refined again.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit pixel scale&amp;quot; is the maximum distance (in pixels) in x or y before the reflection is filtered out.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit omega step scale&amp;quot; is the maximum distance in omega steps before the reflection is filtered out. For example, if the omega step size is 0.25 degrees, and the &amp;quot;Refit omega step scale&amp;quot; is 2, then the maximum allowable difference in omega is 2 * 0.25 degrees = 0.5 degrees.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="text">
            <string>Do refit?</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
           </property>
          </widget>
         </item>
@@ -112,6 +96,9 @@
          <widget class="QLabel" name="refit_ome_step_scale_label">
           <property name="enabled">
            <bool>false</bool>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is not checked: The grain and instrument parameters will be refined once.&lt;/p&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is checked: The grain and instrument parameters will first be refined. Afterwards, a filtering step will filter out reflections that are too far away in x, y, or omega from the predicted values, and then the grain and instrument parameters will be refined again.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit pixel scale&amp;quot; is the maximum distance (in pixels) in x or y before the reflection is filtered out.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit omega step scale&amp;quot; is the maximum distance in omega steps before the reflection is filtered out. For example, if the omega step size is 0.25 degrees, and the &amp;quot;Refit omega step scale&amp;quot; is 2, then the maximum allowable difference in omega is 2 * 0.25 degrees = 0.5 degrees.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="text">
            <string>Refit ome step scale</string>
@@ -128,6 +115,9 @@
             <horstretch>0</horstretch>
             <verstretch>0</verstretch>
            </sizepolicy>
+          </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is not checked: The grain and instrument parameters will be refined once.&lt;/p&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is checked: The grain and instrument parameters will first be refined. Afterwards, a filtering step will filter out reflections that are too far away in x, y, or omega from the predicted values, and then the grain and instrument parameters will be refined again.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit pixel scale&amp;quot; is the maximum distance (in pixels) in x or y before the reflection is filtered out.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit omega step scale&amp;quot; is the maximum distance in omega steps before the reflection is filtered out. For example, if the omega step size is 0.25 degrees, and the &amp;quot;Refit omega step scale&amp;quot; is 2, then the maximum allowable difference in omega is 2 * 0.25 degrees = 0.5 degrees.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
           </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -148,6 +138,9 @@
           <property name="enabled">
            <bool>false</bool>
           </property>
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is not checked: The grain and instrument parameters will be refined once.&lt;/p&gt;&lt;p&gt;If &amp;quot;Do refit?&amp;quot; is checked: The grain and instrument parameters will first be refined. Afterwards, a filtering step will filter out reflections that are too far away in x, y, or omega from the predicted values, and then the grain and instrument parameters will be refined again.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit pixel scale&amp;quot; is the maximum distance (in pixels) in x or y before the reflection is filtered out.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Refit omega step scale&amp;quot; is the maximum distance in omega steps before the reflection is filtered out. For example, if the omega step size is 0.25 degrees, and the &amp;quot;Refit omega step scale&amp;quot; is 2, then the maximum allowable difference in omega is 2 * 0.25 degrees = 0.5 degrees.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
           <property name="alignment">
            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
           </property>
@@ -165,10 +158,180 @@
        </layout>
       </widget>
      </item>
-     <item row="1" column="2">
+     <item row="2" column="2">
       <widget class="QPushButton" name="choose_hkls">
        <property name="text">
         <string>Choose HKLs</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1" colspan="2">
+      <widget class="QGroupBox" name="refinements_group">
+       <property name="title">
+        <string>Refinement Choices</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0" colspan="2">
+         <widget class="QCheckBox" name="fix_strain">
+          <property name="toolTip">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Sets all calibration grains' stretch tensors to identity and holds them fixed during refinement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+          <property name="text">
+           <string>Assume calibration grains strain-free</string>
+          </property>
+          <property name="checked">
+           <bool>false</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <item>
+           <widget class="QLabel" name="refinement_choice_label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a preset refinement choice. Here are descriptions of each:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Fix origin based on current sample/detector position&lt;/span&gt; - Holds detectors fixed along the Y axis during refinement&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Reset origin to grain centroid position&lt;/span&gt; - Set first calibration grain's centroid to [0,0,0] and holds it fixed during refinement&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Reset Y axis origin to grain's Y position&lt;/span&gt; - Sets the first calibration grain's Y position to zero and holds it fixed in Y during refinement&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Custom refinement parameters&lt;/span&gt; - Uses current parameter refinement choices.  Check refinements tab to see current selection.  &lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;: Incompatible choices can be made without proper consideration of the system's degrees of freedom&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Choice: </string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QComboBox" name="refinement_choice">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Select a preset refinement choice. Here are descriptions of each:&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Fix origin based on current sample/detector position&lt;/span&gt; - Holds detectors fixed along the Y axis during refinement&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Reset origin to grain centroid position&lt;/span&gt; - Set first calibration grain's centroid to [0,0,0] and holds it fixed during refinement&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Reset Y axis origin to grain's Y position&lt;/span&gt; - Sets the first calibration grain's Y position to zero and holds it fixed in Y during refinement&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Custom refinement parameters&lt;/span&gt; - Uses current parameter refinement choices.  Check refinements tab to see current selection.  &lt;span style=&quot; font-weight:600;&quot;&gt;Warning&lt;/span&gt;: Incompatible choices can be made without proper consideration of the system's degrees of freedom&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QLabel" name="npdiv_label">
+       <property name="text">
+        <string>Number of Polar Subdivisions:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="num_grains_selected">
+       <property name="text">
+        <string>Number of grains to be refined:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QSpinBox" name="npdiv">
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>100000</number>
+       </property>
+       <property name="value">
+        <number>4</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLabel" name="material_label">
+       <property name="text">
+        <string>Selected Material:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QComboBox" name="material"/>
+     </item>
+     <item row="3" column="1" colspan="2">
+      <widget class="QGroupBox" name="tolerances_group">
+       <property name="title">
+        <string>Tolerances</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_3">
+        <item row="0" column="0">
+         <widget class="QLabel" name="tolerances_selected_grain_label">
+          <property name="text">
+           <string>Selected Grain:</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="tolerances_selected_grain"/>
+        </item>
+        <item row="1" column="0" colspan="2">
+         <widget class="QTableWidget" name="tolerances_table">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="maximumSize">
+           <size>
+            <width>16777215</width>
+            <height>100</height>
+           </size>
+          </property>
+          <attribute name="horizontalHeaderDefaultSectionSize">
+           <number>175</number>
+          </attribute>
+          <attribute name="horizontalHeaderStretchLastSection">
+           <bool>true</bool>
+          </attribute>
+          <attribute name="verticalHeaderVisible">
+           <bool>false</bool>
+          </attribute>
+          <row>
+           <property name="text">
+            <string>New Row</string>
+           </property>
+          </row>
+          <column>
+           <property name="text">
+            <string>2θ</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>η</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>ω</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLabel" name="threshold_label">
+       <property name="text">
+        <string>Threshold:</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="ScientificDoubleSpinBox" name="threshold">
+       <property name="decimals">
+        <number>8</number>
+       </property>
+       <property name="maximum">
+        <double>10000000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>25.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -210,7 +373,19 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>view_grains_table</tabstop>
+  <tabstop>view_refinements</tabstop>
+  <tabstop>material</tabstop>
   <tabstop>choose_hkls</tabstop>
+  <tabstop>tolerances_selected_grain</tabstop>
+  <tabstop>tolerances_table</tabstop>
+  <tabstop>npdiv</tabstop>
+  <tabstop>threshold</tabstop>
+  <tabstop>do_refit</tabstop>
+  <tabstop>refit_pixel_scale</tabstop>
+  <tabstop>refit_ome_step_scale</tabstop>
+  <tabstop>fix_strain</tabstop>
+  <tabstop>refinement_choice</tabstop>
  </tabstops>
  <resources/>
  <connections>
@@ -221,8 +396,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>259</x>
+     <y>546</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -237,8 +412,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>327</x>
+     <y>546</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>
@@ -253,12 +428,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>354</x>
-     <y>218</y>
+     <x>235</x>
+     <y>385</y>
     </hint>
     <hint type="destinationlabel">
-     <x>123</x>
-     <y>253</y>
+     <x>149</x>
+     <y>426</y>
     </hint>
    </hints>
   </connection>
@@ -269,12 +444,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>354</x>
-     <y>218</y>
+     <x>235</x>
+     <y>385</y>
     </hint>
     <hint type="destinationlabel">
-     <x>354</x>
-     <y>253</y>
+     <x>452</x>
+     <y>426</y>
     </hint>
    </hints>
   </connection>
@@ -285,12 +460,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>354</x>
-     <y>218</y>
+     <x>235</x>
+     <y>385</y>
     </hint>
     <hint type="destinationlabel">
-     <x>123</x>
-     <y>290</y>
+     <x>149</x>
+     <y>467</y>
     </hint>
    </hints>
   </connection>
@@ -301,12 +476,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>354</x>
-     <y>218</y>
+     <x>235</x>
+     <y>385</y>
     </hint>
     <hint type="destinationlabel">
-     <x>354</x>
-     <y>290</y>
+     <x>452</x>
+     <y>467</y>
     </hint>
    </hints>
   </connection>

--- a/hexrdgui/resources/ui/refinements_editor.ui
+++ b/hexrdgui/resources/ui/refinements_editor.ui
@@ -10,6 +10,9 @@
     <height>700</height>
    </rect>
   </property>
+  <property name="windowTitle">
+   <string>Refinements Editor</string>
+  </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="3" column="1" colspan="2">
     <widget class="QDialogButtonBox" name="button_box">

--- a/hexrdgui/resources/ui/rotation_series_overlay_editor.ui
+++ b/hexrdgui/resources/ui/rotation_series_overlay_editor.ui
@@ -94,7 +94,7 @@
              <double>360.000000000000000</double>
             </property>
             <property name="value">
-             <double>3.000000000000000</double>
+             <double>1.000000000000000</double>
             </property>
            </widget>
           </item>
@@ -248,6 +248,9 @@
          </property>
          <property name="maximum">
           <double>10000000.000000000000000</double>
+         </property>
+         <property name="value">
+          <double>1.500000000000000</double>
          </property>
         </widget>
        </item>

--- a/hexrdgui/select_grains_dialog.py
+++ b/hexrdgui/select_grains_dialog.py
@@ -17,7 +17,7 @@ class SelectGrainsDialog(QObject):
     accepted = Signal()
     rejected = Signal()
 
-    def __init__(self, num_requested_grains=1, parent=None):
+    def __init__(self, num_requested_grains: int | None = 1, parent=None):
         super().__init__(parent)
         self.ignore_errors = False
 
@@ -26,7 +26,10 @@ class SelectGrainsDialog(QObject):
 
         self.num_requested_grains = num_requested_grains
 
-        if num_requested_grains >= 1:
+        if num_requested_grains is None:
+            # None means any number of grains
+            self.ui.setWindowTitle('Please select grains')
+        elif num_requested_grains >= 1:
             suffix = 's' if num_requested_grains > 1 else ''
             title = f'Please select {num_requested_grains} grain{suffix}'
             self.ui.setWindowTitle(title)
@@ -168,7 +171,10 @@ class SelectGrainsDialog(QObject):
 
         # If the number of rows is equal to the number of requested grains,
         # select all rows automatically for convenience.
-        if len(v) == self.num_requested_grains:
+        if (
+            self.num_requested_grains is not None and
+            len(v) == self.num_requested_grains
+        ):
             selection_model = view.selectionModel()
             command = QItemSelectionModel.Select | QItemSelectionModel.Rows
             for i in range(len(v)):
@@ -231,7 +237,10 @@ class SelectGrainsDialog(QObject):
         button_box = self.ui.button_box
         ok_button = button_box.button(QDialogButtonBox.Ok)
         if ok_button:
-            enable = self.num_selected_grains == self.num_requested_grains
+            enable = (
+                self.num_requested_grains is None or
+                self.num_selected_grains == self.num_requested_grains
+            )
             ok_button.setEnabled(enable)
 
         grains_loaded = self.num_grains_loaded > 0

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import Signal, QModelIndex, Qt
+from PySide6.QtCore import Signal, QModelIndex, Qt, QTimer
 from PySide6.QtGui import QCursor
 from PySide6.QtWidgets import (
     QCheckBox, QDialog, QItemEditorFactory, QMenu, QStyledItemDelegate,
@@ -237,8 +237,13 @@ class MultiColumnDictTreeView(BaseDictTreeView):
         self.open_persistent_editors()
         self.expand_rows()
 
-        # Restore the vertical scroll bar position
-        sb.setValue(prev_pos)
+        def restore_vertical_bar():
+            # Restore the vertical scroll bar position
+            sb.setValue(prev_pos)
+
+        # Do this in the next iteration of the event loop, because
+        # it may require the GUI to finish updating.
+        QTimer.singleShot(0, restore_vertical_bar)
 
 
 class MultiColumnDictTreeViewDialog(QDialog):


### PR DESCRIPTION
We eventually want to use features from our main calibration workflows, such as the "undo" button, and the relative constraints. However, we need to make short-term updates to the HEDM calibration workflow.

This makes several changes, including allowing users to see how the refinement options get changed with different refinement settings, allowing users to select grains to be used, and allowing users to see and set all parameters used as input for `pull_spots()`.

Fixes: #1741