### PR TITLE
Only use 1 thread for OpenBLAS on Mac

### DIFF
--- a/hexrdgui/main.py
+++ b/hexrdgui/main.py
@@ -1,5 +1,10 @@
+import os
 import signal
 import sys
+
+if sys.platform.startswith('darwin'):
+    # Prevent crashing when using OpenBLAS
+    os.environ['OPENBLAS_NUM_THREADS'] = '1'
 
 from PySide6.QtCore import QCoreApplication, Qt
 from PySide6.QtGui import QIcon, QPixmap


### PR DESCRIPTION
This prevents a crashing issue from happening when certain methods are called.

It was necessary to set this environment variable before some of the other imports.