### PR TITLE
Take into account sample tvec for detector borders

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -206,7 +206,7 @@ class PolarView:
 
         # Convert each border to angles
         for i, border in enumerate(borders):
-            angles, _ = panel.cart_to_angles(border)
+            angles, _ = panel.cart_to_angles(border, tvec_s=self.instr.tvec)
             angles = angles.T
             angles[1:, :] = mapAngle(
                 angles[1:, :], np.radians(self.eta_period), units='radians'

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -79,7 +79,12 @@ class InstrumentViewer:
 
         # Convert each border to angles, then stereo
         for i, border in enumerate(borders):
-            angles = np.radians(cart_to_angles(border, panel, self.eta_period))
+            angles = np.radians(cart_to_angles(
+                border,
+                panel,
+                self.eta_period,
+                tvec_s=self.instr_pv.tvec,
+            ))
             borders[i] = angles_to_stereo(angles, self.instr_pv,
                                           self.stereo_size).T
 


### PR DESCRIPTION
For the polar and stereo views, take into account the sample tvec when generating their detector borders.

This change is not necessary for the raw view (no detector borders) and the Cartesian view (where the detector borders should not change).

Fixes: #1719