### PR TITLE
Fix median filter menu checkbox

### DIFF
--- a/hexrdgui/llnl_import_tool_dialog.py
+++ b/hexrdgui/llnl_import_tool_dialog.py
@@ -46,7 +46,7 @@ class LLNLImportToolDialog(QObject):
 
     cancel_workflow = Signal()
 
-    complete_workflow = Signal()
+    complete_workflow = Signal(bool)
 
     def __init__(self, cmap=None, parent=None):
         super().__init__(parent)
@@ -925,14 +925,12 @@ class LLNLImportToolDialog(QObject):
         HexrdConfig().enable_canvas_toolbar.emit(True)
         self.cmap.block_updates(False)
 
-        if self.instrument == 'FIDDLE':
-            # Allow user to change kernel before applying median filter
-            d = MedianFilterDialog(self.ui.parent())
-            d.ui.finished.connect(lambda: self.complete_workflow.emit())
-            HexrdConfig().apply_median_filter_correction = d.exec()
-        else:
+        if self.instrument != 'FIDDLE':
+            # Re-enable median filter correction if it was set
             HexrdConfig().apply_median_filter_correction = self.median_setting
-            self.complete_workflow.emit()
+        # If this is a FIDDLE instrument users will be prompted to set (or not)
+        # the median filter after the import is complete
+        self.complete_workflow.emit(self.instrument == 'FIDDLE')
 
     def show(self):
         self.ui.show()

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -380,10 +380,8 @@ class MainWindow(QObject):
         HexrdConfig().enable_canvas_focus_mode.connect(
             self.enable_canvas_focus_mode)
 
-        # Always assume Physics Package is needed for LLNL import
         self.llnl_import_tool_dialog.complete_workflow.connect(
-            lambda: self.on_action_include_physics_package_toggled(True)
-        )
+            self.on_llnl_import_completed)
 
     def on_state_loaded(self):
         self.update_action_check_states()
@@ -1555,6 +1553,11 @@ class MainWindow(QObject):
 
     def on_action_hedm_import_tool_triggered(self):
         self.simple_image_series_dialog.show()
+
+    def on_llnl_import_completed(self, is_fiddle_instrument):
+        # Always assume Physics Package is needed for LLNL import
+        self.ui.action_apply_median_filter.setChecked(is_fiddle_instrument)
+        self.on_action_include_physics_package_toggled(True)
 
     def on_action_llnl_import_tool_triggered(self):
         dialog = self.llnl_import_tool_dialog


### PR DESCRIPTION
When the median filter is set immediately after the LLNL import workflow is complete the menu option still needs to be toggled "on" if the filter is applied. Make sure that it is.