### PR TITLE
Remove ANSI escapes in the messages widget

### DIFF
--- a/hexrdgui/messages_widget.py
+++ b/hexrdgui/messages_widget.py
@@ -1,4 +1,5 @@
 from contextlib import contextmanager
+import re
 import sys
 
 from PySide6.QtCore import QObject, Qt, Signal
@@ -12,6 +13,9 @@ from hexrdgui.ui_loader import UiLoader
 
 STDOUT_COLOR = 'green'
 STDERR_COLOR = 'red'
+
+# QTextEdit can't handle ansi escapes, so we can remove them
+ANSI_ESCAPE_REGEX = re.compile(r'\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])')
 
 
 class MessagesWidget(QObject):
@@ -86,6 +90,10 @@ class MessagesWidget(QObject):
         HexrdConfig().logging_stderr_stream = sys.stderr
 
     def insert_text(self, text):
+        # First, remove any ansi escapes, because we currently don't
+        # have a way to handle them in QTextEdit.
+        text = ANSI_ESCAPE_REGEX.sub('', text)
+
         # Remove trailing returns so there isn't extra white
         # space that always exists at the bottom of the text edit.
         if self._holding_return:


### PR DESCRIPTION
This fixes a long-standing issue where unreadable characters would be often printed to the messages widget. Those characters were printed because the text, which was intended to go to a regular terminal, included ANSI escapes.

Terminals can handle ANSI escapes fine, but it doesn't look like QTextEdit can handle them currently. Removing ANSI escapes with a regex makes the invalid characters go away.

This is the previous output during fast powder calibration:
![bad-ansi](https://github.com/user-attachments/assets/fddbc9d5-f40e-46dd-bd03-61e2f37a6b9f)

After the fix, it appears like this:
![good-ansi](https://github.com/user-attachments/assets/cc391897-5c4c-4ec1-aefa-c4d8280301e5)
