### PR TITLE
Implement fixes for LLNL workflows

### DIFF
--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -242,7 +242,7 @@ class CalibrationCallbacks(MaterialCalibrationDialogCallbacks):
     def save_picks_to_file(self, selected_file):
         # Reuse the same logic from the HKLPicksTreeViewDialog
         dialog = self.create_hkl_picks_tree_view_dialog()
-        dialog.export_picks(selected_file)
+        dialog.export_picks_from_overlays(selected_file, self.overlays)
 
     def load_picks_from_file(self, selected_file):
         # Reuse the same logic from the HKLPicksTreeViewDialog

--- a/hexrdgui/calibration/calibration_runner.py
+++ b/hexrdgui/calibration/calibration_runner.py
@@ -1045,7 +1045,8 @@ class CalibrationCallbacks(MaterialCalibrationDialogCallbacks):
 
     def save_picks_to_file(self, selected_file):
         # Reuse the same logic from the HKLPicksTreeViewDialog
-        self.edit_picks_dialog.export_picks(selected_file)
+        d = self.edit_picks_dialog
+        d.export_picks_from_overlays(selected_file, self.overlays)
 
     def load_picks_from_file(self, selected_file):
         # Reuse the same logic from the HKLPicksTreeViewDialog

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -182,10 +182,13 @@ class ImageTabWidget(QTabWidget):
             # The new one to add
             idx = len(self.toolbars)
             tb = NavigationToolbar(self.image_canvases[idx], parent, False)
+            tb.setVisible(False)
             # Current detector
             ims = self.ims_for_name(self.image_names[idx])
             sb = ImageSeriesToolbar(ims, self)
             ib = ImageSeriesInfoToolbar(self)
+            sb.set_visible(False)
+            ib.set_visible(False)
 
             # This will put it at the bottom of the central widget
             toolbar = QHBoxLayout()

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -277,6 +277,8 @@ class MainWindow(QObject):
             self.ui.status_bar.clearMessage)
         self.llnl_import_tool_dialog.new_config_loaded.connect(
             self.update_config_gui)
+        self.llnl_import_tool_dialog.instrument_was_selected.connect(
+            self.update_action_check_states)
         self.llnl_import_tool_dialog.cancel_workflow.connect(
             self.load_dummy_images)
         self.config_loaded.connect(

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -273,6 +273,18 @@ class PowderOverlay(Overlay, PolarDistortionObject):
             point_groups[det_key]['rings'] = ring_pts
             point_groups[det_key]['hkls'] = det_hkls
 
+            # Map of ring index to original two theta index
+            counter = 0
+            ring_idx_map = {}
+            for i in range(len(tths)):
+                if i in skipped_tth:
+                    counter += 1
+                    continue
+
+                ring_idx_map[i - counter] = i
+
+            point_groups[det_key]['ring_idx_map'] = ring_idx_map
+
             if plane_data.tThWidth is not None:
                 # Generate the ranges too
                 lower_pts, lower_skipped = self.generate_ring_points(
@@ -692,7 +704,6 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                 'lw': 3.0
             }
         }
-
 
 # Constants
 nans_row = np.nan * np.ones((1, 2))


### PR DESCRIPTION
This fixes a few small issues with LLNL workflows, including:

1. Disable all intensity corrections during LLNL import tool use
2. Fix powder range highlighting (incorrect ranges were sometimes highlighted)
3. Make canvas toolbars invisible by default, to avoid seeing them all stacked on top of each other when switching to a tabbed view
4. Disable zoom canvas during highlight updates, to prevent the highlights from bouncing around
5. Take into account two theta distortion when saving picks

Fixes: #1864
Fixes: #1905