### PR TITLE
Add ability to create waterfall plots

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -35,12 +35,12 @@ from hexrdgui.masking.constants import MaskType
 from hexrdgui.masking.create_polar_mask import create_polar_line_data_from_raw
 from hexrdgui.masking.mask_manager import MaskManager
 from hexrdgui.snip_viewer_dialog import SnipViewerDialog
-from hexrdgui.waterfall_plot import WaterfallPlotDialog
 from hexrdgui.utils.array import split_array
 from hexrdgui.utils.conversions import (
     angles_to_stereo, cart_to_angles, cart_to_pixels, q_to_tth, tth_to_q,
 )
 from hexrdgui.utils.tth_distortion import apply_tth_distortion_if_needed
+from hexrdgui.waterfall_plot import WaterfallPlotDialog
 
 # Increase these font sizes (compared to the global font) by the specified
 # amounts.
@@ -128,6 +128,9 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().panel_distortion_modified.connect(
             self.on_panel_distortion_changed)
 
+        # This *must* be a queued connection, because Mac requires the
+        # progress to be updated on the GUI thread. Otherwise, it will
+        # crash the application on Mac.
         self._update_waterfall_plot_progress.connect(
             self._update_waterfall_plot_progress_slot,
             Qt.QueuedConnection,
@@ -1894,6 +1897,8 @@ class ImageCanvas(FigureCanvas):
             # Compute the integration
             lineouts[i] = self._compute_azimuthal_integral_sum(polar_img)
 
+            # The progress must be updated in the GUI thread. Otherwise,
+            # it will crash on Mac.
             self._update_waterfall_plot_progress.emit()
 
         return lineouts

--- a/hexrdgui/image_mode_widget.py
+++ b/hexrdgui/image_mode_widget.py
@@ -29,6 +29,9 @@ class ImageModeWidget(QObject):
     # Tell the image canvas to show the snip1d
     polar_show_snip1d = Signal()
 
+    # Tell the image canvas to create a waterfall plot
+    create_waterfall_plot = Signal()
+
     raw_show_zoom_dialog = Signal()
 
     def __init__(self, parent=None):
@@ -97,6 +100,8 @@ class ImageModeWidget(QObject):
             self.on_polar_x_axis_type_changed)
         self.ui.polar_active_beam.currentIndexChanged.connect(
             self.on_active_beam_changed)
+        self.ui.create_waterfall_plot.clicked.connect(
+            self.on_create_waterfall_plot_clicked)
 
         HexrdConfig().instrument_config_loaded.connect(
             self.on_instrument_config_load)
@@ -255,6 +260,16 @@ class ImageModeWidget(QObject):
         has_multi_xrs = HexrdConfig().has_multi_xrs
         self.ui.polar_active_beam.setVisible(has_multi_xrs)
         self.ui.polar_active_beam_label.setVisible(has_multi_xrs)
+
+        # We can only make a waterfall plot if there is more than one
+        # frame in the imageseries.
+        # If there are more than 10, that's too many, and let's just ignore
+        # it as well. All of the cases we know of currently should have
+        # no more than 5 frames in the imageseries.
+        can_make_waterfall_plot = (
+            1 < HexrdConfig().imageseries_length <= 10
+        )
+        self.ui.create_waterfall_plot.setVisible(can_make_waterfall_plot)
 
     def auto_generate_cartesian_params(self):
         if HexrdConfig().loading_state:
@@ -479,6 +494,9 @@ class ImageModeWidget(QObject):
 
     def on_active_beam_changed(self):
         HexrdConfig().active_beam_name = self.ui.polar_active_beam.currentText()
+
+    def on_create_waterfall_plot_clicked(self):
+        self.create_waterfall_plot.emit()
 
 
 POLAR_X_AXIS_LABELS_TO_VALUES = {

--- a/hexrdgui/image_mode_widget.py
+++ b/hexrdgui/image_mode_widget.py
@@ -8,6 +8,7 @@ from hexrdgui.azimuthal_overlay_manager import AzimuthalOverlayManager
 from hexrdgui.constants import PolarXAxisType, ViewType
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.image_load_manager import ImageLoadManager
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
 
@@ -145,6 +146,9 @@ class ImageModeWidget(QObject):
             HexrdConfig().set_stereo_show_border)
         self.ui.stereo_project_from_polar.toggled.connect(
             HexrdConfig().set_stereo_project_from_polar)
