### PR TITLE
Refactor exporting the polar view

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1773,7 +1773,7 @@ class ImageCanvas(FigureCanvas):
 
             no_nan_methods = [utils.SnipAlgorithmType.Fast_SNIP_1D]
             if HexrdConfig().polar_snip1d_algorithm not in no_nan_methods:
-                img[self.iviewer.raw_mask] = np.nan
+                img[self.iviewer.warp_mask] = np.nan
 
             background = utils.run_snip1d(img)
 


### PR DESCRIPTION
We were previously exporting raw intensities as `intensities`. Now, we export the exact intensities displayed in the polar view as `intensities`, and the raw intensities are exported as `raw_intensities`.

This also adds several additional arrays that get exported from the polar view, including the erosion mask, tth correction field, and border masks. Overall, this adds a lot of useful arrays to the polar view export.