### PR TITLE
HEDM Calibration: restore grain settings

### DIFF
--- a/hexrdgui/resources/ui/hedm_calibration_options_dialog.ui
+++ b/hexrdgui/resources/ui/hedm_calibration_options_dialog.ui
@@ -180,7 +180,7 @@
            <string>Assume calibration grains strain-free</string>
           </property>
           <property name="checked">
-           <bool>false</bool>
+           <bool>true</bool>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
In the HEDM calibration, if the user does things like unchecking whether the strain is fixed to identity, restore the previous setting that the strain had.

This way, modifying options won't result in a permanent loss of the previous settings. It also enables us to fix the strain by default (which was recommended).