### PR TITLE
Add ability to plot WPPF background and amorphous

### DIFF
--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -101,6 +101,8 @@ class WppfOptionsDialog(QObject):
             self.select_experiment_file)
         self.ui.display_wppf_plot.toggled.connect(
             self.display_wppf_plot_toggled)
+        self.ui.plot_background.toggled.connect(self.plot_background_toggled)
+        self.ui.plot_amorphous.toggled.connect(self.plot_amorphous_toggled)
         self.ui.edit_plot_style.pressed.connect(self.edit_plot_style)
         self.ui.pick_spline_points.clicked.connect(self.pick_spline_points)
 
@@ -618,6 +620,22 @@ class WppfOptionsDialog(QObject):
         self.ui.display_wppf_plot.setChecked(v)
 
     @property
+    def plot_background(self) -> bool:
+        return self.ui.plot_background.isChecked()
+
+    @plot_background.setter
+    def plot_background(self, b: bool):
+        self.ui.plot_background.setChecked(b)
+
+    @property
+    def plot_amorphous(self) -> bool:
+        return self.ui.plot_amorphous.isChecked()
+
+    @plot_amorphous.setter
+    def plot_amorphous(self, b: bool):
+        self.ui.plot_amorphous.setChecked(b)
+
+    @property
     def params_dict(self):
         ret = {}
         for key, param in self.params.param_dict.items():
@@ -678,6 +696,8 @@ class WppfOptionsDialog(QObject):
             'use_experiment_file',
             'experiment_file',
             'display_wppf_plot',
+            'plot_background',
+            'plot_amorphous',
             'params_dict',
             'limit_tth',
             'min_tth',
@@ -699,13 +719,30 @@ class WppfOptionsDialog(QObject):
     def display_wppf_plot_toggled(self):
         HexrdConfig().display_wppf_plot = self.display_wppf_plot
 
+    def plot_background_toggled(self):
+        HexrdConfig().display_wppf_background = self.plot_background
+
+    def plot_amorphous_toggled(self):
+        HexrdConfig().display_wppf_amorphous = self.plot_amorphous
+
     def edit_plot_style(self):
-        dialog = WppfStylePicker(self.ui)
-        dialog.ui.exec()
+        dialog = WppfStylePicker(
+            amorphous_visible=self.include_amorphous,
+            parent=self.ui,
+        )
+        dialog.exec()
 
     def update_gui(self):
-        with block_signals(self.ui.display_wppf_plot):
+        to_block = [
+            self.ui.display_wppf_plot,
+            self.ui.plot_background,
+            self.ui.plot_amorphous,
+        ]
+        with block_signals(*to_block):
             self.display_wppf_plot = HexrdConfig().display_wppf_plot
+            self.plot_background = HexrdConfig().display_wppf_background
+            self.plot_amorphous = HexrdConfig().display_wppf_amorphous
+
             self.update_background_parameters()
             self.update_tree_view()
 
@@ -768,6 +805,8 @@ class WppfOptionsDialog(QObject):
             w = layout.itemAt(i).widget()
             if w is not None:
                 w.setVisible(b)
+
+        self.ui.plot_amorphous.setEnabled(b)
 
         self.on_amorphous_model_changed()
 
@@ -1112,6 +1151,8 @@ class WppfOptionsDialog(QObject):
             'background_method',
             'experiment_file',
             'display_wppf_plot',
+            'plot_background',
+            'plot_amorphous',
         ]
         return [getattr(self.ui, x) for x in names]
 

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -61,7 +61,25 @@ class WppfRunner:
         self.update_param_values()
 
     def rerender_wppf(self):
-        HexrdConfig().wppf_data = list(self.wppf_object.spectrum_sim.data)
+        obj = self.wppf_object
+
+        HexrdConfig().wppf_data = list(obj.spectrum_sim.data)
+
+        background = []
+        if obj.background:
+            background = list(obj.background.data)
+
+        HexrdConfig().wppf_background_lineout = background
+
+        amorphous_lineout = []
+        if obj.amorphous_model is not None:
+            amorphous_lineout = [
+                obj.amorphous_model.tth_list,
+                obj.amorphous_model.amorphous_lineout,
+            ]
+
+        HexrdConfig().wppf_amorphous_lineout = amorphous_lineout
+
         HexrdConfig().rerender_wppf.emit()
 
         # Process events to make sure it visually updates.

