### PR TITLE
Add new layers to physics package

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -697,7 +697,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 if not self.has_physics_package:
                     # We need to create a default physics package
                     # This is for backward compatibility
-                    self.create_default_physics_package()
+                    module = utils.physics_package
+                    module.make_physics_package_from_old_overlay_config(v)
 
             self.update_material_energy(self.materials[material_name])
             self.overlays.append(overlays.from_dict(overlay_dict))

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -601,6 +601,21 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         self.set_euler_angle_convention(conv, convert_config=False)
 
+        def set_physics_and_coatings():
+            pp = state.get('physics_package_dictified', None)
+            self.physics_package_dictified = pp if pp is not None else {}
+            dc = state.get('detector_coatings_dictified', None)
+            self.detector_coatings_dictified = dc if dc is not None else {}
+
+        if 'detector_coatings_dictified' in state:
+            # Physics package and detector coatings need a fully constructed
+            # HexrdConfig object to set their values because they need the
+            # correct detector names. Set the objects later.
+            # This must be set *before* the overlays, because old state files
+            # may trigger a default physics package to be made, and we don't
+            # want to overwrite that.
+            QTimer.singleShot(0, set_physics_and_coatings)
+
         def set_overlays():
             v = state.get('overlays_dictified')
             self.overlays_dictified = v if v is not None else {}
@@ -613,18 +628,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         if '_recent_images' not in state:
             self._recent_images.clear()
-
-        def set_physics_and_coatings():
-            pp = state.get('physics_package_dictified', None)
-            self.physics_package_dictified = pp if pp is not None else {}
-            dc = state.get('detector_coatings_dictified', None)
-            self.detector_coatings_dictified = dc if dc is not None else {}
-
-        if 'detector_coatings_dictified' in state:
-            # Physics package and detector coatings need a fully constructed
-            # HexrdConfig object to set their values because they need the
-            # correct detector names. Set the objects later.
-            QTimer.singleShot(0, set_physics_and_coatings)
 
         self.recent_images_changed.emit()
 
@@ -2334,6 +2337,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             active = v['active']
             d = v['serialized']
             if d.get('pinhole_distortion_type') == 'SampleLayerDistortion':
+                # Change this to the new 'LayerDistortion'
+                d['pinhole_distortion_type'] = 'LayerDistortion'
+
+            if d.get('pinhole_distortion_type') == 'LayerDistortion':
                 # We added pinhole_radius later. Set a default if it is missing.
                 if 'pinhole_radius' not in d['pinhole_distortion_kwargs']:
                     radius = self.physics_package.pinhole_radius

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1422,15 +1422,19 @@ class ImageCanvas(FigureCanvas):
         if obj is None:
             return 'nom'
 
-        if obj.pinhole_distortion_type == 'SampleLayerDistortion':
-            return 'sam'
+        if obj.pinhole_distortion_type == 'LayerDistortion':
+            layer_type = obj.pinhole_distortion_kwargs.get(
+                'layer_type',
+                'sample',
+            )
+            return layer_type[:3]
         else:
             return 'pin'
 
     @property
     def polar_xlabel_suffix(self):
         obj = HexrdConfig().polar_tth_distortion_object
-        if obj and obj.pinhole_distortion_type == 'SampleLayerDistortion':
+        if obj and obj.pinhole_distortion_type == 'LayerDistortion':
             standoff = obj.pinhole_distortion_kwargs.get('layer_standoff',
                                                          None)
             if standoff is not None:

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -88,6 +88,10 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                 HexrdConfig().create_default_physics_package()
 
         if self.tth_distortion_type == 'SampleLayerDistortion':
+            # Rename to the new name
+            self.tth_distortion_type = 'LayerDistortion'
+
+        if self.tth_distortion_type == 'LayerDistortion':
             # We added pinhole_radius later. Set a default if it is missing.
             if 'pinhole_radius' not in self.tth_distortion_kwargs:
                 radius = HexrdConfig().physics_package.pinhole_radius
@@ -457,10 +461,10 @@ class PowderOverlay(Overlay, PolarDistortionObject):
             if has_pinhole_distortion or (
                 (polar_distortion_with_self or offset_distortion) and
                 distortion_object and
-                distortion_object.pinhole_distortion_type == 'SampleLayerDistortion'
+                distortion_object.pinhole_distortion_type == 'LayerDistortion'
             ):
                 # If this overlay has a pinhole distortion of any kind, or
-                # if a sample layer distortion is being applied to the polar
+                # if a layer distortion is being applied to the polar
                 # view, we need to cut off all values past critical beta.
                 # Their correction will be very incorrect.
                 if has_pinhole_distortion:

--- a/hexrdgui/physics_package_manager_dialog.py
+++ b/hexrdgui/physics_package_manager_dialog.py
@@ -54,6 +54,7 @@ class PhysicsPackageManagerDialog:
             'ablator',
             'heatshield',
             'pusher',
+            'reflective',
             'window',
             'pinhole',
         ]
@@ -294,14 +295,17 @@ class PhysicsPackageDiagram:
                             edgecolor=(0, 0, 0)),
         'sample': Rectangle((0.38, 0.2), 0.03, 0.6, facecolor=(0, 0, 1, 0.4),
                             edgecolor=(0, 0, 0)),
+        'reflective': Rectangle((0.41, 0.2), 0.03, 0.6,
+                                facecolor=(1, 0.6, 0, 0.4),
+                                edgecolor=(0, 0, 0)),
         'VISAR': Polygon(
-            [(0.41, 0.4), (0.41, 0.6), (0.91, 0.65), (0.91, 0.35)],
+            [(0.44, 0.4), (0.44, 0.6), (0.91, 0.65), (0.91, 0.35)],
             facecolor=(1, 0, 0, 0.3)),
-        'window': Rectangle((0.4, 0.2), 0.2, 0.6, facecolor=(1, 1, 0, 0.8),
+        'window': Rectangle((0.43, 0.2), 0.2, 0.6, facecolor=(1, 1, 0, 0.8),
                             edgecolor=(0, 0, 0)),
         'pinhole': Polygon(
-            [(0.6, 0.2), (0.6, 0.8), (0.8, 0.8), (0.75, 0.6), (0.6, 0.6),
-             (0.6, 0.4), (0.75, 0.4), (0.75, 0.6), (0.75, 0.4), (0.8, 0.2)],
+            [(0.63, 0.2), (0.63, 0.8), (0.83, 0.8), (0.78, 0.6), (0.63, 0.6),
+             (0.63, 0.4), (0.78, 0.4), (0.78, 0.6), (0.78, 0.4), (0.83, 0.2)],
             facecolor=(0.5, 0.5, 0.5, 0.6), edgecolor=(0, 0, 0))
 
     }
