### PR TITLE
New masking features

### DIFF
--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -345,6 +345,8 @@ class MainWindow(QObject):
         self.new_mask_added.connect(self.mask_manager_dialog.update_tree)
         self.image_mode_widget.tab_changed.connect(
             MaskManager().view_mode_changed)
+        self.image_mode_widget.tab_changed.connect(
+            self.mask_manager_dialog.update_collapsed)
 
         self.ui.action_apply_pixel_solid_angle_correction.toggled.connect(
             HexrdConfig().set_apply_pixel_solid_angle_correction)

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -818,15 +818,12 @@ class MainWindow(QObject):
     def run_apply_hand_drawn_mask(self, dets, line_data):
         if self.image_mode == ViewType.polar:
             for line in line_data:
-                name = unique_name(MaskManager().mask_names, 'polar_mask_0')
                 raw_line = convert_polar_to_raw([line])
-                MaskManager().add_mask(name, raw_line, MaskType.polygon)
+                MaskManager().add_mask(raw_line, MaskType.polygon)
             MaskManager().polar_masks_changed.emit()
         elif self.image_mode == ViewType.raw:
             for det, line in zip(dets, line_data):
-                name = unique_name(MaskManager().mask_names, 'raw_mask_0')
-                MaskManager().add_mask(
-                    name, [(det, line.copy())], MaskType.polygon)
+                MaskManager().add_mask([(det, line.copy())], MaskType.polygon)
             MaskManager().raw_masks_changed.emit()
         self.new_mask_added.emit(self.image_mode)
 
@@ -854,9 +851,8 @@ class MainWindow(QObject):
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             return
 
-        name = unique_name(MaskManager().mask_names, 'laue_mask')
         raw_data = convert_polar_to_raw(data)
-        MaskManager().add_mask(name, raw_data, MaskType.laue)
+        MaskManager().add_mask(raw_data, MaskType.laue)
         self.new_mask_added.emit(self.image_mode)
         MaskManager().polar_masks_changed.emit()
 
@@ -909,9 +905,8 @@ class MainWindow(QObject):
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             return
 
-        name = unique_name(MaskManager().mask_names, 'powder_mask')
         raw_data = convert_polar_to_raw(data)
-        MaskManager().add_mask(name, raw_data, MaskType.powder)
+        MaskManager().add_mask(raw_data, MaskType.powder)
         self.new_mask_added.emit(self.image_mode)
         MaskManager().polar_masks_changed.emit()
 
@@ -974,7 +969,7 @@ class MainWindow(QObject):
         if name in MaskManager().mask_names:
             MaskManager().masks[name].data = ph_masks
         else:
-            MaskManager().add_mask(name, ph_masks, MaskType.pinhole)
+            MaskManager().add_mask(ph_masks, MaskType.pinhole, name=name)
         MaskManager().raw_masks_changed.emit()
 
         self.new_mask_added.emit(self.image_mode)

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -342,7 +342,7 @@ class MainWindow(QObject):
         ImageLoadManager().state_updated.connect(
             self.simple_image_series_dialog.setup_gui)
 
-        self.new_mask_added.connect(self.mask_manager_dialog.update_table)
+        self.new_mask_added.connect(self.mask_manager_dialog.update_tree)
         self.image_mode_widget.tab_changed.connect(
             MaskManager().view_mode_changed)
 

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -76,7 +76,7 @@ from hexrdgui.indexing.fit_grains_tree_view_dialog import (
 )
 from hexrdgui.image_mode_widget import ImageModeWidget
 from hexrdgui.ui_loader import UiLoader
-from hexrdgui.utils import block_signals, unique_name
+from hexrdgui.utils import block_signals
 from hexrdgui.utils.dialog import add_help_url
 from hexrdgui.utils.physics_package import (
     ask_to_create_physics_package_if_missing,

--- a/hexrdgui/masking/hand_drawn_mask_dialog.py
+++ b/hexrdgui/masking/hand_drawn_mask_dialog.py
@@ -230,10 +230,6 @@ class LineBuilder(QObject):
                   'masks.')
             return
 
-        print('%s click: button=%d, x=%d, y=%d, xdata=%f, ydata=%f' %
-              ('double' if event.dblclick else 'single', event.button,
-               event.x, event.y, event.xdata, event.ydata))
-
         if event.inaxes != self.line.axes:
             return
 

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -29,7 +29,7 @@ class Mask(ABC):
         mtype='',
         visible=True,
         show_border=False,
