### PR TITLE
Use default value if state is missing attribute

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -333,7 +333,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self._physics_package = None
         self._detector_coatings = {}
         self._instrument_rigid_body_params = {}
-        self._median_filer_correction = {}
+        self._median_filter_correction = {}
 
         # Make sure that the matplotlib font size matches the application
         self.font_size = self.font_size
@@ -477,7 +477,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'custom_polar_tth_distortion_object_serialized',
             'physics_package_dictified',
             'detector_coatings_dictified',
-            'apply_median_filter_correction'
+            'apply_median_filter_correction',
+            'median_filter_kernel_size'
         ]
 
         state = {}
@@ -3011,22 +3012,22 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @property
     def apply_median_filter_correction(self):
-        return self._median_filer_correction.get('apply', False)
+        return self._median_filter_correction.get('apply', False)
 
     @apply_median_filter_correction.setter
     def apply_median_filter_correction(self, v):
         if v != self.apply_median_filter_correction:
-            self._median_filer_correction['apply'] = v
+            self._median_filter_correction['apply'] = v
             self.deep_rerender_needed.emit()
 
     @property
     def median_filter_kernel_size(self):
-        return self._median_filer_correction.get('kernel', 7)
+        return self._median_filter_correction.get('kernel', 7)
 
     @median_filter_kernel_size.setter
     def median_filter_kernel_size(self, v):
         if v != self.median_filter_kernel_size:
-            self._median_filer_correction['kernel'] = int(v)
+            self._median_filter_correction['kernel'] = int(v)
             self.deep_rerender_needed.emit()
 
 

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -477,6 +477,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'custom_polar_tth_distortion_object_serialized',
             'physics_package_dictified',
             'detector_coatings_dictified',
+            'apply_median_filter_correction'
         ]
 
         state = {}

--- a/hexrdgui/state.py
+++ b/hexrdgui/state.py
@@ -1,5 +1,6 @@
 from PySide6.QtCore import QTimer
 
+import copy
 import h5py
 import numpy as np
 import yaml
@@ -182,10 +183,13 @@ def load(h5_file):
 
         # Rename the state variables to the attribute names...
         renamed_state = {}
-        for name, _ in HexrdConfig()._attributes_to_persist():
+        for name, default in HexrdConfig()._attributes_to_persist():
             old_name = HexrdConfig()._attribute_to_settings_key(name)
             if old_name in state:
                 renamed_state[name] = state.pop(old_name)
+            if name != 'config_instrument' and name not in renamed_state:
+                # If the attribute is not in the state, set it to the default
+                renamed_state[name] = copy.deepcopy(default)
 
         HexrdConfig().load_from_state(renamed_state)
 

--- a/hexrdgui/state.py
+++ b/hexrdgui/state.py
@@ -1,6 +1,7 @@
+import copy
+
 from PySide6.QtCore import QTimer
 
-import copy
 import h5py
 import numpy as np
 import yaml

--- a/hexrdgui/state.py
+++ b/hexrdgui/state.py
@@ -181,14 +181,27 @@ def load(h5_file):
         # Now, load the state
         state = _load_config(h5_file)
 
+        # Don't set these defaults if they are missing.
+        # Not sure why they are missing, but they cause issues if we
+        # apply them.
+        defaults_to_skip = [
+            'config_instrument',
+            'config_calibration',
+            'config_indexing',
+            'config_images',
+        ]
+
         # Rename the state variables to the attribute names...
         renamed_state = {}
         for name, default in HexrdConfig()._attributes_to_persist():
             old_name = HexrdConfig()._attribute_to_settings_key(name)
             if old_name in state:
                 renamed_state[name] = state.pop(old_name)
-            if name != 'config_instrument' and name not in renamed_state:
+
+            # Also set defaults if missing
+            if name not in renamed_state and name not in defaults_to_skip:
                 # If the attribute is not in the state, set it to the default
+                # A deep copy is needed for mutable defaults
                 renamed_state[name] = copy.deepcopy(default)
 
         HexrdConfig().load_from_state(renamed_state)


### PR DESCRIPTION
This branch:
- Makes sure we exclude the median filter and kernel size from QSettings so that we only apply any settings saved in the state
- Fixes a typo
- Use the default value for an attribute if that attribute should be persisted but does not exist in the state file