### PR TITLE
Keep all eta omega map HKLs in workflow export

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1216,7 +1216,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         return self.config['instrument']
 
-    def save_instrument_config(self, output_file):
+    def save_instrument_config(self, output_file, remove_rois=False):
         from hexrdgui.create_hedm_instrument import create_hedm_instrument
 
         styles = {
@@ -1232,6 +1232,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 raise Exception(f'Unknown output extension: {ext}')
 
         instr = create_hedm_instrument()
+        if remove_rois:
+            for panel in instr.detectors.values():
+                panel._roi = None
+
         instr.write_config(output_file, style=styles[ext])
 
     def load_materials(self, f):
@@ -1337,15 +1341,6 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 # This is a master list. Save the active hkls as the more human
                 # readable (h, k, l) tuples instead.
                 active_hkls = plane_data.getHKLs(*active_hkls).tolist()
-
-            # Do not save all active hkls, but only the ones used in the seed
-            # search. Those are the only ones we need.
-            seed_search = cfg['find_orientations']['seed_search']
-            active_hkls = [active_hkls[i] for i in seed_search['hkl_seeds']]
-
-            # Renumber the hkl_seeds from 0 to len(hkl_seeds)
-            num_hkl_seeds = len(seed_search['hkl_seeds'])
-            seed_search['hkl_seeds'] = list(range(num_hkl_seeds))
 
             omaps['active_hkls'] = active_hkls
         else:

--- a/hexrdgui/indexing/fit_grains_results_dialog.py
+++ b/hexrdgui/indexing/fit_grains_results_dialog.py
@@ -706,7 +706,11 @@ class FitGrainsResultsDialog(QObject):
 
         HexrdConfig().save_indexing_config(full_path('workflow.yml'))
         HexrdConfig().save_materials(full_path('materials.h5'))
-        HexrdConfig().save_instrument_config(full_path('instrument.hexrd'))
+        HexrdConfig().save_instrument_config(
+            full_path('instrument.hexrd'),
+            # Remove ROIs, since we are saving the imageseries without them
+            remove_rois=True,
+        )
 
         ims_dict = HexrdConfig().unagg_images
         for det in HexrdConfig().detector_names:

--- a/hexrdgui/indexing/run.py
+++ b/hexrdgui/indexing/run.py
@@ -493,7 +493,7 @@ class FitGrainsRunner(Runner):
     def view_fit_grains_options(self):
         find_orientations = HexrdConfig().indexing_config['find_orientations']
         quaternion_method = find_orientations.get('_quaternion_method')
-        ensure_hkl_seeds_not_excluded = (
+        ensure_active_hkls_not_excluded = (
             self.started_from_indexing and
             quaternion_method == 'seed_search'
         )
@@ -501,7 +501,7 @@ class FitGrainsRunner(Runner):
         # Run dialog for user options
         kwargs = {
             'grains_table': self.grains_table,
-            'ensure_seed_hkls_not_excluded': ensure_hkl_seeds_not_excluded,
+            'ensure_active_hkls_not_excluded': ensure_active_hkls_not_excluded,
             'parent': self.parent,
         }
         dialog = FitGrainsOptionsDialog(**kwargs)


### PR DESCRIPTION
We previously removed all HKLs other than the seed HKLs when exporting the full HEDM workflow. We thought that the non-seed HKLs were not used. However, they were indeed used when measuring completeness in `paintGrid()`.

This typically would only cause minor issues (a difference in the number of orientations kept). However, if only one seed HKL was selected, the completeness measurement would be very off, and many bad orientations would be kept. This was because a single eta omega map is not enough to accurately determine the completeness of an orientation - you typically need at least two or more.

Now we keep all eta omega map HKLs when exporting the full workflow. We seem to get nearly identical results in the GUI and the CLI with this.

Fixes: hexrd/hexrd#802