-        mode=ViewType.raw,
+        mode=None,
         xray_source=None
     ):
         self.type = mtype
@@ -93,7 +93,7 @@ class Mask(ABC):
             mtype=data['mtype'],
             visible=data.get('visible', True),
             show_border=data.get('border', False),
-            mode=data.get('creation_view_mode', ViewType.raw),
+            mode=data.get('creation_view_mode', None),
             xray_source=data.get('xray_source', None),
         )
 
@@ -105,7 +105,7 @@ class RegionMask(Mask):
         mtype='',
         visible=True,
         show_border=False,
-        mode=ViewType.raw,
+        mode=None,
         xray_source=None
     ):
         super().__init__(name, mtype, visible, show_border, mode, xray_source)
@@ -170,7 +170,7 @@ class RegionMask(Mask):
             mtype=data['mtype'],
             visible=data.get('visible', True),
             show_border=data.get('border', False),
-            mode=data.get('creation_view_mode', ViewType.raw),
+            mode=data.get('creation_view_mode', None),
             xray_source=data.get('xray_source', None),
         )
         raw_data = []
@@ -188,7 +188,7 @@ class ThresholdMask(Mask):
         name='',
         mtype='',
         visible=True,
-        mode=ViewType.raw,
+        mode=None,
         xray_source=None
     ):
         super().__init__(name, mtype, visible, mode, xray_source)
@@ -230,7 +230,7 @@ class ThresholdMask(Mask):
             name=data['name'],
             mtype=data['mtype'],
             visible=data.get('visible', True),
-            mode=data.get('creation_view_mode', ViewType.raw),
+            mode=data.get('creation_view_mode', None),
             xray_source=data.get('xray_source', None),
         )
         new_cls.data = [data['min_val'], data['max_val']]
@@ -340,9 +340,10 @@ class MaskManager(QObject, metaclass=QSingleton):
 
     def add_mask(self, data, mtype, name=None, visible=True):
         if mtype == MaskType.threshold:
-            new_mask = ThresholdMask(name, mtype, visible, mode=self.view_mode)
+            new_mask = ThresholdMask(name, mtype, visible)
         else:
-            new_mask = RegionMask(name, mtype, visible, mode=self.view_mode)
+            mode = None if mtype == MaskType.pinhole else self.view_mode
+            new_mask = RegionMask(name, mtype, visible, mode=mode)
         new_mask.data = data
         self.masks[new_mask.name] = new_mask
         self.mask_mgr_dialog_update.emit()

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -23,7 +23,15 @@ from abc import ABC, abstractmethod
 
 
 class Mask(ABC):
-    def __init__(self, name=None, mtype='', visible=True, show_border=False, mode=ViewType.raw, xray_source=None):
+    def __init__(
+        self,
+        name=None,
+        mtype='',
+        visible=True,
+        show_border=False,
+        mode=ViewType.raw,
+        xray_source=None
+    ):
         self.type = mtype
         self.visible = visible
         self.show_border = show_border
@@ -31,7 +39,10 @@ class Mask(ABC):
         self.masked_arrays_view_mode = ViewType.raw
         self.creation_view_mode = mode
         self.xray_source = xray_source
-        if mode == ViewType.polar and HexrdConfig().has_multi_xrs and xray_source is None:
+        if (
+            mode == ViewType.polar and
+            HexrdConfig().has_multi_xrs and xray_source is None
+        ):
             # The x-ray source is only relevant for polar masks
             self.xray_source = HexrdConfig().active_beam_name
         self.name = name
@@ -88,7 +99,15 @@ class Mask(ABC):
 
 
 class RegionMask(Mask):
-    def __init__(self, name='', mtype='', visible=True, show_border=False, mode=ViewType.raw, xray_source=None):
+    def __init__(
+        self,
+        name='',
+        mtype='',
+        visible=True,
+        show_border=False,
+        mode=ViewType.raw,
+        xray_source=None
+    ):
         super().__init__(name, mtype, visible, show_border, mode, xray_source)
         self._raw = None
 
@@ -115,7 +134,10 @@ class RegionMask(Mask):
             )
 
     def get_masked_arrays(self, image_mode=ViewType.raw, instr=None):