--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -69,6 +69,18 @@ DEFAULT_WPPF_PLOT_STYLE = {
     'edgecolors': '#ff0000',
 }
 
+DEFAULT_WPPF_BACKGROUND_STYLE = {
+    'c': '#ff0000',
+    'ls': 'dashed',
+    'lw': 1.0,
+}
+
+DEFAULT_WPPF_AMORPHOUS_STYLE = {
+    'c': '#ff0000',
+    'ls': 'solid',
+    'lw': 1.0,
+}
+
 HEXRD_DIRECTORY_SUFFIX = '.hexrd'
 
 BUFFER_KEY = 'buffer'

--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -63,9 +63,9 @@ DEFAULT_EULER_ANGLE_CONVENTION = {
 }
 
 DEFAULT_WPPF_PLOT_STYLE = {
-    'marker': 'o',
+    'marker': 'x',
     's': 30,
-    'facecolors': '#ffffff',
+    'facecolors': '#0000ff',
     'edgecolors': '#ff0000',
 }
 

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -303,6 +303,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.backup_tth_maxes = {}
         self.overlays = []
         self.wppf_data = None
+        self.wppf_background_lineout = None
+        self.wppf_amorphous_lineout = None
         self._auto_picked_data = None
         self.last_unscaled_azimuthal_integral_data = None
         self._threshold_data = {}
@@ -2752,21 +2754,42 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.unaggregated_images = copy.copy(self.imageseries_dict)
 
     @property
+    def wppf_settings(self) -> dict:
+        return HexrdConfig().config['calibration'].setdefault('wppf', {})
+
+    @property
     def display_wppf_plot(self):
-        settings = HexrdConfig().config['calibration'].setdefault('wppf', {})
-        return settings.setdefault('display_plot', True)
+        return self.wppf_settings.setdefault('display_plot', True)
 
     @display_wppf_plot.setter
     def display_wppf_plot(self, b):
         if self.display_wppf_plot != b:
-            settings = HexrdConfig().config['calibration']['wppf']
-            settings['display_plot'] = b
+            self.wppf_settings['display_plot'] = b
+            self.rerender_wppf.emit()
+
+    @property
+    def display_wppf_background(self):
+        return self.wppf_settings.setdefault('display_background', False)
+
+    @display_wppf_background.setter
+    def display_wppf_background(self, b):
+        if self.display_wppf_background != b:
+            self.wppf_settings['display_background'] = b
+            self.rerender_wppf.emit()
+
+    @property
+    def display_wppf_amorphous(self):
+        return self.wppf_settings.setdefault('display_amorphous', False)
+
+    @display_wppf_amorphous.setter
+    def display_wppf_amorphous(self, b):
+        if self.display_wppf_amorphous != b:
+            self.wppf_settings['display_amorphous'] = b
             self.rerender_wppf.emit()
 
     @property
     def wppf_plot_style(self):
-        settings = HexrdConfig().config['calibration'].setdefault('wppf', {})
-        settings = settings.setdefault('plot_style', {})
+        settings = self.wppf_settings.setdefault('plot_style', {})
         if not settings:
             settings.update(copy.deepcopy(constants.DEFAULT_WPPF_PLOT_STYLE))
         return settings
@@ -2774,8 +2797,37 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     @wppf_plot_style.setter
     def wppf_plot_style(self, s):
         if self.wppf_plot_style != s:
-            settings = HexrdConfig().config['calibration']['wppf']
-            settings['plot_style'] = s
+            self.wppf_settings['plot_style'] = s
+            self.rerender_wppf.emit()
+
+    @property
+    def wppf_background_style(self):
+        settings = self.wppf_settings.setdefault('background_style', {})
+        if not settings:
+            settings.update(
+                copy.deepcopy(constants.DEFAULT_WPPF_BACKGROUND_STYLE)
+            )
+        return settings
+
+    @wppf_background_style.setter
+    def wppf_background_style(self, s):
+        if self.wppf_background_style != s:
+            self.wppf_settings['background_style'] = s
+            self.rerender_wppf.emit()
+
+    @property
+    def wppf_amorphous_style(self):
+        settings = self.wppf_settings.setdefault('amorphous_style', {})
+        if not settings:
+            settings.update(
+                copy.deepcopy(constants.DEFAULT_WPPF_AMORPHOUS_STYLE)
+            )
+        return settings
+
+    @wppf_amorphous_style.setter
+    def wppf_amorphous_style(self, s):
+        if self.wppf_amorphous_style != s:
+            self.wppf_settings['amorphous_style'] = s
             self.rerender_wppf.emit()
 
     @property

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -70,6 +70,8 @@ class ImageCanvas(FigureCanvas):
         self.azimuthal_integral_axis = None
         self.azimuthal_line_artist = None
         self.wppf_plot = None
