### PR TITLE
Physics package fixes

### DIFF
--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -654,7 +654,7 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         kwargs = self.tth_distortion_kwargs.copy()
         if self.pinhole_distortion_type == 'RyggPinholeDistortion':
             # Add our absorption length
-            kwargs['absorption_length'] = HexrdConfig().absorption_length()
+            kwargs['absorption_length'] = HexrdConfig().absorption_length() * 1e-3
         return kwargs
     # END PolarDistortionObject mixin reroutes
 

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -654,7 +654,8 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         kwargs = self.tth_distortion_kwargs.copy()
         if self.pinhole_distortion_type == 'RyggPinholeDistortion':
             # Add our absorption length
-            kwargs['absorption_length'] = HexrdConfig().absorption_length() * 1e-3
+            kwargs['absorption_length'] = HexrdConfig(
+                ).absorption_length() * 1e-3
         return kwargs
     # END PolarDistortionObject mixin reroutes
 

--- a/hexrdgui/physics_package_manager_dialog.py
+++ b/hexrdgui/physics_package_manager_dialog.py
@@ -142,7 +142,7 @@ class PhysicsPackageManagerDialog:
         self.ui.pinhole_density.setValue(physics.pinhole_density)
         if self.instrument_type == 'PXRDIP':
             self.ui.pinhole_thickness.setValue(70)
-            self.ui.pinhole_diameter.setValue(130)
+            self.ui.pinhole_diameter.setValue(300)
         else:
             self.ui.pinhole_thickness.setValue(physics.pinhole_thickness)
             self.ui.pinhole_diameter.setValue(physics.pinhole_diameter)

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -144,7 +144,7 @@ class PinholeCorrectionEditor(QObject):
             }
             if self.rygg_absorption_length_visible:
                 # Only return an absorption length if it is visible
-                output['absorption_length'] = HexrdConfig().absorption_length()
+                output['absorption_length'] = HexrdConfig().absorption_length() * 1e-3
             return output
 
         raise Exception(f'Not implemented for: {dtype}')

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -144,7 +144,7 @@ class PinholeCorrectionEditor(QObject):
             }
             if self.rygg_absorption_length_visible:
                 # Only return an absorption length if it is visible
-                output['absorption_length'] = HexrdConfig().absorption_length() * 1e-3
+                output['absorption_length'] = HexrdConfig().absorption_length()
             return output
 
         raise Exception(f'Not implemented for: {dtype}')
@@ -157,7 +157,7 @@ class PinholeCorrectionEditor(QObject):
         vp = v.copy()
         # These units are in mm, but we display in micrometers
         for key, value in v.items():
-            if key in ('num_phi_elements'):
+            if key in ('num_phi_elements', 'absorption_length'):
                 multiplier = 1
             else:
                 multiplier = 1e3

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -154,14 +154,15 @@ class PinholeCorrectionEditor(QObject):
         if v is None:
             return
 
+        vp = v.copy()
         # These units are in mm, but we display in micrometers
         for key, value in v.items():
-            if key in ('num_phi_elements', 'absorption_length'):
+            if key in ('num_phi_elements'):
                 multiplier = 1
             else:
                 multiplier = 1e3
 
-            v[key] = value * multiplier
+            vp[key] = value * multiplier
 
         physics = HexrdConfig().physics_package
         if physics is None:
@@ -201,7 +202,7 @@ class PinholeCorrectionEditor(QObject):
         for w_name, (key, value) in values.items():
             if w_name.startswith(widget_prefix):
                 # Extract the value from the dict
-                value = v.get(key, value)
+                value = vp.get(key, value)
 
             w = getattr(self.ui, w_name)
             w.setValue(value)


### PR DESCRIPTION
The thicknesses of each layer kept increasing upon repeated selection of pinhole correction. The problem was due too using a dictionary by reference. Fixed by making a copy and editing it instead of original dictionary.