### PR TITLE
Fix issue where "aggregate" is disabled

### DIFF
--- a/hexrdgui/simple_image_series_dialog.py
+++ b/hexrdgui/simple_image_series_dialog.py
@@ -273,7 +273,14 @@ class SimpleImageSeriesDialog(QObject):
             return
 
         enable = True
-        total_frames = np.sum(self.total_frames) / len(self.dets)
+        if HexrdConfig().instrument_has_roi:
+            # Images might be used multiple times
+            # Just use the "super panels" instead of the "subpanels"
+            num_panels = len(HexrdConfig().detector_group_names)
+        else:
+            num_panels = len(self.dets)
+
+        total_frames = np.sum(self.total_frames) / num_panels
         if total_frames - self.empty_frames < 2:
             enable = False
         self.ui.aggregation.setEnabled(enable)


### PR DESCRIPTION
This issue would happen for composite instruments where the same file is used by multiple subpanels.

Basically, we were miscounting when we did the calculation to determine whether aggregation should be enabled. For example, for 32 subpanel Eiger, if there were less than 64 frames in the data, aggregation would be disabled. The new counting should fix that.