+        self.wppf_background_plot = None
+        self.wppf_amorphous_plot = None
         self.auto_picked_data_artists = []
         self.beam_marker_artists = []
         self._transform = lambda x: x
@@ -209,6 +211,14 @@ class ImageCanvas(FigureCanvas):
         if self.wppf_plot:
             self.wppf_plot.remove()
             self.wppf_plot = None
+
+        if self.wppf_background_plot:
+            self.wppf_background_plot.remove()
+            self.wppf_background_plot = None
+
+        if self.wppf_amorphous_plot:
+            self.wppf_amorphous_plot.remove()
+            self.wppf_amorphous_plot = None
 
     def clear_auto_picked_data_artists(self):
         while self.auto_picked_data_artists:
@@ -1734,26 +1744,43 @@ class ImageCanvas(FigureCanvas):
     def update_wppf_plot(self):
         self.clear_wppf_plot()
 
-        if not HexrdConfig().display_wppf_plot:
-            return
-
-        wppf_data = HexrdConfig().wppf_data
         axis = self.azimuthal_integral_axis
         line = self.azimuthal_line_artist
-        if any(x is None for x in (wppf_data, axis, line)):
+        if any(x is None for x in (axis, line)):
             return
 
-        style = HexrdConfig().wppf_plot_style
+        if HexrdConfig().display_wppf_plot:
+            wppf_data = HexrdConfig().wppf_data
+            if not wppf_data:
+                return
 
-        if style.get('marker', 'o') not in Line2D.filled_markers:
-            # Marker is unfilled
-            if 'edgecolors' in style:
-                # Unfilled markers can't have edge colors.
-                # Remove this to avoid a matplotlib warning.
-                style = copy.deepcopy(style)
-                del style['edgecolors']
+            style = HexrdConfig().wppf_plot_style
 
-        self.wppf_plot = axis.scatter(*wppf_data, **style)
+            if style.get('marker', 'o') not in Line2D.filled_markers:
+                # Marker is unfilled
+                if 'edgecolors' in style:
+                    # Unfilled markers can't have edge colors.
+                    # Remove this to avoid a matplotlib warning.
+                    style = copy.deepcopy(style)
+                    del style['edgecolors']
+
+            self.wppf_plot = axis.scatter(*wppf_data, **style)
+
+        if HexrdConfig().display_wppf_background:
+            background = HexrdConfig().wppf_background_lineout
+            if not background:
+                return
+
+            style = HexrdConfig().wppf_background_style
+            self.wppf_background_plot, = axis.plot(*background, **style)
+
+        if HexrdConfig().display_wppf_amorphous:
+            amorphous = HexrdConfig().wppf_amorphous_lineout
+            if not amorphous:
+                return
+
+            style = HexrdConfig().wppf_amorphous_style
+            self.wppf_amorphous_plot, = axis.plot(*amorphous, **style)
 
         # Rescale.
         # This actually ignores the scatter plot data when rescaling,

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -14,29 +14,69 @@
    <string>WPPF Options Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="3" column="0">
-    <widget class="QLabel" name="peak_shape_label">
+   <item row="0" column="0" colspan="3">
+    <widget class="QPushButton" name="select_materials_button">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
      <property name="text">
-      <string>Peak shape:</string>
+      <string>Select Materials</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="refinement_steps_label">
+   <item row="20" column="0" colspan="3">
+    <widget class="QGroupBox" name="param_settings_group">
+     <property name="title">
+      <string>Parameter Settings</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QPushButton" name="export_params">
+        <property name="text">
+         <string>Export</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="import_params">
+        <property name="text">
+         <string>Import</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QPushButton" name="reset_params_to_defaults">
+        <property name="text">
+         <string>Reset to Defaults</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QCheckBox" name="use_experiment_file">
      <property name="text">
