### PR TITLE
Add an "Uncertainty" column to WPPF

### DIFF
--- a/hexrdgui/calibration/tree_item_models.py
+++ b/hexrdgui/calibration/tree_item_models.py
@@ -18,6 +18,10 @@ def _tree_columns_to_indices(columns):
 class CalibrationTreeItemModel(MultiColumnDictTreeItemModel):
     """Subclass the tree item model so we can customize some behavior"""
 
+    # The tolerance for determining if a value and one of its boundaries are
+    # too close and should be colored red in the UI.
+    RED_COLOR_TOLERANCE = 1e-12
+
     def set_config_val(self, path, value):
         super().set_config_val(path, value)
         # Now set the parameter too
@@ -99,7 +103,7 @@ class DefaultCalibrationTreeItemModel(CalibrationTreeItemModel):
             # value red.
             item = self.get_item(index)
             if not item.child_items and item.data(self.VALUE_IDX) is not None:
-                atol = 1e-3
+                atol = self.RED_COLOR_TOLERANCE
                 pairs = [
                     (self.VALUE_IDX, self.MAX_IDX),
                     (self.VALUE_IDX, self.MIN_IDX),
@@ -133,7 +137,7 @@ class DeltaCalibrationTreeItemModel(CalibrationTreeItemModel):
             # If a delta is zero, color both the delta and the value red.
             item = self.get_item(index)
             if not item.child_items and item.data(self.VALUE_IDX) is not None:
-                atol = 1e-3
+                atol = self.RED_COLOR_TOLERANCE
                 if abs(item.data(self.DELTA_IDX)) < atol:
                     return QColor('red')
 

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1000</width>
+    <width>1050</width>
     <height>1000</height>
    </rect>
   </property>

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -17,6 +17,8 @@ KEY_COL = BaseTreeItemModel.KEY_COL
 
 class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
 
+    UNEDITABLE_COLUMN_INDICES = []
+
     def __init__(self, dictionary, columns, parent=None):
         super().__init__(dictionary, parent)
 
@@ -50,13 +52,19 @@ class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
         column = index.column()
         item = self.get_item(index)
         if column != KEY_COL and item.data(column) is not None:
+            # All columns after the first that aren't None are editable,
+            # unless explicitly disabled.
+            editable = True
             if self.has_uneditable_paths:
                 # Need to check if it is uneditable
                 path = tuple(self.path_to_item(item) + [column])
-                if path not in self.uneditable_paths:
-                    flags = flags | Qt.ItemIsEditable
-            else:
-                # All columns after the first that isn't None is editable
+                if path in self.uneditable_paths:
+                    editable = False
+
+            if column in self.UNEDITABLE_COLUMN_INDICES:
+                editable = False
+
+            if editable:
                 flags = flags | Qt.ItemIsEditable
 
         return flags


### PR DESCRIPTION
This shows the standard error as produced by lmfit. It only ever shows the uncertainty for parameters marked `vary` in the most recent refinement.

![image](https://github.com/user-attachments/assets/eba0587a-5651-4fb7-88f4-6fd0a564f7fa)

Fixes: #1872