### PR TITLE
For single XRS, skip XRS-disabling logic

### DIFF
--- a/hexrdgui/calibration/structureless/runner.py
+++ b/hexrdgui/calibration/structureless/runner.py
@@ -512,6 +512,7 @@ class StructurelessCalibrationCallbacks(CalibrationDialogCallbacks):
             ring_indices[xray_source] = ring_idx
 
             if (
+                HexrdConfig().has_multi_xrs and
                 not self.showing_picks_from_all_xray_sources and
                 xray_source != HexrdConfig().active_beam_name
             ):


### PR DESCRIPTION
When we have a single XRS, that XRS still has a name, and there may be some cases where the name of the single XRS doesn't match the name in the picks.

For this reason, we should always skip any multi-xrs logic when we only have a single xrs. In this specific case, this fixes a bug where the only pick path would be disabled if the name did not match.