### PR TITLE
Export masked lineout intensities as nans

### DIFF
--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -92,8 +92,12 @@ class InstrumentViewer:
     def write_image(self, filename='polar_image.npz'):
         filename = Path(filename)
 
-        azimuthal_integration = np.array(
-            HexrdConfig().last_unscaled_azimuthal_integral_data)
+        tth, intensities = (
+            HexrdConfig().last_unscaled_azimuthal_integral_data
+        )
+
+        # Fill in masked values with nan
+        azimuthal_integration = np.array((tth, intensities.filled(np.nan)))
 
         if HexrdConfig().polar_x_axis_type == PolarXAxisType.q:
             # Convert to Q

--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -96,8 +96,11 @@ class InstrumentViewer:
             HexrdConfig().last_unscaled_azimuthal_integral_data
         )
 
-        # Fill in masked values with nan
-        azimuthal_integration = np.array((tth, intensities.filled(np.nan)))
+        # Remove any nan values
+        mask = intensities.mask
+        tth = tth[~mask]
+        intensities = intensities.data[~mask]
+        azimuthal_integration = np.array((tth, intensities))
 
         if HexrdConfig().polar_x_axis_type == PolarXAxisType.q:
             # Convert to Q


### PR DESCRIPTION
Previously, the masked lineout intensities were being filled with zeros accidentally (through a conversion to a numpy array). Instead, we want to fill the masked intensities with nan before exporting.

This fixes the issue.