+
+        ImageLoadManager().new_images_loaded.connect(
+            self.update_visibility_states)
 
     def enable_image_mode_widget(self, b):
         self.ui.tab_widget.setEnabled(b)

--- a/hexrdgui/image_mode_widget.py
+++ b/hexrdgui/image_mode_widget.py
@@ -267,11 +267,11 @@ class ImageModeWidget(QObject):
 
         # We can only make a waterfall plot if there is more than one
         # frame in the imageseries.
-        # If there are more than 10, that's too many, and let's just ignore
+        # If there are more than 20, that's too many, and let's just ignore
         # it as well. All of the cases we know of currently should have
-        # no more than 5 frames in the imageseries.
+        # no more than 15 frames in the imageseries.
         can_make_waterfall_plot = (
-            1 < HexrdConfig().imageseries_length <= 10
+            1 < HexrdConfig().imageseries_length <= 20
         )
         self.ui.create_waterfall_plot.setVisible(can_make_waterfall_plot)
 

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -529,6 +529,9 @@ class ImageTabWidget(QTabWidget):
     def polar_show_snip1d(self):
         self.image_canvases[0].polar_show_snip1d()
 
+    def create_waterfall_plot(self):
+        self.image_canvases[0].create_waterfall_plot()
+
     def export_to_maud(self, filename):
         self.image_canvases[0].export_to_maud(filename)
 

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -90,9 +90,6 @@ from hexrd.resources import instrument_templates
 
 class MainWindow(QObject):
 
-    # Emitted when new images are loaded
-    new_images_loaded = Signal()
-
     # Emitted when a new mask is added
     new_mask_added = Signal(str)
 
@@ -273,7 +270,6 @@ class MainWindow(QObject):
         self.ui.action_run_fit_grains.triggered.connect(
             self.on_action_run_fit_grains_triggered)
         self.ui.action_run_wppf.triggered.connect(self.run_wppf)
-        self.new_images_loaded.connect(self.images_loaded)
         self.ui.image_tab_widget.update_needed.connect(self.update_all)
         self.ui.image_tab_widget.new_mouse_position.connect(
             self.new_mouse_position)
@@ -340,7 +336,7 @@ class MainWindow(QObject):
             self.on_physics_package_modified)
 
         ImageLoadManager().update_needed.connect(self.update_all)
-        ImageLoadManager().new_images_loaded.connect(self.new_images_loaded)
+        ImageLoadManager().new_images_loaded.connect(self.images_loaded)
         ImageLoadManager().images_transformed.connect(self.update_config_gui)
         ImageLoadManager().live_update_status.connect(self.set_live_update)
         ImageLoadManager().state_updated.connect(
@@ -529,7 +525,8 @@ class MainWindow(QObject):
         ImageFileManager().load_dummy_images()
         self.update_all(clear_canvases=True)
         self.ui.action_transform_detectors.setEnabled(False)
-        self.new_images_loaded.emit()
+        # Manually indicate that new images were loaded
+        ImageLoadManager().new_images_loaded.emit()
 
     def open_image_file(self):
         images_dir = HexrdConfig().images_dir

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -314,6 +314,8 @@ class MainWindow(QObject):
             self.ui.image_tab_widget.polar_show_snip1d)
         self.image_mode_widget.raw_show_zoom_dialog.connect(
             self.on_show_raw_zoom_dialog)
+        self.image_mode_widget.create_waterfall_plot.connect(
+            self.ui.image_tab_widget.create_waterfall_plot)
 
         self.ui.action_open_images.triggered.connect(
             self.open_image_files)

--- a/hexrdgui/resources/ui/image_mode_widget.ui
+++ b/hexrdgui/resources/ui/image_mode_widget.ui
@@ -884,6 +884,16 @@
             <item>
              <layout class="QHBoxLayout" name="horizontalLayout_4">
               <item>
