### PR TITLE
Add ability to specify center of rotation

### DIFF
--- a/hexrdgui/calibration/calibration_dialog.py
+++ b/hexrdgui/calibration/calibration_dialog.py
@@ -12,6 +12,7 @@ from hexrd.fitting.calibration.lmfit_param_handling import (
 )
 from hexrd.fitting.calibration.relative_constraints import (
     RelativeConstraintsType,
+    RotationCenter,
 )
 
 from hexrdgui import resource_loader
@@ -42,6 +43,7 @@ class CalibrationDialog(QObject):
     save_picks_clicked = Signal()
     load_picks_clicked = Signal()
     relative_constraints_changed = Signal(RelativeConstraintsType)
+    tilt_center_of_rotation_changed = Signal(RotationCenter)
     engineering_constraints_changed = Signal(str)
 
     pinhole_correction_settings_modified = Signal()
@@ -75,6 +77,7 @@ class CalibrationDialog(QObject):
             self.on_pinhole_correction_settings_modified)
 
         self.populate_relative_constraint_options()
+        self.populate_tilt_rotation_center_options()
 
         self.instr = instr
         self._params_dict = params_dict
@@ -83,12 +86,6 @@ class CalibrationDialog(QObject):
         self.engineering_constraints = engineering_constraints
 
         self._ignore_next_tree_view_update = False
-
-        instr_type = guess_instrument_type(instr.detectors)
-        # Use delta boundaries by default for anything other than TARDIS
-        # and PXRDIP. We might want to change this to a whitelist later.
-        use_delta_boundaries = instr_type not in ('TARDIS', 'PXRDIP')
-        self.delta_boundaries = use_delta_boundaries
 
         self.initialize_advanced_options()
 
@@ -101,6 +98,7 @@ class CalibrationDialog(QObject):
         self.update_visibility_states()
 
         self.load_settings()
+        self.update_relative_constraint_visibilities()
         self.setup_connections()
 
     def setup_connections(self):
@@ -111,6 +109,8 @@ class CalibrationDialog(QObject):
             self.show_picks_from_all_xray_sources_toggled)
         self.ui.relative_constraints.currentIndexChanged.connect(
             self.on_relative_constraints_changed)
