### PR TITLE
Specify sample tilt in physics package dialog

### DIFF
--- a/hexrdgui/const_chi_overlay_editor.py
+++ b/hexrdgui/const_chi_overlay_editor.py
@@ -61,6 +61,7 @@ class ConstChiOverlayEditor(QObject):
 
         HexrdConfig().euler_angle_convention_changed.connect(
             self.euler_angle_convention_changed)
+        HexrdConfig().sample_tilt_modified.connect(self.update_gui)
 
         self.ui.add_chi_value_row.clicked.connect(
             self.add_chi_value)

--- a/hexrdgui/laue_overlay_editor.py
+++ b/hexrdgui/laue_overlay_editor.py
@@ -47,6 +47,7 @@ class LaueOverlayEditor:
             self.euler_angle_convention_changed)
         HexrdConfig().instrument_config_loaded.connect(
             self.update_visibility_states)
+        HexrdConfig().sample_tilt_modified.connect(self.update_gui)
 
     def setup_combo_boxes(self):
         width_shapes = [x.value.capitalize() for x in LaueRangeShape]
@@ -77,7 +78,6 @@ class LaueOverlayEditor:
             overlay = self.overlay
             self.ui.min_energy.setValue(overlay.min_energy)
             self.ui.max_energy.setValue(overlay.max_energy)
-            self.sample_rmat = overlay.sample_rmat
             self.crystal_params = overlay.crystal_params
             self.refinements = overlay.refinements
             self.width_shape = overlay.width_shape
@@ -89,6 +89,8 @@ class LaueOverlayEditor:
             if overlay.has_widths:
                 self.ui.tth_width.setValue(np.degrees(overlay.tth_width))
                 self.ui.eta_width.setValue(np.degrees(overlay.eta_width))
+
+            self.sample_rmat = HexrdConfig().sample_rmat
 
             self.update_enable_states()
             self.update_orientation_suffixes()
@@ -151,11 +153,12 @@ class LaueOverlayEditor:
         overlay.tth_width = self.tth_width
         overlay.eta_width = self.eta_width
         overlay.width_shape = self.width_shape
-        overlay.sample_rmat = self.sample_rmat
         overlay.refinements = self.refinements
         overlay.label_type = self.label_type
         overlay.label_offsets = self.label_offsets
         overlay.xray_source = self.xray_source
+
+        HexrdConfig().sample_rmat = self.sample_rmat
 
         self.overlay.update_needed = True
         HexrdConfig().overlay_config_changed.emit()

--- a/hexrdgui/resources/ui/laue_overlay_editor.ui
+++ b/hexrdgui/resources/ui/laue_overlay_editor.ui
@@ -170,6 +170,9 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
         <property name="decimals">
          <number>8</number>
         </property>
@@ -186,6 +189,9 @@
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
         </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
+        </property>
         <property name="decimals">
          <number>8</number>
         </property>
@@ -201,6 +207,9 @@
        <widget class="ScientificDoubleSpinBox" name="sample_orientation_2">
         <property name="alignment">
          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+        </property>
+        <property name="keyboardTracking">
+         <bool>false</bool>
         </property>
         <property name="decimals">
          <number>8</number>

--- a/hexrdgui/resources/ui/physics_package_manager_dialog.ui
+++ b/hexrdgui/resources/ui/physics_package_manager_dialog.ui
@@ -495,6 +495,36 @@
             </property>
            </widget>
           </item>
+          <item row="2" column="0" colspan="6">
+           <widget class="QLineEdit" name="sample_material_input">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="sample_normal_label">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The normal values are calculated from the sample orientation. &lt;/p&gt;&lt;p&gt;Modify the sample orientation in order to update the normal values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+            </property>
+            <property name="text">
+             <string>Normal</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="sample_material_label">
+            <property name="text">
+             <string>Material</string>
+            </property>
+            <property name="buddy">
+             <cstring>sample_material</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="5">
+           <widget class="QComboBox" name="sample_material"/>
+          </item>
           <item row="4" column="1" colspan="5">
            <widget class="ScientificDoubleSpinBox" name="sample_thickness">
             <property name="suffix">
@@ -505,12 +535,18 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="0" colspan="6">
-           <widget class="QLineEdit" name="sample_material_input">
-            <property name="enabled">
-             <bool>false</bool>
+          <item row="7" column="0">
+           <spacer name="sample_vertical_spacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
             </property>
-           </widget>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
           </item>
           <item row="3" column="1" colspan="5">
            <widget class="ScientificDoubleSpinBox" name="sample_density">
