### PR TITLE
Fix matplotlib version to be less than 3.10

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,9 @@ requirements:
     - python
     - fabio
     - hexrd=={{ hexrd_version }}
-    - matplotlib-base
+    # We have some issue removing artists in matplotlib 3.10
+    # Fix the matplotlib version until that is resolved.
+    - matplotlib-base<3.10
     - Pillow
     - pyhdf
     - pyside6

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ from setuptools import setup, find_packages, Extension
 install_reqs = [
     'hexrd',
     'fabio>=0.11',
-    'matplotlib',
+    # We have some issue removing artists in matplotlib 3.10
+    # Fix the matplotlib version until that is resolved.
+    'matplotlib<3.10',
     'Pillow',
     # PySide 6.8.0 is causing segmentation faults in the testing
     # Keep this version downgraded until that is fixed.


### PR DESCRIPTION
There's some new issue with removing several of our artists starting in matplotlib 3.10 (including overlays, detector borders, the beam marker, and potentially more). It is very common that when `remove()` is called on the artists, that a `NotImplementedError` is raised.

Perhaps this is an issue that will get fixed in matplotlib soon. If not, we'll need to figure out an alternative way to remove the artists.

But for the release coming up, let's just fix the matplotlib version.