+        self.ui.tilt_center_of_rotation.currentIndexChanged.connect(
+            self.on_tilt_center_of_rotation_changed)
         self.ui.engineering_constraints.currentIndexChanged.connect(
             self.on_engineering_constraints_changed)
         self.ui.delta_boundaries.toggled.connect(
@@ -150,7 +150,28 @@ class CalibrationDialog(QObject):
         w = self.ui.relative_constraints
         w.clear()
         for option in options:
-            w.addItem(option.value, option)
+            w.addItem(RELATIVE_CONSTRAINT_LABELS[option], option)
+
+    def populate_tilt_rotation_center_options(self):
+        # We are skipping group constraints until it is actually implemented
+        w = self.ui.tilt_center_of_rotation
+        w.clear()
+        for label in ROTATION_CENTER_LABELS.values():
+            w.addItem(label)
+
+    def set_instrument_defaults(self):
+        # This function should only be called after the Callbacks have been
+        # connected, because the changes here may also affect the Calibrator
+        # classes.
+        instr_type = guess_instrument_type(self.instr.detectors)
+        # Use delta boundaries by default for anything other than TARDIS
+        # and PXRDIP. We might want to change this to a whitelist later.
+        use_delta_boundaries = instr_type not in ('TARDIS', 'PXRDIP')
+        self.delta_boundaries = use_delta_boundaries
+
+        if instr_type == 'FIDDLE':
+            self.relative_constraints = RelativeConstraintsType.system
+            self.tilt_center_of_rotation = RotationCenter.lab_origin
 
     def update_edit_picks_enable_state(self):
         is_polar = HexrdConfig().image_mode == ViewType.polar
@@ -219,6 +240,16 @@ class CalibrationDialog(QObject):
         self.ui.active_beam.setVisible(has_multi_xrs)
         self.ui.active_beam_label.setVisible(has_multi_xrs)
         self.ui.show_picks_from_all_xray_sources.setVisible(has_multi_xrs)
+
+    def update_relative_constraint_visibilities(self):
+        visible = self.relative_constraints != RelativeConstraintsType.none
+
+        tilt_center_widgets = [
+            self.ui.tilt_center_of_rotation,
+            self.ui.tilt_center_of_rotation_label,
+        ]
+        for w in tilt_center_widgets:
+            w.setVisible(visible)
 
     def on_draw_picks_toggled(self, b):
         self.draw_picks_toggled.emit(b)
@@ -347,6 +378,19 @@ class CalibrationDialog(QObject):
 
         w.setCurrentText(v.value)
 
+        self.update_relative_constraint_visibilities()
+
+    @property
+    def tilt_center_of_rotation(self) -> RotationCenter:
+        w = self.ui.tilt_center_of_rotation
+        return ROTATION_CENTER_LABELS_R[w.currentText()]
+
+    @tilt_center_of_rotation.setter
+    def tilt_center_of_rotation(self, v: RotationCenter):
+        w = self.ui.tilt_center_of_rotation
+        text = ROTATION_CENTER_LABELS[v]
+        w.setCurrentText(text)
+
     @property
     def engineering_constraints(self):
         return self.ui.engineering_constraints.currentText()
@@ -405,6 +449,10 @@ class CalibrationDialog(QObject):
 
         self.relative_constraints_changed.emit(self.relative_constraints)
         self.reinitialize_tree_view()
+        self.update_relative_constraint_visibilities()
+
+    def on_tilt_center_of_rotation_changed(self):
+        self.tilt_center_of_rotation_changed.emit(self.tilt_center_of_rotation)
 
     def on_engineering_constraints_changed(self):
         self.engineering_constraints_changed.emit(self.engineering_constraints)
@@ -458,6 +506,9 @@ class CalibrationDialog(QObject):
 
     def update_from_calibrator(self, calibrator):
         self.relative_constraints = calibrator.relative_constraints_type
+        self.tilt_center_of_rotation = (
+            calibrator.relative_constraints.rotation_center
+        )
         self.engineering_constraints = calibrator.engineering_constraints
         self.tth_distortion = calibrator.tth_distortion
         self.params_dict = calibrator.params
@@ -720,6 +771,16 @@ TILT_LABELS_EULER = {
     ('xyz', True): ('X', 'Y', 'Z'),
     ('zxz', False): ('Z', "X'", "Z''"),
 }
+
+RELATIVE_CONSTRAINT_LABELS = {
+    RelativeConstraintsType.none: 'None',
+    RelativeConstraintsType.system: 'Instrument Rigid Body',
+}
+ROTATION_CENTER_LABELS = {
+    RotationCenter.instrument_mean_center: 'Mean Instrument Center',
+    RotationCenter.lab_origin: 'Origin',
+}
+ROTATION_CENTER_LABELS_R = {v: k for k, v in ROTATION_CENTER_LABELS.items()}
 
 
 def guess_engineering_constraints(instr) -> str | None:

--- a/hexrdgui/calibration/calibration_dialog.py
+++ b/hexrdgui/calibration/calibration_dialog.py
@@ -45,6 +45,7 @@ class CalibrationDialog(QObject):
     relative_constraints_changed = Signal(RelativeConstraintsType)
     tilt_center_of_rotation_changed = Signal(RotationCenter)
     engineering_constraints_changed = Signal(str)
+    reset_relative_params_to_zero_clicked = Signal()
 
     pinhole_correction_settings_modified = Signal()
 
@@ -107,6 +108,8 @@ class CalibrationDialog(QObject):
             self.on_active_beam_changed)
         self.ui.show_picks_from_all_xray_sources.toggled.connect(
             self.show_picks_from_all_xray_sources_toggled)
