### PR TITLE
Add beam energy correction to grains

### DIFF
--- a/hexrdgui/calibration/hedm/calibration_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_dialog.py
@@ -226,6 +226,27 @@ class HEDMCalibrationDialog(CalibrationDialog):
             for k, v in settings.items():
                 setattr(self, k, v)
 
+    def validate_parameters(self):
+        super().validate_parameters()
+
+        config = self.tree_view.model().config
+        if 'energy correction' in config['beam']:
+            if any(
+                d['_param'].vary for d in
+                config['beam']['energy correction'].values()
+            ):
+                # We are varying energy correction parameters.
+                # Verify we have at least two grains, or this wouldn't
+                # make sense to do.
+                num_grains = sum(
+                    s.endswith('grain_param_0') for s in self.params_dict
+                )
+                if num_grains < 2:
+                    raise Exception(
+                        'Cannot vary beam energy correction parameters with '
+                        'only one grain'
+                    )
+
 
 class HEDMCalibrationCallbacks(MaterialCalibrationDialogCallbacks):
 

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -74,6 +74,9 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """Emitted when beam vector has changed"""
     beam_vector_changed = Signal()
 
+    """Emitted when beam energy correction is changed"""
+    beam_energy_correction_changed = Signal()
+
     """Emitted when the active beam has switched"""
     active_beam_switched = Signal()
 
@@ -1515,6 +1518,10 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             self.beam_vector_changed.emit()
             return
 
+        if path[:2] == beam_path + ['energy_correction']:
+            self.beam_energy_correction_changed.emit()
+            return
+
         if path[0] == 'detectors' and path[2] == 'transform':
             # If a detector transform was modified, send a signal
             # indicating so
@@ -1561,6 +1568,13 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 # There's going to be one more layer to the path
                 path = path.copy()
                 path.insert(1, self.active_beam_name)
+
+        if (
+            path[:2] == ['beam', 'energy_correction'] and
+            cur_val.get('beam', {}).get('energy_correction') is None
+        ):
+            defaults = HEDMInstrument.create_default_energy_correction()
+            return defaults[path[2]]
 
         # Special case for distortion:
         # If no distortion is specified, return 'None'

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -112,6 +112,8 @@ class ImageCanvas(FigureCanvas):
         HexrdConfig().rerender_auto_picked_data.connect(
             self.draw_auto_picked_data)
         HexrdConfig().beam_vector_changed.connect(self.beam_vector_changed)
+        HexrdConfig().beam_energy_correction_changed.connect(
+            self.beam_energy_correction_changed)
         HexrdConfig().beam_marker_modified.connect(self.update_beam_marker)
         HexrdConfig().oscillation_stage_changed.connect(
             self.oscillation_stage_changed)
@@ -976,6 +978,21 @@ class ImageCanvas(FigureCanvas):
 
         self.update_overlays()
         self.update_beam_marker()
+
+    def beam_energy_correction_changed(self):
+        # Only overlay updates are needed
+        if not self.iviewer or not hasattr(self.iviewer, 'instr'):
+            return
+
+        # Re-draw all overlays from scratch
+        # Technically this would only affect rotation series overlays,
+        # but re-creating overlays is cheap...
+        HexrdConfig().clear_overlay_data()
+
+        beam_config = HexrdConfig().active_beam
+        self.iviewer.instr.energy_correction = beam_config['energy_correction']
+
+        self.update_overlays()
 
     def oscillation_stage_changed(self):
         if not self.iviewer or not hasattr(self.iviewer, 'instr'):

--- a/hexrdgui/resources/calibration/calibration_params_tree_view.yml
+++ b/hexrdgui/resources/calibration/calibration_params_tree_view.yml
@@ -3,6 +3,9 @@ beam:
   vector:
     azimuth: beam_azimuth
     polar angle: beam_polar
+  energy correction:
+    slope: beam_energy_correction_slope
+    intercept: beam_energy_correction_intercept
 oscillation stage:
   chi: instr_chi
   translation:

--- a/hexrdgui/resources/calibration/yaml_to_gui.yml
+++ b/hexrdgui/resources/calibration/yaml_to_gui.yml
@@ -4,6 +4,10 @@ beam:
     azimuth: 'cal_vector_azimuth',
     polar_angle: 'cal_vector_polar'
   }
+  energy_correction:
+    intercept: cal_energy_correction_intercept
+    slope: cal_energy_correction_slope
+    axis: cal_energy_correction_axis
 detectors:
   detector_name:
     distortion:

--- a/hexrdgui/resources/ui/instrument_form_view_widget.ui
+++ b/hexrdgui/resources/ui/instrument_form_view_widget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>765</width>
-    <height>903</height>
+    <height>978</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -27,14 +27,11 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="groupBox">
+    <widget class="QGroupBox" name="beam_group">
      <property name="title">
       <string>Beam Properties</string>
      </property>
-     <layout class="QVBoxLayout" name="verticalLayout_3">
-      <property name="spacing">
-       <number>0</number>
-      </property>
+     <layout class="QGridLayout" name="gridLayout_9">
       <property name="leftMargin">
        <number>0</number>
       </property>
@@ -47,7 +44,93 @@
       <property name="bottomMargin">
        <number>0</number>
       </property>
