### PR TITLE
Multi select masks

### DIFF
--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -368,7 +368,7 @@ class MaskManager(QObject, metaclass=QSingleton):
         }
         self.export_masks_to_file.emit(d)
 
-    def write_all_masks(self, h5py_group=None):
+    def write_masks(self, h5py_group=None):
         d = {
             '__boundary_color': self.boundary_color,
             '__boundary_style': self.boundary_style,
@@ -385,7 +385,7 @@ class MaskManager(QObject, metaclass=QSingleton):
         if 'masks' not in h5py_group:
             h5py_group.create_group('masks')
 
-        self.write_all_masks(h5py_group['masks'])
+        self.write_masks(h5py_group['masks'])
 
     def load_masks(self, h5py_group):
         items = load_masks(h5py_group)

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -481,3 +481,6 @@ class MaskManager(QObject, metaclass=QSingleton):
             # This is the same as the panel buffer, which is why we are
             # doing a `np.logical_and()`.
             panel.panel_buffer = np.logical_and(mask, panel.panel_buffer)
+
+    def get_mask_by_name(self, name):
+        return self.masks[name]

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -53,7 +53,7 @@ class MaskManagerDialog(QObject):
         self.ui.masks_tree.itemChanged.connect(self.update_mask_name)
         self.ui.masks_tree.customContextMenuRequested.connect(
             self.context_menu_event)
-        self.ui.export_masks.clicked.connect(MaskManager().write_all_masks)
+        self.ui.export_masks.clicked.connect(MaskManager().write_masks)
         self.ui.import_masks.clicked.connect(self.import_masks)
         self.ui.panel_buffer.clicked.connect(self.masks_to_panel_buffer)
         self.ui.view_masks.clicked.connect(self.show_masks)
@@ -286,11 +286,11 @@ class MaskManagerDialog(QObject):
         item = self.ui.masks_tree.itemAt(event)
         if item and item.parent():  # Only for mask items, not mode items
             menu = QMenu(self.ui.masks_tree)
-            export = menu.addAction('Export Mask')
+            export = menu.addAction('Export Selected Masks')
             action = menu.exec(QCursor.pos())
             if action == export:
-                selection = item.text(0)
-                MaskManager().write_single_mask(selection)
+                selections = self.ui.masks_tree.selectedItems()
+                MaskManager().write_masks([i.text(0) for i in selections])
 
     def export_masks_to_file(self, data):
         output_file, _ = QFileDialog.getSaveFileName(

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -437,22 +437,23 @@ class MaskManagerDialog(QObject):
         self.ui.apply_changes.setEnabled(False)
 
     def selected_changed(self):
-        selected = self.ui.masks_tree.selectedItems()
-        self.ui.presentation_selector.setEnabled(len(selected) > 1)
-        self.ui.export_selected.setEnabled(len(selected) > 1)
-        self.ui.remove_selected.setEnabled(len(selected) > 1)
-        if len(selected) == 0:
-            return
+        with block_signals(self.ui.presentation_selector):
+            selected = self.ui.masks_tree.selectedItems()
+            self.ui.presentation_selector.setEnabled(len(selected) > 1)
+            self.ui.export_selected.setEnabled(len(selected) > 1)
+            self.ui.remove_selected.setEnabled(len(selected) > 1)
+            if len(selected) == 0:
+                return
 
-        boundary_masks = [MaskType.region, MaskType.polygon, MaskType.pinhole]
-        masks_from_names = [MaskManager().get_mask_by_name(i.text(0)) for i in selected]
-        vis_only = any(mask.type not in boundary_masks for mask in masks_from_names)
-        self.ui.presentation_selector.clear()
-        self.ui.presentation_selector.addItem('None')
-        self.ui.presentation_selector.addItem('Visible')
-        if not vis_only:
-            self.ui.presentation_selector.addItem('Boundary Only')
-            self.ui.presentation_selector.addItem('Visible + Boundary')
+            boundary_masks = [MaskType.region, MaskType.polygon, MaskType.pinhole]
+            masks_from_names = [MaskManager().get_mask_by_name(i.text(0)) for i in selected]
+            vis_only = any(mask.type not in boundary_masks for mask in masks_from_names)
+            self.ui.presentation_selector.clear()
+            self.ui.presentation_selector.addItem('None')
+            self.ui.presentation_selector.addItem('Visible')
+            if not vis_only:
+                self.ui.presentation_selector.addItem('Boundary Only')
+                self.ui.presentation_selector.addItem('Visible + Boundary')
 
     def change_presentation_for_selected(self, text):
         if len(self.ui.masks_tree.selectedItems()) <= 1:

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -68,6 +68,7 @@ class MaskManagerDialog(QObject):
         HexrdConfig().active_beam_switched.connect(self.update_collapsed)
         self.ui.masks_tree.itemSelectionChanged.connect(self.selected_changed)
         self.ui.presentation_selector.currentTextChanged.connect(self.change_presentation_for_selected)
+        self.ui.export_selected.clicked.connect(self.export_selected)
 
     def create_mode_source_string(self, mode, source):
         if mode is None:
@@ -462,3 +463,7 @@ class MaskManagerDialog(QObject):
         else:
             self.change_mask_visibility(mask_names, False)
         MaskManager().masks_changed()
+
+    def export_selected(self):
+        mask_names = [i.text(0) for i in self.ui.masks_tree.selectedItems()]
+        MaskManager().write_masks(mask_names)

--- a/hexrdgui/resources/ui/mask_border_style_picker.ui
+++ b/hexrdgui/resources/ui/mask_border_style_picker.ui
@@ -128,6 +128,11 @@
    <header>scientificspinbox.h</header>
   </customwidget>
  </customwidgets>
+ <tabstops>
+  <tabstop>border_color</tabstop>
+  <tabstop>border_style</tabstop>
+  <tabstop>border_size</tabstop>
+ </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/hexrdgui/resources/ui/mask_border_style_picker.ui
+++ b/hexrdgui/resources/ui/mask_border_style_picker.ui
@@ -129,7 +129,7 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>border_color</tabstop>
+  <tabstop>border_style</tabstop>
   <tabstop>border_style</tabstop>
   <tabstop>border_size</tabstop>
  </tabstops>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -197,6 +197,13 @@
       </widget>
      </item>
      <item>
+      <widget class="Line" name="line_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QComboBox" name="presentation_selector">
        <property name="enabled">
         <bool>false</bool>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -268,12 +268,12 @@
   </layout>
  </widget>
  <tabstops>
+  <tabstop>masks_tree</tabstop>
+  <tabstop>apply_changes</tabstop>
   <tabstop>import_masks</tabstop>
   <tabstop>export_masks</tabstop>
   <tabstop>panel_buffer</tabstop>
   <tabstop>view_masks</tabstop>
-  <tabstop>masks_tree</tabstop>
-  <tabstop>apply_changes</tabstop>
   <tabstop>hide_all_masks</tabstop>
   <tabstop>show_all_masks</tabstop>
   <tabstop>hide_all_boundaries</tabstop>
@@ -281,6 +281,7 @@
   <tabstop>border_color</tabstop>
   <tabstop>presentation_selector</tabstop>
   <tabstop>export_selected</tabstop>
+  <tabstop>remove_selected</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -34,6 +34,9 @@
      <property name="alternatingRowColors">
       <bool>true</bool>
      </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
      <property name="selectionBehavior">
       <enum>QAbstractItemView::SelectRows</enum>
      </property>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -9,138 +9,113 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>662</width>
-    <height>322</height>
+    <width>670</width>
+    <height>296</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Mask Management</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" rowspan="11">
-    <widget class="QTreeWidget" name="masks_tree">
-     <property name="minimumSize">
-      <size>
-       <width>500</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::DoubleClicked</set>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>false</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Presentation</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Remove</string>
-      </property>
-     </column>
-    </widget>
+   <item row="1" column="1" rowspan="2">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+      <widget class="QLabel" name="controls_label">
+       <property name="text">
+        <string>CONTROLS</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="hide_all_masks">
+       <property name="text">
+        <string>Hide All Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_all_masks">
+       <property name="text">
+        <string>Show All Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="hide_all_boundaries">
+       <property name="text">
+        <string>Hide All Boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_all_boundaries">
+       <property name="text">
+        <string>Show All Boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="border_color">
+       <property name="text">
+        <string>Border Color</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="presentaion_selection">
+       <item>
+        <property name="text">
+         <string>Presentation</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Visible</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Border</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Visible + Border</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="export_selected">
+       <property name="text">
+        <string>Export Selected Masks</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
-   <item row="0" column="1">
-    <widget class="QPushButton" name="import_masks">
-     <property name="text">
-      <string>Import Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="export_masks">
-     <property name="text">
-      <string>Export Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QPushButton" name="panel_buffer">
-     <property name="text">
-      <string>Masks to Panel Buffer</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="Line" name="line">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="view_masks">
-     <property name="text">
-      <string>View Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="hide_all_masks">
-     <property name="text">
-      <string>Hide All Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QPushButton" name="show_all_masks">
-     <property name="text">
-      <string>Show All Masks</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1">
-    <widget class="Line" name="line_2">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <widget class="QPushButton" name="hide_all_boundaries">
-     <property name="text">
-      <string>Hide All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="1">
-    <widget class="QPushButton" name="show_all_boundaries">
-     <property name="text">
-      <string>Show All Boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="2">
-    <widget class="QPushButton" name="border_style">
-     <property name="text">
-      <string>Border Style</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
       <widget class="QDialogButtonBox" name="button_box">
@@ -189,19 +164,100 @@
      </item>
     </layout>
    </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QPushButton" name="import_masks">
+       <property name="text">
+        <string>Import Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="export_masks">
+       <property name="text">
+        <string>Export Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="panel_buffer">
+       <property name="text">
+        <string>Masks to Panel Buffer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="view_masks">
+       <property name="text">
+        <string>View Masks</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QTreeWidget" name="masks_tree">
+     <property name="minimumSize">
+      <size>
+       <width>500</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::DoubleClicked</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Presentation</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Remove</string>
+      </property>
+     </column>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
-  <tabstop>masks_tree</tabstop>
   <tabstop>import_masks</tabstop>
   <tabstop>export_masks</tabstop>
   <tabstop>panel_buffer</tabstop>
   <tabstop>view_masks</tabstop>
+  <tabstop>masks_tree</tabstop>
+  <tabstop>apply_changes</tabstop>
   <tabstop>hide_all_masks</tabstop>
   <tabstop>show_all_masks</tabstop>
   <tabstop>hide_all_boundaries</tabstop>
   <tabstop>show_all_boundaries</tabstop>
-  <tabstop>apply_changes</tabstop>
+  <tabstop>border_color</tabstop>
+  <tabstop>presentaion_selection</tabstop>
+  <tabstop>export_selected</tabstop>
  </tabstops>
  <resources/>
  <connections/>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -190,9 +190,9 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="border_color">
+      <widget class="QPushButton" name="border_style">
        <property name="text">
-        <string>Border Color</string>
+        <string>Border Style</string>
        </property>
       </widget>
      </item>
@@ -278,7 +278,7 @@
   <tabstop>show_all_masks</tabstop>
   <tabstop>hide_all_boundaries</tabstop>
   <tabstop>show_all_boundaries</tabstop>
-  <tabstop>border_color</tabstop>
+  <tabstop>border_style</tabstop>
   <tabstop>presentation_selector</tabstop>
   <tabstop>export_selected</tabstop>
   <tabstop>remove_selected</tabstop>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -10,160 +10,13 @@
     <x>0</x>
     <y>0</y>
     <width>670</width>
-    <height>296</height>
+    <height>309</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Mask Management</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="1" column="1" rowspan="2">
-    <layout class="QVBoxLayout" name="verticalLayout">
-     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
-      <widget class="QLabel" name="controls_label">
-       <property name="text">
-        <string>CONTROLS</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Line" name="line">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="hide_all_masks">
-       <property name="text">
-        <string>Hide All Masks</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="show_all_masks">
-       <property name="text">
-        <string>Show All Masks</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Line" name="line_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="hide_all_boundaries">
-       <property name="text">
-        <string>Hide All Boundaries</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="show_all_boundaries">
-       <property name="text">
-        <string>Show All Boundaries</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="Line" name="line_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="border_color">
-       <property name="text">
-        <string>Border Color</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="presentaion_selection">
-       <item>
-        <property name="text">
-         <string>Presentation</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Visible</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Border</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Visible + Border</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="export_selected">
-       <property name="text">
-        <string>Export Selected Masks</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QDialogButtonBox" name="button_box">
-       <property name="standardButtons">
-        <set>QDialogButtonBox::NoButton</set>
-       </property>
-       <property name="centerButtons">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="apply_changes">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>400</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Apply Changes</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>168</width>
-         <height>17</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
@@ -242,6 +95,169 @@
      </column>
     </widget>
    </item>
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::NoButton</set>
+       </property>
+       <property name="centerButtons">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="apply_changes">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>400</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Apply Changes</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="1" rowspan="3">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item alignment="Qt::AlignHCenter|Qt::AlignVCenter">
+      <widget class="QLabel" name="controls_label">
+       <property name="text">
+        <string>CONTROLS</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="hide_all_masks">
+       <property name="text">
+        <string>Hide All Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_all_masks">
+       <property name="text">
+        <string>Show All Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="hide_all_boundaries">
+       <property name="text">
+        <string>Hide All Boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="show_all_boundaries">
+       <property name="text">
+        <string>Show All Boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="Line" name="line_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="border_color">
+       <property name="text">
+        <string>Border Color</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="presentation_selector">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <item>
+        <property name="text">
+         <string>None</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Visible</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Boundary Only</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Visible + Boundary</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="export_selected">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Export Selected Masks</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="remove_selected">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="text">
+        <string>Remove Selected</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -256,7 +272,7 @@
   <tabstop>hide_all_boundaries</tabstop>
   <tabstop>show_all_boundaries</tabstop>
   <tabstop>border_color</tabstop>
-  <tabstop>presentaion_selection</tabstop>
+  <tabstop>presentation_selector</tabstop>
   <tabstop>export_selected</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This PR:
- Rearranges the buttons to try to provide a more intuitive layout
- Add support for multi-select in the tree view (CTRL + left-click to select individual items, SHIFT + left-click at start and SHIFT + left-click at end to select all items in between)
- Can use CTRL + a to select all
- Allows changing the presentation of multiple masks at once
    - If more than one row is selected the combobox on the right will be enabled
    - If one or more of the selected masks are `powder`, `laue`, or `threshold` the options will be limited to `None` or `Visible`. Otherwise the `Boundary only` and `Visible + Boundary` will also be options.
    - The changes are applied to all selected masks immediately
- Adds a button to export selected masks
    - This is functionally the same as selecting multiple rows and using the context menu to export, just provides the option of a button if that is preferred over right-click
    - The button is only enabled when more than one row is selected
- Adds the option to remove multiple masks at a time

![image](https://github.com/user-attachments/assets/8b9ae93c-53f1-4f8c-96d8-e43d42f1770d)


- [x] Relies on #1815, #1848

Fixes #1846