### PR TITLE
Bump actions/upload-artifact@v3 -> actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -93,34 +93,34 @@ jobs:
 
     - name: Upload InstallOutput.log
       if: ${{ failure() }}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: InstallOutput.log
         path: ${{ github.workspace }}/hexrdgui/packaging/_CPack_Packages/*/InstallOutput.log
 
     - name: Upload WIX log ( Windows only )
       if: ${{ failure() && matrix.config.os == 'windows-latest'}}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: wix.log
         path: ${{ github.workspace }}/hexrdgui/packaging/_CPack_Packages/WIX/wix.log
 
     - name: Upload installer package
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HEXRDGUI-v${{env.VERSION}}.${{ matrix.config.package }}
         path: ${{ github.workspace }}/hexrdgui/packaging/HEXRDGUI-${{env.VERSION}}.${{ matrix.config.package }}
 
     - name: Upload installer package Zip ( Windows only )
       if: ${{ matrix.config.os == 'windows-latest'}}
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HEXRDGUI-v${{env.VERSION}}.zip
         path: ${{ github.workspace }}/hexrdgui/packaging/HEXRDGUI-${{env.VERSION}}.zip
 
     - name: Upload the HEXRDGUI conda package ( PRs only )
       if: github.ref != 'refs/heads/master'
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: HEXRDGUI-${{ matrix.config.name }}-${{ env.HEXRDGUI_GIT_DESCRIBE }}.tar.bz2
         path: ${{ github.workspace }}/hexrdgui/packaging/output/**/*.tar.bz2


### PR DESCRIPTION
`v3` of `actions/upload-artifact` and `actions/download-artifact` have been deprecated and will be removed completely on 01/30/25. See the [blog post](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/) for details.

Upgrade to `actions/upload-artifact@v4`