### PR TITLE
Add masks to mouse hover info

### DIFF
--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1254,6 +1254,9 @@ class MainWindow(QObject):
         if 'detectors_str' in info:
             labels.append(info['detectors_str'])
 
+        if 'masks_str' in info:
+            labels.append(info['masks_str'])
+
         return labels
 
     def polar_mouse_info_labels(self, info):
@@ -1279,6 +1282,9 @@ class MainWindow(QObject):
 
         if 'detectors_str' in info:
             labels.append(info['detectors_str'])
+
+        if 'masks_str' in info:
+            labels.append(info['masks_str'])
 
         return labels
 


### PR DESCRIPTION
In the polar and raw views, add mask names to mouse hover info if the mouse is hovering over a masked area.

This helps identify which masks correspond to which names.