### PR TITLE
Fix issue with panel buffer dialog losing focus

### DIFF
--- a/hexrdgui/calibration/panel_buffer_dialog.py
+++ b/hexrdgui/calibration/panel_buffer_dialog.py
@@ -29,6 +29,8 @@ class PanelBufferDialog(QObject):
         loader = UiLoader()
         self.ui = loader.load_file('panel_buffer_dialog.ui')
 
+        self.ui.setWindowTitle(f'Configure panel buffer for {detector}')
+
         # Keep the dialog in front
         flags = self.ui.windowFlags()
         self.ui.setWindowFlags(flags | Qt.Tool)


### PR DESCRIPTION
This fixes an issue where `setData()` would be called with the `enable` status of the panel buffer button when the panel buffer button loses focus! This was highly unexpected behavior, and resulted in a lot of errors and issues...