-        if self.masked_arrays is None or self.masked_arrays_view_mode != image_mode:
+        if (
+            self.masked_arrays is None or
+            self.masked_arrays_view_mode != image_mode
+        ):
             self.update_masked_arrays(image_mode, instr)
 
         return self.masked_arrays
@@ -161,8 +183,15 @@ class RegionMask(Mask):
 
 
 class ThresholdMask(Mask):
-    def __init__(self, name='', mtype='', visible=True, mode=ViewType.raw, xray_source=None):
-        super().__init__(name, mtype, visible, mode=mode, xray_source=xray_source)
+    def __init__(
+        self,
+        name='',
+        mtype='',
+        visible=True,
+        mode=ViewType.raw,
+        xray_source=None
+    ):
+        super().__init__(name, mtype, visible, mode, xray_source)
         self.min_val = -math.inf
         self.max_val = math.inf
 
@@ -261,13 +290,17 @@ class MaskManager(QObject, metaclass=QSingleton):
         HexrdConfig().load_state.connect(self.load_state)
         HexrdConfig().detectors_changed.connect(self.clear_all)
         HexrdConfig().state_loaded.connect(self.rebuild_masks)
-        HexrdConfig().active_beam_switched.connect(self.update_masks_for_active_beam)
+        HexrdConfig().active_beam_switched.connect(
+            self.update_masks_for_active_beam)
 
     def update_masks_for_active_beam(self):
         xrs = HexrdConfig().active_beam_name
         for mask in self.masks.values():
             # If mask's mode or source doesn't match current, hide it
-            if mask.creation_view_mode == ViewType.polar and mask.xray_source != xrs:
+            if (
+                mask.creation_view_mode == ViewType.polar and
+                mask.xray_source != xrs
+            ):
                 if not hasattr(mask, '_original_visible'):
                     # Remember original states so we can toggle back
                     mask._original_visible = mask.visible
@@ -277,8 +310,10 @@ class MaskManager(QObject, metaclass=QSingleton):
             else:
                 # Restore original states if they exist
                 if hasattr(mask, '_original_visible'):
-                    self.update_mask_visibility(mask.name, mask._original_visible)
-                    self.update_border_visibility(mask.name, mask._original_show_border)
+                    self.update_mask_visibility(
+                        mask.name, mask._original_visible)
+                    self.update_border_visibility(
+                        mask.name, mask._original_show_border)
                     # Clear the stored states
                     delattr(mask, '_original_visible')
                     delattr(mask, '_original_show_border')

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -4,6 +4,7 @@ import numpy as np
 import h5py
 from itertools import groupby
 from operator import attrgetter
+import re
 
 from PySide6.QtCore import QObject, Qt
 from PySide6.QtWidgets import (
@@ -44,6 +45,7 @@ class MaskManagerDialog(QObject):
         self.setup_connections()
 
     def show(self):
+        self.create_tree()
         self.ui.show()
 
     def setup_connections(self):
@@ -149,6 +151,15 @@ class MaskManagerDialog(QObject):
         MaskManager().masks_changed()
         self.ui.masks_table.verticalScrollBar().setValue(scroll_value)
 
+
+    def _alphanumeric_sort(self, value):
+        # Split the string into text and number parts so that we
+        # sort by string value lexicographically and the number
+        # value numerically
+        vals = re.split('([0-9]+)', value)
+        print([int(v) if v.isdigit() else v.lower() for v in vals])
+        return [int(v) if v.isdigit() else v.lower() for v in vals]
+
     def update_tree(self):
         if self.ui.masks_tree.topLevelItemCount() == 0:
             self.create_tree()
@@ -193,9 +204,11 @@ class MaskManagerDialog(QObject):
                 # Create mode item
                 mode_item = self.create_mode_item(mode, source)
 
-                # Create items for each mask
-                for mask in masks:
+                # Create items for each mask, sorted naturally by name
+                for mask in sorted(masks,
+                                   key=lambda x: self._alphanumeric_sort(x.name)):
                     self.create_mask_item(mode_item, mask)
+
         self.ui.masks_tree.expandAll()
         self.ui.masks_tree.resizeColumnToContents(0)
         self.ui.masks_tree.resizeColumnToContents(1)

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -190,6 +190,8 @@ class MaskManagerDialog(QObject):
                 for mask in masks:
                     self.create_mask_item(mode_item, mask)
         self.ui.masks_tree.expandAll()
+        self.ui.masks_tree.resizeColumnToContents(0)
+        self.ui.masks_tree.resizeColumnToContents(1)
 
     def track_mask_presentation_change(self, index, mask):
         self.changed_masks[mask.name] = index

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -157,7 +157,6 @@ class MaskManagerDialog(QObject):
         # sort by string value lexicographically and the number
         # value numerically
         vals = re.split('([0-9]+)', value)
-        print([int(v) if v.isdigit() else v.lower() for v in vals])
         return [int(v) if v.isdigit() else v.lower() for v in vals]
 
     def update_tree(self):

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -137,7 +137,7 @@ class MaskManagerDialog(QObject):
             # Make sure it is a mask and not a mode item
             return
 
-        scrollbar = self.ui.masks_table.verticalScrollBar()
+        scrollbar = self.ui.masks_tree.verticalScrollBar()
         scroll_value = scrollbar.value()
         item = self.mask_tree_items.pop(name)
         parent = item.parent()
@@ -149,7 +149,7 @@ class MaskManagerDialog(QObject):
                 self.ui.masks_tree.indexOfTopLevelItem(parent))
             self.mask_tree_items.pop(parent.text(0))
         MaskManager().masks_changed()
