### PR TITLE
Add background intensity to WPPF amorphous plot

### DIFF
--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -83,6 +83,9 @@ class WppfOptionsDialog(QObject):
         # Trigger logic for changing amorphous setting
         self.on_include_amorphous_toggled()
 
+        # Always default to the first tab
+        self.ui.tab_widget.setCurrentIndex(0)
+
         self.update_gui()
         self.setup_connections()
 

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -88,9 +88,16 @@ class WppfRunner:
 
         amorphous_lineout = []
         if obj.amorphous_model is not None:
+            tth_list = obj.amorphous_model.tth_list
+            intensity = obj.amorphous_model.amorphous_lineout
+            if len(background) > 1:
+                # background[1] is the background intensity.
+                # We will automatically add the background, if present.
+                intensity += background[1]
+
             amorphous_lineout = [
-                obj.amorphous_model.tth_list,
-                obj.amorphous_model.amorphous_lineout,
+                tth_list,
+                intensity,
             ]
 
         HexrdConfig().wppf_amorphous_lineout = amorphous_lineout

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -412,7 +412,7 @@
            <item row="2" column="1">
             <widget class="QCheckBox" name="plot_amorphous">
              <property name="toolTip">
-              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Include plot of amorphous model (default: red line) in the lineout. The background is added to the amorphous model automatically.&lt;/p&gt;&lt;p&gt;The style of the amorphous model plot can be edited by clicking &amp;quot;Edit Plot Style&amp;quot;.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
              </property>
              <property name="text">
               <string>Plot amorphous model?</string>


### PR DESCRIPTION
If background intensity is available, add it to the WPPF amorphous plot automatically.

Fixes: #1906