### PR TITLE
Do not allow memoized median output to be modified

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -971,10 +971,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         # (such as polar or stereo)
         if HexrdConfig().apply_median_filter_correction:
             for name, img in images_dict.items():
+                # Since this is memoized, make a copy so we won't modify
+                # the original.
                 images_dict[name] = medfilt2d_memoized(
                     img,
                     kernel_size=HexrdConfig().median_filter_kernel_size
-                )
+                ).copy()
 
         # Create this corrections dict, even if we don't use it, because
         # it updates the `intensity_corrections_dict` that may be used


### PR DESCRIPTION
Make a copy of the memoized median filter output so that we can be sure the array will not be modified.

This was causing a bug where, if you had one state file loaded in with the median filter applied, and you load in another state file that has the median filter applied, the memoized output was somehow modified and made the image data invalid.

Making a copy of the memoized output ensures that it won't be modified.