### PR TITLE
Fiddle image names

### DIFF
--- a/hexrdgui/llnl_import_tool_dialog.py
+++ b/hexrdgui/llnl_import_tool_dialog.py
@@ -133,7 +133,7 @@ class LLNLImportToolDialog(QObject):
         self.current_image_selection = None
         self.defaults = {}
         self.import_in_progress = False
-        self.loaded_images = []
+        self.loaded_images = {}
         self.canvas = parent.image_tab_widget.active_canvas
         self.detector_images = {}
         self.atlas_coords = None
@@ -162,6 +162,7 @@ class LLNLImportToolDialog(QObject):
             self.ui.instr_settings,
             self.ui.load_atlas,
             self.ui.atlas_label,
+            self.ui.completed_dets_and_ips,
             visible=False)
 
         self.update_config_settings()
@@ -210,9 +211,6 @@ class LLNLImportToolDialog(QObject):
         for w in widgets:
             w.setVisible(visible)
             w.setEnabled(visible)
-        # Resize on show/hide widgets to prevent large empty spaces
-        self.ui.setMinimumHeight(315)
-        QTimer.singleShot(0, lambda: self.ui.adjustSize())
 
     def set_default_color(self):
         self.outline_color = '#00ffff'
@@ -560,10 +558,11 @@ class LLNLImportToolDialog(QObject):
         file_name = Path(selected_file).stem
         if file_name.endswith('999'):
             self.ui.detector_files_label.setText(file_name)
-            self.loaded_images.append(selected_file)
+            self.ui.detector_files_label.setToolTip(file_name)
             self.detector_images[self.detector]['data'] = selected_file
         else:
             self.ui.dark_files_label.setText(file_name)
+            self.ui.dark_files_label.setToolTip(file_name)
             self.detector_images[self.detector]['dark'] = selected_file
         selected = self.detector_images[self.detector]
 
@@ -592,13 +591,21 @@ class LLNLImportToolDialog(QObject):
                 self.detector_images.setdefault(self.detector, {})
                 self.detector_images[self.detector]['data'] = data
                 self.detector_images[self.detector]['dark'] = dark
+                self.loaded_images[f'{self.detector} data'] = data
+                self.loaded_images[f'{self.detector} dark'] = dark
                 self.accept_detector(data, dark)
             self.detector = original_det
             # Update UI to reflect selected & found files
             self.ui.detector_files_label.setText(
                 Path(self.detector_images[self.detector]['data']).stem
             )
+            self.ui.detector_files_label.setToolTip(
+                Path(self.detector_images[self.detector]['data']).stem
+            )
             self.ui.dark_files_label.setText(
+                Path(self.detector_images[self.detector]['dark']).stem
+            )
+            self.ui.dark_files_label.setToolTip(
                 Path(self.detector_images[self.detector]['dark']).stem
             )
             self.current_image_selection = self.detector
@@ -628,7 +635,7 @@ class LLNLImportToolDialog(QObject):
                                             dir=HexrdConfig().images_dir
                                         )
         if selected_file:
-            self.loaded_images.append(selected_file)
+            self.loaded_images[self.image_plate] = selected_file
             HexrdConfig().set_images_dir(selected_file)
 
             files, manual = ImageLoadManager().load_images([selected_file])
@@ -658,6 +665,7 @@ class LLNLImportToolDialog(QObject):
 
             file_names = [os.path.split(f[0])[1] for f in files]
             self.ui.image_plate_files_label.setText(', '.join(file_names))
+            self.ui.image_plate_files_label.setToolTip(', '.join(file_names))
             self.enable_widgets(
                 self.ui.add_transform,
                 self.ui.finalize,
@@ -826,8 +834,19 @@ class LLNLImportToolDialog(QObject):
             self.ui.add_transform,
             self.ui.accept_detector,
             enabled=False)