+               <widget class="QPushButton" name="create_waterfall_plot">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Create a waterfall plot using the images in the image series.&lt;/p&gt;&lt;p&gt;This will first generate a polar view image for every index in the image series (which can be time-consuming depending on the polar resolution settings). Each polar view images is then used to create an azimuthal lineout.&lt;/p&gt;&lt;p&gt;The azimuthal lineouts for each of the polar view images is then plotted together in a waterfall plot dialog. This dialog allows plots to be adjusted as needed.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Waterfall Plot</string>
+                </property>
+               </widget>
+              </item>
+              <item>
                <spacer name="horizontalSpacer">
                 <property name="orientation">
                  <enum>Qt::Horizontal</enum>
@@ -1051,8 +1061,26 @@
   <tabstop>cartesian_plane_normal_rotate_x</tabstop>
   <tabstop>cartesian_virtual_plane_distance</tabstop>
   <tabstop>cartesian_plane_normal_rotate_y</tabstop>
+  <tabstop>polar_active_beam</tabstop>
+  <tabstop>polar_pixel_size_tth</tabstop>
+  <tabstop>polar_pixel_size_eta</tabstop>
+  <tabstop>polar_res_tth_min</tabstop>
+  <tabstop>polar_res_tth_max</tabstop>
+  <tabstop>polar_res_eta_min</tabstop>
+  <tabstop>polar_res_eta_max</tabstop>
+  <tabstop>polar_apply_snip1d</tabstop>
+  <tabstop>polar_snip1d_width</tabstop>
+  <tabstop>polar_snip1d_algorithm</tabstop>
+  <tabstop>polar_snip1d_numiter</tabstop>
+  <tabstop>polar_show_snip1d</tabstop>
+  <tabstop>polar_apply_erosion</tabstop>
+  <tabstop>polar_apply_tth_distortion</tabstop>
+  <tabstop>polar_tth_distortion_overlay</tabstop>
   <tabstop>polar_azimuthal_overlays</tabstop>
   <tabstop>azimuthal_offset</tabstop>
+  <tabstop>polar_x_axis_type</tabstop>
+  <tabstop>create_waterfall_plot</tabstop>
+  <tabstop>polar_apply_scaling_to_lineout</tabstop>
   <tabstop>stereo_size</tabstop>
   <tabstop>stereo_show_border</tabstop>
   <tabstop>stereo_project_from_polar</tabstop>

