### PR TITLE
Invalidate polar masks on detector transform

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -17,6 +17,7 @@ from hexrd import instrument
 from hexrdgui.constants import ViewType
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType
+from hexrdgui.masking.mask_manager import MaskManager
 from hexrdgui.utils import SnipAlgorithmType, run_snip1d, snip_width_pixels
 
 tvec_c = ct.zeros_3
@@ -503,7 +504,6 @@ class PolarView:
 
     def apply_visible_masks(self, img):
         # Apply user-specified masks if they are present
-        from hexrdgui.masking.mask_manager import MaskManager
         img = img.copy()
         total_mask = self.warp_mask
         for mask in MaskManager().masks.values():
@@ -523,7 +523,6 @@ class PolarView:
 
     def apply_boundary_masks(self, img):
         # Apply user-specified masks if they are present
-        from hexrdgui.masking.mask_manager import MaskManager
         img = img.copy()
         total_mask = self.warp_mask
         for mask in MaskManager().masks.values():
@@ -592,6 +591,9 @@ class PolarView:
 
             # Update the individual detector image
             self.create_warp_image(det)
+
+        # Invalidate the masks that match these detectors
+        MaskManager().invalidate_detector_masks(detectors)
 
         # Generate the final image
         self.generate_image()

--- a/hexrdgui/masking/create_polar_mask.py
+++ b/hexrdgui/masking/create_polar_mask.py
@@ -1,6 +1,5 @@
 import numpy as np
 
-from hexrdgui.calibration.polarview import PolarView
 from hexrdgui.constants import ViewType
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
@@ -45,6 +44,7 @@ def convert_raw_to_polar(instr, det, line, apply_tth_distortion=True):
 
 
 def create_polar_mask(line_data):
+    from hexrdgui.calibration.polarview import PolarView
     from hexrdgui.masking.mask_manager import MaskManager
     # Calculate current image dimensions
     # If we pass `None` to the polar view, it is a dummy polar view

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -326,6 +326,11 @@ class MaskManager(QObject, metaclass=QSingleton):
     def mask_names(self):
         return list(self.masks.keys())
 
+    def invalidate_detector_masks(self, det_keys: list[str]):
+        for mask in self.masks.values():
+            if any(v[0] in det_keys for v in mask.data):
+                mask.invalidate_masked_arrays()
+
     def setup_connections(self):
         self.threshold_mask_changed.connect(self.threshold_toggled)
         HexrdConfig().save_state.connect(self.save_state)


### PR DESCRIPTION
The polar masks need to be regenerated when the detectors are transformed. This adds functionality that does so.