### PR TITLE
Enable pinhole correction for the Cartesian view

### DIFF
--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -115,7 +115,8 @@ class InstrumentViewer:
     def make_dpanel(self):
         self.dpanel = self.dplane.display_panel(self.dpanel_sizes,
                                                 self.pixel_size,
-                                                self.instr.beam_vector)
+                                                self.instr.beam_vector,
+                                                self.instr.source_distance)
         self.dpanel.name = 'dpanel'
         self.dpanel._distortion = FakeDistortionObject(self.dpanel, self.instr)
 

--- a/hexrdgui/calibration/display_plane.py
+++ b/hexrdgui/calibration/display_plane.py
@@ -43,7 +43,7 @@ class DisplayPlane:
 
         return (del_x, del_y)
 
-    def display_panel(self, sizes, mps, bvec=None):
+    def display_panel(self, sizes, mps, bvec=None, xrs_dist=None):
 
         del_x = sizes[0]
         del_y = sizes[1]
@@ -55,6 +55,7 @@ class DisplayPlane:
             rows=nrows_map, cols=ncols_map,
             pixel_size=(mps, mps),
             tvec=self.tvec, tilt=self.tilt,
-            bvec=bvec)
+            bvec=bvec,
+            xrs_dist=xrs_dist)
 
         return display_panel

--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -122,11 +122,11 @@ KNOWN_DETECTOR_NAMES = {
         'IMAGE-PLATE-U',
     ],
     'FIDDLE': [
-        'ic2',
-        'ic3',
-        'ic5',
-        'ic7',
-        'ic8',
+        'CAMERA-02',
+        'CAMERA-03',
+        'CAMERA-05',
+        'CAMERA-07',
+        'CAMERA-08',
     ],
     'DEXELAS_COMPOSITE': [
         'ff1_0_0',


### PR DESCRIPTION
The panel needs to have the source distance specified on it to use with pinhole correction.

We've never had to use pinhole correction in the Cartesian view (TARDIS and PXRDIP cannot be used with the Cartesian view), so we did not encounter this issue until now.