### PR TITLE
Allow changing line style and width for mask borders

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -2074,8 +2074,8 @@ class ImageCanvas(FigureCanvas):
             return
 
         kwargs = {
-            'lw': 1,
-            'linestyle': '--',
+            'lw': MaskManager().boundary_width,
+            'ls': MaskManager().boundary_style,
             'color': MaskManager().boundary_color
         }
         self._mask_boundary_artists += axis.plot(

--- a/hexrdgui/masking/mask_border_style_picker.py
+++ b/hexrdgui/masking/mask_border_style_picker.py
@@ -1,0 +1,60 @@
+from PySide6.QtCore import QObject
+from PySide6.QtGui import QColor
+from PySide6.QtWidgets import QColorDialog
+
+from hexrdgui.ui_loader import UiLoader
+
+
+class MaskBorderStylePicker(QObject):
+
+    def __init__(self, original_color, original_style, original_width, parent=None):
+        super().__init__(parent)
+
+        loader = UiLoader()
+        self.ui = loader.load_file('mask_border_style_picker.ui', parent)
+        self.original_color = original_color
+        self.original_style = original_style
+        self.original_width = original_width
+        self.color = original_color
+        self.style = original_style
+        self.width = original_width
+
+        self.setup_ui()
+        self.setup_connections()
+
+    def setup_ui(self):
+        self.ui.border_color.setText(self.original_color)
+        self.ui.border_color.setStyleSheet('QPushButton {background-color: %s}' % self.original_color)
+        self.ui.border_style.setCurrentText(self.original_style)
+        self.ui.border_size.setValue(self.original_width)
+
+    def exec(self):
+        self.ui.adjustSize()
+        return self.ui.exec()
+
+    def setup_connections(self):
+        self.ui.border_color.clicked.connect(self.pick_color)
+        self.ui.border_style.currentIndexChanged.connect(self.update_style)
+        self.ui.border_size.valueChanged.connect(self.update_width)
+        self.ui.button_box.rejected.connect(self.reject)
+
+    def pick_color(self):
+        dialog = QColorDialog(QColor(self.original_color), self.ui)
+        if dialog.exec():
+            self.color = dialog.selectedColor().name()
+            self.ui.border_color.setText(self.color)
+            self.ui.border_color.setStyleSheet('QPushButton {background-color: %s}' % self.color)
+
+    def update_style(self):
+        self.style = self.ui.border_style.currentText()
+
+    def update_width(self):
+        self.width = self.ui.border_size.value()
+
+    def reject(self):
+        self.color = self.original_color
+        self.style = self.original_style
+        self.width = self.original_width
+
+    def result(self):
+        return self.color, self.style, self.width

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -210,7 +210,8 @@ class MaskManager(QObject, metaclass=QSingleton):
         self.masks = {}
         self.view_mode = ViewType.raw
         self.boundary_color = '#000'  # Default to black
-
+        self.boundary_style = 'dashed'
+        self.boundary_width = 1
         self.setup_connections()
 
     @property
@@ -280,12 +281,18 @@ class MaskManager(QObject, metaclass=QSingleton):
     def write_single_mask(self, name):
         d = {
             name: self.masks[name].serialize(),
-            '__boundary_color': self.boundary_color
+            '__boundary_color': self.boundary_color,
+            '__boundary_style': self.boundary_style,
+            '__boundary_width': self.boundary_width,
         }
         self.export_masks_to_file.emit(d)
 
     def write_all_masks(self, h5py_group=None):
-        d = {'__boundary_color': self.boundary_color}
+        d = {
+            '__boundary_color': self.boundary_color,
+            '__boundary_style': self.boundary_style,
+            '__boundary_width': self.boundary_width,
+        }
         for name, mask_info in self.masks.items():
             d[name] = mask_info.serialize()
         if h5py_group:
@@ -304,8 +311,8 @@ class MaskManager(QObject, metaclass=QSingleton):
         actual_view_mode = self.view_mode
         self.view_mode = ViewType.raw
         for key, data in items.items():
-            if key == '__boundary_color':
-                self.boundary_color = data
+            if key.startswith('__boundary_'):
+                setattr(self, key.split('__', 1)[1], data)
                 continue
             elif data['mtype'] == MaskType.threshold:
                 new_mask = ThresholdMask.deserialize(data)

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -11,6 +11,7 @@ from PySide6.QtWidgets import (
 from PySide6.QtGui import QCursor, QColor
 
 
+from hexrdgui.masking.mask_border_style_picker import MaskBorderStylePicker
 from hexrdgui.utils import block_signals
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType, MaskStatus
@@ -56,7 +57,7 @@ class MaskManagerDialog(QObject):
         self.ui.show_all_boundaries.clicked.connect(self.show_all_boundaries)
         MaskManager().mask_mgr_dialog_update.connect(self.update_table)
         MaskManager().export_masks_to_file.connect(self.export_masks_to_file)
-        self.ui.border_color.clicked.connect(self.set_boundary_color)
+        self.ui.border_style.clicked.connect(self.edit_style)
 
     def update_table(self):
         with block_signals(self.ui.masks_table):
@@ -250,8 +251,15 @@ class MaskManagerDialog(QObject):
         self.update_presentation_selector()
         MaskManager().masks_changed()
 
-    def set_boundary_color(self):
-        dialog = QColorDialog(QColor(MaskManager().boundary_color), self.ui)
-        if dialog.exec():
-            MaskManager().boundary_color = dialog.selectedColor().name()
-            MaskManager().masks_changed()
+    def edit_style(self):
+        dialog = MaskBorderStylePicker(
+            MaskManager().boundary_color,
+            MaskManager().boundary_style,
+            MaskManager().boundary_width
+        )
+        dialog.exec()
+        color, style, width = dialog.result()
+        MaskManager().boundary_color = color
+        MaskManager().boundary_style = style
+        MaskManager().boundary_width = width
+        MaskManager().masks_changed()

--- a/hexrdgui/resources/ui/mask_border_style_picker.ui
+++ b/hexrdgui/resources/ui/mask_border_style_picker.ui
@@ -1,0 +1,166 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>border_style_2</class>
+ <widget class="QDialog" name="border_style_2">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>497</width>
+    <height>114</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Border Style</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QGroupBox" name="border_style_group">
+     <property name="title">
+      <string>Border Style</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="4">
+       <widget class="QLabel" name="border_style_label">
+        <property name="text">
+         <string>Line Style:</string>
+        </property>
+        <property name="buddy">
+         <cstring>border_style</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="border_color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>border_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="border_color">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QComboBox" name="border_style">
+        <item>
+         <property name="text">
+          <string>solid</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dotted</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dashed</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>dashdot</string>
+         </property>
+        </item>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="border_size_label">
+        <property name="text">
+         <string>Line Width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>border_size</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="ScientificDoubleSpinBox" name="border_size">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>0.000001000000000</double>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>ScientificDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>scientificspinbox.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>button_box</sender>
+   <signal>accepted()</signal>
+   <receiver>border_style_2</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>button_box</sender>
+   <signal>rejected()</signal>
+   <receiver>border_style_2</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -136,9 +136,9 @@
     </widget>
    </item>
    <item row="8" column="1" colspan="2">
-    <widget class="QPushButton" name="border_color">
+    <widget class="QPushButton" name="border_style">
      <property name="text">
-      <string>Border Color</string>
+      <string>Border Style</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Adds options to set mask border line style as well as thickness.

![image](https://github.com/user-attachments/assets/bd1ad23f-7e4e-4959-8391-b9d75bdb0b9a)

Fixes #1845