### PR TITLE
Fix several issues with panel distortion

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -78,6 +78,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when the oscillation stage changes"""
     oscillation_stage_changed = Signal()
 
+    """Emitted when a panel's distortion is modified
+
+    The key is the name of the panel that was modified
+    """
+    panel_distortion_modified = Signal(str)
+
     """Emitted when the option to show the saturation level is changed"""
     show_saturation_level_changed = Signal()
 
@@ -1381,7 +1387,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         # If it is None, remove the distortion dict
         # If it is not None, then create the distortion dict if not present
         dist_func_path = ['distortion', 'function_name']
-        if len(path) > 4 and path[2:5] == dist_func_path:
+        if len(path) > 3 and path[2:4] == dist_func_path:
             cur_val = cur_val[path[0]][path[1]]
             if value == 'None' and 'distortion' in cur_val:
                 del cur_val['distortion']
@@ -1392,6 +1398,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                         [0.] * self.num_distortion_parameters(value)
                     )
                 }
+
+            self.panel_distortion_modified.emit(path[1])
             return
 
         try:
@@ -1446,6 +1454,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             # Overlays need to update their instrument objects when
             # the oscillation stage changes.
             self.oscillation_stage_changed.emit()
+            return
+
+        if path[2:4] == ['distortion', 'parameters']:
+            self.panel_distortion_modified.emit(path[1])
             return
 
         # Otherwise, assume we need to re-render the whole image

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -435,6 +435,10 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                     tvec_c=self.tvec
                 )
 
+                # !!! distortion
+                if panel.distortion is not None:
+                    xys_full = panel.distortion.apply_inverse(xys_full)
+
             # skip if ring not on panel
             if len(xys_full) == 0:
                 skipped_tth.append(i)
@@ -588,10 +592,6 @@ class PowderOverlay(Overlay, PolarDistortionObject):
             elif display_mode in [ViewType.raw, ViewType.cartesian]:
 
                 if display_mode == ViewType.raw:
-                    # !!! distortion
-                    if panel.distortion is not None:
-                        xys = panel.distortion.apply_inverse(xys)
-
                     # Convert to pixel coordinates and swap columns
                     xys = panel.cartToPixel(xys)[:, [1, 0]]
 

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -213,12 +213,6 @@ class RotationSeriesOverlay(Overlay):
             valid_ids, valid_hkls, valid_angs, valid_xys, ang_pixel_size = psim
             omegas = valid_angs[0][:, 2]
 
-            # !!! FIXME: these angles do not change with a change in grain position
-            # Is this expected? See: https://github.com/HEXRD/hexrdgui/issues/1383#issuecomment-1501950293
-            # For now, do not use them, and instead take the valid_xys and convert
-            # them to angles.
-            # angles = valid_angs[0][:, :2]
-            # !!! FIXME: does the above issue also mean the omegas are wrong?
             angles, _ = panel.cart_to_angles(valid_xys[0], tvec_c=self.tvec_c)
 
             # Fix eta period


### PR DESCRIPTION
This fixes a number of issues with panel distortion, including the following:

1. Distortion functions could not be selected in the instrument form view
2. The overlays would not update properly when distortion parameters would change
3. Overlays in the Cartesian view were never distortion-corrected
4. Powder overlays were only correctly distorted in the raw view

All of these issues are now fixed.

Depends on: https://github.com/HEXRD/hexrd/pull/784

Fixes: #1807