### PR TITLE
Upgrade macos to 13 for packaging

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-12,
+            os: macos-13,
             package: 'dmg'
           }
         - {


### PR DESCRIPTION
macos 12 is deprecated and will not work soon.