### PR TITLE
Ignore old view generation errors

### DIFF
--- a/hexrdgui/async_worker.py
+++ b/hexrdgui/async_worker.py
@@ -50,12 +50,13 @@ class AsyncWorker(QRunnable):
     '''
 
     def __init__(self, fn, *args, **kwargs):
-        super(AsyncWorker, self).__init__()
+        super().__init__()
         # Store constructor arguments (re-used for processing)
         self.fn = fn
         self.args = args
         self.kwargs = kwargs
         self.signals = AsyncWorkerSignals()
+        self.print_error_traceback = True
 
         # If the function signature accepts an 'update_progress'
         # function, set it to emit the progress signal.
@@ -72,7 +73,9 @@ class AsyncWorker(QRunnable):
         try:
             result = self.fn(*self.args, **self.kwargs)
         except:
-            traceback.print_exc()
+            if self.print_error_traceback:
+                traceback.print_exc()
+
             exctype, value = sys.exc_info()[:2]
             self.signals.error.emit((exctype, value, traceback.format_exc()))
         else:


### PR DESCRIPTION
View generations occur asynchronously in a background thread. Sometimes, they can take a long time to perform. If a user modifies settings while the view is being generated (such as reducing the resolution to speed up the view generation time), the old view would produce errors when it finished because the settings changed unexpectedly.

Stopping threads is difficult, and usually requires adding checks within the code so that the thread can check if it should exit early. Rather than doing that, which could be time-consuming, require many code modifications, and may not even be effective (if something causes the bottleneck to be somewhere that the early exit flag cannot be checked easily), we now just check when the old view generation is complete (either when it errors out or finishes successfully) if a new view began generating while it was running. If so, it now cleanly ignores the error or does not perform the update (in case of success).