### PR TITLE
Before modifying, make copy of image if needed

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1087,6 +1087,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 # Convert to float. This is especially important
                 # for nan, since it is a float...
                 img = img.astype(float)
+            elif not img.flags.writeable:
+                # Need to make a copy
+                img = img.copy()
+                images_dict[det_key] = img
 
             img[~panel.panel_buffer] = fill_value
             images_dict[det_key] = img
@@ -1121,6 +1125,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             if (np.issubdtype(type(fill_value), np.floating) and
                     not np.issubdtype(img.dtype, np.floating)):
                 img = img.astype(float)
+                images_dict[det] = img
+            elif not img.flags.writeable:
+                # Need to make a copy
+                img = img.copy()
                 images_dict[det] = img
 
             img[~mask] = fill_value


### PR DESCRIPTION
For some imageseries types (particularly HDF5), the returned numpy array is not writeable for some reason. An error is thrown if we try to modify it in place.

So we should check if the image is writeable before trying to modify it. If it's not writeable, we make a copy that *is* writeable.

Fixes: #1840