### PR TITLE
Continue to use tar.bz2 files instead of new default .conda files

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -132,9 +132,11 @@ jobs:
     - name: Upload the package to anaconda channel (only on master)
       if: github.ref == 'refs/heads/master' || contains(github.ref, 'refs/tags/')
       working-directory: hexrdgui/packaging
+      # force tar.bz2 files with '--set conda_build.pkg_format 1'
       run: |
           conda activate hexrdgui-package
           conda install --override-channels -c conda-forge anaconda-client
+          conda config --set conda_build.pkg_format 1
           anaconda --token ${{ secrets.ANACONDA_TOKEN }} upload --force --user HEXRD --label ${HEXRDGUI_PACKAGE_LABEL} output/**/*.tar.bz2
       # This is need to ensure ~/.profile or ~/.bashrc are used so the activate
       # command works.


### PR DESCRIPTION
As explained in HEXRD/hexrd#750:

> conda_build >= 25.1.0 use .conda files by default
See https://docs.conda.io/projects/conda-build/en/latest/release-notes.html#enhancements
