### PR TITLE
Add ability to display WPPF difference plot

### DIFF
--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -49,6 +49,7 @@ class WppfOptionsDialog(QObject):
 
     run = Signal()
     undo_clicked = Signal()
+    object_reset = Signal()
     finished = Signal()
 
     def __init__(self, parent=None):
@@ -244,6 +245,7 @@ class WppfOptionsDialog(QObject):
         self._wppf_object = None
         self.update_enable_states()
         self.update_degree_of_crystallinity()
+        self.object_reset.emit()
 
     def preview_spectrum(self):
         had_object = self._wppf_object is not None

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -20,6 +20,7 @@ class WppfRunner:
         self.undo_stack.clear()
 
         self.clear_wppf_plots()
+        HexrdConfig().show_wppf_difference_axis = False
 
     def clear_wppf_plots(self):
         HexrdConfig().wppf_data = None
@@ -72,7 +73,10 @@ class WppfRunner:
         self.update_param_values()
 
     def rerender_wppf(self):
+        self.clear_wppf_plots()
         obj = self.wppf_object
+        if obj is None:
+            return
 
         HexrdConfig().wppf_data = list(obj.spectrum_sim.data)
 
@@ -153,6 +157,12 @@ class WppfRunner:
             HexrdConfig().material_modified.emit(name)
 
         HexrdConfig().overlay_config_changed.emit()
+
+        dialog = self.wppf_options_dialog
+        # Use underscore method so we don't accidentally auto-create one
+        self.wppf_object = dialog._wppf_object
+
+        self.rerender_wppf()
 
     def on_object_reset(self):
         # Clear the WPPF plots

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -19,6 +19,15 @@ class WppfRunner:
         self.wppf_options_dialog = None
         self.undo_stack.clear()
 
+        self.clear_wppf_plots()
+
+    def clear_wppf_plots(self):
+        HexrdConfig().wppf_data = None
+        HexrdConfig().wppf_background_lineout = None
+        HexrdConfig().wppf_amorphous_lineout = None
+
+        HexrdConfig().rerender_wppf.emit()
+
     def run(self):
         self.validate()
 
@@ -39,6 +48,7 @@ class WppfRunner:
         dialog = WppfOptionsDialog(self.parent)
         dialog.run.connect(self.run_wppf)
         dialog.undo_clicked.connect(self.pop_undo_stack)
+        dialog.object_reset.connect(self.on_object_reset)
         dialog.finished.connect(self.clear)
         dialog.show()
         self.wppf_options_dialog = dialog
@@ -143,6 +153,10 @@ class WppfRunner:
             HexrdConfig().material_modified.emit(name)
 
         HexrdConfig().overlay_config_changed.emit()
+
+    def on_object_reset(self):
+        # Clear the WPPF plots
+        self.clear_wppf_plots()
 
     def update_param_values(self):
         # Update the param values with their new values from the wppf_object

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -127,6 +127,13 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     """
     deep_rerender_needed = Signal()
 
+    """Rerenders entire polar canvas, without re-generating polar data
+
+    This is needed if you are changing the grid of displayed axes, such as
+    showing/hiding the WPPF difference curve.
+    """
+    force_rerender_polar = Signal()
+
     """Emitted when detectors have been added or removed"""
     detectors_changed = Signal()
 
@@ -2785,6 +2792,31 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def display_wppf_amorphous(self, b):
         if self.display_wppf_amorphous != b:
             self.wppf_settings['display_amorphous'] = b
+            self.rerender_wppf.emit()
+
+    @property
+    def show_wppf_difference_axis(self) -> bool:
+        return self.wppf_settings.setdefault('show_difference_axis', False)
+
+    @show_wppf_difference_axis.setter
+    def show_wppf_difference_axis(self, b: bool):
+        if self.show_wppf_difference_axis != b:
+            self.wppf_settings['show_difference_axis'] = b
+            # Do a force rerender of the polar view since we change the
+            # number of axes displayed.
+            self.force_rerender_polar.emit()
+
+    @property
+    def show_wppf_difference_as_percent(self) -> bool:
+        return self.wppf_settings.setdefault(
+            'show_difference_as_percent',
+            False,
+        )
+
+    @show_wppf_difference_as_percent.setter
+    def show_wppf_difference_as_percent(self, b: bool):
+        if self.show_wppf_difference_as_percent != b:
+            self.wppf_settings['show_difference_as_percent'] = b
             self.rerender_wppf.emit()
 
     @property

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -197,17 +197,7 @@
    </item>
    <item row="15" column="0" colspan="3">
     <layout class="QGridLayout" name="gridLayout_3">
-     <item row="1" column="2">
-      <widget class="QCheckBox" name="plot_amorphous">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Plot amorphous model?</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="QCheckBox" name="plot_background">
        <property name="toolTip">
         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of the background (default: red dashed line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the background plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
@@ -217,10 +207,13 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="delta_boundaries">
+     <item row="2" column="2">
+      <widget class="QCheckBox" name="plot_amorphous">
+       <property name="toolTip">
+        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
-        <string>Use delta boundaries</string>
+        <string>Plot amorphous model?</string>
        </property>
       </widget>
      </item>
@@ -235,6 +228,27 @@
       <widget class="QPushButton" name="edit_plot_style">
        <property name="text">
         <string>Edit Plot Style</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QCheckBox" name="delta_boundaries">
+       <property name="text">
+        <string>Use delta boundaries</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="show_difference_curve">
+       <property name="text">
+        <string>Show difference curve?</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="show_difference_as_percent">
+       <property name="text">
+        <string>Show difference as percent?</string>
        </property>
       </widget>
      </item>
@@ -446,6 +460,8 @@
   <tabstop>max_tth</tabstop>
   <tabstop>display_wppf_plot</tabstop>
   <tabstop>edit_plot_style</tabstop>
+  <tabstop>show_difference_curve</tabstop>
+  <tabstop>show_difference_as_percent</tabstop>
   <tabstop>delta_boundaries</tabstop>
   <tabstop>plot_background</tabstop>
   <tabstop>plot_amorphous</tabstop>


### PR DESCRIPTION
This adds the ability to display a difference plot between the WPPF
curve and the azimuthal lineout as a separate plot at the bottom of
the polar view canvas.
    
The difference plot can be displayed as either absolute difference (default)
or a percent difference.
    
The difference plot is also exported with the WPPF data when an export
is performed.

<img width="1157" height="989" alt="image" src="https://github.com/user-attachments/assets/d816875b-51a3-4263-80f7-8a8e52578769" />
    
Fixes: #852