### PR TITLE
get cartesian view invalid pixels to be nan.

### DIFF
--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -22,6 +22,8 @@ from .display_plane import DisplayPlane
 def cartesian_viewer():
     return InstrumentViewer()
 
+def get_xray_propagation_sign(instr):
+    return np.sign(instr.beam_vector[2])
 
 class InstrumentViewer:
 
@@ -40,7 +42,8 @@ class InstrumentViewer:
         self.detector_corners = {}
 
         dist = HexrdConfig().cartesian_virtual_plane_distance
-        dplane_tvec = np.array([0., 0., -dist])
+        sgn = get_xray_propagation_sign(self.instr)
+        dplane_tvec = np.array([0., 0., sgn*dist])
 
         rotate_x = HexrdConfig().cartesian_plane_normal_rotate_x
         rotate_y = HexrdConfig().cartesian_plane_normal_rotate_y

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -535,6 +535,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 pinhole_settings.pop('pinhole_radius') * 2
             )
 
+        if self.cartesian_virtual_plane_distance < 0:
+            # We used to allow this to be negative, but now must be positive.
+            # Taking the absolute value should correct this adequately.
+            self.cartesian_virtual_plane_distance = abs(
+                self.cartesian_virtual_plane_distance)
+
         # All QSettings come back as strings. So check that we are dealing with
         # a boolean and convert if necessary
         if not isinstance(self.live_update, bool):
@@ -2511,7 +2517,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def _set_cartesian_pixel_size(self, v):
         if v != self.cartesian_pixel_size:
             self.config['image']['cartesian']['pixel_size'] = v
-            self.rerender_needed.emit()
+            if self.image_mode == constants.ViewType.cartesian:
+                self.rerender_needed.emit()
 
     cartesian_pixel_size = property(_cartesian_pixel_size,
                                     _set_cartesian_pixel_size)
@@ -2520,9 +2527,13 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self.config['image']['cartesian']['virtual_plane_distance']
 
     def set_cartesian_virtual_plane_distance(self, v):
+        if v < 0:
+            raise RuntimeError(f'Invalid plane distance: {v}')
+
         if v != self.cartesian_virtual_plane_distance:
             self.config['image']['cartesian']['virtual_plane_distance'] = v
-            self.rerender_needed.emit()
+            if self.image_mode == constants.ViewType.cartesian:
+                self.rerender_needed.emit()
 
     cartesian_virtual_plane_distance = property(
         _cartesian_virtual_plane_distance,
@@ -2534,7 +2545,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def set_cartesian_plane_normal_rotate_x(self, v):
         if v != self.cartesian_plane_normal_rotate_x:
             self.config['image']['cartesian']['plane_normal_rotate_x'] = v
-            self.rerender_needed.emit()
+            if self.image_mode == constants.ViewType.cartesian:
+                self.rerender_needed.emit()
 
     cartesian_plane_normal_rotate_x = property(
         _cartesian_plane_normal_rotate_x,
@@ -2546,7 +2558,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def set_cartesian_plane_normal_rotate_y(self, v):
         if v != self.cartesian_plane_normal_rotate_y:
             self.config['image']['cartesian']['plane_normal_rotate_y'] = v
-            self.rerender_needed.emit()
+            if self.image_mode == constants.ViewType.cartesian:
+                self.rerender_needed.emit()
 
     cartesian_plane_normal_rotate_y = property(
         _cartesian_plane_normal_rotate_y,

--- a/hexrdgui/image_mode_widget.py
+++ b/hexrdgui/image_mode_widget.py
@@ -40,6 +40,9 @@ class ImageModeWidget(QObject):
         # Always start with raw tab
         self.ui.tab_widget.setCurrentIndex(0)
 
+        # Don't allow negative distances
+        self.ui.cartesian_virtual_plane_distance.setMinimum(1e-8)
+
         # Hide stereo_project_from_polar for now, as projecting from polar
         # appears to give a better image (lines up better with overlays)
         # than projecting from raw.

--- a/hexrdgui/resources/ui/image_mode_widget.ui
+++ b/hexrdgui/resources/ui/image_mode_widget.ui
@@ -38,7 +38,7 @@
       <enum>QTabWidget::Rounded</enum>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>1</number>
      </property>
      <property name="iconSize">
       <size>
@@ -166,6 +166,9 @@
               </property>
               <property name="decimals">
                <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>0.000000000000000</double>
               </property>
               <property name="maximum">
                <double>1000000.000000000000000</double>


### PR DESCRIPTION
As above. The other change is that the distance is always in the direction of the x-ray propagation direction. negative distances should not be specified for the image anymore.

Previous view vs current view comparison below:

<img width="517" alt="Screenshot 2024-12-16 at 3 15 13 PM" src="https://github.com/user-attachments/assets/633d52a1-b140-4994-8c2d-7d620dc6b9b3" />

![Screenshot 2024-12-16 at 3 12 42 PM](https://github.com/user-attachments/assets/f714dc16-084c-45a5-be9d-c61ae9f96b4e)
