### PR TITLE
Memoize projection to polar view

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -5,6 +5,7 @@ from skimage.morphology import footprint_rectangle
 from skimage.transform import warp
 
 from hexrd.transforms.xfcapi import mapAngle
+from hexrd.utils.decorators import memoize
 from hexrd.utils.warnings import ignore_warnings
 
 from hexrd import constants as ct
@@ -592,7 +593,7 @@ class PolarView:
 # `_project_on_detector_plane()` is one of the functions that takes the
 # longest when generating the polar view.
 # Memoize this so we can regenerate the polar view faster
-# @memoize(maxsize=16)
+@memoize(maxsize=16)
 def project_on_detector(angular_grid,
                         ntth, neta,
                         func_projection,


### PR DESCRIPTION
This function was memoized in the past, and appears to have been "un-memoized" by accident. After the polar view has been generated one time, this memoization substantially improves the performance of re-generating the same polar view using the same settings (for example, switching to a different image mode and then coming back).