### PR TITLE
Separate physics package and detector filters

### DIFF
--- a/hexrdgui/absorption_correction_options_dialog.py
+++ b/hexrdgui/absorption_correction_options_dialog.py
@@ -45,6 +45,12 @@ class AbsorptionCorrectionOptionsDialog:
         # FIXME: Update to use defaults once they've been added to HEXRD
         return
 
+    @property
+    def any_detector_filters_applied(self):
+        det_names = HexrdConfig().detector_names
+        all_filters = [HexrdConfig().detector_filter(det) for det in det_names]
+        return any(filter.thickness > 0 for filter in all_filters)
+
     def update_gui(self):
         # Filter info is set per detector
         self.ui.detectors.addItems(HexrdConfig().detector_names)
@@ -79,7 +85,7 @@ class AbsorptionCorrectionOptionsDialog:
             self.ui.filter_material.setCurrentText(filter.material)
         self.ui.filter_density.setValue(filter.density)
         self.ui.filter_thickness.setValue(filter.thickness)
-        self.ui.apply_filters.setChecked(filter.thickness > 0)
+        self.ui.apply_filters.setChecked(self.any_detector_filters_applied)
         # COATING
         if coating.material not in self.mat_options:
             self.ui.coating_material_input.setText(coating.material)

--- a/hexrdgui/absorption_correction_options_dialog.py
+++ b/hexrdgui/absorption_correction_options_dialog.py
@@ -1,9 +1,5 @@
-import h5py
-
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.ui_loader import UiLoader
-
-from hexrd.material import _angstroms, _kev, Material
 
 
 class AbsorptionCorrectionOptionsDialog:
@@ -65,10 +61,17 @@ class AbsorptionCorrectionOptionsDialog:
             w.insertSeparator(2 + len(custom_mats))
 
         # Set default values
-        filter = HexrdConfig().detector_filter(self.ui.detectors.currentText())
-        coating = HexrdConfig().detector_coating(
-            self.ui.detectors.currentText())
-        phosphor = HexrdConfig().detector_phosphor(self.ui.detectors.currentText())
+        det = self.ui.detectors.currentText()
+        if (filter := HexrdConfig().detector_filter(det)) is None:
+            HexrdConfig().update_detector_filter(det)
+            filter = HexrdConfig().detector_filter(det)
+        if (coating := HexrdConfig().detector_coating(det)) is None:
+            HexrdConfig().update_detector_coating(det)
+            coating = HexrdConfig().detector_coating(det)
+        if (phosphor := HexrdConfig().detector_phosphor(det)) is None:
+            HexrdConfig().update_detector_phosphor(det)
+            phosphor = HexrdConfig().detector_phosphor(det)
+
         # FILTER
         if filter.material not in self.mat_options:
             self.ui.filter_material_input.setText(filter.material)

--- a/hexrdgui/absorption_correction_options_dialog.py
+++ b/hexrdgui/absorption_correction_options_dialog.py
@@ -79,6 +79,7 @@ class AbsorptionCorrectionOptionsDialog:
             self.ui.filter_material.setCurrentText(filter.material)
         self.ui.filter_density.setValue(filter.density)
         self.ui.filter_thickness.setValue(filter.thickness)
+        self.ui.apply_filters.setChecked(filter.thickness > 0)
         # COATING
         if coating.material not in self.mat_options:
             self.ui.coating_material_input.setText(coating.material)
@@ -86,6 +87,7 @@ class AbsorptionCorrectionOptionsDialog:
             self.ui.coating_material.setCurrentText(coating.material)
         self.ui.coating_density.setValue(coating.density)
         self.ui.coating_thickness.setValue(coating.thickness)
+        self.ui.apply_coating.setChecked(coating.thickness > 0)
         # PHOSPHOR
         if phosphor.material not in self.mat_options:
             self.ui.phosphor_material_input.setText(phosphor.material)
@@ -93,6 +95,7 @@ class AbsorptionCorrectionOptionsDialog:
             self.ui.phosphor_material.setCurrentText(phosphor.material)
         self.ui.phosphor_density.setValue(phosphor.density)
         self.ui.phosphor_thickness.setValue(phosphor.thickness)
+        self.ui.apply_phosphor.setChecked(phosphor.thickness > 0)
         self.ui.phosphor_readout_length.setValue(phosphor.readout_length)
         self.ui.phosphor_pre_U0.setValue(phosphor.pre_U0)
 
@@ -106,6 +109,9 @@ class AbsorptionCorrectionOptionsDialog:
         self.ui.button_box.accepted.connect(self.accept_changes)
         self.ui.button_box.accepted.connect(self.ui.accept)
         self.ui.button_box.rejected.connect(self.ui.reject)