@@ -335,6 +339,9 @@ class PhysicsPackageDiagram:
         self.clear()
         count = 0
         offset = 0
+        rename_text = {
+            'reflective': 'reflective coating',
+        }
         for key, patch in self.patches.items():
             p = copy.deepcopy(patch)
             if not show_dict.get(key, True):
@@ -355,6 +362,7 @@ class PhysicsPackageDiagram:
                 p.set_x(p.xy[0] + offset + count * 0.01)
 
             self.ax.add_patch(p)
-            self.add_text(p, key)
+            label = rename_text.get(key, key)
+            self.add_text(p, label)
             count += 1
         self.fig.canvas.draw_idle()

--- a/hexrdgui/physics_package_manager_dialog.py
+++ b/hexrdgui/physics_package_manager_dialog.py
@@ -6,7 +6,7 @@ from matplotlib.patches import Rectangle, Polygon
 from matplotlib.backends.backend_qtagg import FigureCanvas
 from matplotlib.figure import Figure
 
-from PySide6.QtWidgets import QSizePolicy
+from PySide6.QtWidgets import QSizePolicy, QWidget
 
 from hexrdgui import resource_loader
 from hexrdgui.hexrd_config import HexrdConfig
@@ -40,35 +40,50 @@ class PhysicsPackageManagerDialog:
     def show(self, delete_if_canceled=False):
         self.delete_if_canceled = delete_if_canceled
         self.setup_form()
+        self.draw_diagram()
         self.ui.show()
 
     @property
-    def material_selectors(self):
+    def layer_names(self) -> list[str]:
+        return self.non_sample_layer_names + ['sample']
+
+    @property
+    def non_sample_layer_names(self) -> list[str]:
+        # All layer names excluding the sample
+        return [
+            'ablator',
+            'heatshield',
+            'pusher',
+            'window',
+            'pinhole',
+        ]
+
+    @property
+    def material_selectors(self) -> dict[str, QWidget]:
         return {
-            'sample': self.ui.sample_material,
-            'pinhole': self.ui.pinhole_material,
-            'window': self.ui.window_material
+            k: getattr(self.ui, f'{k}_material')
+            for k in self.layer_names
         }
 
     @property
-    def material_inputs(self):
+    def material_inputs(self) -> dict[str, QWidget]:
         return {
-            'sample': self.ui.sample_material_input,
-            'pinhole': self.ui.pinhole_material_input,
-            'window': self.ui.window_material_input
+            k: getattr(self.ui, f'{k}_material_input')
+            for k in self.layer_names
         }
 
     @property
     def density_inputs(self):
         return {
-            'sample': self.ui.sample_density,
-            'pinhole': self.ui.pinhole_density,
-            'window': self.ui.window_density
+            k: getattr(self.ui, f'{k}_density')
+            for k in self.layer_names
         }
 
     def setup_connections(self):
-        self.ui.show_pinhole.toggled.connect(self.toggle_pinhole)
-        self.ui.show_window.toggled.connect(self.toggle_window)
+        for k in self.non_sample_layer_names:
+            w = getattr(self.ui, f'show_{k}')
+            w.toggled.connect(lambda b, k=k: self.toggle_layer(b, k))
+
         self.ui.button_box.accepted.connect(self.accept_changes)
         self.ui.button_box.accepted.connect(self.ui.accept)
         self.ui.button_box.rejected.connect(self.ui.reject)
@@ -138,9 +153,11 @@ class PhysicsPackageManagerDialog:
 
     def setup_form(self):
         mat_names = list(HexrdConfig().materials.keys())
+        all_options = {}
         for key, w in self.material_selectors.items():
             custom_mats = list(self.additional_materials.get(key, {}))
             options = ['Enter Manually', *custom_mats, *mat_names]
+            all_options[key] = options
             w.clear()
             w.addItems(options)
             w.insertSeparator(1)
@@ -160,37 +177,61 @@ class PhysicsPackageManagerDialog:
         else:
             self.ui.pinhole_thickness.setValue(physics.pinhole_thickness)
             self.ui.pinhole_diameter.setValue(physics.pinhole_diameter)
-        # WINDOW
-        if physics.window_material not in options:
-            self.ui.window_material_input.setText(
-                physics.window_material)
-        else:
-            self.ui.window_material.setCurrentText(
-                physics.window_material)
-        self.ui.window_density.setValue(physics.window_density)
-        self.ui.window_thickness.setValue(physics.window_thickness)
-        # SAMPLE
-        if physics.sample_material not in options:
-            self.ui.sample_material_input.setText(
-                physics.sample_material)
-        else:
-            self.ui.sample_material.setCurrentText(
-                physics.sample_material)
-        self.ui.sample_density.setValue(physics.sample_density)
-        self.ui.sample_thickness.setValue(physics.sample_thickness)
+
+        # THE REST
+        layer_names = self.layer_names
+        # Remove pinhole, cause we did that manually
+        layer_names.remove('pinhole')
+
+        material_selectors = self.material_selectors
+        material_inputs = self.material_inputs
+        for name in layer_names:
+            material = getattr(physics, f'{name}_material')
+            if material not in all_options[name]:
+                w = material_inputs[name]
+                w.setText(material)
+            else:
+                w = material_selectors[name]
+                w.setCurrentText(material)
+
+            for key in ('density', 'thickness'):
+                attr = f'{name}_{key}'
+                w = getattr(self.ui, attr)
+                w.setValue(getattr(physics, attr))
+
+        self.update_layer_enable_states()
 
     def draw_diagram(self):
-        window = self.ui.show_window.isChecked()
-        pinhole = self.ui.show_pinhole.isChecked()
-        self.diagram.update_diagram(window, pinhole)
+        show_dict = {
+            k: getattr(self.ui, f'show_{k}').isChecked()
+            for k in self.non_sample_layer_names
+        }
+        self.diagram.update_diagram(show_dict)
 
-    def toggle_window(self, enabled):
-        self.ui.window_tab.setEnabled(enabled)
+    def toggle_layer(self, enabled: bool, name: str):
+        w = getattr(self.ui, f'{name}_tab')
+        w.setEnabled(enabled)
         self.draw_diagram()
 
