### PR TITLE
Remove min subtraction in scaling

### DIFF
--- a/hexrdgui/scaling.py
+++ b/hexrdgui/scaling.py
@@ -12,16 +12,18 @@ def none(x: np.ndarray) -> np.ndarray:
 
 
 def sqrt(x: np.ndarray) -> np.ndarray:
-    return np.sqrt(x + 1)
+    y = np.sqrt(x + 1)
+    return y - np.nanmin(y)
 
 
 def log(x: np.ndarray) -> np.ndarray:
-    return np.log(x + 1)
+    y = np.log(x + 1)
+    return y - np.nanmin(y)
 
 
 def log_log_sqrt(x: np.ndarray) -> np.ndarray:
-    return np.log(np.log(np.sqrt(x + 1) + 1) + 1)
-
+    y = np.log(np.log(np.sqrt(x + 1) + 1) + 1)
+    return y - np.nanmin(y)
 
 # This decorator automatically rescales the transform output to have
 # the same range as the transform input.


### PR DESCRIPTION
The min subtraction was causing some inconsistencies in coloring within the same dataset, because if someone, for example, masks out (or performs something like an erosion on) the data which eliminates the old minimum in the data, it would appear that all of the data values are rescaled.

We also should include a `+ 1` for the square root cases that will eliminate most negative values we'd encounter.

The only case where the data may be adversely affected by this change would be cases where there are some very negative values in the data. Perhaps this happens for some datasets with dark background subtraction.

Fixes: #1878