-      <string>Refinement Steps:</string>
+      <string>Use Experiment File</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="background_method_label">
+   <item row="1" column="0">
+    <widget class="QLabel" name="method_label">
      <property name="text">
-      <string>Background Method:</string>
+      <string>WPPF Method:</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QComboBox" name="peak_shape"/>
+   <item row="12" column="1">
+    <widget class="QLineEdit" name="experiment_file">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
    </item>
    <item row="1" column="1" colspan="2">
     <widget class="QComboBox" name="method">
@@ -52,20 +92,10 @@
      </item>
     </widget>
    </item>
-   <item row="18" column="0" colspan="3">
-    <layout class="QVBoxLayout" name="tree_view_layout"/>
+   <item row="3" column="1" colspan="2">
+    <widget class="QComboBox" name="peak_shape"/>
    </item>
-   <item row="11" column="1">
-    <widget class="QLineEdit" name="experiment_file">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="21" column="0" colspan="3">
+   <item row="22" column="0" colspan="3">
     <layout class="QHBoxLayout" name="button_layout">
      <item>
       <widget class="QPushButton" name="save_plot">
@@ -148,14 +178,72 @@
      </item>
     </layout>
    </item>
-   <item row="8" column="0" colspan="3">
-    <widget class="QPushButton" name="pick_spline_points">
+   <item row="4" column="1" colspan="2">
+    <widget class="QComboBox" name="background_method"/>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="refinement_steps_label">
      <property name="text">