+        self.ui.apply_filters.toggled.connect(self.toggle_apply_filters)
+        self.ui.apply_coating.toggled.connect(self.toggle_apply_coating)
+        self.ui.apply_phosphor.toggled.connect(self.toggle_apply_phosphor)
 
     def exec(self):
         return self.ui.exec()
@@ -130,8 +136,9 @@ class AbsorptionCorrectionOptionsDialog:
         else:
             self.density_inputs[category].setValue(0.0)
 
-    def filter_info_changed(self):
-        det_name = self.ui.detectors.currentText()
+    def filter_info_changed(self, new_value=None, det_name=None):
+        if det_name is None:
+            det_name = self.ui.detectors.currentText()
         self.filters.setdefault(det_name, {})
         self.filters[det_name]['density'] = self.ui.filter_density.value()
         self.filters[det_name]['thickness'] = self.ui.filter_thickness.value()
@@ -176,3 +183,35 @@ class AbsorptionCorrectionOptionsDialog:
                 density=self.ui.phosphor_density.value(),
                 thickness=self.ui.phosphor_thickness.value()
             )
+
+    def toggle_apply_filters(self, checked):
+        if not checked:
+            self.ui.filter_thickness.setValue(0.0)
+            for det in HexrdConfig().detector_names:
+                self.filter_info_changed(det_name=det)
+        self.ui.detectors.setEnabled(checked)
+        self.ui.filter_material.setEnabled(checked)
+        index = self.ui.filter_material.currentIndex()
+        self.ui.filter_material_input.setEnabled(checked and index == 0)
+        self.ui.filter_density.setEnabled(checked)
+        self.ui.filter_thickness.setEnabled(checked)
+
+    def toggle_apply_coating(self, checked):
+        if not checked:
+            self.ui.coating_thickness.setValue(0.0)
+        self.ui.coating_material.setEnabled(checked)
+        index = self.ui.coating_material.currentIndex()
+        self.ui.coating_material_input.setEnabled(checked and index == 0)
+        self.ui.coating_density.setEnabled(checked)
+        self.ui.coating_thickness.setEnabled(checked)
+
+    def toggle_apply_phosphor(self, checked):
+        if not checked:
+            self.ui.phosphor_thickness.setValue(0.0)
+        self.ui.phosphor_material.setEnabled(checked)
+        index = self.ui.phosphor_material.currentIndex()
+        self.ui.phosphor_material_input.setEnabled(checked and index == 0)
+        self.ui.phosphor_density.setEnabled(checked)
+        self.ui.phosphor_thickness.setEnabled(checked)
+        self.ui.phosphor_readout_length.setEnabled(checked)
+        self.ui.phosphor_pre_U0.setEnabled(checked)

--- a/hexrdgui/create_hedm_instrument.py
+++ b/hexrdgui/create_hedm_instrument.py
@@ -22,13 +22,14 @@ def create_hedm_instrument():
     # that expect it
     if HexrdConfig().physics_package is not None:
         iconfig['physics_package'] = HexrdConfig().physics_package
