### PR TITLE
Remove invalid tab stop

### DIFF
--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -198,7 +198,6 @@
   <tabstop>show_all_masks</tabstop>
   <tabstop>hide_all_boundaries</tabstop>
   <tabstop>show_all_boundaries</tabstop>
-  <tabstop>border_color</tabstop>
   <tabstop>apply_changes</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
This was producing a warning when the GUI booted up.