+        self.ui.reset_relative_params_to_zero.clicked.connect(
+            self.on_reset_relative_params_to_zero_clicked)
         self.ui.relative_constraints.currentIndexChanged.connect(
             self.on_relative_constraints_changed)
         self.ui.tilt_center_of_rotation.currentIndexChanged.connect(
@@ -245,6 +248,7 @@ class CalibrationDialog(QObject):
         visible = self.relative_constraints != RelativeConstraintsType.none
 
         tilt_center_widgets = [
+            self.ui.reset_relative_params_to_zero,
             self.ui.tilt_center_of_rotation,
             self.ui.tilt_center_of_rotation_label,
         ]
@@ -431,6 +435,9 @@ class CalibrationDialog(QObject):
         # They should all have identical settings. Just take the first one.
         first = next(iter(v.values()))
         self.pinhole_correction_editor.update_from_object(first)
+
+    def on_reset_relative_params_to_zero_clicked(self):
+        self.reset_relative_params_to_zero_clicked.emit()
 
     def on_relative_constraints_changed(self):
         # If the relative constraints is not None, then the engineering

--- a/hexrdgui/calibration/calibration_dialog.py
+++ b/hexrdgui/calibration/calibration_dialog.py
@@ -372,11 +372,7 @@ class CalibrationDialog(QObject):
     def relative_constraints(self, v: RelativeConstraintsType):
         v = v if v is not None else RelativeConstraintsType.none
         w = self.ui.relative_constraints
-        options = [w.itemText(i) for i in range(w.count())]
-        if v.value not in options:
-            raise Exception(f'Invalid relative constraints: {v.value}')
-
-        w.setCurrentText(v.value)
+        w.setCurrentText(RELATIVE_CONSTRAINT_LABELS[v])
 
         self.update_relative_constraint_visibilities()
 

--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -114,6 +114,13 @@ KNOWN_DETECTOR_NAMES = {
         'IMAGE-PLATE-R',
         'IMAGE-PLATE-U',
     ],
+    'FIDDLE': [
+        'ic2',
+        'ic3',
+        'ic5',
+        'ic7',
+        'ic8',
+    ],
 }
 
 KEY_ROTATE_ANGLE_FINE = 0.00175

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -3067,7 +3067,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self._physics_package
 
     def update_physics_package(self, instr_type=None, **kwargs):
-        if instr_type is None:
+        if instr_type not in ('TARDIS', 'PXRDIP'):
             self._physics_package = None
         elif self.physics_package is None:
             all_kwargs = PHYSICS_PACKAGE_DEFAULTS.HED

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -326,6 +326,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self._apply_absorption_correction = False
         self._physics_package = None
         self._detector_coatings = {}
+        self._instrument_rigid_body_params = {}
 
         # Make sure that the matplotlib font size matches the application
         self.font_size = self.font_size
@@ -428,6 +429,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('sample_tilt', [0, 0, 0]),
             ('azimuthal_offset', 0.0),
             ('_active_beam_name', None),
+            ('_instrument_rigid_body_params', {}),
             ('recent_state_files', []),
             ('apply_absorption_correction', False),
             ('physics_package_dictified', None),
@@ -467,6 +469,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'azimuthal_overlays',
             'azimuthal_offset',
             '_recent_images',
+            '_instrument_rigid_body_params',
         ]
 
         state = {}

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -284,7 +284,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.live_update = True
         self._show_saturation_level = False
         self._stitch_raw_roi_images = False
-        self._roi_lock_group_transforms = False
         self._tab_images = False
         self.previous_active_material = None
         self.collapsed_state = []
@@ -406,7 +405,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('config_indexing', None),
             ('config_image', None),
             ('_stitch_raw_roi_images', False),
-            ('_roi_lock_group_transforms', False),
             ('font_size', 11),
             ('images_dir', None),
             ('working_dir', '.'),
@@ -2682,15 +2680,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     stitch_raw_roi_images = property(get_stitch_raw_roi_images,
                                      set_stitch_raw_roi_images)
-
-    def get_roi_lock_group_transforms(self):
-        return self._roi_lock_group_transforms and self.instrument_has_roi
-
-    def set_roi_lock_group_transforms(self, v):
-        self._roi_lock_group_transforms = v
-
-    roi_lock_group_transforms = property(get_roi_lock_group_transforms,
-                                         set_roi_lock_group_transforms)
 
     def tab_images(self):
         return self._tab_images