-    def toggle_pinhole(self, enabled):
-        self.ui.pinhole_tab.setEnabled(enabled)
-        self.draw_diagram()
+    def update_layer_enable_states(self):
+        for name in self.non_sample_layer_names:
+            enable = self.layer_thickness(name) != 0.0
+            self.set_layer_enabled(name, enable)
+
+    def set_layer_enabled(self, name: str, enable: bool):
+        w = getattr(self.ui, f'show_{name}')
+        w.setChecked(enable)
+
+    def layer_enabled(self, name: str) -> bool:
+        w = getattr(self.ui, f'{name}_tab')
+        return w.isEnabled()
+
+    def layer_thickness(self, name: str) -> float:
+        if not self.layer_enabled(name):
+            return 0.0
+
+        w = getattr(self.ui, f'{name}_thickness')
+        return w.value()
 
     def material_changed(self, index, category):
         material = self.material_selectors[category].currentText()
@@ -212,7 +253,8 @@ class PhysicsPackageManagerDialog:
             self.density_inputs[category].setValue(0.0)
 
         if HexrdConfig().has_physics_package:
-            self.ui.absorption_length.setValue(HexrdConfig().absorption_length())
+            self.ui.absorption_length.setValue(
+                HexrdConfig().absorption_length())
 
     def accept_changes(self):
         materials = {}
@@ -223,17 +265,14 @@ class PhysicsPackageManagerDialog:
                 materials[key] = selector.currentText()
 
         kwargs = {
-            'sample_material': materials['sample'],
-            'sample_density': self.ui.sample_density.value(),
-            'sample_thickness': self.ui.sample_thickness.value(),
-            'window_material': materials['window'],
-            'window_density': self.ui.window_density.value(),
-            'window_thickness': self.ui.window_thickness.value(),
-            'pinhole_material': materials['pinhole'],
             'pinhole_diameter': self.ui.pinhole_diameter.value(),
-            'pinhole_thickness': self.ui.pinhole_thickness.value(),
-            'pinhole_density': self.ui.pinhole_density.value(),
         }
+        for name in self.layer_names:
+            kwargs[f'{name}_material'] = materials[name]
+            for key in ('density', 'thickness'):
+                attr = f'{name}_{key}'
+                kwargs[attr] = getattr(self.ui, attr).value()
+
         HexrdConfig().update_physics_package(**kwargs)
 
         if HexrdConfig().apply_absorption_correction:
@@ -243,7 +282,6 @@ class PhysicsPackageManagerDialog:
 
 class PhysicsPackageDiagram:
 