-    for det in HexrdConfig().detector_names:
-        iconfig['detectors'][det]['filter'] = (
-            HexrdConfig().detector_filter(det))
-        iconfig['detectors'][det]['coating'] = (
-            HexrdConfig().detector_coating(det))
-        iconfig['detectors'][det]['phosphor'] = (
-            HexrdConfig().detector_phosphor(det))
+    if HexrdConfig().apply_absorption_correction:
+        for det in HexrdConfig().detector_names:
+            iconfig['detectors'][det]['filter'] = (
+                HexrdConfig().detector_filter(det))
+            iconfig['detectors'][det]['coating'] = (
+                HexrdConfig().detector_coating(det))
+            iconfig['detectors'][det]['phosphor'] = (
+                HexrdConfig().detector_phosphor(det))
 
     kwargs = {
         'instrument_config': iconfig,

--- a/hexrdgui/create_hedm_instrument.py
+++ b/hexrdgui/create_hedm_instrument.py
@@ -20,7 +20,7 @@ def create_hedm_instrument():
 
     # Make sure that the physics package is included for instruments
     # that expect it
-    if HexrdConfig().physics_package is not None:
+    if HexrdConfig().use_physics_package:
         iconfig['physics_package'] = HexrdConfig().physics_package
     if HexrdConfig().apply_absorption_correction:
         for det in HexrdConfig().detector_names:

--- a/hexrdgui/create_hedm_instrument.py
+++ b/hexrdgui/create_hedm_instrument.py
@@ -20,7 +20,7 @@ def create_hedm_instrument():
 
     # Make sure that the physics package is included for instruments
     # that expect it
-    if HexrdConfig().use_physics_package:
+    if HexrdConfig().has_physics_package:
         iconfig['physics_package'] = HexrdConfig().physics_package
     if HexrdConfig().apply_absorption_correction:
         for det in HexrdConfig().detector_names:

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -3058,24 +3058,31 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def physics_package(self):
         return self._physics_package
 
+    @physics_package.setter
+    def physics_package(self, value):
+        self._physics_package = value
+
     def update_physics_package(self, instr_type=None, **kwargs):
         if instr_type not in ('TARDIS', 'PXRDIP'):
-            self._physics_package = None
-        elif self.physics_package is None:
+            raise ValueError(
+                f'Expected physics package instrument type to be either '
+                f'"TARDIS" or "PXRDIP", got {instr_type} instead.'
+            )
+        if self.physics_package is None:
             all_kwargs = PHYSICS_PACKAGE_DEFAULTS.HED
             all_kwargs.update(**kwargs)
-            self._physics_package = HEDPhysicsPackage(**all_kwargs)
+            self.physics_package = HEDPhysicsPackage(**all_kwargs)
         else:
-            self._physics_package.deserialize(**kwargs)
+            self.physics_package.deserialize(**kwargs)
         self.physics_package_modified.emit()
 
     def create_default_physics_package(self):
-        self._physics_package = HEDPhysicsPackage(
+        self.physics_package = HEDPhysicsPackage(
             **PHYSICS_PACKAGE_DEFAULTS.HED)
         self.physics_package_modified.emit()
 
     def absorption_length(self):
-        if self._physics_package is None:
+        if self.physics_package is None:
             raise ValueError(
                 f'Cannot calculate absorption length without physics package')
         return self.physics_package.pinhole_absorption_length(

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -597,7 +597,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         def set_physics_and_coatings():
             pp = state.get('physics_package_dictified', None)
             self.physics_package_dictified = pp if pp is not None else {}
-            dc = state.get('detector_coatings_dictified')
+            dc = state.get('detector_coatings_dictified', None)
             self.detector_coatings_dictified = dc if dc is not None else {}
 
         if 'detector_coatings_dictified' in state:

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -3079,12 +3079,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.use_physics_package = bool(value is not None)
 
     def update_physics_package(self, **kwargs):
-        if not self.use_physics_package:
+        if self.physics_package is None:
             all_kwargs = PHYSICS_PACKAGE_DEFAULTS.HED
             all_kwargs.update(**kwargs)
             self.physics_package = HEDPhysicsPackage(**all_kwargs)
-        else:
-            self.physics_package.deserialize(**kwargs)
+        self.physics_package.deserialize(**kwargs)
         self.physics_package_modified.emit()
 
     def create_default_physics_package(self):

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -3058,8 +3058,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         if v != self.use_physics_package:
             self._use_physics_package = v
             self.physics_package_modified.emit()
-        if self.use_physics_package and self.physics_package is None:
-            self.create_default_physics_package()
+            if self.use_physics_package:
+                self.create_default_physics_package()
+            else:
+                self.physics_package = None
 
     @property
     def physics_package_dictified(self):

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -3147,6 +3147,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self._detector_coatings[det_name].get('filter', None)
 
     def update_detector_filter(self, det_name, **kwargs):
+        if det_name not in self.detector_names:
+            return None
         self._set_detector_coatings('filter')
         filter = self._detector_coatings[det_name]['filter']
         filter.deserialize(**kwargs)
@@ -3156,6 +3158,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self._detector_coatings[det_name].get('coating', None)
 
     def update_detector_coating(self, det_name, **kwargs):
+        if det_name not in self.detector_names:
+            return None
         self._set_detector_coatings('coating')
         coating = self._detector_coatings[det_name]['coating']
         coating.deserialize(**kwargs)
@@ -3165,6 +3169,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return self._detector_coatings[det_name].get('phosphor', None)
 
     def update_detector_phosphor(self, det_name, **kwargs):
+        if det_name not in self.detector_names:
+            return None
         self._set_detector_coatings('phosphor')
         phosphor = self._detector_coatings[det_name]['phosphor']
         phosphor.deserialize(**kwargs)

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -3053,7 +3053,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @use_physics_package.setter
     def use_physics_package(self, v):
-        self._use_physics_package = v
+        if v != self.use_physics_package:
+            self._use_physics_package = v
+            self.physics_package_modified.emit()
+        if self.use_physics_package and self.physics_package is None:
+            self.create_default_physics_package()
 
     @property
     def physics_package_dictified(self):
@@ -3072,7 +3076,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @physics_package.setter
     def physics_package(self, value):
         self._physics_package = value
-        self.use_physics_package = bool(value is None)
+        self.use_physics_package = bool(value is not None)
 
     def update_physics_package(self, **kwargs):
         if not self.use_physics_package:
@@ -3084,7 +3088,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.physics_package_modified.emit()
 
     def create_default_physics_package(self):
-        self.use_physics_package = True
         self.physics_package = HEDPhysicsPackage(
             **PHYSICS_PACKAGE_DEFAULTS.HED)
         self.physics_package_modified.emit()

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -27,7 +27,9 @@ from hexrdgui import resource_loader
 from hexrdgui import utils
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.singletons import QSingleton
-from hexrdgui.utils.physics_package import ask_to_create_physics_package_if_missing
+from hexrdgui.utils.physics_package import (
+    ask_to_create_physics_package_if_missing
+)
 
 import hexrdgui.resources.calibration
 import hexrdgui.resources.indexing

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -28,6 +28,7 @@ from hexrdgui import utils
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.singletons import QSingleton
 from hexrdgui.utils.guess_instrument_type import guess_instrument_type
+from hexrdgui.utils.physics_package import ask_to_create_physics_package_if_missing
 
 import hexrdgui.resources.calibration
 import hexrdgui.resources.indexing
@@ -3082,7 +3083,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.physics_package_modified.emit()
 
     def absorption_length(self):
-        if self.physics_package is None:
+        if not ask_to_create_physics_package_if_missing():
             raise ValueError(
                 f'Cannot calculate absorption length without physics package')
         return self.physics_package.pinhole_absorption_length(

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -27,7 +27,6 @@ from hexrdgui import resource_loader
 from hexrdgui import utils
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.singletons import QSingleton
-from hexrdgui.utils.guess_instrument_type import guess_instrument_type
 from hexrdgui.utils.physics_package import ask_to_create_physics_package_if_missing
 
 import hexrdgui.resources.calibration
@@ -328,6 +327,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self._physics_package = None
         self._detector_coatings = {}
         self._instrument_rigid_body_params = {}
+        self._use_physics_package = False
 
         # Make sure that the matplotlib font size matches the application
         self.font_size = self.font_size
@@ -433,6 +433,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             ('_instrument_rigid_body_params', {}),
             ('recent_state_files', []),
             ('apply_absorption_correction', False),
+            ('use_physics_package', False),
             ('physics_package_dictified', None),
             ('custom_polar_tth_distortion_object_serialized', None),
             ('detector_coatings_dictified', {}),
@@ -553,6 +554,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.show_all_colormaps = self.show_all_colormaps == 'true'
         if not isinstance(self.apply_absorption_correction, bool):
             self.apply_absorption_correction = self.apply_absorption_correction == 'true'
+        if not isinstance(self.use_physics_package, bool):
+            self.use_physics_package = self.use_physics_package == 'true'
 
         # This is None sometimes. Make sure it is an empty list instead.
         if self.recent_state_files is None:
@@ -703,7 +706,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                     continue
 
             if overlay_dict.get('tth_distortion_type') is not None:
-                if self.physics_package is None:
+                if not self.use_physics_package:
                     # We need to create a default physics package
                     # This is for backward compatibility
                     self.create_default_physics_package()
@@ -2435,7 +2438,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def custom_polar_tth_distortion_object_serialized(self, v):
         obj = None
         if v is not None:
-            if self.physics_package is None:
+            if not self.use_physics_package:
                 # This requires a physics package to deserialize
                 self.create_default_physics_package()
 
@@ -3045,15 +3048,22 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.deep_rerender_needed.emit()
 
     @property
+    def use_physics_package(self):
+        return self._use_physics_package
+
+    @use_physics_package.setter
+    def use_physics_package(self, v):
+        self._use_physics_package = v
+
+    @property
     def physics_package_dictified(self):
-        if self.physics_package is None:
+        if not self.use_physics_package:
             return None
         return self.physics_package.serialize()
 
     @physics_package_dictified.setter
     def physics_package_dictified(self, v):
-        instr_type = guess_instrument_type(self.detector_names)
-        self.update_physics_package(instr_type, **v)
+        self.update_physics_package(**v)
 
     @property
     def physics_package(self):
@@ -3062,14 +3072,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @physics_package.setter
     def physics_package(self, value):
         self._physics_package = value
+        self.use_physics_package = bool(value is None)
 
-    def update_physics_package(self, instr_type=None, **kwargs):
-        if instr_type not in ('TARDIS', 'PXRDIP'):
-            raise ValueError(
-                f'Expected physics package instrument type to be either '
-                f'"TARDIS" or "PXRDIP", got {instr_type} instead.'
-            )
-        if self.physics_package is None:
+    def update_physics_package(self, **kwargs):
+        if not self.use_physics_package:
             all_kwargs = PHYSICS_PACKAGE_DEFAULTS.HED
             all_kwargs.update(**kwargs)
             self.physics_package = HEDPhysicsPackage(**all_kwargs)
@@ -3078,6 +3084,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.physics_package_modified.emit()
 
     def create_default_physics_package(self):
+        self.use_physics_package = True
         self.physics_package = HEDPhysicsPackage(
             **PHYSICS_PACKAGE_DEFAULTS.HED)
         self.physics_package_modified.emit()

--- a/hexrdgui/llnl_import_tool_dialog.py
+++ b/hexrdgui/llnl_import_tool_dialog.py
@@ -620,6 +620,7 @@ class LLNLImportToolDialog(QObject):
         self.ui.instrument.setDisabled(False)
         HexrdConfig().enable_canvas_toolbar.emit(True)
         self.cmap.block_updates(False)
+        HexrdConfig().use_physics_package = True
         self.physics_package_manager.show()
 
     def show(self):

--- a/hexrdgui/llnl_import_tool_dialog.py
+++ b/hexrdgui/llnl_import_tool_dialog.py
@@ -36,7 +36,7 @@ class LLNLImportToolDialog(QObject):
 
     cancel_workflow = Signal()
 
-    def __init__(self, cmap=None, physics_package_manager=None, parent=None):
+    def __init__(self, cmap=None, parent=None):
         super().__init__(parent)
 
         loader = UiLoader()
@@ -59,7 +59,6 @@ class LLNLImportToolDialog(QObject):
         self.import_in_progress = False
         self.loaded_images = []
         self.canvas = parent.image_tab_widget.active_canvas
-        self.physics_package_manager = physics_package_manager
 
         # Disable these by default.
         # If we disable these in Qt Designer, there are some weird bugs
@@ -620,8 +619,6 @@ class LLNLImportToolDialog(QObject):
         self.ui.instrument.setDisabled(False)
         HexrdConfig().enable_canvas_toolbar.emit(True)
         self.cmap.block_updates(False)
-        HexrdConfig().use_physics_package = True
-        self.physics_package_manager.show()
 
     def show(self):
         self.ui.show()

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -482,8 +482,8 @@ class MainWindow(QObject):
             # Turn off absorption correction
             self.ui.action_apply_absorption_correction.setChecked(False)
 
-            # Set the physics package to None
-            HexrdConfig().update_physics_package()
+            # Remove the physics package
+            HexrdConfig().physics_package = None
 
             # Turn off all detector coatings
             HexrdConfig().detector_coatings_dictified = {}

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -476,12 +476,8 @@ class MainWindow(QObject):
         visible = instr_type in ('TARDIS', 'PXRDIP')
 
         self.ui.action_physics_package_editor.setVisible(visible)
-        self.ui.action_apply_absorption_correction.setVisible(visible)
 
         if not visible:
-            # Turn off absorption correction
-            self.ui.action_apply_absorption_correction.setChecked(False)
-
             # Remove the physics package
             HexrdConfig().physics_package = None
 
@@ -1667,15 +1663,6 @@ class MainWindow(QObject):
         if not b:
             # Just turn it off and return
             HexrdConfig().apply_absorption_correction = b
-            return
-
-        # Make sure the physics package exists first
-        if HexrdConfig().physics_package is None:
-            msg = (
-                'Physics package must be set before absorption correction can be '
-                'applied. See the "Physics Package" editor under the "Edit" menu.'
-            )
-            QMessageBox.warning(self.ui, 'HEXRD', msg)
             return
 
         # Get the user to first select the absorption correction options

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -138,7 +138,6 @@ class MainWindow(QObject):
         self.simple_image_series_dialog = SimpleImageSeriesDialog(self.ui)
         self.llnl_import_tool_dialog = LLNLImportToolDialog(
                                         self.color_map_editor,
-                                        self.physics_package_manager_dialog,
                                         self.ui)
         self.image_stack_dialog = ImageStackDialog(
                                     self.ui, self.simple_image_series_dialog)
@@ -1559,7 +1558,12 @@ class MainWindow(QObject):
         self.simple_image_series_dialog.show()
 
     def on_action_llnl_import_tool_triggered(self):
-        self.llnl_import_tool_dialog.show()
+        dialog = self.llnl_import_tool_dialog
+        dialog.show()
+        # Always assume Physics Package is needed for LLNL import
+        dialog.ui.complete.clicked.connect(
+            lambda: self.on_action_apply_physics_package_toggled(True)
+        )
 
     def on_action_image_stack_triggered(self):
         self.image_stack_dialog.show()
@@ -1662,9 +1666,9 @@ class MainWindow(QObject):
 
     def on_action_apply_physics_package_toggled(self, b):
         self.ui.action_edit_physics_package.setEnabled(b)
+        HexrdConfig().use_physics_package = b
         if not b:
             # Just turn it off and return
-            HexrdConfig().use_physics_package = b
             return
 
         # Get the user to select the physics package options
@@ -1674,15 +1678,10 @@ class MainWindow(QObject):
         def _cancel():
             # Canceled... uncheck the action.
             self.ui.action_apply_physics_package.setChecked(False)
-            self.ui.action_edit_physics_package.setEnabled(b)
-            return
+            self.ui.action_edit_physics_package.setEnabled(False)
+            HexrdConfig().use_physics_package = False
 
         dialog.ui.rejected.connect(_cancel)
-
-        # The user should have modified HexrdConfig's physics
-        # package options already. Just apply it now.
-        HexrdConfig().use_physics_package = b
-
 
     def action_apply_absorption_correction_toggled(self, b):
         if not b:

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -17,9 +17,6 @@ from hexrdgui.utils import array_index_in_list
 from hexrdgui.utils.conversions import (
     angles_to_cart, angles_to_stereo, cart_to_angles
 )
-from hexrdgui.utils.physics_package import (
-    ask_to_create_physics_package_if_missing
-)
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
@@ -86,9 +83,9 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         from hexrdgui.hexrd_config import HexrdConfig
 
         if self.tth_distortion_type is not None:
-            if not ask_to_create_physics_package_if_missing():
+            if not HexrdConfig().has_physics_package:
                 # This will require a physics package
-                return
+                HexrdConfig().create_default_physics_package()
 
         if self.tth_distortion_type == 'SampleLayerDistortion':
             # We added pinhole_radius later. Set a default if it is missing.

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -17,6 +17,7 @@ from hexrdgui.utils import array_index_in_list
 from hexrdgui.utils.conversions import (
     angles_to_cart, angles_to_stereo, cart_to_angles
 )
+from hexrdgui.utils.physics_package import ask_to_create_physics_package_if_missing
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 
@@ -83,9 +84,9 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         from hexrdgui.hexrd_config import HexrdConfig
 
         if self.tth_distortion_type is not None:
-            if HexrdConfig().physics_package is None:
+            if not ask_to_create_physics_package_if_missing():
                 # This will require a physics package
-                HexrdConfig().create_default_physics_package()
+                return
 
         if self.tth_distortion_type == 'SampleLayerDistortion':
             # We added pinhole_radius later. Set a default if it is missing.

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -17,7 +17,9 @@ from hexrdgui.utils import array_index_in_list
 from hexrdgui.utils.conversions import (
     angles_to_cart, angles_to_stereo, cart_to_angles
 )
-from hexrdgui.utils.physics_package import ask_to_create_physics_package_if_missing
+from hexrdgui.utils.physics_package import (
+    ask_to_create_physics_package_if_missing
+)
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
 
 

--- a/hexrdgui/physics_package_manager_dialog.py
+++ b/hexrdgui/physics_package_manager_dialog.py
@@ -73,9 +73,13 @@ class PhysicsPackageManagerDialog:
         for k, w in self.material_selectors.items():
             w.currentIndexChanged.connect(
                 lambda index, k=k: self.material_changed(index, k))
-        HexrdConfig().instrument_config_loaded.connect(self.update_instrument_type)
+        HexrdConfig().instrument_config_loaded.connect(
+            self.update_instrument_type)
+        HexrdConfig().detectors_changed(self.initialize_detector_coatings)
 
     def initialize_detector_coatings(self):
+        # Reset detector coatings to make sure they're in sync w/ current dets
+        HexrdConfig().detector_coatings_dictified = {}
         for det in HexrdConfig().detector_names:
             HexrdConfig().update_detector_filter(det)
             HexrdConfig().update_detector_coating(det)

--- a/hexrdgui/physics_package_manager_dialog.py
+++ b/hexrdgui/physics_package_manager_dialog.py
@@ -75,7 +75,8 @@ class PhysicsPackageManagerDialog:
                 lambda index, k=k: self.material_changed(index, k))
         HexrdConfig().instrument_config_loaded.connect(
             self.update_instrument_type)
-        HexrdConfig().detectors_changed.connect(self.initialize_detector_coatings)
+        HexrdConfig().detectors_changed.connect(
+            self.initialize_detector_coatings)
 
     def initialize_detector_coatings(self):
         # Reset detector coatings to make sure they're in sync w/ current dets

--- a/hexrdgui/physics_package_manager_dialog.py
+++ b/hexrdgui/physics_package_manager_dialog.py
@@ -119,7 +119,7 @@ class PhysicsPackageManagerDialog:
                 HexrdConfig().update_detector_filter(
                     det, **FILTER_DEFAULTS.PXRDIP)
         else:
-            HexrdConfig().update_physics_package(instr_type=None)
+            HexrdConfig().physics_package = None
         self.instrument_type = new_instr_type
 
     def setup_form(self):

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -154,6 +154,11 @@ class PinholeCorrectionEditor(QObject):
         if v is None:
             return
 
+        if not HexrdConfig().has_physics_package:
+            return
+
+        physics = HexrdConfig().physics_package
+
         vp = v.copy()
         # These units are in mm, but we display in micrometers
         for key, value in v.items():
@@ -163,10 +168,6 @@ class PinholeCorrectionEditor(QObject):
                 multiplier = 1e3
 
             vp[key] = value * multiplier
-
-        if not ask_to_create_physics_package_if_missing():
-            return
-        physics = HexrdConfig().physics_package
 
         # Values are (key, default)
         values = {
@@ -408,7 +409,7 @@ class PinholeCorrectionEditor(QObject):
         return 0
 
     def on_rygg_absorption_length_selector_changed(self):
-        if not ask_to_create_physics_package_if_missing():
+        if not HexrdConfig().has_physics_package:
             # Cannot update
             return
 

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -164,9 +164,9 @@ class PinholeCorrectionEditor(QObject):
 
             vp[key] = value * multiplier
 
-        physics = HexrdConfig().physics_package
-        if physics is None:
+        if not ask_to_create_physics_package_if_missing():
             return
+        physics = HexrdConfig().physics_package
 
         # Values are (key, default)
         values = {
@@ -408,7 +408,7 @@ class PinholeCorrectionEditor(QObject):
         return 0
 
     def on_rygg_absorption_length_selector_changed(self):
-        if HexrdConfig().physics_package is None:
+        if not ask_to_create_physics_package_if_missing():
             # Cannot update
             return
 

--- a/hexrdgui/resources/ui/absorption_correction_options_dialog.ui
+++ b/hexrdgui/resources/ui/absorption_correction_options_dialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>347</width>
-    <height>365</height>
+    <height>443</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -355,6 +355,10 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>apply_filters</tabstop>
+  <tabstop>apply_coating</tabstop>
+  <tabstop>apply_phosphor</tabstop>
+  <tabstop>tab_widget</tabstop>
   <tabstop>detectors</tabstop>
   <tabstop>filter_material</tabstop>
   <tabstop>filter_material_input</tabstop>

--- a/hexrdgui/resources/ui/absorption_correction_options_dialog.ui
+++ b/hexrdgui/resources/ui/absorption_correction_options_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>500</width>
-    <height>332</height>
+    <width>347</width>
+    <height>365</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -20,16 +20,46 @@
    <string>Absorption Correction Editor</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="1" column="0" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="apply_filters">
+     <property name="text">
+      <string>Filter</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1" alignment="Qt::AlignHCenter">
+    <widget class="QCheckBox" name="apply_coating">
+     <property name="text">
+      <string>Coating</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2" alignment="Qt::AlignLeft">
+    <widget class="QCheckBox" name="apply_phosphor">
+     <property name="text">
+      <string>Phosphor</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_2">
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QDialogButtonBox" name="button_box">
        <property name="standardButtons">
         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
        </property>
       </widget>
      </item>
-     <item row="0" column="0">
+     <item row="1" column="0">
       <widget class="QTabWidget" name="tab_widget">
        <property name="tabPosition">
         <enum>QTabWidget::North</enum>
@@ -308,6 +338,13 @@
      </item>
     </layout>
    </item>
+   <item row="0" column="0" colspan="3" alignment="Qt::AlignHCenter">
+    <widget class="QLabel" name="apply_label">
+     <property name="text">
+      <string>Apply:</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -318,7 +355,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>tab_widget</tabstop>
   <tabstop>detectors</tabstop>
   <tabstop>filter_material</tabstop>
   <tabstop>filter_material_input</tabstop>

--- a/hexrdgui/resources/ui/main_window.ui
+++ b/hexrdgui/resources/ui/main_window.ui
@@ -217,7 +217,7 @@
      <property name="title">
       <string>Physics Package</string>
      </property>
-     <addaction name="action_apply_physics_package"/>
+     <addaction name="action_include_physics_package"/>
      <addaction name="action_edit_physics_package"/>
     </widget>
     <addaction name="menu_intensity_corrections"/>
@@ -880,12 +880,12 @@
     <string>Preconfigured</string>
    </property>
   </action>
-  <action name="action_apply_physics_package">
+  <action name="action_include_physics_package">
    <property name="checkable">
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Apply Physics Package</string>
+    <string>Include Physics Package</string>
    </property>
   </action>
   <action name="action_edit_physics_package">

--- a/hexrdgui/resources/ui/main_window.ui
+++ b/hexrdgui/resources/ui/main_window.ui
@@ -213,6 +213,13 @@
      <addaction name="action_apply_absorption_correction"/>
      <addaction name="action_subtract_minimum"/>
     </widget>
+    <widget class="QMenu" name="menu_physics_package">
+     <property name="title">
+      <string>Physics Package</string>
+     </property>
+     <addaction name="action_apply_physics_package"/>
+     <addaction name="action_edit_physics_package"/>
+    </widget>
     <addaction name="menu_intensity_corrections"/>
     <addaction name="action_edit_euler_angle_convention"/>
     <addaction name="action_edit_reset_instrument_config"/>
@@ -221,7 +228,7 @@
     <addaction name="action_edit_refinements"/>
     <addaction name="action_image_calculator"/>
     <addaction name="action_edit_config"/>
-    <addaction name="action_physics_package_editor"/>
+    <addaction name="menu_physics_package"/>
    </widget>
    <widget class="QMenu" name="menu_run">
     <property name="title">
@@ -873,9 +880,17 @@
     <string>Preconfigured</string>
    </property>
   </action>
-  <action name="action_physics_package_editor">
+  <action name="action_apply_physics_package">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
    <property name="text">
-    <string>Physics Package</string>
+    <string>Apply Physics Package</string>
+   </property>
+  </action>
+  <action name="action_edit_physics_package">
+   <property name="text">
+    <string>Edit Physics Package</string>
    </property>
   </action>
  </widget>

--- a/hexrdgui/resources/ui/main_window.ui
+++ b/hexrdgui/resources/ui/main_window.ui
@@ -889,6 +889,9 @@
    </property>
   </action>
   <action name="action_edit_physics_package">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
    <property name="text">
     <string>Edit Physics Package</string>
    </property>

--- a/hexrdgui/utils/physics_package.py
+++ b/hexrdgui/utils/physics_package.py
@@ -4,7 +4,7 @@ from PySide6.QtWidgets import QMessageBox
 def ask_to_create_physics_package_if_missing() -> bool:
     from hexrdgui.hexrd_config import HexrdConfig  # Avoid circular import
 
-    if HexrdConfig().physics_package is not None:
+    if HexrdConfig().use_physics_package:
         return True
 
     msg = (

--- a/hexrdgui/utils/physics_package.py
+++ b/hexrdgui/utils/physics_package.py
@@ -1,9 +1,9 @@
 from PySide6.QtWidgets import QMessageBox
 
-from hexrdgui.hexrd_config import HexrdConfig
-
 
 def ask_to_create_physics_package_if_missing() -> bool:
+    from hexrdgui.hexrd_config import HexrdConfig  # Avoid circular import
+
     if HexrdConfig().physics_package is not None:
         return True
 

--- a/hexrdgui/utils/physics_package.py
+++ b/hexrdgui/utils/physics_package.py
@@ -1,10 +1,10 @@
 from PySide6.QtWidgets import QMessageBox
 
+from hexrdgui.hexrd_config import HexrdConfig
+
 
 def ask_to_create_physics_package_if_missing() -> bool:
-    from hexrdgui.hexrd_config import HexrdConfig  # Avoid circular import
-
-    if HexrdConfig().use_physics_package:
+    if HexrdConfig().has_physics_package:
         return True
 
     msg = (


### PR DESCRIPTION
All instruments should have the option to apply the physics package, the absorption correction, or both. This PR:
- Removes restrictions around which instruments have the option to add a physics package
- Removes restrictions around which instruments have the option to apply absorption correction
- The physics package is no longer a prerequisite for absorption correction

Relies on HEXRD/HEXRD#741