-      <item>
+      <item row="3" column="2">
+       <widget class="QLabel" name="energy_correction_intercept_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Intercept:</string>
+        </property>
+        <property name="buddy">
+         <cstring>cal_energy_correction_intercept</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="energy_correction_slope_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Slope:</string>
+        </property>
+        <property name="buddy">
+         <cstring>cal_energy_correction_slope</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="apply_energy_correction">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Apply HEDM Energy Correction?</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="ScientificDoubleSpinBox" name="cal_energy_correction_slope">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string> eV/mm</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="ScientificDoubleSpinBox" name="cal_energy_correction_intercept">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="suffix">
+         <string> mm</string>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="minimum">
+         <double>-1000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="4">
        <widget class="QGroupBox" name="groupBox_2">
         <property name="title">
          <string>Energy</string>
@@ -131,7 +214,7 @@
         </layout>
        </widget>
       </item>
-      <item>
+      <item row="1" column="0" colspan="4">
        <widget class="QGroupBox" name="groupBox_3">
         <property name="title">
          <string>Vector</string>
@@ -467,6 +550,36 @@
         </layout>
        </widget>
       </item>
+      <item row="2" column="2">
+       <widget class="QLabel" name="energy_correction_axis_label">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Axis:</string>
+        </property>
+        <property name="buddy">
+         <cstring>cal_energy_correction_axis</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3">
+       <widget class="QComboBox" name="cal_energy_correction_axis">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&amp;quot;Energy Correction&amp;quot; is for applying a small beam energy correction factor to grain positions in an HEDM workflow. The synchrotron beam gradients are sometimes not flat, and an energy correction along the x or y axes can improve the results.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Intercept&amp;quot; is the center of the beam gradient along the specifix axis (where the energy is equal to the beam energy specified in the instrument configuration), in millimeters.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;The &amp;quot;Slope&amp;quot; is the adjustment in the beam energy as a grain gets farther away from the intercept along the specified axis, in eV/mm.&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;These parameters are available to use in the various calibration workflows.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <item>
+         <property name="text">
+          <string>y</string>
+         </property>
+        </item>
+        <item>
+         <property name="text">
+          <string>x</string>
+         </property>
+        </item>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -538,72 +651,6 @@
          <property name="spacing">
           <number>0</number>
          </property>
-         <item row="0" column="2">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_1">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="suffix">
-            <string> mm</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_15">
-           <property name="text">
-            <string>Translation:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="3">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_2">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="prefix">
-            <string/>
-           </property>
-           <property name="suffix">
-            <string> mm</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="1">
           <widget class="ScientificDoubleSpinBox" name="cal_det_translation_0">
            <property name="alignment">
@@ -617,66 +664,6 @@
            </property>
            <property name="suffix">
             <string> mm</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0">
-          <widget class="QLabel" name="label_16">
-           <property name="text">
-            <string>Rotation:</string>
-           </property>
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="1">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_0">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string>°</string>
-           </property>
-           <property name="decimals">
-            <number>8</number>
-           </property>
-           <property name="minimum">
-            <double>-100000.000000000000000</double>
-           </property>
-           <property name="maximum">
-            <double>100000.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.100000000000000</double>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="2">
-          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_1">
-           <property name="alignment">
-            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-           </property>
-           <property name="keyboardTracking">
-            <bool>false</bool>
-           </property>
-           <property name="suffix">
-            <string>°</string>
            </property>
            <property name="decimals">
             <number>8</number>
@@ -714,6 +701,132 @@
            </property>
            <property name="singleStep">
             <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_1">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="suffix">
+            <string> mm</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_translation_2">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="prefix">
+            <string/>
+           </property>
+           <property name="suffix">
+            <string> mm</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_0">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Rotation:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="ScientificDoubleSpinBox" name="cal_det_tilt_1">
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+           </property>
+           <property name="keyboardTracking">
+            <bool>false</bool>
+           </property>
+           <property name="suffix">
+            <string>°</string>
+           </property>
+           <property name="decimals">
+            <number>8</number>
+           </property>
+           <property name="minimum">
+            <double>-100000.000000000000000</double>
+           </property>
+           <property name="maximum">
+            <double>100000.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.100000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>Translation:</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
            </property>
           </widget>
          </item>
@@ -1410,6 +1523,10 @@
   <tabstop>beam_vector_cartesian_z</tabstop>
   <tabstop>beam_vector_is_finite</tabstop>
   <tabstop>beam_vector_magnitude</tabstop>
+  <tabstop>apply_energy_correction</tabstop>
+  <tabstop>cal_energy_correction_axis</tabstop>
+  <tabstop>cal_energy_correction_slope</tabstop>
+  <tabstop>cal_energy_correction_intercept</tabstop>
   <tabstop>cal_det_current</tabstop>
   <tabstop>cal_det_add</tabstop>
   <tabstop>cal_det_remove</tabstop>


### PR DESCRIPTION
This allows a slope (in eV/mm), intercept (in mm), and axis ('x' or 'y') to be specified for a beam energy correction according to grain positions.

This is important to take into consideration gradients in the beam energy profile, such that some grains may "experience" a different beam energy than others.

The option to add the HEDM beam energy correction was added to the instrument form view. If added, it also goes into the tree view, and the slope and the intercept will appear in the HEDM calibration as well as refinable parameters.

Depends on: hexrd/hexrd#819