-        self.ui.masks_table.verticalScrollBar().setValue(scroll_value)
+        self.ui.masks_tree.verticalScrollBar().setValue(scroll_value)
 
 
     def _alphanumeric_sort(self, value):

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -67,6 +67,8 @@ class MaskManagerDialog(QObject):
         HexrdConfig().active_beam_switched.connect(self.update_collapsed)
 
     def create_mode_source_string(self, mode, source):
+        if mode is None:
+            return 'Global'
         mode_str = f'{mode.capitalize()} Mode'
         source_str = f' - {source}' if source else ''
         return f'{mode_str}{source_str}'
@@ -191,7 +193,10 @@ class MaskManagerDialog(QObject):
             # Sort masks by creation view mode and xray source
             sorted_masks = sorted(
                 MaskManager().masks.values(),
-                key=attrgetter('creation_view_mode', 'xray_source')
+                key=lambda mask: (
+                    mask.creation_view_mode or '',
+                    mask.xray_source or ''
+                )
             )
 
             # Group masks by creation view mode and xray source

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -85,9 +85,11 @@ class MaskManagerDialog(QObject):
         text = self.create_mode_source_string(mode, source)
         mode_item = QTreeWidgetItem([text])
         mode_item.setFlags(Qt.ItemIsEnabled)
-        mode_item.setFont(0, QFont(mode_item.font(0).family(),
-                                    mode_item.font(0).pointSize(),
-                                    QFont.Bold))
+        mode_item.setFont(0, QFont(
+            mode_item.font(0).family(),
+            mode_item.font(0).pointSize(),
+            QFont.Bold
+        ))
         self.ui.masks_tree.addTopLevelItem(mode_item)
         self.mask_tree_items[mode_item.text(0)] = mode_item
         self.ui.masks_tree.expandItem(mode_item)
@@ -95,8 +97,9 @@ class MaskManagerDialog(QObject):
 
     def create_mask_item(self, parent_item, mask):
         mask_item = QTreeWidgetItem([mask.name])
-        mask_item.setFlags(Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable)
-        # Store the original mask name in the item's data for use when name is changed
+        mask_item.setFlags(
+            Qt.ItemIsEnabled | Qt.ItemIsSelectable | Qt.ItemIsEditable)
+        # Store the original mask name in the item's data
         mask_item.setData(0, Qt.UserRole, mask.name)
         parent_item.addChild(mask_item)
         self.mask_tree_items[mask.name] = mask_item
@@ -119,7 +122,8 @@ class MaskManagerDialog(QObject):
         # Add push button to remove mask
         pb = QPushButton('Remove Mask')
         self.ui.masks_tree.setItemWidget(mask_item, 2, pb)
-        pb.clicked.connect(lambda checked, k=mask.name: self.remove_mask_item(k))
+        pb.clicked.connect(
+            lambda checked, k=mask.name: self.remove_mask_item(k))
 
     def update_mask_item(self, mask):
         item = self.mask_tree_items[mask.name]
@@ -181,8 +185,11 @@ class MaskManagerDialog(QObject):
             )
 
             # Group masks by creation view mode and xray source