-    offset = 0.20
     patches = {
         'laser drive': Polygon(
             [(0.05, 0.2), (0.05, 0.8), (0.2, 0.75), (0.2, 0.25)],
@@ -273,7 +311,6 @@ class PhysicsPackageDiagram:
         self.ax = self.fig.add_subplot()
         self.ax.set_axis_off()
         self.ax.set_aspect(1)
-        self.update_diagram()
 
     def clear(self):
         for text, patch in zip(self.ax.texts, self.ax.patches):
@@ -294,24 +331,29 @@ class PhysicsPackageDiagram:
         self.ax.text(x, y, label, ha='center', va='center',
                      rotation=90, fontsize='small')
 
-    def update_diagram(self, show_window=True, show_pinhole=True):
+    def update_diagram(self, show_dict: dict[str, bool]):
         self.clear()
         count = 0
+        offset = 0
         for key, patch in self.patches.items():
             p = copy.deepcopy(patch)
-            if key == 'window' and not show_window:
+            if not show_dict.get(key, True):
+                # Compute width of the patch and adjust the offset
+                if isinstance(p, Polygon):
+                    xy = p.get_xy()
+                    width = xy[:, 0].max() - xy[:, 0].min()
+                else:
+                    width = p.get_width()
+
+                offset -= width
                 continue
-            if key == 'pinhole':
-                if not show_pinhole:
-                    continue
-                if not show_window:
-                    # Shift the pinhole over since no window is present
-                    p.xy[:, 0] -= self.offset
-            # Add some spacing between each layer
+
+            # Apply offset, and add some spacing between each layer
             if isinstance(p, Polygon):
-                p.xy[:, 0] += count * 0.01
+                p.xy[:, 0] += (offset + count * 0.01)
             elif isinstance(p, Rectangle):
-                p.set_x(p.xy[0] + count * 0.01)
+                p.set_x(p.xy[0] + offset + count * 0.01)
+
             self.ax.add_patch(p)
             self.add_text(p, key)
             count += 1

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -42,6 +42,8 @@ class PinholeCorrectionEditor(QObject):
         self.ui.correction_type.setCurrentIndex(0)
         self.correction_type_changed()
 
+        self.setup_layer_options()
+
         self.load_pinhole_materials()
         self.populate_rygg_absorption_length_options()
         self.on_rygg_absorption_length_selector_changed()
@@ -76,6 +78,10 @@ class PinholeCorrectionEditor(QObject):
 
         self.ui.apply_to_polar_view.toggled.connect(
             self.on_apply_to_polar_view_toggled)
+
+    def setup_layer_options(self):
+        labels = list(REVERSED_LAYER_TYPES)
+        self.ui.layer_type.addItems(labels)
 
     def synchronize_values(self):
         with block_signals(*self.all_widgets):
@@ -133,7 +139,7 @@ class PinholeCorrectionEditor(QObject):
         if dtype is None:
             return None
         elif dtype == 'LayerDistortion':
-            layer_type = self.ui.layer_type.currentText().lower()
+            layer_type = REVERSED_LAYER_TYPES[self.ui.layer_type.currentText()]
             return {
                 'layer_type': layer_type,
                 'layer_standoff': physics.layer_standoff(layer_type) * 1e-3,
@@ -215,6 +221,10 @@ class PinholeCorrectionEditor(QObject):
                 value = vp.get(key, value)
 
             w = getattr(self.ui, w_name)
+
+            if key == 'layer_type':
+                # Map it to the combobox name
+                value = LAYER_TYPES[value]
 
             if isinstance(w, QComboBox):
                 f = w.setCurrentText
@@ -585,3 +595,13 @@ TYPE_MAP = {
     'RyggPinholeDistortion': RyggPinholeDistortion,
 }
 REVERSED_TYPE_MAP = {v: k for k, v in TYPE_MAP.items()}
+
+LAYER_TYPES = {
+    'ablator': 'Ablator',
+    'heatshield': 'Heatshield',
+    'pusher': 'Pusher',
+    'sample': 'Sample',
+    'reflective': 'Reflective Coating',
+    'window': 'Window',
+}
+REVERSED_LAYER_TYPES = {v: k for k, v in LAYER_TYPES.items()}

--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -9,7 +9,7 @@ from PySide6.QtWidgets import (
 import hexrd.resources
 from hexrd.material import _angstroms, _kev, Material
 from hexrd.xrdutil.phutil import (
-    JHEPinholeDistortion, RyggPinholeDistortion, SampleLayerDistortion,
+    JHEPinholeDistortion, RyggPinholeDistortion, LayerDistortion,
 )
 
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
@@ -48,6 +48,8 @@ class PinholeCorrectionEditor(QObject):
         self.setup_connections()
 
     def setup_connections(self):
+        self.ui.layer_type.currentIndexChanged.connect(self.update_gui)
+
         for w in self.all_widgets:
             if isinstance(w, (QDoubleSpinBox, QSpinBox)):
                 w.valueChanged.connect(self.on_settings_modified)
@@ -98,7 +100,7 @@ class PinholeCorrectionEditor(QObject):
             'None': None,
             'Pinhole (JHE)': 'JHEPinholeDistortion',
             'Pinhole (Rygg)': 'RyggPinholeDistortion',
-            'Sample Layer': 'SampleLayerDistortion',
+            'Layer': 'LayerDistortion',
         }
         if v in conversions:
             v = conversions[v]
@@ -111,12 +113,18 @@ class PinholeCorrectionEditor(QObject):
             None: 'None',
             'JHEPinholeDistortion': 'Pinhole (JHE)',
             'RyggPinholeDistortion': 'Pinhole (Rygg)',
-            'SampleLayerDistortion': 'Sample Layer',
+            'LayerDistortion': 'Layer',
         }
         if v in conversions:
             v = conversions[v]
 
         self.ui.correction_type.setCurrentText(v)
+
+    def update_gui(self):
+        # This will trigger any needed updates
+        # The getter grabs values from the physics package, while
+        # the setter sets values in the UI.
+        self.correction_kwargs = self.correction_kwargs
 
     @property
     def correction_kwargs(self):
@@ -124,10 +132,12 @@ class PinholeCorrectionEditor(QObject):
         physics = HexrdConfig().physics_package
         if dtype is None:
             return None
-        elif dtype == 'SampleLayerDistortion':
+        elif dtype == 'LayerDistortion':
+            layer_type = self.ui.layer_type.currentText().lower()
             return {
-                'layer_standoff': physics.window_thickness * 1e-3,
-                'layer_thickness': physics.sample_thickness * 1e-3,
+                'layer_type': layer_type,
+                'layer_standoff': physics.layer_standoff(layer_type) * 1e-3,
+                'layer_thickness': physics.layer_thickness(layer_type) * 1e-3,
                 'pinhole_thickness': physics.pinhole_thickness * 1e-3,
                 'pinhole_radius': physics.pinhole_radius * 1e-3,
             }
@@ -162,7 +172,7 @@ class PinholeCorrectionEditor(QObject):
         vp = v.copy()
         # These units are in mm, but we display in micrometers
         for key, value in v.items():
-            if key in ('num_phi_elements', 'absorption_length'):
+            if key in ('num_phi_elements', 'absorption_length', 'layer_type'):
                 multiplier = 1
             else:
                 multiplier = 1e3
@@ -171,14 +181,13 @@ class PinholeCorrectionEditor(QObject):
 
         # Values are (key, default)
         values = {
-            'sample_layer_standoff': ('layer_standoff',
-                                      physics.window_thickness),
-            'sample_layer_thickness': ('layer_thickness',
-                                       physics.sample_thickness),
-            'sample_pinhole_thickness': ('pinhole_thickness',
-                                         physics.pinhole_thickness),
-            'sample_pinhole_diameter': ('pinhole_diameter',
-                                        physics.pinhole_diameter),
+            'layer_type': ('layer_type', 'sample'),
+            'layer_standoff': ('layer_standoff', physics.window_thickness),
+            'layer_thickness': ('layer_thickness', physics.sample_thickness),
+            'layer_pinhole_thickness': ('layer_pinhole_thickness',
+                                        physics.pinhole_thickness),
+            'layer_pinhole_diameter': ('layer_pinhole_diameter',
+                                       physics.pinhole_diameter),
             'rygg_diameter': ('pinhole_diameter', physics.pinhole_diameter),
             'rygg_thickness': ('pinhole_thickness', physics.pinhole_thickness),
             'rygg_num_phi_elements': ('num_phi_elements', 30),
@@ -189,8 +198,8 @@ class PinholeCorrectionEditor(QObject):
         }
 
         dtype = self.correction_type
-        if dtype == 'SampleLayerDistortion':
-            widget_prefix = 'sample_'
+        if dtype == 'LayerDistortion':
+            widget_prefix = 'layer_'
         elif dtype == 'RyggPinholeDistortion':
             widget_prefix = 'rygg_'
         elif dtype == 'JHEPinholeDistortion':
@@ -206,18 +215,24 @@ class PinholeCorrectionEditor(QObject):
                 value = vp.get(key, value)
 
             w = getattr(self.ui, w_name)
-            w.setValue(value)
+
+            if isinstance(w, QComboBox):
+                f = w.setCurrentText
+            else:
+                f = w.setValue
+            f(value)
 
         if dtype == 'RyggPinholeDistortion':
             self.auto_select_rygg_absorption_length()
 
     @property
-    def sample_layer_widgets(self):
+    def layer_widgets(self):
         return [
-            self.ui.sample_layer_standoff,
-            self.ui.sample_layer_thickness,
-            self.ui.sample_pinhole_thickness,
-            self.ui.sample_pinhole_diameter,
+            self.ui.layer_type,
+            self.ui.layer_standoff,
+            self.ui.layer_thickness,
+            self.ui.layer_pinhole_thickness,
+            self.ui.layer_pinhole_diameter,
         ]
 
     @property
@@ -254,7 +269,7 @@ class PinholeCorrectionEditor(QObject):
     def all_widgets(self):
         # Except for the correction type
         return [
-            *self.sample_layer_widgets,
+            *self.layer_widgets,
             *self.jhe_widgets,
             *self.rygg_widgets,
             *self.apply_panel_buffer_buttons,
@@ -295,7 +310,7 @@ class PinholeCorrectionEditor(QObject):
             QMessageBox.critical(self.ui, 'HEXRD', msg)
 
         source_distance_needed_types = (
-            'SampleLayerDistortion',
+            'LayerDistortion',
             'RyggPinholeDistortion',
         )
         if self.correction_type in source_distance_needed_types:
@@ -565,7 +580,7 @@ class PinholeCorrectionEditor(QObject):
 
 
 TYPE_MAP = {
-    'SampleLayerDistortion': SampleLayerDistortion,
+    'LayerDistortion': LayerDistortion,
     'JHEPinholeDistortion': JHEPinholeDistortion,
     'RyggPinholeDistortion': RyggPinholeDistortion,
 }

--- a/hexrdgui/polar_distortion_object.py
+++ b/hexrdgui/polar_distortion_object.py
@@ -1,7 +1,7 @@
 from hexrd.xrdutil.phutil import (
     polar_tth_corr_map_rygg_pinhole, JHEPinholeDistortion,
-    RyggPinholeDistortion, SampleLayerDistortion, tth_corr_map_pinhole,
-    tth_corr_map_rygg_pinhole, tth_corr_map_sample_layer,
+    RyggPinholeDistortion, LayerDistortion, tth_corr_map_pinhole,
+    tth_corr_map_rygg_pinhole, tth_corr_map_layer,
 )
 
 
@@ -33,7 +33,7 @@ class PolarDistortionObject:
             None: False,
             'JHEPinholeDistortion': False,
             'RyggPinholeDistortion': True,
-            'SampleLayerDistortion': False,
+            'LayerDistortion': False,
         }
 
         if self.pinhole_distortion_type not in rets:
@@ -54,7 +54,7 @@ class PolarDistortionObject:
         funcs = {
             'JHEPinholeDistortion': tth_corr_map_pinhole,
             'RyggPinholeDistortion': tth_corr_map_rygg_pinhole,
-            'SampleLayerDistortion': tth_corr_map_sample_layer,
+            'LayerDistortion': tth_corr_map_layer,
         }
 
         if self.pinhole_distortion_type not in funcs:
@@ -66,6 +66,9 @@ class PolarDistortionObject:
             **self.pinhole_distortion_kwargs,
             'instrument': instr,
         }
+        if 'layer_type' in kwargs:
+            # The tth_corr_map functions don't take this
+            kwargs.pop('layer_type')
 
         return f(**kwargs)
 
@@ -105,17 +108,18 @@ class PolarDistortionObject:
             }
             return RyggPinholeDistortion(**kwargs)
 
