### PR TITLE
Keep valid images after detectors added/removed

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -869,17 +869,19 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         return len(next(iter(self.imageseries_dict.values())))
 
     @property
-    def has_dummy_images(self):
+    def has_all_dummy_images(self):
         if not self.imageseries_dict:
             return False
 
-        first_ims = next(iter(self.imageseries_dict.values()))
-        return getattr(first_ims, 'is_dummy', False)
+        return all(
+            getattr(ims, 'is_dummy', False)
+            for ims in self.imageseries_dict.values()
+        )
 
     @property
     def has_images(self):
         # There are images, and they are not dummy images
-        return bool(self.imageseries_dict and not self.has_dummy_images)
+        return bool(self.imageseries_dict and not self.has_all_dummy_images)
 
     @property
     def omega_imageseries_dict(self):

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -147,8 +147,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """
     update_status_bar = Signal(str)
 
-    """Emitted when the load_panel_state has been cleared"""
-    load_panel_state_reset = Signal()
+    """Emitted when the load_panel_state has been modified"""
+    load_panel_state_modified = Signal()
 
     """Emitted when the Euler angle convention changes"""
     euler_angle_convention_changed = Signal()
@@ -1099,15 +1099,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                          **kwargs):
         hexrd.imageseries.save.write(ims, write_file, selected_format,
                                      **kwargs)
-
-    def clear_images(self, initial_load=False):
-        self.reset_unagg_imgs()
-        self.imageseries_dict.clear()
-        # Set this instead of clearing so the signal gets emitted
-        self.recent_images = {}
-        if self.load_panel_state is not None and not initial_load:
-            self.load_panel_state.clear()
-            self.load_panel_state_reset.emit()
 
     def load_instrument_config(self, path, import_raw=False):
         old_detectors = self.detector_names

--- a/hexrdgui/image_file_manager.py
+++ b/hexrdgui/image_file_manager.py
@@ -77,13 +77,14 @@ class ImageFileManager(metaclass=Singleton):
                 s = load_panel_state
                 # Need this index for some load panel state items
                 ims_idx = list(ims_dict).index(det_key)
-                load_panel_modified = True
                 for list_key in ('trans', 'dark', 'dark_files'):
                     if len(s.get(list_key, [])) > ims_idx:
                         s[list_key].pop(ims_idx)
+                        load_panel_modified = True
 
                 if det_key in s.get('rect', {}):
                     s['rect'].pop(det_key)
+                    load_panel_modified = True
 
             # This image will not be kept
             ims_dict.pop(det_key)

--- a/hexrdgui/image_file_manager.py
+++ b/hexrdgui/image_file_manager.py
@@ -2,7 +2,6 @@ import glob
 import os
 import numpy as np
 import tempfile
-import traceback
 import yaml
 import h5py
 
@@ -28,21 +27,99 @@ class ImageFileManager(metaclass=Singleton):
         self.path = []
 
     def load_dummy_images(self, initial=False):
-        HexrdConfig().clear_images(initial)
-        detectors = HexrdConfig().detector_names
+        detector_names = HexrdConfig().detector_names
         iconfig = HexrdConfig().instrument_config
-        for det in detectors:
-            cols = iconfig['detectors'][det]['pixels']['columns']
-            rows = iconfig['detectors'][det]['pixels']['rows']
-            shape = (rows, cols)
+
+        ims_dict = HexrdConfig().imageseries_dict
+        unagg_dict = HexrdConfig().unaggregated_images
+        recent_images = HexrdConfig().recent_images
+        load_panel_state = HexrdConfig().load_panel_state
+
+        recent_images_modified = False
+        load_panel_modified = False
+
+        def get_shape(det_key: str) -> tuple[int, int]:
+            # Get the shape of a specific detector
+            cols = iconfig['detectors'][det_key]['pixels']['columns']
+            rows = iconfig['detectors'][det_key]['pixels']['rows']
+            return (rows, cols)
+
+        def make_dummy_ims(shape: tuple[int, int]) -> imageseries.ImageSeries:
+            # Make a dummy imageseries
             data = np.ones(shape, dtype=np.uint8)
             ims = imageseries.open(None, 'array', data=data)
 
             # Set a flag on these image series indicating that they are
             # dummies.
             ims.is_dummy = True
+            return ims
 
-            HexrdConfig().imageseries_dict[det] = ims
+        # Check if we will keep any images. If so, we will make
+        # the dummy images the same length as the kept images.
+        ims_length = 1
+        unagg_length = None
+
+        # First, remove any images that no longer belong,
+        # or whose shape does not match.
+        for det_key, ims in list(ims_dict.items()):
+            keep = (
+                det_key in detector_names and
+                ims.shape == get_shape(det_key)
+            )
+            if keep:
+                # Record the imageseries length and unagg length
+                ims_length = len(ims)
+                if unagg_dict:
+                    unagg_length = len(unagg_dict[det_key])
+                continue
+
+            if load_panel_state and not initial:
+                s = load_panel_state
+                # Need this index for some load panel state items
+                ims_idx = list(ims_dict).index(det_key)
+                load_panel_modified = True
+                for list_key in ('trans', 'dark', 'dark_files'):
+                    if len(s.get(list_key, [])) > ims_idx:
+                        s[list_key].pop(ims_idx)
+
+                if det_key in s.get('rect', {}):
+                    s['rect'].pop(det_key)
+
+            # This image will not be kept
+            ims_dict.pop(det_key)
+            if unagg_dict and det_key in unagg_dict:
+                unagg_dict.pop(det_key)
+
+            if det_key in recent_images:
+                recent_images.pop(det_key)
+                recent_images_modified = True
+
+        # Now make dummy images for missing ones
+        for det_key in detector_names:
+            if det_key in ims_dict:
+                # Already have an imageseries here
+                continue
+
+            det_shape = get_shape(det_key)
+
+            # Make a dummy image
+            shape = (ims_length, *det_shape)
+            ims_dict[det_key] = make_dummy_ims(shape)
+
+            if unagg_length is not None:
+                shape = (unagg_length, *det_shape)
+                unagg_dict[det_key] = make_dummy_ims(shape)
+
+        # In case the imageseries length was shorted, truncate
+        # the current imageseries index
+        if HexrdConfig().current_imageseries_idx >= ims_length:
+            HexrdConfig().current_imageseries_idx = ims_length - 1
+
+        if recent_images_modified:
+            HexrdConfig().recent_images_changed.emit()
+
+        if load_panel_modified:
+            HexrdConfig().load_panel_state_modified.emit()
 
     def load_images(self, detectors, file_names, options=None):
         HexrdConfig().imageseries_dict.clear()

--- a/hexrdgui/simple_image_series_dialog.py
+++ b/hexrdgui/simple_image_series_dialog.py
@@ -87,7 +87,7 @@ class SimpleImageSeriesDialog(QObject):
 
     def setup_connections(self):
         HexrdConfig().detectors_changed.connect(self.config_changed)
-        HexrdConfig().load_panel_state_reset.connect(self.config_changed)
+        HexrdConfig().load_panel_state_modified.connect(self.config_changed)
 
         self.ui.image_files.clicked.connect(self.select_images)
         self.ui.select_dark.clicked.connect(self.select_dark_img)

--- a/hexrdgui/simple_image_series_dialog.py
+++ b/hexrdgui/simple_image_series_dialog.py
@@ -116,12 +116,19 @@ class SimpleImageSeriesDialog(QObject):
         self.state = HexrdConfig().load_panel_state
         self.num_dets = len(HexrdConfig().detector_names)
         self.state.setdefault('agg', UI_AGG_INDEX_NONE)
-        self.state.setdefault(
-            'trans', [UI_TRANS_INDEX_NONE for x in range(self.num_dets)])
-        self.state.setdefault(
-            'dark', [UI_DARK_INDEX_NONE for x in range(self.num_dets)])
-        self.state.setdefault(
-            'dark_files', [None for x in range(self.num_dets)])
+
+        list_defaults = {
+            'trans': UI_TRANS_INDEX_NONE,
+            'dark': UI_DARK_INDEX_NONE,
+            'dark_files': None,
+        }
+
+        for k, default in list_defaults.items():
+            if k not in self.state:
+                self.state[k] = []
+
+            while len(self.state[k]) < self.num_dets:
+                self.state[k].append(default)
 
     def state_loaded(self):
         self.update_config_variables()

--- a/hexrdgui/state.py
+++ b/hexrdgui/state.py
@@ -239,7 +239,8 @@ def load_imageseries_dict(h5_file):
 
     root = 'images'
     for det, ims in list(h5_file[root].items()):
-        imsd[det] = imageseries.open(h5_file, 'hdf5', path=f'{root}/{det}')
+        imsd[det] = imageseries.open(h5_file, 'hdf5', path=f'{root}/{det}',
+                                     close_when_finished=False)
 
     HexrdConfig().reset_unagg_imgs(new_imgs=True)
 


### PR DESCRIPTION
Previously, if detectors were added/removed from the instrument form view, we would automatically clear all the imageseries. We can instead, however, keep the imageseries that are still valid. If one particular detector does not contain good images, this will allow, for example, that detector to just be removed.

The imageseries that are considered "valid" and are kept are only ones whose detector name still exists in the list of detectors, and whose shape matches the detector shape.

Depends on: https://github.com/HEXRD/hexrd/pull/790

Fixes: #1821