--- a/hexrdgui/resources/ui/calibration_dialog.ui
+++ b/hexrdgui/resources/ui/calibration_dialog.ui
@@ -20,7 +20,41 @@
       <string>Constraints</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="1" column="0">
+      <item row="0" column="0">
+       <widget class="QLabel" name="relative_constraints_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Relative constraints:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QCheckBox" name="delta_boundaries">
+        <property name="text">
+         <string>Use delta for boundaries</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QPushButton" name="mirror_constraints_from_first_detector">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If clicked, the &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; (if &amp;quot;Use delta for boundaries&amp;quot; is checked) settings of the first detector's tilt/translation parameters will be copied to all other detectors' tilt/translation parameters.&lt;/p&gt;&lt;p&gt;This is helpful if you have many detectors and want to modify all of their &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; settings in a similar way.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Mirror Constraints from First Detector</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QComboBox" name="relative_constraints">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Instrument Rigid Body&amp;quot; means all detectors in the entire instrument are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
        <widget class="QLabel" name="engineering_constraints_label">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -30,14 +64,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="delta_boundaries">
-        <property name="text">
-         <string>Use delta for boundaries</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QComboBox" name="engineering_constraints">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -54,30 +81,20 @@
         </item>
        </widget>
       </item>
-      <item row="3" column="0" colspan="2">
-       <widget class="QPushButton" name="mirror_constraints_from_first_detector">
+      <item row="1" column="0">
+       <widget class="QLabel" name="tilt_center_of_rotation_label">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If clicked, the &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; (if &amp;quot;Use delta for boundaries&amp;quot; is checked) settings of the first detector's tilt/translation parameters will be copied to all other detectors' tilt/translation parameters.&lt;/p&gt;&lt;p&gt;This is helpful if you have many detectors and want to modify all of their &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; settings in a similar way.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation to be used for tilt parameters when relative constraints are enabled.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Instrument Center&amp;quot; will cause the panels to be rotated about the mean center of the detectors when the tilt is modified.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; will cause the panels to be rotated about lab origin (i. e., [0, 0, 0]) when the tilt is modified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>Mirror Constraints from First Detector</string>
+         <string>Tilt center of rotation:</string>
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="relative_constraints_label">
+      <item row="1" column="1">
+       <widget class="QComboBox" name="tilt_center_of_rotation">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Relative constraints:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="relative_constraints">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation to be used for tilt parameters when relative constraints are enabled.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Instrument Center&amp;quot; will cause the panels to be rotated about the mean center of the detectors when the tilt is modified.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; will cause the panels to be rotated about lab origin (i. e., [0, 0, 0]) when the tilt is modified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
@@ -484,6 +501,7 @@ See scipy.optimize.least_squares for more details.</string>
   <tabstop>active_beam</tabstop>
   <tabstop>show_picks_from_all_xray_sources</tabstop>
   <tabstop>relative_constraints</tabstop>
+  <tabstop>tilt_center_of_rotation</tabstop>
   <tabstop>engineering_constraints</tabstop>
   <tabstop>delta_boundaries</tabstop>
   <tabstop>mirror_constraints_from_first_detector</tabstop>

--- a/hexrdgui/resources/ui/calibration_dialog.ui
+++ b/hexrdgui/resources/ui/calibration_dialog.ui
@@ -20,24 +20,24 @@
       <string>Constraints</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="0" column="0">
-       <widget class="QLabel" name="relative_constraints_label">
+      <item row="0" column="1">
+       <widget class="QComboBox" name="relative_constraints">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Relative constraints:</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Instrument Rigid Body&amp;quot; means all detectors in the entire instrument are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
-       <widget class="QCheckBox" name="delta_boundaries">
+      <item row="2" column="0">
+       <widget class="QLabel" name="tilt_center_of_rotation_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation to be used for tilt parameters when relative constraints are enabled.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Instrument Center&amp;quot; will cause the panels to be rotated about the mean center of the detectors when the tilt is modified.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; will cause the panels to be rotated about lab origin (i. e., [0, 0, 0]) when the tilt is modified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
         <property name="text">