-        def tth_sample_layer_distortion(panel):
+        def tth_layer_distortion(panel):
             kwargs = {
                 **self.pinhole_distortion_kwargs,
                 'panel': panel,
             }
-            return SampleLayerDistortion(**kwargs)
+            kwargs.setdefault('layer_type', 'sample')
+            return LayerDistortion(**kwargs)
 
         known_types = {
             'JHEPinholeDistortion': tth_jhe_pinhole_distortion,
             'RyggPinholeDistortion': tth_rygg_pinhole_distortion,
-            'SampleLayerDistortion': tth_sample_layer_distortion,
+            'LayerDistortion': tth_layer_distortion,
         }
 
         if self.pinhole_distortion_type not in known_types:

--- a/hexrdgui/powder_overlay_editor.py
+++ b/hexrdgui/powder_overlay_editor.py
@@ -414,8 +414,8 @@ class PowderOverlayEditor:
                 return
 
             if self.pinhole_correction_type is None:
-                # Since we hide None, let's switch to sample layer offset
-                self.pinhole_correction_type = 'SampleLayerDistortion'
+                # Since we hide None, let's switch to layer distortion
+                self.pinhole_correction_type = 'LayerDistortion'
 
         self.update_config()
 

--- a/hexrdgui/resources/ui/image_mode_widget.ui
+++ b/hexrdgui/resources/ui/image_mode_widget.ui
@@ -794,7 +794,7 @@
                  <bool>true</bool>
                 </property>
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Pinhole Camera Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                 <property name="text">
                  <string>Apply 2θ distortion?</string>
@@ -807,7 +807,7 @@
                  <bool>false</bool>
                 </property>
                 <property name="toolTip">
-                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Sample Layer Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Apply 2θ distortion from an overlay to the polar view.&lt;/p&gt;&lt;p&gt;2θ distortion may only be applied using an overlay that has Pinhole Camera Distortion enabled.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                 </property>
                </widget>
               </item>

--- a/hexrdgui/resources/ui/physics_package_manager_dialog.ui
+++ b/hexrdgui/resources/ui/physics_package_manager_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>793</width>
-    <height>438</height>
+    <width>1243</width>
+    <height>524</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -91,9 +91,29 @@
          </widget>
         </item>
         <item>
-         <widget class="QCheckBox" name="show_pinhole">
+         <widget class="QCheckBox" name="show_ablator">
           <property name="text">
-           <string>Pinhole</string>
+           <string>Ablator</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="show_heatshield">
+          <property name="text">
+           <string>Heatshield</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="show_pusher">
+          <property name="text">
+           <string>Pusher</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -104,6 +124,16 @@
          <widget class="QCheckBox" name="show_window">
           <property name="text">
            <string>Window</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="show_pinhole">
+          <property name="text">
+           <string>Pinhole</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -152,6 +182,9 @@
           <property name="text">
            <string>Package Type</string>
           </property>
+          <property name="buddy">
+           <cstring>comboBox</cstring>
+          </property>
          </widget>
         </item>
         <item>
@@ -195,8 +228,248 @@
          <enum>QTabWidget::North</enum>
         </property>
         <property name="currentIndex">
-         <number>0</number>
+         <number>3</number>
         </property>
