### PR TITLE
Update before installing EGL on Linux tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,7 +57,7 @@ jobs:
 
     - name: Install EGL on Linux (PySide6 needs it)
       if: ${{ matrix.config.name == 'Linux' }}
-      run: sudo apt-get install -y libegl1-mesa-dev
+      run: sudo apt-get update && sudo apt-get install -y libegl1-mesa-dev
 
     - name: Set environment variable to work around setuptools/numpy issue
       run: echo 'SETUPTOOLS_USE_DISTUTILS=stdlib' >> $GITHUB_ENV


### PR DESCRIPTION
This is necessary for EGL to be installed correctly, and for the tests to then run...