### PR TITLE
Organize WPPF options into tabs

### DIFF
--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -14,20 +14,10 @@
    <string>WPPF Options Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0" colspan="3">
-    <widget class="QPushButton" name="select_materials_button">
-     <property name="toolTip">
-      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-     </property>
-     <property name="text">
-      <string>Select Materials</string>
-     </property>
-    </widget>
-   </item>
-   <item row="20" column="0" colspan="3">
+   <item row="12" column="0" colspan="2">
     <widget class="QGroupBox" name="param_settings_group">
      <property name="title">
-      <string>Parameter Settings</string>
+      <string>Parameters</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
@@ -54,48 +44,7 @@
      </layout>
     </widget>
    </item>
-   <item row="12" column="0">
-    <widget class="QCheckBox" name="use_experiment_file">
-     <property name="text">
-      <string>Use Experiment File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="method_label">
-     <property name="text">
-      <string>WPPF Method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="1">
-    <widget class="QLineEdit" name="experiment_file">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1" colspan="2">
-    <widget class="QComboBox" name="method">
-     <item>
-      <property name="text">
-       <string>LeBail</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Rietveld</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
-    <widget class="QComboBox" name="peak_shape"/>
-   </item>
-   <item row="22" column="0" colspan="3">
+   <item row="14" column="0" colspan="2">
     <layout class="QHBoxLayout" name="button_layout">
      <item>
       <widget class="QPushButton" name="save_plot">
