### PR TITLE
Fix resetting the parameters for WPPF

### DIFF
--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -283,7 +283,7 @@ class WppfOptionsDialog(QObject):
         return generate_params(**kwargs)
 
     def reset_params(self):
-        self.params.param_dict = self.generate_params()
+        self.params.param_dict = self.generate_params().param_dict
         self.update_tree_view()
 
     def update_params(self):


### PR DESCRIPTION
We need to set the `param_dict` object onto the WPPF parameters, not the params itself.