-            for (mode, source), masks in groupby(sorted_masks,
-                                               key=attrgetter('creation_view_mode', 'xray_source')):
+            grouped = groupby(
+                sorted_masks,
+                key=attrgetter('creation_view_mode', 'xray_source')
+            )
+            for (mode, source), masks in grouped:
                 # Create mode item
                 mode_item = self.create_mode_item(mode, source)
 

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -66,7 +66,7 @@ class MaskManagerDialog(QObject):
 
     def create_mode_source_string(self, mode, source):
         mode_str = f'{mode.capitalize()} Mode'
-        source_str = f' - {source} Source' if source else ''
+        source_str = f' - {source}' if source else ''
         return f'{mode_str}{source_str}'
 
     def update_presentation_combo(self, item, mask):
@@ -90,6 +90,7 @@ class MaskManagerDialog(QObject):
                                     QFont.Bold))
         self.ui.masks_tree.addTopLevelItem(mode_item)
         self.mask_tree_items[mode_item.text(0)] = mode_item
+        self.ui.masks_tree.expandItem(mode_item)
         return mode_item
 
     def create_mask_item(self, parent_item, mask):

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -63,18 +63,22 @@ class MaskManagerDialog(QObject):
         self.ui.apply_changes.clicked.connect(self.apply_changes)
 
     def update_tree(self):
-        # Sort masks by creation view mode
+        # Sort masks by creation view mode and xray source
         sorted_masks = sorted(
             MaskManager().masks.values(),
-            key=attrgetter('creation_view_mode')
+            key=attrgetter('creation_view_mode', 'xray_source')
         )
         with block_signals(self.ui.masks_tree):
             self.ui.masks_tree.clear()
-            # Group masks by creation view mode
-            for mode, masks in groupby(sorted_masks,
-                                       key=attrgetter('creation_view_mode')):
-                # Create header item based on the mode the masks were created in
-                mode_item = QTreeWidgetItem([f'{mode.capitalize()} Mode Masks'])
+            # Group masks by creation view mode and xray source
+            for (mode, source), masks in groupby(sorted_masks,
+                                               key=attrgetter('creation_view_mode', 'xray_source')):
+                # Create header item based on the mode and source
+                mode_str = f'{mode.capitalize()} Mode'
+                source_str = f' - {source} Source' if source else ''
+                mode_item = QTreeWidgetItem([f'{mode_str}{source_str}'])
+                mode_item.setFlags(Qt.ItemIsEnabled)  # Keep enabled but prevent editing
+                mode_item.setFont(0, QFont(mode_item.font(0).family(), mode_item.font(0).pointSize(), QFont.Bold))
                 self.ui.masks_tree.addTopLevelItem(mode_item)
 
                 for mask in masks:

--- a/hexrdgui/masking/mask_regions_dialog.py
+++ b/hexrdgui/masking/mask_regions_dialog.py
@@ -274,13 +274,11 @@ class MaskRegionsDialog(QObject):
 
     def create_masks(self):
         for data in self.raw_mask_coords:
-            name = unique_name(
-                MaskManager().mask_names, f'{self.image_mode}_mask_0')
             if self.image_mode == 'raw':
                 coords = [data]
             elif self.image_mode == 'polar':
                 coords = convert_polar_to_raw(data)
