### PR TITLE
Mask manager dialog

### DIFF
--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -177,6 +177,10 @@ class InstrumentViewer:
                 data[f'border_mask_{name}'] = mask.get_masked_arrays(
                     self.type,
                 )
+            elif mask.highlight:
+                data[f'highlight_mask_{name}'] = mask.get_masked_arrays(
+                    self.type,
+                )
 
         keep_detectors = HexrdConfig().azimuthal_lineout_detectors
         if (

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1079,7 +1079,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                     # Only apply visible masks for display
                     continue
 
-                if not mask.visible and not mask.show_border and not mask.highlight:
+                if not mask.visible and not mask.show_border:
                     # This mask should not be applied at all.
                     continue
 

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1079,7 +1079,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                     # Only apply visible masks for display
                     continue
 
-                if not mask.visible and not mask.show_border:
+                if not mask.visible and not mask.show_border and not mask.highlight:
                     # This mask should not be applied at all.
                     continue
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -122,6 +122,10 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().oscillation_stage_changed.connect(
             self.oscillation_stage_changed)
         MaskManager().polar_masks_changed.connect(self.polar_masks_changed)
+        # Update mask highlights without re-running expensive mask logic
+        MaskManager().mask_highlights_changed.connect(
+            self.mask_highlights_changed
+        )
         HexrdConfig().overlay_renamed.connect(self.overlay_renamed)
         HexrdConfig().azimuthal_options_modified.connect(
             self.update_azimuthal_integral_plot)
@@ -1573,6 +1577,19 @@ class ImageCanvas(FigureCanvas):
             self.iviewer and
             self.iviewer.project_from_polar
         )
+
+    def mask_highlights_changed(self):
+        if not self.iviewer:
+            return
+
+        if self.mode == ViewType.raw:
+            self.clear_mask_highlights()
+            for det_name, ax in self.raw_axes.items():
+                self.highlight_masks(ax, det_name)
+            return
+
+        if self.mode in (ViewType.polar, ViewType.stereo):
+            self.update_mask_highlights(self.axis)
 
     def polar_masks_changed(self):
         skip = (

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -1239,37 +1239,12 @@ class ImageCanvas(FigureCanvas):
             self.axis.autoscale(False)
             self.axis.set_ylabel(r'$\eta$ [deg]', **self.label_kwargs_polar_y)
             self.axis.label_outer()
-
-            self.update_mask_boundaries(self.axis)
-            self.update_mask_highlights(self.axis)
-
-            # Get the "tth" vector
-            angular_grid = self.iviewer.angular_grid
-            tth = np.degrees(angular_grid[1][0])
-
-            if self.azimuthal_integral_axis is None:
-                axis = self.figure.add_subplot(grid[3, 0], sharex=self.axis)
-                data = (tth, self.compute_azimuthal_integral_sum())
-                unscaled = (tth, self.compute_azimuthal_integral_sum(False))
-                self.azimuthal_line_artist, = axis.plot(*data, '-k', lw=2.5)
-                HexrdConfig().last_unscaled_azimuthal_integral_data = unscaled
-
-                self.azimuthal_integral_axis = axis
-                self.update_azimuthal_plot_overlays()
-                self.update_wppf_plot()
-
-                self._setup_azimuthal_axis(axis)
-            else:
-                self.update_azimuthal_integral_plot()
-                axis = self.azimuthal_integral_axis
-
-            # Update the xlabel in case it was modified (via tth distortion)
-            self.update_azimuthal_axis_xlabel()
         else:
             rescale_image = False
             self.axes_images[0].set_data(img)
 
         self.update_mask_boundaries(self.axis)
+        self.update_mask_highlights(self.axis)
 
         # Get the "tth" vector
         angular_grid = self.iviewer.angular_grid

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -465,7 +465,7 @@ class ImageTabWidget(QTabWidget):
             for mask in MaskManager().masks.values():
                 if (
                     mask.type == MaskType.threshold or
-                    (not mask.visible and not mask.show_border)
+                    (not mask.visible and not mask.show_border and not mask.highlight)
                 ):
                     continue
 

--- a/hexrdgui/masking/mask_border_style_picker.py
+++ b/hexrdgui/masking/mask_border_style_picker.py
@@ -7,7 +7,15 @@ from hexrdgui.ui_loader import UiLoader
 
 class MaskBorderStylePicker(QObject):
 
-    def __init__(self, original_color, original_style, original_width, parent=None):
+    def __init__(
+        self,
+        original_color,
+        original_style,
+        original_width,
+        original_highlight,
+        original_highlight_opacity,
+        parent=None
+    ):
         super().__init__(parent)
 
         loader = UiLoader()

--- a/hexrdgui/masking/mask_border_style_picker.py
+++ b/hexrdgui/masking/mask_border_style_picker.py
@@ -23,6 +23,8 @@ class MaskBorderStylePicker(QObject):
         self.original_color = original_color
         self.original_style = original_style
         self.original_width = original_width
+        self.original_highlight = original_highlight
+        self.original_highlight_opacity = original_highlight_opacity
 
         self.reset_ui()
         self.setup_connections()
@@ -32,14 +34,18 @@ class MaskBorderStylePicker(QObject):
         self.ui.border_color.setStyleSheet('QPushButton {background-color: %s}' % self.original_color)
         self.ui.border_style.setCurrentText(self.original_style)
         self.ui.border_size.setValue(self.original_width)
+        self.ui.highlight_color.setText(self.original_highlight)
+        self.ui.highlight_color.setStyleSheet('QPushButton {background-color: %s}' % self.original_highlight)
+        self.ui.opacity.setValue(self.original_highlight_opacity)
 
     def exec(self):
         self.ui.adjustSize()
         return self.ui.exec()
 
     def setup_connections(self):
-        self.ui.border_color.clicked.connect(self.pick_color)
+        self.ui.border_color.clicked.connect(lambda: self.pick_color('border'))
         self.ui.button_box.rejected.connect(self.reject)
+        self.ui.highlight_color.clicked.connect(lambda: self.pick_color('highlight'))
 
     @property
     def color(self):
@@ -53,15 +59,29 @@ class MaskBorderStylePicker(QObject):
     def width(self):
         return self.ui.border_size.value()
 
-    def pick_color(self):
-        dialog = QColorDialog(QColor(self.original_color), self.ui)
+    @property
+    def highlight(self):
+        return self.ui.highlight_color.text()
+
+    @property
+    def opacity(self):
+        return self.ui.opacity.value()
+
+    def pick_color(self, type):
+        options = {
+            'border': self.original_color,
+            'highlight': self.original_highlight,
+            'border_ui': self.ui.border_color,
+            'highlight_ui': self.ui.highlight_color
+        }
+        dialog = QColorDialog(QColor(options[type]), self.ui)
         if dialog.exec():
             color = dialog.selectedColor().name()
-            self.ui.border_color.setText(color)
-            self.ui.border_color.setStyleSheet('QPushButton {background-color: %s}' % color)
+            options[f'{type}_ui'].setText(color)
+            options[f'{type}_ui'].setStyleSheet('QPushButton {background-color: %s}' % color)
 
     def reject(self):
         self.reset_ui()
 
     def result(self):
-        return self.color, self.style, self.width
+        return self.color, self.style, self.width, self.highlight, self.opacity

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -31,7 +31,7 @@ class Mask(ABC):
         show_border=False,
         mode=None,
         xray_source=None,
-        highlight=False
+        highlight=False,
     ):
         self.type = mtype
         self.visible = visible
