### PR TITLE
Only draw lineout powder lines if XRS matches

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -517,6 +517,15 @@ class ImageCanvas(FigureCanvas):
         plot(h_ranges, 'h_ranges', highlight_style['ranges'])
 
     def draw_azimuthal_powder_lines(self, overlay):
+        if (
+            HexrdConfig().has_multi_xrs and
+            overlay.xray_source is not None and
+            HexrdConfig().active_beam_name != overlay.xray_source
+        ):
+            # This overlay's x-ray source does not match the active one.
+            # Skip it.
+            return
+
         az_axis = self.azimuthal_integral_axis
         if az_axis is None or not overlay.hkl_means:
             # Can't draw


### PR DESCRIPTION
If a powder overlay is only for a specific x-ray source, only draw its mean lines in the lineout if the active x-ray source matches.

Fixes: #1822