-            MaskManager().add_mask(name, coords, MaskType.region)
+            MaskManager().add_mask(coords, MaskType.region)
 
         masks_changed_signal = {
             'raw': MaskManager().raw_masks_changed,

--- a/hexrdgui/masking/mask_regions_dialog.py
+++ b/hexrdgui/masking/mask_regions_dialog.py
@@ -280,7 +280,7 @@ class MaskRegionsDialog(QObject):
                 coords = [data]
             elif self.image_mode == 'polar':
                 coords = convert_polar_to_raw(data)
-            mask = MaskManager().add_mask(name, coords, MaskType.region)
+            MaskManager().add_mask(name, coords, MaskType.region)
 
         masks_changed_signal = {
             'raw': MaskManager().raw_masks_changed,

--- a/hexrdgui/masking/mask_regions_dialog.py
+++ b/hexrdgui/masking/mask_regions_dialog.py
@@ -2,7 +2,6 @@ from PySide6.QtCore import QObject, Signal, Qt
 
 from hexrdgui.masking.create_raw_mask import convert_polar_to_raw
 from hexrdgui.interactive_template import InteractiveTemplate
-from hexrdgui.utils import unique_name
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.masking.mask_manager import MaskManager

--- a/hexrdgui/masking/threshold_mask_dialog.py
+++ b/hexrdgui/masking/threshold_mask_dialog.py
@@ -65,7 +65,7 @@ class ThresholdMaskDialog(QObject):
         self.gather_input()
         if MaskManager().threshold_mask is None:
             MaskManager().add_mask(
-                'threshold', self.values, MaskType.threshold)
+                self.values, MaskType.threshold, name='threshold')
         else:
             MaskManager().threshold_mask.data = self.values
         self.mask_applied.emit()

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -2,6 +2,9 @@
 <ui version="4.0">
  <class>mask_manager</class>
  <widget class="QDialog" name="mask_manager">
+  <property name="enabled">
+   <bool>true</bool>
+  </property>
   <property name="geometry">
    <rect>
     <x>0</x>
@@ -14,6 +17,37 @@
    <string>Mask Management</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="1" colspan="2">
+    <widget class="QPushButton" name="view_masks">
+     <property name="text">
+      <string>View Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1" colspan="2">
+    <widget class="QPushButton" name="show_all_masks">
+     <property name="text">
+      <string>Show All Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1" rowspan="2" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::NoButton</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1" colspan="2">
+    <widget class="QPushButton" name="hide_all_boundaries">
+     <property name="text">
+      <string>Hide All Boundaries</string>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="1" colspan="2">
     <widget class="QPushButton" name="export_masks">
      <property name="text">
@@ -21,14 +55,21 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QPushButton" name="hide_all_masks">
+   <item row="8" column="1" colspan="2">
+    <widget class="QPushButton" name="border_color">
      <property name="text">
-      <string>Hide All Masks</string>
+      <string>Border Color</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="0" rowspan="11">
+   <item row="2" column="1" colspan="2">
+    <widget class="QPushButton" name="panel_buffer">
+     <property name="text">
+      <string>Masks to Panel Buffer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" rowspan="12">
     <widget class="QTableWidget" name="masks_table">
      <property name="minimumSize">
       <size>
@@ -90,13 +131,6 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QPushButton" name="panel_buffer">
-     <property name="text">
-      <string>Masks to Panel Buffer</string>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="1" colspan="2">
     <widget class="QPushButton" name="import_masks">
      <property name="text">
@@ -104,41 +138,20 @@
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QPushButton" name="show_all_masks">
+   <item row="4" column="1" colspan="2">
+    <widget class="QPushButton" name="hide_all_masks">
      <property name="text">
-      <string>Show All Masks</string>
+      <string>Hide All Masks</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QPushButton" name="view_masks">
+   <item row="9" column="1" colspan="2">
+    <widget class="QPushButton" name="apply_changes">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
      <property name="text">
-      <string>View Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1" rowspan="2" colspan="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::NoButton</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QPushButton" name="hide_all_boundaries">
-     <property name="text">
-      <string>Hide All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="2">
-    <widget class="QPushButton" name="border_color">
-     <property name="text">
-      <string>Border Color</string>
+      <string>Apply Changes</string>
      </property>
     </widget>
    </item>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -70,7 +70,7 @@
     </widget>
    </item>
    <item row="0" column="0" rowspan="12">
-    <widget class="QTableWidget" name="masks_table">
+    <widget class="QTreeWidget" name="masks_tree">
      <property name="minimumSize">
       <size>
        <width>500</width>
@@ -92,18 +92,6 @@
      <property name="sortingEnabled">
       <bool>false</bool>
      </property>
-     <attribute name="horizontalHeaderCascadingSectionResizes">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="horizontalHeaderMinimumSectionSize">
-      <number>52</number>
-     </attribute>
-     <attribute name="horizontalHeaderDefaultSectionSize">
-      <number>150</number>
-     </attribute>
-     <attribute name="horizontalHeaderStretchLastSection">
-      <bool>true</bool>
-     </attribute>
      <column>
       <property name="text">
        <string>Name</string>
@@ -158,7 +146,7 @@
   </layout>
  </widget>
  <tabstops>
-  <tabstop>masks_table</tabstop>
+  <tabstop>masks_tree</tabstop>
   <tabstop>panel_buffer</tabstop>
   <tabstop>import_masks</tabstop>
   <tabstop>export_masks</tabstop>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -9,67 +9,15 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>681</width>
-    <height>297</height>
+    <width>662</width>
+    <height>322</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Mask Management</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="1" colspan="2">
-    <widget class="QPushButton" name="view_masks">
-     <property name="text">
-      <string>View Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QPushButton" name="show_all_masks">
-     <property name="text">
-      <string>Show All Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1" rowspan="2" colspan="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::NoButton</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1" colspan="2">
-    <widget class="QPushButton" name="hide_all_boundaries">
-     <property name="text">
-      <string>Hide All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QPushButton" name="export_masks">
-     <property name="text">
-      <string>Export Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="2">
-    <widget class="QPushButton" name="border_color">
-     <property name="text">
-      <string>Border Color</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QPushButton" name="panel_buffer">
-     <property name="text">
-      <string>Masks to Panel Buffer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" rowspan="12">
+   <item row="0" column="0" rowspan="11">
     <widget class="QTreeWidget" name="masks_tree">
      <property name="minimumSize">
       <size>
@@ -112,44 +60,146 @@
      </column>
     </widget>
    </item>
-   <item row="7" column="1" colspan="2">
-    <widget class="QPushButton" name="show_all_boundaries">
-     <property name="text">
-      <string>Show All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
+   <item row="0" column="1">
     <widget class="QPushButton" name="import_masks">
      <property name="text">
       <string>Import Masks</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
+   <item row="1" column="1">
+    <widget class="QPushButton" name="export_masks">
+     <property name="text">
+      <string>Export Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QPushButton" name="panel_buffer">
+     <property name="text">
+      <string>Masks to Panel Buffer</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1">
+    <widget class="QPushButton" name="view_masks">
+     <property name="text">
+      <string>View Masks</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="1">
     <widget class="QPushButton" name="hide_all_masks">
      <property name="text">
       <string>Hide All Masks</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1" colspan="2">
-    <widget class="QPushButton" name="apply_changes">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
+   <item row="6" column="1">
+    <widget class="QPushButton" name="show_all_masks">
      <property name="text">
-      <string>Apply Changes</string>
+      <string>Show All Masks</string>
      </property>
     </widget>
+   </item>
+   <item row="7" column="1">
+    <widget class="Line" name="line_2">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="8" column="1">
+    <widget class="QPushButton" name="hide_all_boundaries">
+     <property name="text">
+      <string>Hide All Boundaries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="9" column="1">
+    <widget class="QPushButton" name="show_all_boundaries">
+     <property name="text">
+      <string>Show All Boundaries</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
+    <widget class="QPushButton" name="border_color">
+     <property name="text">
+      <string>Border Color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::NoButton</set>
+       </property>
+       <property name="centerButtons">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="apply_changes">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>400</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Apply Changes</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>168</width>
+         <height>17</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>
  <tabstops>
   <tabstop>masks_tree</tabstop>
-  <tabstop>panel_buffer</tabstop>
   <tabstop>import_masks</tabstop>
   <tabstop>export_masks</tabstop>
+  <tabstop>panel_buffer</tabstop>
+  <tabstop>view_masks</tabstop>
+  <tabstop>hide_all_masks</tabstop>
+  <tabstop>show_all_masks</tabstop>
+  <tabstop>hide_all_boundaries</tabstop>
+  <tabstop>show_all_boundaries</tabstop>
+  <tabstop>border_color</tabstop>
+  <tabstop>apply_changes</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
- [x] Only apply changes to mask presentation on button press, not automatically
- [x] Remember which image mode a mask was created in
- [x] Remember which x-ray source was selected when the mask was created (if applicable)
- [x] Update mask manager dialog to use a tree view instead of a table view
- [x] Organize masks by view mode + x-ray source in tree
- [x] Keep backwards compatibility with old mask file versions
- [x] Automatically hide masks that were not created in the current view mode with the current x-ray source
- [x] Collapse mask categories that do not match current x-ray source
- [x] ~Allow users to skip this automatic mask hiding functionality if desired~ Skipping for now
- [x] Make sure that masks are sorted properly based on name then value
- [x] Remove old print statement in the hand drawn mask dialog
- [x] Add new top-level category that is not view mode specific ("global" or something similar)
- [x] Move info and "apply changes" button to bottom of dialog
- [x] Test threshold masking in all image modes

Addresses #1791 