### PR TITLE
Fix the application name on macos

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -28,6 +28,8 @@ requirements:
     - matplotlib-base<3.10
     - Pillow
     - pyhdf
+    # This next one is needed to fix the app name on Mac
+    - pyobjc-framework-cocoa  # [osx]
     - pyside6
     - pyyaml
     - silx-base

--- a/hexrdgui/macos_fix_app_name.py
+++ b/hexrdgui/macos_fix_app_name.py
@@ -1,0 +1,28 @@
+import sys
+
+
+def macos_fix_app_name():
+    # This fixes the bundle name to be "HEXRD"
+    # Otherwise, it is displayed as "Python" in the top-left corner
+    # of the OSX menu bar.
+    # pyobjc-framework-Cocoa is required for this to work.
+    if not sys.platform.startswith('darwin'):
+        return
+
+    try:
+        from Foundation import NSBundle
+    except ImportError:
+        return
+
+    bundle = NSBundle.mainBundle()
+    if not bundle:
+        return
+
+    app_info = (
+        bundle.localizedInfoDictionary() or
+        bundle.infoDictionary()
+    )
+    if app_info is None:
+        return
+
+    app_info['CFBundleName'] = 'HEXRD'

--- a/hexrdgui/main.py
+++ b/hexrdgui/main.py
@@ -8,6 +8,7 @@ from PySide6.QtWidgets import QApplication
 from hexrdgui import resource_loader
 from hexrdgui.argument_parser import ArgumentParser
 from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.macos_fix_app_name import macos_fix_app_name
 from hexrdgui.main_window import MainWindow
 import hexrdgui.resources.icons
 
@@ -27,6 +28,10 @@ def main():
     QCoreApplication.setApplicationName('hexrd')
 
     app = QApplication(sys.argv)
+
+    if sys.platform.startswith('darwin'):
+        # Fix some osx-specific stuff
+        macos_fix_app_name()
 
     # Apply parsed arguments to the HexrdConfig() object
     apply_parsed_args_to_hexrd_config(parsed_args)

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import os
+import platform
 from setuptools import setup, find_packages, Extension
 
 install_reqs = [
@@ -15,6 +16,10 @@ install_reqs = [
     'pyyaml',
     'silx',
 ]
+
+if platform.system() == 'Darwin':
+    # This is needed to fix the application name on Mac
+    install_reqs.append('pyobjc-framework-cocoa')
 
 setup(
     name='hexrdgui',


### PR DESCRIPTION
Unfortunately, this requires a third-party library, since macos requires these things to be edited in Objective C (which Python cannot natively do).

However, the third-party library appears reliable.

Here is what the app name appeared as previously:

<img width="259" alt="Screenshot 2025-03-13 at 7 46 18 PM" src="https://github.com/user-attachments/assets/80aaf05f-d8c1-4615-b31e-264010666c75" />

But now it displays "HEXRD" instead of "Python" in both places.