@@ -532,31 +568,149 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="sample_material_label">
-            <property name="text">
-             <string>Material</string>
+          <item row="6" column="1" colspan="5">
+           <layout class="QHBoxLayout" name="sample_normal_layout">
+            <item>
+             <widget class="ScientificDoubleSpinBox" name="sample_normal_0">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The normal values are calculated from the sample orientation. &lt;/p&gt;&lt;p&gt;Modify the sample orientation in order to update the normal values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-10000000.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100000000.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ScientificDoubleSpinBox" name="sample_normal_1">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The normal values are calculated from the sample orientation. &lt;/p&gt;&lt;p&gt;Modify the sample orientation in order to update the normal values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-10000000.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100000000.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ScientificDoubleSpinBox" name="sample_normal_2">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The normal values are calculated from the sample orientation. &lt;/p&gt;&lt;p&gt;Modify the sample orientation in order to update the normal values.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="readOnly">
+               <bool>true</bool>
+              </property>
+              <property name="buttonSymbols">
+               <enum>QAbstractSpinBox::NoButtons</enum>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-10000000.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>100000000.000000000000000</double>
+              </property>
+              <property name="singleStep">
+               <double>0.100000000000000</double>
+              </property>
+              <property name="value">
+               <double>0.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="toolTip">
+             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The orientation of the sample. &lt;/p&gt;&lt;p&gt;The angle convention used is set via &amp;quot;Edit&amp;quot;-&amp;gt;&amp;quot;Euler Angle Convention&amp;quot;.&lt;/p&gt;&lt;p&gt;The sample orientation is not saved until &amp;quot;OK&amp;quot; is clicked.&lt;/p&gt;&lt;p&gt;The sample orientation is also accessible and editable in the Laue overlay and Const Chi overlay settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
             </property>
-            <property name="buddy">
-             <cstring>sample_material</cstring>
+            <property name="text">
+             <string>Orientation</string>
             </property>
            </widget>
           </item>
-          <item row="0" column="1" colspan="5">
-           <widget class="QComboBox" name="sample_material"/>
-          </item>
-          <item row="5" column="0">
-           <spacer name="sample_vertical_spacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
-            </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
-            </property>
-           </spacer>
+          <item row="5" column="1" colspan="5">
+           <layout class="QHBoxLayout" name="sample_tilt_layout">
+            <item>
+             <widget class="ScientificDoubleSpinBox" name="sample_tilt_0">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The orientation of the sample. &lt;/p&gt;&lt;p&gt;The angle convention used is set via &amp;quot;Edit&amp;quot;-&amp;gt;&amp;quot;Euler Angle Convention&amp;quot;.&lt;/p&gt;&lt;p&gt;The sample orientation is not saved until &amp;quot;OK&amp;quot; is clicked.&lt;/p&gt;&lt;p&gt;The sample orientation is also accessible and editable in the Laue overlay and Const Chi overlay settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-1000000.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1000000.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ScientificDoubleSpinBox" name="sample_tilt_1">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The orientation of the sample. &lt;/p&gt;&lt;p&gt;The angle convention used is set via &amp;quot;Edit&amp;quot;-&amp;gt;&amp;quot;Euler Angle Convention&amp;quot;.&lt;/p&gt;&lt;p&gt;The sample orientation is not saved until &amp;quot;OK&amp;quot; is clicked.&lt;/p&gt;&lt;p&gt;The sample orientation is also accessible and editable in the Laue overlay and Const Chi overlay settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-1000000.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1000000.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="ScientificDoubleSpinBox" name="sample_tilt_2">
+              <property name="toolTip">
+               <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;The orientation of the sample. &lt;/p&gt;&lt;p&gt;The angle convention used is set via &amp;quot;Edit&amp;quot;-&amp;gt;&amp;quot;Euler Angle Convention&amp;quot;.&lt;/p&gt;&lt;p&gt;The sample orientation is not saved until &amp;quot;OK&amp;quot; is clicked.&lt;/p&gt;&lt;p&gt;The sample orientation is also accessible and editable in the Laue overlay and Const Chi overlay settings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>-1000000.000000000000000</double>
+              </property>
+              <property name="maximum">
+               <double>1000000.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </item>
          </layout>
         </widget>
@@ -873,6 +1027,12 @@
   <tabstop>sample_material_input</tabstop>
   <tabstop>sample_density</tabstop>
   <tabstop>sample_thickness</tabstop>
+  <tabstop>sample_tilt_0</tabstop>
+  <tabstop>sample_tilt_1</tabstop>
+  <tabstop>sample_tilt_2</tabstop>
+  <tabstop>sample_normal_0</tabstop>
+  <tabstop>sample_normal_1</tabstop>
+  <tabstop>sample_normal_2</tabstop>
   <tabstop>reflective_material</tabstop>
   <tabstop>reflective_material_input</tabstop>
   <tabstop>reflective_density</tabstop>


### PR DESCRIPTION
This adds the ability to specify the sample tilt within the physics package dialog. This sample tilt is synchronized with the sample tilt settings within the Laue overlay editor and the Const Chi editor.

We will be using this sample tilt (convertable to sample rmat or sample normal) in a variety of places, including WPPF and the absorption correction.

<img width="790" height="87" alt="image" src="https://github.com/user-attachments/assets/f208158c-d824-4416-8b2a-3d74aa5ec4f7" />

Fixes: #1801