-        self.ui.completed_dets_and_ips.setText(
-            ', '.join(set(self.completed)))
+        self.set_widget_visibility(
+            self.ui.completed_dets_and_ips,
+            visible=True)
+        if self.instrument == 'PXRDIP':
+            shared_file = next(iter(self.loaded_images.values()))
+            self.loaded_images[self.current_image_selection] = shared_file
+        loaded = [
+            f'{d}: {Path(self.loaded_images[d]).stem}'
+            for d in sorted(self.loaded_images)
+        ]
+        text = '\n'.join(set(loaded))
+        self.ui.completed_text.setText(text)
+        self.ui.completed_text.setToolTip(text)
 
     def finalize(self):
         detectors = self.ip_and_det_defaults['default_config'].get(
@@ -899,9 +918,13 @@ class LLNLImportToolDialog(QObject):
         self.ui.image_plates.setCurrentIndex(0)
         self.ui.detectors.setCurrentIndex(0)
         self.ui.image_plate_files_label.setText('')
+        self.ui.image_plate_files_label.setToolTip('')
         self.ui.detector_files_label.setText('')
+        self.ui.detector_files_label.setToolTip('')
         self.ui.dark_files_label.setText('')
-        self.ui.completed_dets_and_ips.setText('')
+        self.ui.dark_files_label.setToolTip('')
+        self.ui.completed_text.setText('')
+        self.ui.completed_text.setToolTip('')
         not_default = self.ui.config_selection.currentIndex() != 0
         self.ui.load_config.setEnabled(not_default)
         self.ui.config_file_label.setEnabled(not_default)
@@ -1004,7 +1027,7 @@ class LLNLImportToolDialog(QObject):
             det_config = HexrdConfig().config['instrument']['detectors'][det]
             det_config['buffer'] = self.edited_images[det]['panel_buffer']
 
-        HexrdConfig().recent_images = self.loaded_images
+        HexrdConfig().recent_images = list(self.loaded_images.values())
 
         self.close_widget()
         self.ui.instrument.setDisabled(False)

--- a/hexrdgui/llnl_import_tool_dialog.py
+++ b/hexrdgui/llnl_import_tool_dialog.py
@@ -874,7 +874,7 @@ class LLNLImportToolDialog(QObject):
             f'{d}: {Path(self.loaded_images[d]).stem}'
             for d in sorted(self.loaded_images)
         ]
-        text = '\n'.join(set(loaded))
+        text = '\n'.join(loaded)
         self.ui.completed_text.setText(text)
         self.ui.completed_text.setToolTip(text)
 

--- a/hexrdgui/resources/ui/llnl_import_tool_dialog.ui
+++ b/hexrdgui/resources/ui/llnl_import_tool_dialog.ui
@@ -6,9 +6,21 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>565</width>
+    <width>429</width>
     <height>883</height>
    </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="maximumSize">
+   <size>
+    <width>450</width>
+    <height>524287</height>
+   </size>
   </property>
   <property name="windowTitle">
    <string>LLNL Import Tool</string>
@@ -770,30 +782,7 @@
        <string>Finalize Instrument</string>
       </property>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0" colspan="2">
-        <widget class="QLabel" name="completed_label">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string>Completed Detectors:</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="completed_dets_and_ips">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QPushButton" name="cancel">
          <property name="enabled">
           <bool>true</bool>
@@ -803,7 +792,17 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="2">
+        <widget class="QPushButton" name="complete">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Complete and Reload Instrument</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
         <spacer name="horizontalSpacer">
          <property name="orientation">
           <enum>Qt::Horizontal</enum>
@@ -816,14 +815,58 @@
          </property>
         </spacer>
        </item>
-       <item row="1" column="2">
-        <widget class="QPushButton" name="complete">
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="completed_label">
          <property name="enabled">
-          <bool>false</bool>
+          <bool>true</bool>
          </property>
          <property name="text">
-          <string>Complete and Reload Instrument</string>
+          <string>Completed Detectors:</string>
          </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="3">
+        <widget class="QScrollArea" name="completed_dets_and_ips">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="widgetResizable">
+          <bool>true</bool>
+         </property>
+         <widget class="QWidget" name="completed_dets_and_ips_content">
+          <property name="geometry">
+           <rect>
+            <x>0</x>
+            <y>0</y>
+            <width>385</width>
+            <height>68</height>
+           </rect>
+          </property>
+          <layout class="QVBoxLayout" name="verticalLayout_2">
+           <item>
+            <widget class="QLabel" name="completed_text">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="wordWrap">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>

--- a/hexrdgui/resources/ui/llnl_import_tool_dialog.ui
+++ b/hexrdgui/resources/ui/llnl_import_tool_dialog.ui
@@ -18,7 +18,7 @@
   </property>
   <property name="maximumSize">
    <size>
-    <width>450</width>
+    <width>524287</width>
     <height>524287</height>
    </size>
   </property>


### PR DESCRIPTION
As requested by @saransh13 :

Previously when users changed the detector or image plate that had already been loaded and/or cropped the text was not updated and the image was not re-loaded. Now the previously selected image is loaded, the text label is updated, and if
it is an image plate the completed template is drawn in the preciously selected position.

Additionally, the completed detectors list now also contains a reference to the file associated with the completed detectors and/or image plates.