@@ -232,6 +232,11 @@ class ThresholdMask(Mask):
     def highlight(self):
         return False
 
+    @highlight.setter
+    def highlight(self, value):
+        # Threshold masks do not support highlight; ignore assignments
+        pass
+
     def update_masked_arrays(self, view=ViewType.raw):
         self.masked_arrays = recompute_raw_threshold_mask()
 
@@ -283,6 +288,9 @@ class MaskManager(QObject, metaclass=QSingleton):
     The argument is the dict of data to export to hdf5
     """
     export_masks_to_file = Signal(dict)
+
+    """Emitted when mask highlight states change"""
+    mask_highlights_changed = Signal()
 
     def __init__(self):
         super().__init__(None)
@@ -360,6 +368,9 @@ class MaskManager(QObject, metaclass=QSingleton):
     def view_mode_changed(self, mode):
         self.view_mode = mode
         self.update_masks_for_active_beam()
+
+    def highlights_changed(self):
+        self.mask_highlights_changed.emit()
 
     def masks_changed(self):
         if self.view_mode in (ViewType.polar, ViewType.stereo):

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -36,7 +36,7 @@ class Mask(ABC):
         self.type = mtype
         self.visible = visible
         self.show_border = show_border
-        self.highlight = highlight
+        self._highlight = highlight
         self.masked_arrays = None
         self.masked_arrays_view_mode = ViewType.raw
         self.creation_view_mode = mode
@@ -88,6 +88,16 @@ class Mask(ABC):
     def serialize(self):
         pass
 
+    @property
+    @abstractmethod
+    def highlight(self):
+        pass
+
+    @highlight.setter
+    @abstractmethod
+    def highlight(self, value):
+        pass
+
     @classmethod
     def deserialize(cls, data):
         return cls(
@@ -122,6 +132,16 @@ class RegionMask(Mask):
     def data(self, values):
         self._raw = values
         self.invalidate_masked_arrays()
+
+    @property
+    def highlight(self):
+        return self._highlight
+
+    @highlight.setter
+    def highlight(self, value):
+        if self.type == MaskType.powder:
+            return
+        self._highlight = value
 
     def update_masked_arrays(self, view=ViewType.raw, instr=None):
         self.masked_arrays_view_mode = view
@@ -207,6 +227,10 @@ class ThresholdMask(Mask):
         self.min_val = values[0]
         self.max_val = values[1]
         self.invalidate_masked_arrays()
+
+    @property
+    def highlight(self):
+        return False
 
     def update_masked_arrays(self, view=ViewType.raw):
         self.masked_arrays = recompute_raw_threshold_mask()

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -129,12 +129,6 @@ class MaskManagerDialog(QObject):
         presentation_combo.currentIndexChanged.connect(
             lambda i, k=mask: self.track_mask_presentation_change(i, k))
 
-        # Add push button to remove mask
-        pb = QPushButton('Remove Mask')
-        self.ui.masks_tree.setItemWidget(mask_item, 2, pb)
-        pb.clicked.connect(
-            lambda checked, k=mask.name: self.remove_mask_item(k))
-
     def update_mask_item(self, mask):
         item = self.mask_tree_items[mask.name]
         item.setText(0, mask.name)

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -415,9 +415,9 @@ class MaskManagerDialog(QObject):
     def selected_changed(self):
         with block_signals(self.ui.presentation_selector):
             selected = self.ui.masks_tree.selectedItems()
-            self.ui.presentation_selector.setEnabled(len(selected) > 1)
-            self.ui.export_selected.setEnabled(len(selected) > 1)
-            self.ui.remove_selected.setEnabled(len(selected) > 1)
+            self.ui.presentation_selector.setEnabled(len(selected) >= 1)
+            self.ui.export_selected.setEnabled(len(selected) >= 1)
+            self.ui.remove_selected.setEnabled(len(selected) >= 1)
 
             # Update highlight states for masks
             masks_from_names = [MaskManager().get_mask_by_name(i.text(0)) for i in selected]
@@ -441,7 +441,7 @@ class MaskManagerDialog(QObject):
                 self.ui.presentation_selector.addItem('Visible + Boundary')
 
     def change_presentation_for_selected(self, text):
-        if len(self.ui.masks_tree.selectedItems()) <= 1:
+        if len(self.ui.masks_tree.selectedItems()) < 1:
             return
 
         mask_names = [i.text(0) for i in self.ui.masks_tree.selectedItems()]

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -430,12 +430,7 @@ class MaskManagerDialog(QObject):
                 # Only update the mask highlights if the selected masks have changed
                 # Debounce the update to avoid re-drawing too often
                 self.selected_masks = masks_from_names
-                if not hasattr(self, '_mask_highlight_update_timer'):
-                    timer = QTimer()
-                    timer.setSingleShot(True)
-                    timer.timeout.connect(MaskManager().masks_changed)
-                    self._mask_highlight_update_timer = timer
-                self._mask_highlight_update_timer.start(100)
+                MaskManager().highlights_changed()
 
             if len(selected) == 0:
                 return

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -70,6 +70,7 @@ class MaskManagerDialog(QObject):
             self.change_presentation_for_selected)
         self.ui.export_selected.clicked.connect(self.export_selected)
         self.ui.remove_selected.clicked.connect(self.remove_selected_masks)
+        self.ui.finished.connect(self.ui.masks_tree.clearSelection)
 
     def create_mode_source_string(self, mode, source):
         if mode is None:

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -38,6 +38,7 @@ class MaskManagerDialog(QObject):
 
         self.changed_masks = {}
         self.mask_tree_items = {}
+        self.selected_masks = []
 
         add_help_url(self.ui.button_box,
                      'configuration/masking/#managing-masks')
@@ -429,11 +430,20 @@ class MaskManagerDialog(QObject):
             self.ui.presentation_selector.setEnabled(len(selected) > 1)
             self.ui.export_selected.setEnabled(len(selected) > 1)
             self.ui.remove_selected.setEnabled(len(selected) > 1)
+
+            # Update highlight states for masks
+            masks_from_names = [MaskManager().get_mask_by_name(i.text(0)) for i in selected]
+            for mask in self.selected_masks:
+                mask.highlight = False
+            for mask in masks_from_names:
+                mask.highlight = True
+            self.selected_masks = masks_from_names
+            MaskManager().masks_changed()
+
             if len(selected) == 0:
                 return
 
             boundary_masks = [MaskType.region, MaskType.polygon, MaskType.pinhole]
-            masks_from_names = [MaskManager().get_mask_by_name(i.text(0)) for i in selected]
             vis_only = any(mask.type not in boundary_masks for mask in masks_from_names)
             self.ui.presentation_selector.clear()
             self.ui.presentation_selector.addItem('None')

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -409,13 +409,17 @@ class MaskManagerDialog(QObject):
         dialog = MaskBorderStylePicker(
             MaskManager().boundary_color,
             MaskManager().boundary_style,
-            MaskManager().boundary_width
+            MaskManager().boundary_width,
+            MaskManager().highlight_color,
+            MaskManager().highlight_opacity
         )
         if dialog.exec():
-            color, style, width = dialog.result()
+            color, style, width, highlight, opacity = dialog.result()
             MaskManager().boundary_color = color
             MaskManager().boundary_style = style
             MaskManager().boundary_width = width
+            MaskManager().highlight_color = highlight
+            MaskManager().highlight_opacity = opacity
             MaskManager().masks_changed()
 
     def apply_changes(self):

--- a/hexrdgui/resources/ui/mask_border_style_picker.ui
+++ b/hexrdgui/resources/ui/mask_border_style_picker.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>border_style_2</class>
- <widget class="QDialog" name="border_style_2">
+ <class>border_style_dialog</class>
+ <widget class="QDialog" name="border_style_dialog">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>497</width>
-    <height>114</height>
+    <height>185</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -110,6 +110,80 @@
     </widget>
    </item>
    <item>
+    <widget class="QGroupBox" name="highlight_style_group">
+     <property name="title">
+      <string>Selected Mask Highlight</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="highlight_color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>border_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="highlight_color">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="autoDefault">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="opacity_label">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+        <property name="buddy">
+         <cstring>border_size</cstring>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="ScientificDoubleSpinBox" name="opacity">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>2</number>
+        </property>
+        <property name="minimum">
+         <double>0.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>0.500000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>40</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="button_box">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -129,16 +203,18 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>border_style</tabstop>
+  <tabstop>border_color</tabstop>
   <tabstop>border_style</tabstop>
   <tabstop>border_size</tabstop>
+  <tabstop>highlight_color</tabstop>
+  <tabstop>opacity</tabstop>
  </tabstops>
  <resources/>
  <connections>
   <connection>
    <sender>button_box</sender>
    <signal>accepted()</signal>
-   <receiver>border_style_2</receiver>
+   <receiver>border_style_dialog</receiver>
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
@@ -154,7 +230,7 @@
   <connection>
    <sender>button_box</sender>
    <signal>rejected()</signal>
-   <receiver>border_style_2</receiver>
+   <receiver>border_style_dialog</receiver>
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -49,50 +49,6 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
-    <widget class="QTreeWidget" name="masks_tree">
-     <property name="minimumSize">
-      <size>
-       <width>500</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="contextMenuPolicy">
-      <enum>Qt::CustomContextMenu</enum>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::DoubleClicked</set>
-     </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="selectionBehavior">
-      <enum>QAbstractItemView::SelectRows</enum>
-     </property>
-     <property name="sortingEnabled">
-      <bool>false</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Presentation</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignCenter</set>
-      </property>
-     </column>
-    </widget>
-   </item>
    <item row="3" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -262,6 +218,59 @@
       </spacer>
      </item>
     </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QTreeWidget" name="masks_tree">
+     <property name="minimumSize">
+      <size>
+       <width>500</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="contextMenuPolicy">
+      <enum>Qt::CustomContextMenu</enum>
+     </property>
+     <property name="sizeAdjustPolicy">
+      <enum>QAbstractScrollArea::AdjustToContents</enum>
+     </property>
+     <property name="editTriggers">
+      <set>QAbstractItemView::DoubleClicked</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>false</bool>
+     </property>
+     <attribute name="headerCascadingSectionResizes">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="headerStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Presentation</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
+     </column>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -234,7 +234,7 @@
       <enum>QAbstractScrollArea::AdjustToContents</enum>
      </property>
      <property name="editTriggers">
-      <set>QAbstractItemView::DoubleClicked</set>
+      <set>QAbstractItemView::NoEditTriggers</set>
      </property>
      <property name="alternatingRowColors">
       <bool>true</bool>

--- a/hexrdgui/resources/ui/mask_manager_dialog.ui
+++ b/hexrdgui/resources/ui/mask_manager_dialog.ui
@@ -79,6 +79,9 @@
       <property name="text">
        <string>Name</string>
       </property>
+      <property name="textAlignment">
+       <set>AlignCenter</set>
+      </property>
      </column>
      <column>
       <property name="text">
@@ -86,11 +89,6 @@
       </property>
       <property name="textAlignment">
        <set>AlignCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Remove</string>
       </property>
      </column>
     </widget>


### PR DESCRIPTION
- Remove the "remove mask" column in favor of the "remove selected" option
- Remove the presentation combo boxes for each mask. Instead, list the current presentation status as text as use global presentation selection drop-down for selected masks
- Remove the "apply changes" button since all updates are now immediate
- Highlight masks as they are selected
- Add options to set highlight color and opacity in the style dialog

Relies on #1849 