@@ -178,259 +127,408 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="background_method"/>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="refinement_steps_label">
-     <property name="text">
-      <string>Refinement Steps:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="peak_shape_label">
-     <property name="text">
-      <string>Peak shape:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0" colspan="3">
-    <layout class="QGridLayout" name="gridLayout_3">
-     <item row="2" column="1">
-      <widget class="QCheckBox" name="plot_background">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of the background (default: red dashed line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the background plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Plot background?</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QCheckBox" name="plot_amorphous">
-       <property name="toolTip">
-        <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string>Plot amorphous model?</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0" colspan="2">
-      <widget class="QCheckBox" name="display_wppf_plot">
-       <property name="text">
-        <string>Display WPPF plot in polar view?</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QPushButton" name="edit_plot_style">
-       <property name="text">
-        <string>Edit Plot Style</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QCheckBox" name="delta_boundaries">
-       <property name="text">
-        <string>Use delta boundaries</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="show_difference_curve">
-       <property name="text">
-        <string>Show difference curve?</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="show_difference_as_percent">
-       <property name="text">
-        <string>Show difference as percent?</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="19" column="0" colspan="3">
-    <layout class="QVBoxLayout" name="tree_view_layout"/>
-   </item>
-   <item row="13" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="limit_tth_layout">
+   <item row="11" column="0" colspan="2">
+    <layout class="QVBoxLayout" name="tree_view_layout">
      <item>
-      <widget class="QCheckBox" name="limit_tth">
-       <property name="text">
-        <string>Limit 2θ?</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="ScientificDoubleSpinBox" name="min_tth">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="decimals">
-        <number>8</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="limit_tth_hyphen">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
+      <widget class="QTabWidget" name="tab_widget">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
-       <property name="text">
-        <string>-</string>
+       <property name="currentIndex">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="ScientificDoubleSpinBox" name="max_tth">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="keyboardTracking">
-        <bool>false</bool>
-       </property>
-       <property name="suffix">
-        <string>°</string>
-       </property>
-       <property name="decimals">
-        <number>8</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
+       <widget class="QWidget" name="general_tab">
+        <attribute name="title">
+         <string>General</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_5">
+         <item row="1" column="1">
+          <widget class="QComboBox" name="method">
+           <item>
+            <property name="text">
+             <string>LeBail</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Rietveld</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="method_label">
+           <property name="text">
+            <string>WPPF Method:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QLabel" name="refinement_steps_label">
+           <property name="text">
+            <string>Refinement Steps:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QSpinBox" name="refinement_steps">
+           <property name="minimum">
+            <number>1</number>
+           </property>
+           <property name="maximum">
+            <number>10000000</number>
+           </property>
+           <property name="value">
+            <number>10</number>
+           </property>
+          </widget>
+         </item>
+         <item row="10" column="0">
+          <spacer name="verticalSpacer">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="0" column="0" colspan="4">
+          <widget class="QPushButton" name="select_materials_button">
+           <property name="toolTip">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Only materials with powder overlays can be selected&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="text">
+            <string>Select Materials</string>
+           </property>
+          </widget>
+         </item>
+         <item row="5" column="0" colspan="4">
+          <layout class="QHBoxLayout" name="horizontalLayout_5">
+           <item>
+            <widget class="QCheckBox" name="use_experiment_file">
+             <property name="text">
+              <string>Use Experiment File</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLineEdit" name="experiment_file">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="select_experiment_file_button">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="text">
+              <string>Select File</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="7" column="0" rowspan="2" colspan="4">
+          <layout class="QHBoxLayout" name="limit_tth_layout">
+           <item>
+            <widget class="QCheckBox" name="limit_tth">
+             <property name="text">
+              <string>Limit 2θ?</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ScientificDoubleSpinBox" name="min_tth">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="keyboardTracking">
+              <bool>false</bool>
+             </property>
+             <property name="suffix">
+              <string>°</string>
+             </property>
+             <property name="decimals">
+              <number>8</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="limit_tth_hyphen">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>-</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="ScientificDoubleSpinBox" name="max_tth">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="keyboardTracking">
+              <bool>false</bool>
+             </property>
+             <property name="suffix">
+              <string>°</string>
+             </property>
+             <property name="decimals">
+              <number>8</number>
+             </property>
+             <property name="maximum">
+              <double>100000.000000000000000</double>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="4" column="2">
+          <widget class="QLabel" name="peak_shape_label">
+           <property name="text">
+            <string>Peak shape:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="4" column="3">
+          <widget class="QComboBox" name="peak_shape"/>
+         </item>
+         <item row="4" column="0" colspan="2">
+          <widget class="QCheckBox" name="delta_boundaries">
+           <property name="text">
+            <string>Use delta boundaries</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="background_tab">
+        <attribute name="title">
+         <string>Background</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_4">
+         <item row="1" column="0" colspan="2">
+          <widget class="QPushButton" name="pick_spline_points">
+           <property name="text">
+            <string>Pick Spline Points</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0">
+          <widget class="QLabel" name="background_method_label">
+           <property name="text">
+            <string>Background Method:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="background_method"/>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <layout class="QVBoxLayout" name="background_method_parameters_layout"/>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <spacer name="verticalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="plot_tab">
+        <attribute name="title">
+         <string>Plots</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_6">
+         <item row="0" column="0">
+          <layout class="QGridLayout" name="gridLayout_3">
+           <item row="1" column="1">
+            <widget class="QCheckBox" name="show_difference_as_percent">
+             <property name="text">
+              <string>Show difference as percent?</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QCheckBox" name="show_difference_curve">
+             <property name="text">
+              <string>Show difference curve?</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0" colspan="2">
+            <widget class="QCheckBox" name="display_wppf_plot">
+             <property name="text">
+              <string>Display WPPF plot in polar view?</string>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QPushButton" name="edit_plot_style">
+             <property name="text">
+              <string>Edit Plot Style</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QCheckBox" name="plot_background">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of the background (default: red dashed line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the background plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Plot background?</string>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QCheckBox" name="plot_amorphous">
+             <property name="toolTip">
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+             </property>
+             <property name="text">
+              <string>Plot amorphous model?</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item row="1" column="0">
+          <spacer name="verticalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="amorphous_tab">
+        <attribute name="title">
+         <string>Amorphous</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_7">
+         <item row="0" column="0">
+          <widget class="QGroupBox" name="amorphous_group">
+           <property name="title">
+            <string/>
+           </property>
+           <layout class="QGridLayout" name="gridLayout">
+            <item row="1" column="0">
+             <widget class="QCheckBox" name="include_amorphous">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the sample contains some amorphous (such as liquid or glass) phases, check this box to include amorphous parameters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="text">
+               <string>Includes amorphous phases?</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="4">
+             <layout class="QHBoxLayout" name="amorphous_options_layout">
+              <item>
+               <widget class="QLabel" name="amorphous_model_label">
+                <property name="text">
+                 <string>Amorphous Model:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QComboBox" name="amorphous_model"/>
+              </item>
+              <item>
+               <widget class="QLabel" name="num_amorphous_peaks_label">
+                <property name="text">
+                 <string>Number of amorphous peaks:</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QSpinBox" name="num_amorphous_peaks">
+                <property name="minimum">
+                 <number>1</number>
+                </property>
+                <property name="maximum">
+                 <number>100000</number>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QPushButton" name="amorphous_select_experiment_files">
+                <property name="toolTip">
+                 <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Experiment file to be used with the amorphous model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+                </property>
+                <property name="text">
+                 <string>Select Experiment Files</string>
+                </property>
+               </widget>
+              </item>
+             </layout>
+            </item>
+            <item row="1" column="3">
+             <widget class="QLabel" name="degree_of_crystallinity_label">
+              <property name="text">
+               <string>Degree of Crystallinity: 1</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              </property>
+             </widget>
+            </item>
+            <item row="3" column="0" colspan="4">
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="10" column="0" colspan="3">
-    <layout class="QVBoxLayout" name="background_method_parameters_layout"/>
-   </item>
-   <item row="2" column="1" colspan="2">
-    <widget class="QSpinBox" name="refinement_steps">
-     <property name="minimum">
-      <number>1</number>
-     </property>
-     <property name="maximum">
-      <number>10000000</number>
-     </property>
-     <property name="value">
-      <number>10</number>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="2">
-    <widget class="QPushButton" name="select_experiment_file_button">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Select File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="background_method_label">
-     <property name="text">
-      <string>Background Method:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0" colspan="3">
-    <widget class="QPushButton" name="pick_spline_points">
-     <property name="text">
-      <string>Pick Spline Points</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="3">
-    <widget class="QGroupBox" name="amorphous_group">
-     <property name="title">
-      <string/>
-     </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="1" column="3">
-       <widget class="QLabel" name="degree_of_crystallinity_label">
-        <property name="text">
-         <string>Degree of Crystallinity: 1</string>
-        </property>
-        <property name="alignment">
-         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0" colspan="4">
-       <layout class="QHBoxLayout" name="amorphous_options_layout">
-        <item>
-         <widget class="QLabel" name="amorphous_model_label">
-          <property name="text">
-           <string>Amorphous Model:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QComboBox" name="amorphous_model"/>
-        </item>
-        <item>
-         <widget class="QLabel" name="num_amorphous_peaks_label">
-          <property name="text">
-           <string>Number of amorphous peaks:</string>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QSpinBox" name="num_amorphous_peaks">
-          <property name="minimum">
-           <number>1</number>
-          </property>
-          <property name="maximum">
-           <number>100000</number>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QPushButton" name="amorphous_select_experiment_files">
-          <property name="toolTip">
-           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Experiment file to be used with the amorphous model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-          </property>
-          <property name="text">
-           <string>Select Experiment Files</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="include_amorphous">
-        <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;If the sample contains some amorphous (such as liquid or glass) phases, check this box to include amorphous parameters.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-        </property>
-        <property name="text">
-         <string>Includes amorphous phases?</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
    </item>
   </layout>
  </widget>
@@ -442,29 +540,30 @@
   </customwidget>
  </customwidgets>
  <tabstops>
+  <tabstop>tab_widget</tabstop>
   <tabstop>select_materials_button</tabstop>
   <tabstop>method</tabstop>
   <tabstop>refinement_steps</tabstop>
+  <tabstop>delta_boundaries</tabstop>
   <tabstop>peak_shape</tabstop>
-  <tabstop>background_method</tabstop>
-  <tabstop>pick_spline_points</tabstop>
-  <tabstop>include_amorphous</tabstop>
-  <tabstop>amorphous_model</tabstop>
-  <tabstop>num_amorphous_peaks</tabstop>
-  <tabstop>amorphous_select_experiment_files</tabstop>
   <tabstop>use_experiment_file</tabstop>
   <tabstop>experiment_file</tabstop>
   <tabstop>select_experiment_file_button</tabstop>
   <tabstop>limit_tth</tabstop>
   <tabstop>min_tth</tabstop>
   <tabstop>max_tth</tabstop>
+  <tabstop>background_method</tabstop>
+  <tabstop>pick_spline_points</tabstop>
   <tabstop>display_wppf_plot</tabstop>
   <tabstop>edit_plot_style</tabstop>
   <tabstop>show_difference_curve</tabstop>
   <tabstop>show_difference_as_percent</tabstop>
-  <tabstop>delta_boundaries</tabstop>
   <tabstop>plot_background</tabstop>
   <tabstop>plot_amorphous</tabstop>
+  <tabstop>include_amorphous</tabstop>
+  <tabstop>amorphous_model</tabstop>
+  <tabstop>num_amorphous_peaks</tabstop>
+  <tabstop>amorphous_select_experiment_files</tabstop>
   <tabstop>export_params</tabstop>
   <tabstop>import_params</tabstop>
   <tabstop>reset_params_to_defaults</tabstop>

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -447,6 +447,19 @@
             <string/>
            </property>
            <layout class="QGridLayout" name="gridLayout">
+            <item row="4" column="0" colspan="4">
+             <spacer name="verticalSpacer_4">
+              <property name="orientation">
+               <enum>Qt::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
             <item row="1" column="0">
              <widget class="QCheckBox" name="include_amorphous">
               <property name="toolTip">
@@ -454,6 +467,16 @@
               </property>
               <property name="text">
                <string>Includes amorphous phases?</string>
+              </property>
+             </widget>
+            </item>
+            <item row="1" column="3">
+             <widget class="QLabel" name="degree_of_crystallinity_label">
+              <property name="text">
+               <string>Degree of Crystallinity: 1</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
               </property>
              </widget>
             </item>
@@ -498,28 +521,25 @@
               </item>
              </layout>
             </item>
-            <item row="1" column="3">
-             <widget class="QLabel" name="degree_of_crystallinity_label">
-              <property name="text">
-               <string>Degree of Crystallinity: 1</string>
+            <item row="3" column="0">
+             <widget class="QLabel" name="amorphous_expt_smoothing_label">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For an experimental amorphous model, this is the width of the gaussian kernel smoothing function.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
-              <property name="alignment">
-               <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+              <property name="text">
+               <string>Experimental Pattern Smoothing:</string>
               </property>
              </widget>
             </item>
-            <item row="3" column="0" colspan="4">
-             <spacer name="verticalSpacer_4">
-              <property name="orientation">
-               <enum>Qt::Vertical</enum>
+            <item row="3" column="1">
+             <widget class="QSpinBox" name="amorphous_expt_smoothing">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;For an experimental amorphous model, this is the width of the gaussian kernel smoothing function.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
               </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>20</width>
-                <height>40</height>
-               </size>
+              <property name="maximum">
+               <number>1000000</number>
               </property>
-             </spacer>
+             </widget>
             </item>
            </layout>
           </widget>
@@ -564,6 +584,7 @@
   <tabstop>amorphous_model</tabstop>
   <tabstop>num_amorphous_peaks</tabstop>
   <tabstop>amorphous_select_experiment_files</tabstop>
+  <tabstop>amorphous_expt_smoothing</tabstop>
   <tabstop>export_params</tabstop>
   <tabstop>import_params</tabstop>
   <tabstop>reset_params_to_defaults</tabstop>


### PR DESCRIPTION
This organizes the various WPPF options into separate tabs, like so:

<img width="1333" height="1186" alt="image" src="https://github.com/user-attachments/assets/a623dcdf-c376-47d8-be42-864629f061c9" />

The tab organization makes it easier for users to navigate and keep track of the various options available.

This PR also adds the ability to specify smoothing for experimental amorphous models.

Fixes: #1899