+        <widget class="QWidget" name="ablator_tab">
+         <attribute name="title">
+          <string>Ablator</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="2" column="0">
+           <widget class="QLabel" name="ablator_density_label">
+            <property name="text">
+             <string>Density</string>
+            </property>
+            <property name="buddy">
+             <cstring>ablator_density</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <spacer name="ablator_vertical_spacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>160</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="ablator_material_label">
+            <property name="text">
+             <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>ablator_material</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="6">
+           <widget class="QLineEdit" name="ablator_material_input">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="ablator_thickness_label">
+            <property name="text">
+             <string>Thickness</string>
+            </property>
+            <property name="buddy">
+             <cstring>ablator_thickness</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="ablator_thickness">
+            <property name="suffix">
+             <string> μm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="ablator_density">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> g/cc</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="5">
+           <widget class="QComboBox" name="ablator_material"/>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="heatshield_tab">
+         <attribute name="title">
+          <string>Heatshield</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_7">
+          <item row="0" column="0">
+           <widget class="QLabel" name="heatshield_material_label">
+            <property name="text">
+             <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>heatshield_material</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <spacer name="heatshield_vertical_spacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>160</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0" colspan="6">
+           <widget class="QLineEdit" name="heatshield_material_input">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="heatshield_thickness_label">
+            <property name="text">
+             <string>Thickness</string>
+            </property>
+            <property name="buddy">
+             <cstring>heatshield_thickness</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="heatshield_density_label">
+            <property name="text">
+             <string>Density</string>
+            </property>
+            <property name="buddy">
+             <cstring>heatshield_density</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="heatshield_thickness">
+            <property name="suffix">
+             <string> μm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="heatshield_density">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> g/cc</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="5">
+           <widget class="QComboBox" name="heatshield_material"/>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="pusher_tab">
+         <attribute name="title">
+          <string>Pusher</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_8">
+          <item row="0" column="0">
+           <widget class="QLabel" name="pusher_material_label">
+            <property name="text">
+             <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>pusher_material</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <spacer name="pusher_vertical_spacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>160</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="1" column="0" colspan="6">
+           <widget class="QLineEdit" name="pusher_material_input">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="pusher_density_label">
+            <property name="text">
+             <string>Density</string>
+            </property>
+            <property name="buddy">
+             <cstring>pusher_density</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="pusher_thickness_label">
+            <property name="text">
+             <string>Thickness</string>
+            </property>
+            <property name="buddy">
+             <cstring>pusher_thickness</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="pusher_thickness">
+            <property name="suffix">
+             <string> μm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="pusher_density">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> g/cc</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="5">
+           <widget class="QComboBox" name="pusher_material"/>
+          </item>
+         </layout>
+        </widget>
         <widget class="QWidget" name="sample_tab">
          <attribute name="title">
           <string>Sample</string>
@@ -206,6 +479,9 @@
            <widget class="QLabel" name="sample_density_label">
             <property name="text">
              <string>Density</string>
+            </property>
+            <property name="buddy">
+             <cstring>sample_density</cstring>
             </property>
            </widget>
           </item>
@@ -241,12 +517,18 @@
             <property name="text">
              <string>Thickness</string>
             </property>
+            <property name="buddy">
+             <cstring>sample_thickness</cstring>
+            </property>
            </widget>
           </item>
           <item row="0" column="0">
            <widget class="QLabel" name="sample_material_label">
             <property name="text">
              <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>sample_material</cstring>
             </property>
            </widget>
           </item>
@@ -255,6 +537,86 @@
           </item>
           <item row="5" column="0">
            <spacer name="sample_vertical_spacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="window_tab">
+         <attribute name="title">
+          <string>Window</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_2">
+          <item row="3" column="1" colspan="3">
+           <widget class="ScientificDoubleSpinBox" name="window_thickness">
+            <property name="suffix">
+             <string> μm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="window_material_label">
+            <property name="text">
+             <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>window_material</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="3">
+           <widget class="QComboBox" name="window_material"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="window_density_label">
+            <property name="text">
+             <string>Density</string>
+            </property>
+            <property name="buddy">
+             <cstring>window_density</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="window_thickness_label">
+            <property name="text">
+             <string>Thickness</string>
+            </property>
+            <property name="buddy">
+             <cstring>window_thickness</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="3">
+           <widget class="ScientificDoubleSpinBox" name="window_density">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> g/cc</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0" colspan="4">
+           <widget class="QLineEdit" name="window_material_input">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <spacer name="window_vertical_spacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
             </property>
@@ -277,6 +639,9 @@
            <widget class="QLabel" name="pinhole_material_label">
             <property name="text">
              <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>pinhole_material</cstring>
             </property>
            </widget>
           </item>
@@ -321,12 +686,18 @@
             <property name="text">
              <string>Thickness</string>
             </property>
+            <property name="buddy">
+             <cstring>pinhole_thickness</cstring>
+            </property>
            </widget>
           </item>
           <item row="4" column="0">
            <widget class="QLabel" name="pinhole_diameter_label">
             <property name="text">
              <string>Diameter</string>
+            </property>
+            <property name="buddy">
+             <cstring>pinhole_diameter</cstring>
             </property>
            </widget>
           </item>
@@ -342,6 +713,9 @@
             <property name="text">
              <string>Density</string>
             </property>
+            <property name="buddy">
+             <cstring>pinhole_density</cstring>
+            </property>
            </widget>
           </item>
           <item row="4" column="1" colspan="3">
@@ -356,6 +730,9 @@
             <property name="text">
              <string>Absorption Length</string>
             </property>
+            <property name="buddy">
+             <cstring>absorption_length</cstring>
+            </property>
            </widget>
           </item>
           <item row="5" column="1" colspan="3">
@@ -364,77 +741,6 @@
              <double>0.100000000000000</double>
             </property>
            </widget>
-          </item>
-         </layout>
-        </widget>
-        <widget class="QWidget" name="window_tab">
-         <attribute name="title">
-          <string>Window</string>
-         </attribute>
-         <layout class="QGridLayout" name="gridLayout_2">
-          <item row="3" column="1" colspan="3">
-           <widget class="ScientificDoubleSpinBox" name="window_thickness">
-            <property name="suffix">
-             <string> μm</string>
-            </property>
-            <property name="singleStep">
-             <double>0.100000000000000</double>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="window_material_label">
-            <property name="text">
-             <string>Material</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="3">
-           <widget class="QComboBox" name="window_material"/>
-          </item>
-          <item row="2" column="0">
-           <widget class="QLabel" name="window_density_label">
-            <property name="text">
-             <string>Density</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
-           <widget class="QLabel" name="window_thickness_label">
-            <property name="text">
-             <string>Thickness</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1" colspan="3">
-           <widget class="ScientificDoubleSpinBox" name="window_density">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="suffix">
-             <string> g/cc</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0" colspan="4">
-           <widget class="QLineEdit" name="window_material_input">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <spacer name="window_vertical_spacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
           </item>
          </layout>
         </widget>
@@ -453,33 +759,39 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>show_ablator</tabstop>
+  <tabstop>show_heatshield</tabstop>
+  <tabstop>show_pusher</tabstop>
+  <tabstop>show_window</tabstop>
+  <tabstop>show_pinhole</tabstop>
+  <tabstop>comboBox</tabstop>
   <tabstop>tab_widget</tabstop>
