### PR TITLE
Update `dict_modified()` arguments

### DIFF
--- a/hexrdgui/tree_views/generic_picks_tree_view.py
+++ b/hexrdgui/tree_views/generic_picks_tree_view.py
@@ -622,7 +622,7 @@ class GenericPicksTreeView(BaseDictTreeView):
 
 class GenericPicksTreeViewDialog(QDialog):
 
-    dict_modified = Signal()
+    dict_modified = Signal(QModelIndex)
 
     def __init__(self, dictionary, coords_type=ViewType.polar, canvas=None,
                  parent=None):

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -277,7 +277,7 @@ class MultiColumnDictTreeView(BaseDictTreeView):
 
 class MultiColumnDictTreeViewDialog(QDialog):
 
-    dict_modified = Signal()
+    dict_modified = Signal(QModelIndex)
 
     def __init__(self, dictionary, columns, parent=None):
         super().__init__(parent)


### PR DESCRIPTION
These were changed recently to use a `QModelIndex` argument in their signal.

Fixes: #1861