### PR TITLE
Change mask presentation selector when masks are selected

### DIFF
--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -444,6 +444,16 @@ class MaskManagerDialog(QObject):
                 self.ui.presentation_selector.addItem('Boundary Only')
                 self.ui.presentation_selector.addItem('Visible + Boundary')
 
+            if any(mask.visible for mask in masks_from_names):
+                if not vis_only and all(mask.show_border for mask in masks_from_names):
+                    self.ui.presentation_selector.setCurrentIndex(3)
+                else:
+                    self.ui.presentation_selector.setCurrentIndex(1)
+            elif not vis_only and any(mask.show_border for mask in masks_from_names):
+                self.ui.presentation_selector.setCurrentIndex(2)
+            else:
+                self.ui.presentation_selector.setCurrentIndex(0)
+
     def change_presentation_for_selected(self, text):
         if len(self.ui.masks_tree.selectedItems()) < 1:
             return


### PR DESCRIPTION
This branch addresses an issue raised by @saransh13: When masks are selected the presentation selector does not change, so if you want to set them all to `None` you would have to change it to `Visible` then back to `None`.

When a masks are selected we now try to change the presentation selector to best match the selected masks.