+  <tabstop>ablator_material</tabstop>
+  <tabstop>ablator_material_input</tabstop>
+  <tabstop>ablator_density</tabstop>
+  <tabstop>ablator_thickness</tabstop>
+  <tabstop>heatshield_material</tabstop>
+  <tabstop>heatshield_material_input</tabstop>
+  <tabstop>heatshield_density</tabstop>
+  <tabstop>heatshield_thickness</tabstop>
+  <tabstop>pusher_material</tabstop>
+  <tabstop>pusher_material_input</tabstop>
+  <tabstop>pusher_density</tabstop>
+  <tabstop>pusher_thickness</tabstop>
   <tabstop>sample_material</tabstop>
   <tabstop>sample_material_input</tabstop>
   <tabstop>sample_density</tabstop>
   <tabstop>sample_thickness</tabstop>
+  <tabstop>window_material</tabstop>
+  <tabstop>window_material_input</tabstop>
+  <tabstop>window_density</tabstop>
+  <tabstop>window_thickness</tabstop>
   <tabstop>pinhole_material</tabstop>
   <tabstop>pinhole_material_input</tabstop>
   <tabstop>pinhole_density</tabstop>
   <tabstop>pinhole_thickness</tabstop>
   <tabstop>pinhole_diameter</tabstop>
-  <tabstop>window_material</tabstop>
-  <tabstop>window_material_input</tabstop>
-  <tabstop>window_density</tabstop>
-  <tabstop>window_thickness</tabstop>
-  <tabstop>sample_material</tabstop>
-  <tabstop>sample_density</tabstop>
-  <tabstop>pinhole_material</tabstop>
-  <tabstop>pinhole_material_input</tabstop>
-  <tabstop>pinhole_density</tabstop>
-  <tabstop>pinhole_thickness</tabstop>
-  <tabstop>pinhole_diameter</tabstop>
-  <tabstop>window_material</tabstop>
-  <tabstop>window_material_input</tabstop>
-  <tabstop>window_density</tabstop>
-  <tabstop>window_thickness</tabstop>
-  <tabstop>sample_thickness</tabstop>
-  <tabstop>sample_material_input</tabstop>
+  <tabstop>absorption_length</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrdgui/resources/ui/physics_package_manager_dialog.ui
+++ b/hexrdgui/resources/ui/physics_package_manager_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1243</width>
-    <height>524</height>
+    <width>1298</width>
+    <height>527</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -114,6 +114,16 @@
          <widget class="QCheckBox" name="show_pusher">
           <property name="text">
            <string>Pusher</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QCheckBox" name="show_reflective">
+          <property name="text">
+           <string>Reflective</string>
           </property>
           <property name="checked">
            <bool>true</bool>
@@ -550,6 +560,86 @@
           </item>
          </layout>
         </widget>
+        <widget class="QWidget" name="reflective_tab">
+         <attribute name="title">
+          <string>Reflective</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_9">
+          <item row="1" column="0" colspan="6">
+           <widget class="QLineEdit" name="reflective_material_input">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="reflective_density_label">
+            <property name="text">
+             <string>Density</string>
+            </property>
+            <property name="buddy">
+             <cstring>pusher_density</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="reflective_thickness_label">
+            <property name="text">
+             <string>Thickness</string>
+            </property>
+            <property name="buddy">
+             <cstring>pusher_thickness</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="reflective_material_label">
+            <property name="text">
+             <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>pusher_material</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <spacer name="reflective_vertical_spacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="3" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="reflective_thickness">
+            <property name="suffix">
+             <string> μm</string>
+            </property>
+            <property name="singleStep">
+             <double>0.100000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1" colspan="5">
+           <widget class="ScientificDoubleSpinBox" name="reflective_density">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="suffix">
+             <string> g/cc</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="5">
+           <widget class="QComboBox" name="reflective_material"/>
+          </item>
+         </layout>
+        </widget>
         <widget class="QWidget" name="window_tab">
          <attribute name="title">
           <string>Window</string>
@@ -762,6 +852,7 @@
   <tabstop>show_ablator</tabstop>
   <tabstop>show_heatshield</tabstop>
   <tabstop>show_pusher</tabstop>
+  <tabstop>show_reflective</tabstop>
   <tabstop>show_window</tabstop>
   <tabstop>show_pinhole</tabstop>
   <tabstop>comboBox</tabstop>
@@ -782,6 +873,10 @@
   <tabstop>sample_material_input</tabstop>
   <tabstop>sample_density</tabstop>
   <tabstop>sample_thickness</tabstop>
+  <tabstop>reflective_material</tabstop>
+  <tabstop>reflective_material_input</tabstop>
+  <tabstop>reflective_density</tabstop>
+  <tabstop>reflective_thickness</tabstop>
   <tabstop>window_material</tabstop>
   <tabstop>window_material_input</tabstop>
   <tabstop>window_density</tabstop>

--- a/hexrdgui/resources/ui/pinhole_correction_editor.ui
+++ b/hexrdgui/resources/ui/pinhole_correction_editor.ui
@@ -184,33 +184,8 @@
        <item row="1" column="0">
         <widget class="QComboBox" name="layer_type">
          <property name="currentIndex">
-          <number>1</number>
+          <number>-1</number>
          </property>
-         <item>
-          <property name="text">
-           <string>Window</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Sample</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Pusher</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Heatshield</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Ablator</string>
-          </property>
-         </item>
         </widget>
        </item>
        <item row="1" column="1">

--- a/hexrdgui/resources/ui/pinhole_correction_editor.ui
+++ b/hexrdgui/resources/ui/pinhole_correction_editor.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>815</width>
-    <height>309</height>
+    <height>310</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -42,27 +42,58 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="none_tab">
       <attribute name="title">
        <string>None</string>
       </attribute>
      </widget>
-     <widget class="QWidget" name="sample_layer_tab">
+     <widget class="QWidget" name="layer_tab">
       <attribute name="title">
-       <string>Sample Layer</string>
+       <string>Layer</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_4">
-       <item row="2" column="2">
-        <widget class="QLabel" name="label">
+       <item row="0" column="2">
+        <widget class="QLabel" name="layer_pinhole_thickness_label">
          <property name="text">
-          <string>Pinhole Diameter</string>
+          <string>Pinhole Thickness</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="ScientificDoubleSpinBox" name="sample_layer_standoff">
+       <item row="3" column="2">
+        <widget class="ScientificDoubleSpinBox" name="layer_pinhole_diameter">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>30</height>
+          </size>
+         </property>
+         <property name="keyboardTracking">
+          <bool>false</bool>
+         </property>
+         <property name="suffix">
+          <string> μm</string>
+         </property>
+         <property name="decimals">
+          <number>8</number>
+         </property>
+         <property name="maximum">
+          <double>100000000.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.010000000000000</double>
+         </property>
+         <property name="value">
+          <double>200.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="ScientificDoubleSpinBox" name="layer_thickness">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -82,7 +113,7 @@
           <number>8</number>
          </property>
          <property name="minimum">