-         <string>Use delta for boundaries</string>
+         <string>Tilt center of rotation:</string>
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <widget class="QPushButton" name="mirror_constraints_from_first_detector">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If clicked, the &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; (if &amp;quot;Use delta for boundaries&amp;quot; is checked) settings of the first detector's tilt/translation parameters will be copied to all other detectors' tilt/translation parameters.&lt;/p&gt;&lt;p&gt;This is helpful if you have many detectors and want to modify all of their &amp;quot;Vary&amp;quot; and &amp;quot;Delta&amp;quot; settings in a similar way.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -47,24 +47,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QComboBox" name="relative_constraints">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Instrument Rigid Body&amp;quot; means all detectors in the entire instrument are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="engineering_constraints_label">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Add engineering constraints for:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <widget class="QComboBox" name="engineering_constraints">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -81,20 +64,44 @@
         </item>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="tilt_center_of_rotation_label">
+      <item row="3" column="0">
+       <widget class="QLabel" name="engineering_constraints_label">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation to be used for tilt parameters when relative constraints are enabled.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Instrument Center&amp;quot; will cause the panels to be rotated about the mean center of the detectors when the tilt is modified.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; will cause the panels to be rotated about lab origin (i. e., [0, 0, 0]) when the tilt is modified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Add engineering constraints for certain instrument types. This may add extra parameters to the table.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;For example, for TARDIS, the distance between IMAGE-PLATE-2 and IMAGE-PLATE-4 must be within a certain range. If TARDIS is selected, a new parameter is added with default values for this distance.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If the instrument type can be guessed, it will be selected automatically when the dialog first appears. For example, TARDIS is automatically selected if any of the detector names are IMAGE-PLATE-2, IMAGE-PLATE-3, or IMAGE-PLATE-4.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
         <property name="text">
-         <string>Tilt center of rotation:</string>
+         <string>Add engineering constraints for:</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="0" column="0">
+       <widget class="QLabel" name="relative_constraints_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Options to set relative constraints between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;None&amp;quot; means no relative constraints.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;System&amp;quot; means all detectors are relatively constrained to one another. In this case, the mean center of the detectors and a mean tilt may be refined.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Relative constraints:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
        <widget class="QComboBox" name="tilt_center_of_rotation">
         <property name="toolTip">
          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation to be used for tilt parameters when relative constraints are enabled.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Instrument Center&amp;quot; will cause the panels to be rotated about the mean center of the detectors when the tilt is modified.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; will cause the panels to be rotated about lab origin (i. e., [0, 0, 0]) when the tilt is modified.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0">
+       <widget class="QCheckBox" name="delta_boundaries">
+        <property name="text">
+         <string>Use delta for boundaries</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QPushButton" name="reset_relative_params_to_zero">
+        <property name="text">
+         <string>Reset Relative Params to Zero</string>
         </property>
        </widget>
       </item>
@@ -501,6 +508,7 @@ See scipy.optimize.least_squares for more details.</string>
   <tabstop>active_beam</tabstop>
   <tabstop>show_picks_from_all_xray_sources</tabstop>
   <tabstop>relative_constraints</tabstop>
+  <tabstop>reset_relative_params_to_zero</tabstop>
   <tabstop>tilt_center_of_rotation</tabstop>
   <tabstop>engineering_constraints</tabstop>
   <tabstop>delta_boundaries</tabstop>

--- a/hexrdgui/resources/ui/calibration_slider_widget.ui
+++ b/hexrdgui/resources/ui/calibration_slider_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>448</width>
-    <height>673</height>
+    <height>781</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout">
@@ -23,7 +23,17 @@
    <property name="bottomMargin">
     <number>0</number>
    </property>
-   <item row="3" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
+    <widget class="QPushButton" name="push_reset_config">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the instrument configuration to the state when the most recent instrument file was loaded, or when the program started.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Reset Configuration</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0" colspan="2">
     <widget class="QGroupBox" name="translation_group">
      <property name="title">
       <string>Translation</string>
@@ -184,7 +194,10 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="1" column="1">
+    <widget class="QComboBox" name="detector"/>
+   </item>
+   <item row="8" column="0" colspan="2">
     <widget class="QGroupBox" name="beam_group">
      <property name="title">
       <string>Beam</string>