--- a/hexrdgui/waterfall_plot.py
+++ b/hexrdgui/waterfall_plot.py
@@ -1,0 +1,270 @@
+from typing import Callable
+
+from PySide6.QtCore import Qt
+from PySide6.QtGui import QResizeEvent
+from PySide6.QtWidgets import (
+    QDialog, QLabel, QSizePolicy, QVBoxLayout, QWidget
+)
+
+from matplotlib.axes import Axes
+from matplotlib.backend_bases import FigureCanvasBase, KeyEvent, MouseEvent
+from matplotlib.backends.backend_qtagg import (
+    NavigationToolbar2QT as NavigationToolbar
+)
+from matplotlib.figure import Figure
+import numpy as np
+
+# Line data is a list of (x, y) for each line
+LineData = list[tuple[np.ndarray, np.ndarray]]
+
+
+class WaterfallPlot:
+    """Waterfall Plot
+
+    This class manages button clicks and key events for interactions
+    with a waterfall plot
+    """
+    def __init__(self, ax: Axes, line_data: LineData):
+        self.ax = ax
+        self.create_lines(line_data)
+
+        self.currently_dragging = None
+        self._prev_mouse_coords = None
+        self._shift_held = False
+
+        self._mpl_cids = []
+
+        self.connect()
+
+    def create_lines(self, line_data: LineData):
+        # Compute a default offset
+        offset = np.nanmax([np.nanmax(y) for _, y in line_data])
+        offset *= 1.05
+
+        lines = []
+        for i, (x, y) in enumerate(line_data):
+            lines.append(self.ax.plot(
+                x,
+                y + offset * i,
+                lw=2.5,
+                label=f'Frame {i + 1}',
+            )[0])
+
+        self.lines = lines
+
+        self.ax.legend()
+
+        # Also cache the line data for mouse interactions
+        cached_line_data = []
+        for line in lines:
+            cached_line_data.append(np.array(line.get_data()).T)
+        self._cached_line_data = cached_line_data
+
+    @property
+    def figure(self) -> Figure:
+        return self.ax.figure
+
+    @property
+    def canvas(self) -> FigureCanvasBase:
+        return self.figure.canvas
+
+    @property
+    def _mpl_callbacks(self) -> dict[str, Callable]:
+        return {
+            'button_press_event': self.on_button_press,
+            'button_release_event': self.on_button_release,
+            'key_press_event': self.on_key_press,
+            'key_release_event': self.on_key_release,
+            'motion_notify_event': self.on_motion,
+            'scroll_event': self.on_scroll,
+        }
+
+    def on_button_press(self, event: MouseEvent):
+        if event.inaxes is not self.ax:
+            return
+
+        if self.ax.get_navigate_mode() is not None:
+            # Zooming or panning is active. Ignore this click.
+            return
+
+        coords_clicked = np.array((event.xdata, event.ydata))
+
+        # Find the closest line, and drag that one
+        closest_line_idx = self._find_closest_line(coords_clicked)
+
+        self._prev_mouse_coords = coords_clicked
+        self.currently_dragging = closest_line_idx
+
+    def on_button_release(self, event: MouseEvent):
+        self.currently_dragging = None
+        self._prev_mouse_coords = None
+        self.canvas.draw_idle()
+
+    def on_key_press(self, event: KeyEvent):
+        if event.key == 'shift':
+            self._shift_held = True
+
+    def on_key_release(self, event: KeyEvent):
+        if event.key == 'shift':
+            self._shift_held = False
+
+    def on_motion(self, event: MouseEvent):
+        if self.currently_dragging is None or event.inaxes is not self.ax:
+            return
+
+        mouse_coords = np.array((event.xdata, event.ydata))
+        adjustment = mouse_coords - self._prev_mouse_coords
+        if not self._shift_held:
+            # If shift is not held, only allow y to vary
+            adjustment[0] = 0
+
+        data = self._cached_line_data[self.currently_dragging]
+        line = self.lines[self.currently_dragging]
+        data += adjustment
+
+        line.set_data(data.T)
+
+        # Rescale the axes
+        # Maybe this is something we want the user to be able to disable?
+        self.ax.relim()
+        self.ax.autoscale_view()
+
+        # Redraw
+        self.canvas.draw_idle()
+
+        self._prev_mouse_coords = mouse_coords
+
+    def on_scroll(self, event: MouseEvent):
+        mouse_coords = np.array((event.xdata, event.ydata))
+
+        # Find the closest line, and drag that one
+        closest_line_idx = self._find_closest_line(mouse_coords)
+
+        base_scale = 1.1
+        if event.button == 'up':
+            # Increase the data intensity
+            scale_factor = base_scale
+        else:
+            # Decrease the data intensity
+            scale_factor = 1 / base_scale
+
+        data = self._cached_line_data[closest_line_idx]
+
+        # Don't allow the mean to change
+        mean_y = np.nanmean(data[:, 1])
+
+        data[:, 1] = (data[:, 1] - mean_y) * scale_factor + mean_y
+
+        line = self.lines[closest_line_idx]
+        line.set_data(data.T)
+
+        # Redraw
+        self.canvas.draw_idle()
+
+    def _find_closest_line(self, coords: np.ndarray) -> int:
+        # Find the closest line to a set of coordinates and return
+        # the closest line index
+        min_distance = np.inf
+        closest_line_idx = -1
+        for i, data in enumerate(self._cached_line_data):
+            distances = np.sqrt((data - coords)**2).sum(axis=1)
+            min_dist = np.nanmin(distances)
+            if min_dist < min_distance:
+                min_distance = min_dist
+                closest_line_idx = i
+
+        return closest_line_idx
+
+    def connect(self):
+        for k, f in self._mpl_callbacks.items():
+            cid = self.canvas.mpl_connect(k, f)
+            self._mpl_cids.append(cid)
+
+    def disconnect(self):
+        for cid in self._mpl_cids:
+            self.canvas.mpl_disconnect(cid)
+
+        self._mpl_cids.clear()
+
+
+class WaterfallPlotDialog(QDialog):
+    def __init__(self, ax: Axes, line_data: LineData, parent: QWidget = None):
+        super().__init__(parent)
+
+        self.setWindowTitle('Waterfall Plot')
+
+        # Add minimize, maximize, and close buttons
+        self.setWindowFlags(
+            Qt.WindowMinimizeButtonHint |
+            Qt.WindowMaximizeButtonHint |
+            Qt.WindowCloseButtonHint
+        )
+
+        self.waterfall_plot = WaterfallPlot(ax, line_data)
+        canvas = self.waterfall_plot.canvas
+
+        layout = QVBoxLayout()
+        self.setLayout(layout)
+
+        # Add a label describing the mouse interactions
+        label1 = QLabel(
+            'Click and drag a plot to adjust Y. '
+            'Hold shift and then click and drag a plot to adjust both X and Y.'
+        )
+        label2 = QLabel(
+            'Hover mouse over a line and use the mouse wheel to rescale '
+            'the intensities of that line'
+        )
+        for label in (label1, label2):
+            label.setAlignment(Qt.AlignCenter)
+            label.setSizePolicy(QSizePolicy.Minimum, QSizePolicy.Minimum)
+            layout.addWidget(label)
+
+        # Add the canvas
+        canvas.figure.tight_layout()
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+        layout.addWidget(canvas)
+
+        # Add a navigation toolbar too
+        self.toolbar = NavigationToolbar(canvas, self)
+        self.toolbar.setSizePolicy(QSizePolicy.Preferred, QSizePolicy.Minimum)
+        layout.addWidget(self.toolbar)
+        layout.setAlignment(self.toolbar, Qt.AlignCenter)
+
+    def resizeEvent(self, event: QResizeEvent):
+        # We override this function because we want the matplotlib canvas
+        # to also resize whenever the dialog is resized.
+        super().resizeEvent(event)
+        self.waterfall_plot.figure.tight_layout()
+
+
+if __name__ == '__main__':
+    from PySide6.QtWidgets import QApplication
+
+    import matplotlib.pyplot as plt
+
+    app = QApplication()
+
+    # Test example
+    fig, ax = plt.subplots()
+    data1 = np.load('example_integration.npy')
+    data2 = data1.copy()
+    data3 = data2.copy()
+
+    line_data = []
+    for data in (data1, data2, data3):
+        line_data.append((*data.T,))
+
+    label_kwargs = {
+        'fontsize': 15,
+        'family': 'serif',
+    }
+    ax.set_ylabel(r'Azimuthal Average', **label_kwargs)
+
+    polar_xlabel = r'2$\theta_{{nom}}$ [deg]'
+    ax.set_xlabel(polar_xlabel, **label_kwargs)
+
+    dialog = WaterfallPlotDialog(ax, line_data)
+    dialog.show()
+
+    app.exec()


### PR DESCRIPTION
If the loaded data is an imageseries with 2 to 10 frames per detector, a new button appears in the polar view settings named "Waterfall Plot".

If clicked, an azimuthal lineout is computed for every frame in the imageseries, and the results are displayed in an interactive waterfall plot.

Since the azimuthal lineout intensities are arbitrarily scaled and offset, the plots can be vertically stacked on top of one another with some spacing between. Clicking and dragging allows one to move a plot up/down. Shift-clicking and dragging also allows the plot to move left/right (which is typically not advised since two theta should not change). Using the mouse wheel while hovering over a lineout causes that lineout to scale up/down in relative intensity.

In summary, this allows for easy comparison of the different azimuthal lineouts for each frame in the imageseries.

![image](https://github.com/user-attachments/assets/d15327f3-bd61-4da2-8b56-7a3634e0f04b)