-          <double>0.100000000000000</double>
+          <double>0.000000000000000</double>
          </property>
          <property name="maximum">
           <double>10000000.000000000000000</double>
@@ -91,12 +122,33 @@
           <double>0.010000000000000</double>
          </property>
          <property name="value">
-          <double>150.000000000000000</double>
+          <double>5.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLabel" name="layer_thickness_label">
+         <property name="text">
+          <string>Layer Thickness</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="layer_type_label">
+         <property name="text">
+          <string>Layer Type</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QLabel" name="layer_pinhole_diameter_label">
+         <property name="text">
+          <string>Pinhole Diameter</string>
          </property>
         </widget>
        </item>
        <item row="1" column="2">
-        <widget class="ScientificDoubleSpinBox" name="sample_pinhole_thickness">
+        <widget class="ScientificDoubleSpinBox" name="layer_pinhole_thickness">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -129,8 +181,40 @@
          </property>
         </widget>
        </item>
+       <item row="1" column="0">
+        <widget class="QComboBox" name="layer_type">
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Window</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Sample</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Pusher</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Heatshield</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Ablator</string>
+          </property>
+         </item>
+        </widget>
+       </item>
        <item row="1" column="1">
-        <widget class="ScientificDoubleSpinBox" name="sample_layer_thickness">
+        <widget class="ScientificDoubleSpinBox" name="layer_standoff">
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -150,7 +234,7 @@
           <number>8</number>
          </property>
          <property name="minimum">
-          <double>0.100000000000000</double>
+          <double>0.000000000000000</double>
          </property>
          <property name="maximum">
           <double>10000000.000000000000000</double>
@@ -159,59 +243,7 @@
           <double>0.010000000000000</double>
          </property>
          <property name="value">
-          <double>5.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="sample_layer_standoff_label">
-         <property name="text">
-          <string>Layer Standoff</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="sample_layer_thickness_label">
-         <property name="text">
-          <string>Layer Thickness</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="sample_pinhole_thickness_label">
-         <property name="text">
-          <string>Pinhole Thickness</string>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="2">
-        <widget class="ScientificDoubleSpinBox" name="sample_pinhole_diameter">
-         <property name="enabled">
-          <bool>false</bool>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>30</height>
-          </size>
-         </property>
-         <property name="keyboardTracking">
-          <bool>false</bool>
-         </property>
-         <property name="suffix">
-          <string> μm</string>
-         </property>
-         <property name="decimals">
-          <number>8</number>
-         </property>
-         <property name="maximum">
-          <double>100000000.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.010000000000000</double>
-         </property>
-         <property name="value">
-          <double>200.000000000000000</double>
+          <double>150.000000000000000</double>
          </property>
         </widget>
        </item>
@@ -227,6 +259,13 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="layer_standoff_label">
+         <property name="text">
+          <string>Layer Standoff</string>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>
@@ -533,7 +572,7 @@
      </item>
      <item>
       <property name="text">
-       <string>Sample Layer</string>
+       <string>Layer</string>
       </property>
      </item>
      <item>
@@ -591,10 +630,8 @@ This will override any overlays that are currently being used for polar distorti
  <tabstops>
   <tabstop>correction_type</tabstop>
   <tabstop>tab_widget</tabstop>
-  <tabstop>sample_layer_standoff</tabstop>
-  <tabstop>sample_layer_thickness</tabstop>
-  <tabstop>sample_pinhole_thickness</tabstop>
-  <tabstop>sample_pinhole_diameter</tabstop>
+  <tabstop>layer_pinhole_thickness</tabstop>
+  <tabstop>layer_pinhole_diameter</tabstop>
   <tabstop>rygg_diameter</tabstop>
   <tabstop>rygg_thickness</tabstop>
   <tabstop>rygg_num_phi_elements</tabstop>

--- a/hexrdgui/utils/physics_package.py
+++ b/hexrdgui/utils/physics_package.py
@@ -16,3 +16,42 @@ def ask_to_create_physics_package_if_missing() -> bool:
         return True
 
     return False
+
+
+def make_physics_package_from_old_overlay_config(overlay_config: list[dict]):
+    # This function is only present for backward-compatibility with older
+    # state files.
+    # In the past, settings such as the sample layer and window thickness
+    # were set individually on each overlay, and did not have global settings
+    # stored in the physics package. If we load a state file that was set
+    # up this way, we'll read some of the settings and set up the physics
+    # package accordingly.
+    if HexrdConfig().has_physics_package:
+        return
+
+    HexrdConfig().create_default_physics_package()
+    physics = HexrdConfig().physics_package
+
+    for overlay_dict in overlay_config:
+        distortion_type = overlay_dict.get('tth_distortion_type')
+        if not distortion_type:
+            continue
+
+        # In the older state files, layer distortion was always called
+        # "SampleLayerDistortion"
+        settings = overlay_dict.get('tth_distortion_kwargs', {})
+        if distortion_type == 'SampleLayerDistortion':
+            if settings.get('layer_thickness'):
+                physics.sample_thickness = settings.get('layer_thickness') * 1e3
+            if settings.get('layer_standoff'):
+                physics.window_thickness = settings.get('layer_standoff') * 1e3
+            if settings.get('pinhole_thickness'):
+                physics.pinhole_thickness = settings['pinhole_thickness'] * 1e3
+        else:
+            # Assume it contains pinhole settings (Rygg or JHE)
+            if settings.get('pinhole_radius'):
+                physics.pinhole_radius = settings['pinhole_radius'] * 1e3
+            if settings.get('pinhole_diameter'):
+                physics.pinhole_diameter = settings['pinhole_diameter'] * 1e3
+            if settings.get('pinhole_thickness'):
+                physics.pinhole_thickness = settings['pinhole_thickness'] * 1e3


### PR DESCRIPTION
This adds layers for the ablator, heatshield, and pusher. The "Sample Layer" pinhole correction was now also generalized to a "Layer" pinhole correction, and the layer type is selected from a dropdown menu. The layer types include the ablator, heatshield, pusher, sample, and window. The layer standoff for each layer is correctly computed so that they may be used for two theta distortion.

This also fixes a bug where if a layer (such as window/pinhole) were disabled in the physics package, it would have an effect on the UI, but it wouldn't have an effect on the internal calculations. Now, if a layer is disabled, its thickness is set to 0 as well.

Depends on: hexrd/hexrd#795

Fixes: #1792