@@ -355,6 +368,44 @@
     </widget>
    </item>
    <item row="4" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="locked_center_of_rotation_label">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation when tilts are applied.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Center&amp;quot; means the center of the whole instrument if &amp;quot;Instrument Rigid Body&amp;quot; is selected, and it means the center of the selected detector's group if &amp;quot;Group Rigid Body&amp;quot; is selected.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; means [0, 0, 0] (the lab origin).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Center of Rotation:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="locked_center_of_rotation">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The center of rotation when tilts are applied.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Mean Center&amp;quot; means the center of the whole instrument if &amp;quot;Instrument Rigid Body&amp;quot; is selected, and it means the center of the selected detector's group if &amp;quot;Group Rigid Body&amp;quot; is selected.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Origin&amp;quot; means [0, 0, 0] (the lab origin).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Mean Center</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Origin</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Detector:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
     <widget class="QGroupBox" name="tilt_group">
      <property name="title">
       <string>Tilt</string>
@@ -524,27 +575,7 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Detector:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <widget class="QPushButton" name="push_reset_config">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Reset the instrument configuration to the state when the most recent instrument file was loaded, or when the program started.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Reset Configuration</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QComboBox" name="detector"/>
-   </item>
-   <item row="7" column="0" colspan="2">
+   <item row="10" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -558,13 +589,30 @@
     </spacer>
    </item>
    <item row="2" column="0" colspan="2">
-    <widget class="QCheckBox" name="roi_lock_group_transforms">
+    <widget class="QCheckBox" name="lock_relative_transforms">
      <property name="toolTip">
-      <string>If checked, when a detector is transformed (translation or tilt), all other detectors in the same group will be transformed in a similar way. For translation, all detectors will be translated by the same amount, and in the same direction. For tilt, all detectors in the same group will be rotated about the mean of the detector centers.</string>
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Lock relative transformations between the detectors.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;If checked, several additional options will appear that define how the detector transformations will be locked. For example, all detectors in the same instrument or group may be transformed via rigid body constraints. And, the center of rotation when tilts are applied may be specified as well.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
      </property>
      <property name="text">
-      <string>Lock ROI Group Transformations</string>
+      <string>Lock relative transformations</string>
      </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QComboBox" name="lock_relative_transforms_setting">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Instrument Rigid Body&amp;quot; means to transform all detectors in the entire instrument in the same way.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;&amp;quot;Group Rigid Body&amp;quot; means to transform all detectors in the selected detector's group in the same way. This setting requires all detectors to have their &amp;quot;group&amp;quot; specified in the instrument config.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <item>
+      <property name="text">
+       <string>Instrument Rigid Body</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Group Rigid Body</string>
+      </property>
+     </item>
     </widget>
    </item>
   </layout>
@@ -578,7 +626,9 @@
  </customwidgets>
  <tabstops>
   <tabstop>detector</tabstop>
-  <tabstop>roi_lock_group_transforms</tabstop>
+  <tabstop>lock_relative_transforms</tabstop>
+  <tabstop>lock_relative_transforms_setting</tabstop>
+  <tabstop>locked_center_of_rotation</tabstop>
   <tabstop>sb_translation_range</tabstop>
   <tabstop>slider_translation_0</tabstop>
   <tabstop>sb_translation_0</tabstop>


### PR DESCRIPTION
For relative constraints, when tilts are applied to the detectors, the center of rotation is an additional setting that can be varied. Specifying a center of rotation that better matches what is expected in the experiment will result in calibrations with greater accuracy and speed.

For example, for FIDDLE, if there is any tilt whatsoever, then the detectors must have rotated about the lab origin (0, 0, 0). Requiring the detectors to be rotated about the origin ensures that the calibration will match what is expected from the experiment.

For other detector setups, such as the Eiger, the mean center of the instrument better matches what is expected if a tilt must be applied.

This PR also sets the default settings for FIDDLE calibration to use instrument rigid body (system) constraints, as well as using the Origin for the center of rotation.

Depends on: hexrd/hexrd#735