-      <string>Pick Spline Points</string>
+      <string>Refinement Steps:</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="0" colspan="3">
+   <item row="3" column="0">
+    <widget class="QLabel" name="peak_shape_label">
+     <property name="text">
+      <string>Peak shape:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="15" column="0" colspan="3">
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="1" column="2">
+      <widget class="QCheckBox" name="plot_amorphous">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Plot amorphous model?</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="plot_background">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of the background (default: red dashed line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the background plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string>Plot background?</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="delta_boundaries">
+       <property name="text">
+        <string>Use delta boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0" colspan="2">
+      <widget class="QCheckBox" name="display_wppf_plot">
+       <property name="text">
+        <string>Display WPPF plot in polar view?</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QPushButton" name="edit_plot_style">
+       <property name="text">
+        <string>Edit Plot Style</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="19" column="0" colspan="3">
+    <layout class="QVBoxLayout" name="tree_view_layout"/>
+   </item>
+   <item row="13" column="0" colspan="3">
     <layout class="QHBoxLayout" name="limit_tth_layout">
      <item>
       <widget class="QCheckBox" name="limit_tth">
@@ -220,6 +308,9 @@
      </item>
     </layout>
    </item>
+   <item row="10" column="0" colspan="3">
+    <layout class="QVBoxLayout" name="background_method_parameters_layout"/>
+   </item>
    <item row="2" column="1" colspan="2">
     <widget class="QSpinBox" name="refinement_steps">
      <property name="minimum">
@@ -233,55 +324,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="background_method"/>
-   </item>
-   <item row="14" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="plot_options_layout">
-     <item>
-      <widget class="QCheckBox" name="display_wppf_plot">
-       <property name="text">
-        <string>Display WPPF plot in polar view?</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="edit_plot_style">
-       <property name="text">
-        <string>Edit Plot Style</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="11" column="0">
-    <widget class="QCheckBox" name="use_experiment_file">
-     <property name="text">
-      <string>Use Experiment File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="3">
-    <layout class="QVBoxLayout" name="background_method_parameters_layout"/>
-   </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QPushButton" name="select_materials_button">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Select Materials</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="0">
-    <widget class="QCheckBox" name="delta_boundaries">
-     <property name="text">
-      <string>Use delta boundaries</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="2">
+   <item row="12" column="2">
     <widget class="QPushButton" name="select_experiment_file_button">
      <property name="enabled">
       <bool>false</bool>
@@ -291,56 +334,26 @@
      </property>
     </widget>
    </item>
-   <item row="19" column="0" colspan="3">
-    <widget class="QGroupBox" name="param_settings_group">
-     <property name="title">
-      <string>Parameter Settings</string>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout">
-      <item>
-       <widget class="QPushButton" name="export_params">
-        <property name="text">
-         <string>Export</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="import_params">
-        <property name="text">
-         <string>Import</string>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <widget class="QPushButton" name="reset_params_to_defaults">
-        <property name="text">
-         <string>Reset to Defaults</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="method_label">
+   <item row="4" column="0">
+    <widget class="QLabel" name="background_method_label">
      <property name="text">
-      <string>WPPF Method:</string>
+      <string>Background Method:</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0" colspan="3">
+   <item row="8" column="0" colspan="3">
+    <widget class="QPushButton" name="pick_spline_points">
+     <property name="text">
+      <string>Pick Spline Points</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="3">
     <widget class="QGroupBox" name="amorphous_group">
      <property name="title">
       <string/>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="1">
-       <widget class="QLabel" name="degree_of_crystallinity_label">
-        <property name="text">
-         <string>Degree of Crystallinity: 1</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QCheckBox" name="include_amorphous">
         <property name="toolTip">
@@ -351,7 +364,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0" colspan="2">
+      <item row="1" column="0" colspan="3">
        <layout class="QHBoxLayout" name="amorphous_options_layout">
         <item>
          <widget class="QLabel" name="amorphous_model_label">
@@ -382,6 +395,13 @@
         </item>
        </layout>
       </item>
+      <item row="0" column="1" colspan="2">
+       <widget class="QLabel" name="degree_of_crystallinity_label">
+        <property name="text">
+         <string>Degree of Crystallinity: 1</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -400,10 +420,11 @@
   <tabstop>refinement_steps</tabstop>
   <tabstop>peak_shape</tabstop>
   <tabstop>background_method</tabstop>
+  <tabstop>pick_spline_points</tabstop>
+  <tabstop>include_amorphous</tabstop>
   <tabstop>amorphous_model</tabstop>
   <tabstop>amorphous_experiment_file</tabstop>
   <tabstop>amorphous_experiment_file_select</tabstop>
-  <tabstop>pick_spline_points</tabstop>
   <tabstop>use_experiment_file</tabstop>
   <tabstop>experiment_file</tabstop>
   <tabstop>select_experiment_file_button</tabstop>
@@ -413,6 +434,8 @@
   <tabstop>display_wppf_plot</tabstop>
   <tabstop>edit_plot_style</tabstop>
   <tabstop>delta_boundaries</tabstop>
+  <tabstop>plot_background</tabstop>
+  <tabstop>plot_amorphous</tabstop>
   <tabstop>export_params</tabstop>
   <tabstop>import_params</tabstop>
   <tabstop>reset_params_to_defaults</tabstop>
@@ -431,12 +454,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>98</x>
-     <y>191</y>
+     <x>109</x>
+     <y>460</y>
     </hint>
     <hint type="destinationlabel">
-     <x>533</x>
-     <y>192</y>
+     <x>753</x>
+     <y>461</y>
     </hint>
    </hints>
   </connection>
@@ -447,12 +470,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>98</x>
-     <y>191</y>
+     <x>109</x>
+     <y>460</y>
     </hint>
     <hint type="destinationlabel">
-     <x>625</x>
-     <y>192</y>
+     <x>1038</x>
+     <y>462</y>
     </hint>
    </hints>
   </connection>
@@ -463,12 +486,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>109</x>
-     <y>254</y>
+     <x>121</x>
+     <y>528</y>
     </hint>
     <hint type="destinationlabel">
-     <x>310</x>
-     <y>254</y>
+     <x>662</x>
+     <y>529</y>
     </hint>
    </hints>
   </connection>
@@ -479,12 +502,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>109</x>
-     <y>254</y>
+     <x>121</x>
+     <y>528</y>
     </hint>
     <hint type="destinationlabel">
-     <x>417</x>
-     <y>254</y>
+     <x>697</x>
+     <y>559</y>
     </hint>
    </hints>
   </connection>
@@ -495,12 +518,12 @@
    <slot>setEnabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>109</x>
-     <y>254</y>
+     <x>121</x>
+     <y>528</y>
     </hint>
     <hint type="destinationlabel">
-     <x>525</x>
-     <y>254</y>
+     <x>1037</x>
+     <y>529</y>
     </hint>
    </hints>
   </connection>

--- a/hexrdgui/resources/ui/wppf_style_picker.ui
+++ b/hexrdgui/resources/ui/wppf_style_picker.ui
@@ -6,9 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>661</width>
-    <height>136</height>
+    <width>774</width>
+    <height>307</height>
    </rect>
+  </property>
+  <property name="windowTitle">
+   <string>WPPF Plot Style</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <property name="leftMargin">
@@ -23,70 +26,111 @@
    <property name="bottomMargin">
     <number>6</number>
    </property>
-   <item row="2" column="0" colspan="2">
-    <widget class="QGroupBox" name="style_group">
+   <item row="1" column="0" colspan="2">
+    <widget class="QGroupBox" name="background_group">
      <property name="title">
-      <string/>
+      <string>Background Plot</string>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
-      <item row="0" column="5">
-       <widget class="QLabel" name="face_color_label">
+      <item row="0" column="4">
+       <widget class="QLabel" name="background_line_width_label">
         <property name="text">
-         <string>Face color:</string>
+         <string>Line Width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>background_line_width</cstring>
         </property>
        </widget>
       </item>
-      <item row="0" column="7">
-       <widget class="QLabel" name="edge_color_label">
+      <item row="0" column="0">
+       <widget class="QLabel" name="background_color_label">
         <property name="text">
-         <string>Edge color:</string>
+         <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>background_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QComboBox" name="background_line_style"/>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="background_color">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="background_line_style_label">
+        <property name="text">
+         <string>Line Style:</string>
+        </property>
+        <property name="buddy">
+         <cstring>background_line_style</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="ScientificDoubleSpinBox" name="background_line_width">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QGroupBox" name="simulated_spectrum_group">
+     <property name="title">
+      <string>Simulated Spectrum</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="marker_label">
+        <property name="text">
+         <string>Marker:</string>
+        </property>
+        <property name="buddy">
+         <cstring>marker</cstring>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QComboBox" name="marker"/>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="marker_label">
-        <property name="text">
-         <string>Marker:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
+      <item row="0" column="2">
        <widget class="QLabel" name="marker_size_label">
         <property name="text">
          <string>Size:</string>
         </property>
-       </widget>
-      </item>
-      <item row="0" column="6">
-       <widget class="QPushButton" name="face_color">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
+        <property name="buddy">
+         <cstring>marker_size</cstring>
         </property>
        </widget>
       </item>
-      <item row="0" column="8">
-       <widget class="QPushButton" name="edge_color">
-        <property name="text">
-         <string/>
-        </property>
-        <property name="checkable">
-         <bool>true</bool>
-        </property>
-        <property name="checked">
-         <bool>false</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
+      <item row="0" column="3">
        <widget class="ScientificDoubleSpinBox" name="marker_size">
         <property name="keyboardTracking">
          <bool>false</bool>
@@ -105,14 +149,121 @@
         </property>
        </widget>
       </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="face_color_label">
+        <property name="text">
+         <string>Face color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>face_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="QPushButton" name="face_color">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="6">
+       <widget class="QLabel" name="edge_color_label">
+        <property name="text">
+         <string>Edge color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>edge_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="7">
+       <widget class="QPushButton" name="edge_color">
+        <property name="text">
+         <string/>
+        </property>
+        <property name="checkable">
+         <bool>true</bool>
+        </property>
+        <property name="checked">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
-   <item row="3" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="amorphous_group">
+     <property name="title">
+      <string>Amorphous Plot</string>
      </property>
+     <layout class="QGridLayout" name="gridLayout_4">
+      <item row="0" column="0">
+       <widget class="QLabel" name="amorphous_color_label">
+        <property name="text">
+         <string>Color:</string>
+        </property>
+        <property name="buddy">
+         <cstring>amorphous_color</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QPushButton" name="amorphous_color">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="2">
+       <widget class="QLabel" name="amorphous_line_style_label">
+        <property name="text">
+         <string>Line Style:</string>
+        </property>
+        <property name="buddy">
+         <cstring>amorphous_line_style</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="3">
+       <widget class="QComboBox" name="amorphous_line_style"/>
+      </item>
+      <item row="0" column="4">
+       <widget class="QLabel" name="amorphous_line_width_label">
+        <property name="text">
+         <string>Line Width:</string>
+        </property>
+        <property name="buddy">
+         <cstring>amorphous_line_width</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="5">
+       <widget class="ScientificDoubleSpinBox" name="amorphous_line_width">
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>100000.000000000000000</double>
+        </property>
+        <property name="singleStep">
+         <double>0.100000000000000</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
@@ -129,6 +280,12 @@
   <tabstop>marker_size</tabstop>
   <tabstop>face_color</tabstop>
   <tabstop>edge_color</tabstop>
+  <tabstop>background_color</tabstop>
+  <tabstop>background_line_style</tabstop>
+  <tabstop>background_line_width</tabstop>
+  <tabstop>amorphous_color</tabstop>
+  <tabstop>amorphous_line_style</tabstop>
+  <tabstop>amorphous_line_width</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/hexrdgui/wppf_style_picker.py
+++ b/hexrdgui/wppf_style_picker.py
@@ -13,19 +13,24 @@ from hexrdgui.utils import block_signals
 
 class WppfStylePicker(QObject):
 
-    def __init__(self, parent=None):
+    def __init__(self, amorphous_visible=False, parent=None):
         super().__init__(parent)
 
         loader = UiLoader()
         self.ui = loader.load_file('wppf_style_picker.ui', parent)
         self.ui.installEventFilter(enter_key_filter)
 
-        self.style = copy.deepcopy(HexrdConfig().wppf_plot_style)
-        self.original_style = copy.deepcopy(self.style)
+        self.original_style = copy.deepcopy(self.style_config)
+
+        self.ui.amorphous_group.setVisible(amorphous_visible)
 
         self.setup_combo_boxes()
         self.setup_connections()
         self.update_gui()
+
+    def exec(self):
+        self.ui.adjustSize()
+        return self.ui.exec()
 
     def setup_connections(self):
         self.ui.marker.currentIndexChanged.connect(self.update_config)
@@ -33,10 +38,27 @@ class WppfStylePicker(QObject):
         self.ui.edge_color.pressed.connect(self.pick_color)
         self.ui.face_color.pressed.connect(self.pick_color)
 
+        self.ui.background_color.clicked.connect(self.pick_color)
+        self.ui.background_line_style.currentIndexChanged.connect(
+            self.update_config)
+        self.ui.background_line_width.valueChanged.connect(self.update_config)
+
+        self.ui.amorphous_color.clicked.connect(self.pick_color)
+        self.ui.amorphous_line_style.currentIndexChanged.connect(
+            self.update_config)
+        self.ui.amorphous_line_width.valueChanged.connect(self.update_config)
+
         # Reset the style if the dialog is rejected
         self.ui.rejected.connect(self.reset_style)
 
     def setup_combo_boxes(self):
+        line_styles = [
+            'solid',
+            'dotted',
+            'dashed',
+            'dashdot'
+        ]
+
         marker_styles = [
             '.',
             'o',
@@ -50,6 +72,14 @@ class WppfStylePicker(QObject):
         for s in marker_styles:
             w.addItem(s)
 
+        w = self.ui.background_line_style
+        for s in line_styles:
+            w.addItem(s)
+
+        w = self.ui.amorphous_line_style
+        for s in line_styles:
+            w.addItem(s)
+
     @property
     def all_widgets(self):
         return [
@@ -57,34 +87,102 @@ class WppfStylePicker(QObject):
             self.ui.marker_size,
             self.ui.face_color,
             self.ui.edge_color,
+            self.ui.background_color,
+            self.ui.background_line_style,
+            self.ui.background_line_width,
+            self.ui.amorphous_color,
+            self.ui.amorphous_line_style,
+            self.ui.amorphous_line_width,
         ]
 
     def reset_style(self):
-        if self.style == self.original_style:
+        if self.style_config == self.original_style:
             # Nothing really to do...
             return
 
-        self.style = copy.deepcopy(self.original_style)
-        HexrdConfig().wppf_plot_style = copy.deepcopy(self.style)
+        self.style_config = copy.deepcopy(self.original_style)
         self.update_gui()
 
     def update_gui(self):
-        style = self.style
         with block_signals(*self.all_widgets):
-            self.ui.marker.setCurrentText(style['marker'])
-            self.ui.marker_size.setValue(style['s'])
-            self.ui.face_color.setText(style['facecolors'])
-            self.ui.edge_color.setText(style['edgecolors'])
+            self.style_gui = self.style_config
 
         self.update_button_colors()
 
     def update_config(self):
-        style = self.style
-        style['marker'] = self.ui.marker.currentText()
-        style['s'] = self.ui.marker_size.value()
-        style['facecolors'] = self.ui.face_color.text()
-        style['edgecolors'] = self.ui.edge_color.text()
-        HexrdConfig().wppf_plot_style = copy.deepcopy(style)
+        self.style_config = self.style_gui
+
+    @property
+    def style_config(self) -> dict:
+        return {
+            'plot': HexrdConfig().wppf_plot_style,
+            'background': HexrdConfig().wppf_background_style,
+            'amorphous': HexrdConfig().wppf_amorphous_style,
+        }
+
+    @style_config.setter
+    def style_config(self, v: dict):
+        HexrdConfig().wppf_plot_style = v['plot']
+        HexrdConfig().wppf_background_style = v['background']
+        HexrdConfig().wppf_amorphous_style = v['amorphous']
+
+    @property
+    def style_gui(self) -> dict:
+        return {
+            'plot': self.plot_style_gui,
+            'background': self.background_style_gui,
+            'amorphous': self.amorphous_style_gui,
+        }
+
+    @style_gui.setter
+    def style_gui(self, v: dict):
+        self.plot_style_gui = v['plot']
+        self.background_style_gui = v['background']
+        self.amorphous_style_gui = v['amorphous']
+
+    @property
+    def plot_style_gui(self) -> dict:
+        return {
+            'marker': self.ui.marker.currentText(),
+            's': self.ui.marker_size.value(),
+            'facecolors': self.ui.face_color.text(),
+            'edgecolors': self.ui.edge_color.text(),
+        }
+
+    @plot_style_gui.setter
+    def plot_style_gui(self, v: dict):
+        self.ui.marker.setCurrentText(v['marker'])
+        self.ui.marker_size.setValue(v['s'])
+        self.ui.face_color.setText(v['facecolors'])
+        self.ui.edge_color.setText(v['edgecolors'])
+
+    @property
+    def background_style_gui(self) -> dict:
+        return {
+            'c': self.ui.background_color.text(),
+            'ls': self.ui.background_line_style.currentText(),
+            'lw': self.ui.background_line_width.value(),
+        }
+
+    @background_style_gui.setter
+    def background_style_gui(self, v: dict):
+        self.ui.background_color.setText(v['c'])
+        self.ui.background_line_style.setCurrentText(v['ls'])
+        self.ui.background_line_width.setValue(v['lw'])
+
+    @property
+    def amorphous_style_gui(self) -> dict:
+        return {
+            'c': self.ui.amorphous_color.text(),
+            'ls': self.ui.amorphous_line_style.currentText(),
+            'lw': self.ui.amorphous_line_width.value(),
+        }
+
+    @amorphous_style_gui.setter
+    def amorphous_style_gui(self, v: dict):
+        self.ui.amorphous_color.setText(v['c'])
+        self.ui.amorphous_line_style.setCurrentText(v['ls'])
+        self.ui.amorphous_line_width.setValue(v['lw'])
 
     def pick_color(self):
         # This should only be called by signals/slots
@@ -99,6 +197,11 @@ class WppfStylePicker(QObject):
             self.update_config()
 
     def update_button_colors(self):
-        buttons = [self.ui.face_color, self.ui.edge_color]
+        buttons = [
+            self.ui.face_color,
+            self.ui.edge_color,
+            self.ui.background_color,
+            self.ui.amorphous_color,
+        ]
         for b in buttons:
             b.setStyleSheet(f'QPushButton {{background-color: {b.text()}}}')


### PR DESCRIPTION
This adds a couple of checkboxes to the WPPF options dialog to plot the background and amorphous on the azimuthal lineout in the polar view.

There are also options to edit the styles of these plots within "Edit Plot Style".

Fixes: #1892