### PR TITLE
Add texture support to WPPF

### DIFF
--- a/hexrdgui/calibration/tree_item_models.py
+++ b/hexrdgui/calibration/tree_item_models.py
@@ -59,6 +59,10 @@ class CalibrationTreeItemModel(MultiColumnDictTreeItemModel):
 
         setattr(param, attribute, value)
 
+        if attribute == 'vary' and hasattr(param, '_on_vary_modified'):
+            # Trigger the callback function
+            param._on_vary_modified()
+
     def data(self, index, role):
         if (
             role in (Qt.BackgroundRole, Qt.ForegroundRole) and

--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -2136,6 +2136,7 @@ class WppfOptionsDialog(QObject):
     def on_texture_params_modified(self):
         self.update_simulated_polar_dialog()
         self.update_pole_figure_plots()
+        self.update_texture_index_label()
 
     def update_simulated_polar_dialog(self):
         # FIXME: recalculate `self._last_texture_pv_sim`
@@ -2230,6 +2231,22 @@ class WppfOptionsDialog(QObject):
                 **kwargs,
             })
         return ret
+
+    def update_texture_index_label(self):
+        obj = self._wppf_object
+        mat_name = self.ui.selected_texture_material.currentText()
+        w = self.ui.texture_index_label
+
+        if (
+            not isinstance(obj, Rietveld) or
+            obj.texture_model.get(mat_name) is None
+        ):
+            v = 'None'
+        else:
+            j = obj.texture_model[mat_name].J(self.params)
+            v = f'{j:.2f}'
+
+        w.setText(f'Texture index: {v}')
 
 
 def generate_params(method, materials, peak_shape, bkgmethod, amorphous_model,

--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -1,5 +1,7 @@
 import copy
+from functools import partial
 from pathlib import Path
+import sys
 
 import h5py
 import lmfit
@@ -9,26 +11,37 @@ import re
 import yaml
 
 from PySide6.QtCore import QObject, Signal
-from PySide6.QtWidgets import QFileDialog, QHBoxLayout, QMessageBox, QWidget
+from PySide6.QtWidgets import (
+    QCheckBox, QComboBox, QFileDialog, QHBoxLayout, QInputDialog, QMessageBox
+)
 
-from hexrdgui import resource_loader
+from hexrd import constants as ct
 from hexrd.instrument import unwrap_dict_to_h5, unwrap_h5_to_dict
 from hexrd.material import _angstroms
+from hexrd.projections.polar import bin_polar_view
+from hexrd.utils.hkl import hkl_to_str
 from hexrd.wppf import LeBail, Rietveld
 from hexrd.wppf.amorphous import AMORPHOUS_MODEL_TYPES, Amorphous
+from hexrd.wppf.phase import Material_Rietveld
+from hexrd.wppf.texture import HarmonicModel
 from hexrd.wppf.WPPF import peakshape_dict
 from hexrd.wppf.wppfsupport import (
     background_methods, _generate_default_parameters_LeBail,
     _generate_default_parameters_Rietveld,
 )
 
+from hexrdgui import resource_loader
 from hexrdgui.calibration.tree_item_models import (
     _tree_columns_to_indices,
     DefaultCalibrationTreeItemModel,
     DeltaCalibrationTreeItemModel,
 )
+from hexrdgui.calibration.wppf_simulated_polar_dialog import (
+    WppfSimulatedPolarDialog,
+)
 from hexrdgui.dynamic_widget import DynamicWidget
 from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.html_delegate import aligned_sub_sup_html, HtmlDelegate
 from hexrdgui.point_picker_dialog import PointPickerDialog
 from hexrdgui.select_items_dialog import SelectItemsDialog
 from hexrdgui.tree_views.multi_column_dict_tree_view import (
@@ -69,8 +82,12 @@ class WppfOptionsDialog(QObject):
         self._wppf_object = None
         self._prev_background_method = None
         self._undo_stack = []
+        self._last_pv_binned = None
+        self._last_texture_pv_sim = None
+        self._texture_simulated_polar_dialog = None
 
         self.amorphous_experiment_files = []
+        self._texture_settings = self._default_texture_settings
 
         self.params = self.generate_params()
         self.initialize_tree_view()
@@ -120,6 +137,17 @@ class WppfOptionsDialog(QObject):
             self.on_num_amorphous_peaks_value_changed)
         self.ui.amorphous_select_experiment_files.clicked.connect(
             self.select_amorphous_experiment_files)
+
+        self.ui.selected_texture_material.currentIndexChanged.connect(
+            self.on_selected_texture_material_changed)
+        for w in self.texture_material_setting_widgets:
+            changed_signal(w).connect(self.on_texture_material_setting_changed)
+        for w in self.texture_binning_settings_widgets:
+            changed_signal(w).connect(self.on_texture_binning_setting_changed)
+        self.ui.texture_show_simulated_spectrum.clicked.connect(
+            self.on_texture_show_simulated_spectrum_clicked)
+        self.ui.texture_plot_pole_figures.clicked.connect(
+            self.on_texture_plot_pole_figures_clicked)
 
         self.ui.export_params.clicked.connect(self.export_params)
         self.ui.import_params.clicked.connect(self.import_params)
@@ -187,6 +215,8 @@ class WppfOptionsDialog(QObject):
 
         self.ui.show_difference_as_percent.setVisible(
             self.show_difference_curve)
+
+        self.update_texture_model_enable_states()
 
     def populate_background_methods(self):
         self.ui.background_method.addItems(list(background_methods.keys()))
@@ -359,6 +389,13 @@ class WppfOptionsDialog(QObject):
                     msg = f'Failed to load amorphous experiment file: {e}'
                     raise Exception(msg)
 
+        if self.varying_texture_and_non_texture_params:
+            msg = (
+                'Texture parameters cannot be varied at the same time as '
+                'non-texture parameters.'
+            )
+            raise Exception(msg)
+
     def generate_params(self):
         kwargs = {
             'method': self.method,
@@ -366,6 +403,7 @@ class WppfOptionsDialog(QObject):
             'peak_shape': self.peak_shape_index,
             'bkgmethod': self.background_method_dict,
             'amorphous_model': None,
+            'texture_model': self.texture_model_dict,
         }
         if self.include_amorphous:
             kwargs['amorphous_model'] = Amorphous(
@@ -379,7 +417,7 @@ class WppfOptionsDialog(QObject):
         self.params = self.generate_params()
         self.update_tree_view()
 
-    def update_params(self):
+    def update_params(self, update_tree_view=True):
         if not hasattr(self, 'params'):
             # Params have not been created yet. Nothing to update.
             return
@@ -394,7 +432,9 @@ class WppfOptionsDialog(QObject):
             params[key] = param
 
         self.params = params
-        self.update_tree_view()
+
+        if update_tree_view:
+            self.update_tree_view()
 
     def show(self):
         self.ui.show()
@@ -404,9 +444,20 @@ class WppfOptionsDialog(QObject):
         selected = self.selected_materials
         items = [(name, name in selected) for name in materials]
         dialog = SelectItemsDialog(items, 'Select Materials', self.ui)
-        if dialog.exec() and self.selected_materials != dialog.selected_items:
-            self.selected_materials = dialog.selected_items
-            self.update_params()
+        while True:
+            if (
+                dialog.exec() and
+                self.selected_materials != dialog.selected_items
+            ):
+                if not dialog.selected_items:
+                    msg = 'At least one material must be selected'
+                    QMessageBox.critical(self.ui, 'Material Required', msg)
+                    print(msg, file=sys.stderr)
+                    continue
+
+                self.selected_materials = dialog.selected_items
+                self.update_params()
+            break
 
     @property
     def powder_overlay_materials(self):
@@ -427,6 +478,7 @@ class WppfOptionsDialog(QObject):
     @selected_materials.setter
     def selected_materials(self, v):
         self._selected_materials = v
+        self.update_texture_material_options()
 
     @property
     def materials(self):
@@ -794,6 +846,7 @@ class WppfOptionsDialog(QObject):
             'limit_tth',
             'min_tth',
             'max_tth',
+            'texture_settings',
         ]
         for key in keys:
             settings[key] = getattr(self, key)
@@ -848,6 +901,8 @@ class WppfOptionsDialog(QObject):
             self.update_tree_view()
 
         self.update_enable_states()
+        self.update_texture_material_options()
+        self.update_texture_gui()
 
     def update_background_parameters(self):
         if self.background_method == self._prev_background_method:
@@ -890,7 +945,7 @@ class WppfOptionsDialog(QObject):
 
         # We may need to update the parameters as well, since some background
         # methods have parameters.
-        self.update_params()
+        self.update_params(update_tree_view=False)
         self.reset_background_param_values()
 
     def clear_background_stderr(self):
@@ -921,9 +976,8 @@ class WppfOptionsDialog(QObject):
 
     def on_chebyshev_num_params_changed(self):
         # Reset the background parameters
-        self.update_params()
+        self.update_params(update_tree_view=False)
         self.reset_background_param_values()
-        self.update_tree_view()
 
     def on_include_amorphous_toggled(self):
         b = self.include_amorphous
@@ -1014,6 +1068,8 @@ class WppfOptionsDialog(QObject):
             parent=self.parent(),
             model_class=self.tree_view_model_class,
         )
+        # Use html so we can render superscripts and subscripts
+        self.tree_view.setItemDelegate(HtmlDelegate())
         self.tree_view.check_selection_index = 2
         self.ui.tree_view_layout.addWidget(self.tree_view)
 
@@ -1034,10 +1090,22 @@ class WppfOptionsDialog(QObject):
         self.tree_view.verticalScrollBar().setValue(scroll_value)
 
     def update_tree_view(self):
+        # Keep the same scroll position
+        scrollbar = self.tree_view.verticalScrollBar()
+        scroll_value = scrollbar.value()
+
         tree_dict = self.tree_view_dict_of_params
         self.tree_view.model().config = tree_dict
         self.update_disabled_paths()
         self.tree_view.reset_gui()
+
+        if scroll_value != 0:
+            # Restore scroll bar position
+            # We only do this if the value wasn't zero because
+            # scrollbar.value() won't reflect the actual value until
+            # the next iteration of the event loop, and repeated calls
+            # to `scrollbar.value()` ultimately turn to 0.
+            scrollbar.setValue(scroll_value)
 
     @property
     def tree_view_dict_of_params(self):
@@ -1076,6 +1144,10 @@ class WppfOptionsDialog(QObject):
                     '_min': param.min,
                     '_max': param.max,
                 })
+
+            # Make a callback for when `vary` gets modified by the user.
+            f = partial(self.on_param_vary_modified, param=param)
+            param._on_vary_modified = f
 
             return d
 
@@ -1220,6 +1292,24 @@ class WppfOptionsDialog(QObject):
             this_template = copy.deepcopy(materials_template)
             recursively_format_mat(mat, this_config, this_template)
 
+        # Add texture parameters
+        if self.includes_texture:
+            texture_dict = tree_dict.setdefault('Texture', {})
+            for mat_name in self.textured_materials:
+                # Look for param names that match
+                prefix = f'{mat_name}_c_'
+                matching_names = [k for k in params if k.startswith(prefix)]
+                if not matching_names:
+                    continue
+
+                mat_config = texture_dict.setdefault(mat_name, {})
+                for name in matching_names:
+                    suffix = name[len(prefix):]
+                    ell, i, j = [int(k) for k in suffix.split('_')]
+                    # Align the superscript and subscript vertically
+                    k = aligned_sub_sup_html('C', f'{ell}', f'{i},{j}')
+                    mat_config[k] = create_param_item(params[name])
+
         # Now all keys should have been used. Verify this is true.
         if sorted(used_params) != sorted(list(params.keys())):
             used = ', '.join(sorted(used_params))
@@ -1284,6 +1374,7 @@ class WppfOptionsDialog(QObject):
         # Those will be disabled.
         results = []
         cur_path = []
+
         def recurse(d):
             if isinstance(d, list):
                 for i, v in enumerate(d):
@@ -1364,6 +1455,17 @@ class WppfOptionsDialog(QObject):
             k: v.stderr for k, v in res.params.items()
             if v.vary and v.stderr
         }
+
+    def on_param_vary_modified(self, param):
+        # If it is a texture parameter, mark all other texture
+        # parameters as the same for that material.
+        if '_c_' in param.name:
+            mat_name = param.name.split('_c_')[0]
+            for p in self.params.values():
+                if p.name.startswith(f'{mat_name}_c_'):
+                    p.vary = param.vary
+
+            self.update_tree_view()
 
     def on_show_difference_curve_toggled(self):
         HexrdConfig().show_wppf_difference_axis = (
@@ -1464,6 +1566,10 @@ class WppfOptionsDialog(QObject):
                 **self.amorphous_kwargs,
             )
 
+        extra_kwargs = {}
+        if self.includes_texture:
+            extra_kwargs['texture_model'] = self.texture_model_dict
+
         return {
             'expt_spectrum': expt_spectrum,
             'params': self.params,
@@ -1474,13 +1580,14 @@ class WppfOptionsDialog(QObject):
             'bkgmethod': self.background_method_dict,
             'peakshape': self.peak_shape,
             'amorphous_model': amorphous_model,
+            **extra_kwargs,
         }
 
     def update_wppf_object(self):
         obj = self._wppf_object
         kwargs = self.wppf_object_kwargs
 
-        skip_list = ['expt_spectrum', 'amorphous_model']
+        skip_list = ['expt_spectrum', 'amorphous_model', 'texture_model']
 
         for key, val in kwargs.items():
             if key in skip_list:
@@ -1608,6 +1715,9 @@ class WppfOptionsDialog(QObject):
 
         stack_item = {k: copy.deepcopy(v) for k, v in stack_item.items()}
 
+        # Copy texture figures over. We need to keep the originals.
+        self._copy_texture_figs(self._wppf_object, stack_item['_wppf_object'])
+
         self._undo_stack.append(stack_item)
         self.update_undo_enable_state()
 
@@ -1622,13 +1732,445 @@ class WppfOptionsDialog(QObject):
         self.update_enable_states()
         self.update_tree_view()
 
+        if self.varying_texture_params:
+            # The texture parameters must have changed from this "undo".
+            self.on_texture_params_modified()
+
         self.undo_clicked.emit()
 
     def update_undo_enable_state(self):
         self.ui.undo_last_run.setEnabled(len(self._undo_stack) > 0)
 
+    @property
+    def texture_material_setting_widgets(self) -> list:
+        return [
+            self.ui.include_texture_model,
+            self.ui.texture_ell_max,
+            self.ui.texture_sample_symmetry,
+        ]
 
-def generate_params(method, materials, peak_shape, bkgmethod, amorphous_model):
+    @property
+    def texture_binning_settings_widgets(self) -> list:
+        return [
+            self.ui.texture_azimuthal_interval,
+            self.ui.texture_integration_range,
+        ]
+
+    def update_texture_material_options(self):
+        valid_mats = self.selected_materials
+
+        w = self.ui.selected_texture_material
+        prev_selected = w.currentText()
+        with block_signals(w):
+            w.clear()
+            w.addItems(valid_mats)
+            if prev_selected in valid_mats:
+                w.setCurrentText(prev_selected)
+
+        # Also verify all modeled materials are present. Remove any
+        # that are not.
+        self.prune_invalid_texture_materials()
+        self.on_selected_texture_material_changed()
+
+    def on_selected_texture_material_changed(self):
+        self.update_texture_model_gui()
+
+    def update_texture_model_gui(self):
+        mat_name = self.ui.selected_texture_material.currentText()
+        model_kwargs = self.texture_model_kwargs
+        checked = mat_name in model_kwargs
+        if checked:
+            settings = model_kwargs[mat_name]
+        else:
+            settings = self._default_texture_model_settings
+
+        with block_signals(*self.texture_material_setting_widgets):
+            self.ui.include_texture_model.setChecked(checked)
+            self.ui.texture_sample_symmetry.setCurrentText(settings['ssym'])
+            self.ui.texture_ell_max.setValue(settings['ell_max'])
+
+        self.update_texture_model_enable_states()
+
+    def update_texture_model_enable_states(self):
+        # Determine whether we should disable the model texture
+        # and
+        w = self.ui.include_texture_model
+        is_rietveld = self.method == 'Rietveld'
+        if not is_rietveld:
+            w.setChecked(False)
+
+        has_object = self._wppf_object is not None
+        enable = is_rietveld and not has_object
+        w.setEnabled(enable)
+
+        # Now enable/disable all the other widgets
+        enable = w.isChecked() and not has_object
+        widgets = [
+            self.ui.texture_sample_symmetry_label,
+            self.ui.texture_sample_symmetry,
+            self.ui.texture_ell_max_label,
+            self.ui.texture_ell_max,
+        ]
+
+        for w in widgets:
+            w.setEnabled(enable)
+
+        self.ui.spectrum_binning_group.setEnabled(is_rietveld)
+
+        # Now figure out if we should enable pole figure plotting
+        self.ui.texture_plot_pole_figures.setEnabled(
+            self.can_plot_pole_figures)
+
+    def on_texture_material_setting_changed(self):
+        mat_name = self.ui.selected_texture_material.currentText()
+        checked = self.ui.include_texture_model.isChecked()
+        model_kwargs = self.texture_model_kwargs
+
+        if not checked:
+            if mat_name in model_kwargs:
+                del model_kwargs[mat_name]
+        else:
+            ssym = self.ui.texture_sample_symmetry.currentText()
+            # Force ell_max to be an even number
+            ell_max = self.ui.texture_ell_max.value()
+            if ell_max % 2 != 0:
+                msg = 'Spherical harmonic max must be an even number'
+                QMessageBox.critical(self.ui, 'HEXRD', msg)
+                print(msg, file=sys.stderr)
+
+                ell_max += 1
+                w = self.ui.texture_ell_max
+                with block_signals(w):
+                    w.setValue(ell_max)
+
+            model_kwargs[mat_name] = {
+                'ssym': ssym,
+                'ell_max': ell_max,
+            }
+
+        self.update_texture_model_enable_states()
+
+        # New params might be present
+        # This will update the tree view
+        self.update_params()
+
+    def update_texture_binning_settings_gui(self):
+        settings = self.texture_settings
+        settings_map = {
+            'azimuthal_interval': 'texture_azimuthal_interval',
+            'integration_range': 'texture_integration_range',
+        }
+        for key, w_name in settings_map.items():
+            w = getattr(self.ui, w_name)
+            w.setValue(settings[key])
+
+    def save_texture_binning_settings(self):
+        settings = self.texture_settings
+        settings_map = {
+            'azimuthal_interval': 'texture_azimuthal_interval',
+            'integration_range': 'texture_integration_range',
+        }
+        for key, w_name in settings_map.items():
+            w = getattr(self.ui, w_name)
+            settings[key] = w.value()
+
+    def invalidate_texture_data(self):
+        self._last_pv_binned = None
+        self._last_texture_pv_sim = None
+        self.clear_texture_data()
+
+    def on_texture_binning_setting_changed(self):
+        self.save_texture_binning_settings()
+
+        # Invalidate the texture data
+        self.invalidate_texture_data()
+        self.update_simulated_polar_dialog()
+
+    def compute_binned_polar_view(self):
+        canvas = HexrdConfig().active_canvas
+        if canvas.mode != 'polar' or canvas.iviewer is None:
+            return
+
+        settings = self.texture_settings
+
+        self._last_pv_binned = bin_polar_view(
+            canvas.iviewer.pv,
+            canvas.iviewer.img,
+            settings['azimuthal_interval'],
+            settings['integration_range'],
+        )
+
+    @property
+    def polar_extent(self) -> list[float] | None:
+        canvas = HexrdConfig().active_canvas
+        if canvas.mode != 'polar' or canvas.iviewer is None:
+            return
+
+        return canvas.iviewer._extent
+
+    @property
+    def varying_texture_params(self):
+        for mat_name in self.textured_materials:
+            prefix = f'{mat_name}_c_'
+            for param in self.params.values():
+                if param.name.startswith(prefix) and param.vary:
+                    return True
+
+        return False
+
+    @property
+    def varying_texture_and_non_texture_params(self):
+        if not self.varying_texture_params:
+            return False
+
+        prefixes = [f'{mat_name}_c_' for mat_name in self.textured_materials]
+        for name, param in self.params.items():
+            if param.vary and not any(name.startswith(x) for x in prefixes):
+                return True
+
+        return False
+
+    @property
+    def can_plot_pole_figures(self) -> bool:
+        obj = self._wppf_object
+        if not isinstance(obj, Rietveld):
+            # Nothing to do
+            return False
+
+        def is_zero(v: float) -> bool:
+            return np.isclose(v, 0)
+
+        params = self.params
+
+        # If we find any non-zero parameters, we can plot pole figures
+        for model in obj.texture_model.values():
+            if model is None:
+                continue
+
+            for name in model.parameter_names:
+                if name in params and not is_zero(params[name].value):
+                    return True
+
+        return False
+
+    def _copy_texture_figs(self, obj1, obj2):
+        # We need to keep the original texture figures, so copy those over.
+        if obj1 is None or obj2 is None:
+            return
+
+        for model_key, model1 in obj1.texture_model.items():
+            model2 = obj2.texture_model[model_key]
+            if model1 is None or model2 is None:
+                continue
+
+            if hasattr(model1, 'fig_new'):
+                model2.fig_new = model1.fig_new
+                model2.ax_new = model1.ax_new
+
+    def clear_texture_data(self):
+        obj = self._wppf_object
+        if not isinstance(obj, Rietveld):
+            # Nothing to do
+            return
+
+        for model in obj.texture_model.values():
+            if model is None or not model.pfdata:
+                continue
+
+            # Clear it
+            model.pfdata = {}
+
+    def ensure_texture_data(self):
+        obj = self._wppf_object
+        if not isinstance(obj, Rietveld):
+            raise Exception('Cannot make texture data without Rietveld object')
+
+        if not obj.texture_models_have_pfdata:
+            self.update_texture_data()
+
+    def update_texture_data(self):
+        obj = self._wppf_object
+        if not isinstance(obj, Rietveld):
+            return
+
+        if self._last_pv_binned is None:
+            # A recompute is necessary
+            self.compute_binned_polar_view()
+
+        settings = self.texture_settings
+
+        # This also updates the texture data on all of the texture models
+        obj.compute_texture_data(
+            self._last_pv_binned,
+            bvec=HexrdConfig().beam_vector,
+            evec=ct.eta_vec,
+            azimuthal_interval=settings['azimuthal_interval'],
+        )
+
+    def on_texture_show_simulated_spectrum_clicked(self):
+        if self._last_pv_binned is None:
+            # A recompute is necessary
+            self.compute_binned_polar_view()
+
+        pv_bin = self._last_pv_binned
+        pv_sim = self._last_texture_pv_sim
+        extent = self.polar_extent
+
+        d = self._texture_simulated_polar_dialog
+        if d is None:
+            d = WppfSimulatedPolarDialog(pv_bin, pv_sim, extent)
+            self._texture_simulated_polar_dialog = d
+        else:
+            # Ensure the data is up-to-date
+            d.extent = extent
+            d.set_data(pv_bin, pv_sim)
+
+        d.ui.show()
+
+    def on_texture_plot_pole_figures_clicked(self):
+        obj = self._wppf_object
+        if not isinstance(obj, Rietveld):
+            return
+
+        if len(self.textured_materials) > 1:
+            # Get the user to pick a material
+            items = self.textured_materials
+            mat_name, ok = QInputDialog.getItem(
+                self.ui, 'Pole Figures', 'Select material', items, 0, False)
+            if not ok:
+                return
+        else:
+            mat_name = self.textured_materials[0]
+
+        mat = HexrdConfig().material(mat_name)
+        hkls = mat.planeData.getHKLs()
+
+        items = []
+        for hkl in hkls:
+            items.append([hkl_to_str(hkl), False])
+
+        # Only select the first one by default
+        items[0][1] = True
+
+        # Get the user to select HKLs to use
+        dialog = SelectItemsDialog(items, 'Select HKLs')
+        if not dialog.exec():
+            return
+
+        hkl_is_selected = [x[1] for x in dialog.items]
+        selected_hkls = hkls[hkl_is_selected]
+        if selected_hkls.size == 0:
+            return
+
+        model = obj.texture_model[mat_name]
+
+        if hasattr(model, 'fig_new'):
+            # Hide the old plot for this harmonic model
+            model.fig_new.canvas.manager.window.hide()
+
+        model.calc_new_pole_figure(self.params, selected_hkls, plot=True)
+
+    def on_texture_params_modified(self):
+        self.update_simulated_polar_dialog()
+        self.update_pole_figure_plots()
+
+    def update_simulated_polar_dialog(self):
+        # FIXME: recalculate `self._last_texture_pv_sim`
+        d = self._texture_simulated_polar_dialog
+        if d is None or not d.ui.isVisible():
+            return
+
+        if self._last_pv_binned is None:
+            self.compute_binned_polar_view()
+
+        d.set_data(self._last_pv_binned, self._last_texture_pv_sim)
+
+    def update_pole_figure_plots(self):
+        obj = self._wppf_object
+        if not isinstance(obj, Rietveld):
+            return
+
+        for model in obj.texture_model.values():
+            if model is None:
+                continue
+
+            if model.new_pf_plots_visible:
+                model.update_new_pf_plot_data(self.params)
+
+    def update_texture_gui(self):
+        self.update_texture_model_gui()
+        self.update_texture_binning_settings_gui()
+
+    @property
+    def texture_settings(self):
+        return self._texture_settings
+
+    @texture_settings.setter
+    def texture_settings(self, v):
+        self._texture_settings = v
+
+        # Validate materials in the texture model dict are selected
+        # materials. Remove materials that are not.
+        self.prune_invalid_texture_materials()
+        self.update_texture_gui()
+
+    def prune_invalid_texture_materials(self):
+        valid_mats = self.selected_materials
+        for name in list(self.texture_model_kwargs):
+            if name not in valid_mats:
+                self.texture_model_kwargs.pop(name)
+
+    @property
+    def _default_texture_settings(self):
+        return {
+            'model_kwargs': {},
+            'azimuthal_interval': 5,
+            'integration_range': 1,
+        }
+
+    @property
+    def _default_texture_model_settings(self):
+        return {
+            'ssym': 'axial',
+            'ell_max': 16,
+        }
+
+    @property
+    def includes_texture(self) -> bool:
+        return bool(self.textured_materials)
+
+    @property
+    def textured_materials(self) -> list[str]:
+        if self.method != 'Rietveld':
+            return []
+
+        return list(self.texture_model_kwargs)
+
+    @property
+    def texture_model_kwargs(self) -> dict[str]:
+        return self.texture_settings['model_kwargs']
+
+    @property
+    def texture_model_dict(self) -> dict[str, HarmonicModel]:
+        if self.method != 'Rietveld':
+            return {}
+
+        ret = {}
+        settings = self.texture_settings
+        for k, kwargs in settings['model_kwargs'].items():
+            mat = HexrdConfig().material(k)
+            ret[k] = HarmonicModel(**{
+                'material': Material_Rietveld(material_obj=mat),
+                'bvec': HexrdConfig().beam_vector,
+                'evec': ct.eta_vec,
+                'sample_normal': HexrdConfig().sample_normal,
+                **kwargs,
+            })
+        return ret
+
+
+def generate_params(method, materials, peak_shape, bkgmethod, amorphous_model,
+                    texture_model):
     func_dict = {
         'LeBail': _generate_default_parameters_LeBail,
         'Rietveld': _generate_default_parameters_Rietveld,
@@ -1636,11 +2178,17 @@ def generate_params(method, materials, peak_shape, bkgmethod, amorphous_model):
     if method not in func_dict:
         raise Exception(f'Unknown method: {method}')
 
+    kwargs = {
+        'amorphous_model': amorphous_model,
+    }
+    if method == 'Rietveld':
+        kwargs['texture_model'] = texture_model
+
     return func_dict[method](
         materials,
         peak_shape,
         bkgmethod,
-        amorphous_model=amorphous_model,
+        **kwargs,
     )
 
 
@@ -1691,6 +2239,9 @@ class DefaultWPPFTreeItemModel(DefaultCalibrationTreeItemModel):
     COLUMN_INDICES = _tree_columns_to_indices(COLUMNS)
     UNEDITABLE_COLUMN_INDICES = [COLUMN_INDICES['Uncertainty']]
 
+    def on_boolean_toggled(self, b, path):
+        pass
+
 
 class DeltaWPPFTreeItemModel(DeltaCalibrationTreeItemModel):
     COLUMNS = {
@@ -1699,6 +2250,18 @@ class DeltaWPPFTreeItemModel(DeltaCalibrationTreeItemModel):
     }
     COLUMN_INDICES = _tree_columns_to_indices(COLUMNS)
     UNEDITABLE_COLUMN_INDICES = [COLUMN_INDICES['Uncertainty']]
+
+    def on_boolean_toggled(self, b, path):
+        pass
+
+
+def changed_signal(w):
+    if isinstance(w, QCheckBox):
+        return w.toggled
+    elif isinstance(w, QComboBox):
+        return w.currentIndexChanged
+
+    return w.valueChanged
 
 
 if __name__ == '__main__':

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -80,6 +80,9 @@ class WppfRunner:
         self.write_params_to_materials()
         self.update_param_values()
 
+        # Save the new settings so state files will have them
+        dialog.save_settings()
+
     def rerender_wppf(self):
         self.clear_wppf_plots()
         obj = self.wppf_object

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -59,15 +59,6 @@ class WppfRunner:
         self.wppf_object = dialog.wppf_object
         varying_texture = dialog.varying_texture_params
 
-        if varying_texture:
-            # Ensure texture data is set on the WPPF object.
-            # This might be time-consuming.
-            dialog.ensure_texture_data()
-        else:
-            # If there are any non-texture refinements, we ought
-            # to clear the texture data.
-            dialog.clear_texture_data()
-
         # Work around differences in WPPF objects
         if isinstance(self.wppf_object, Rietveld):
             if varying_texture:

--- a/hexrdgui/calibration/wppf_simulated_polar_dialog.py
+++ b/hexrdgui/calibration/wppf_simulated_polar_dialog.py
@@ -1,0 +1,150 @@
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QSizePolicy
+
+from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.figure import Figure
+import numpy as np
+
+from hexrdgui.color_map_editor import ColorMapEditor
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.navigation_toolbar import NavigationToolbar
+from hexrdgui.ui_loader import UiLoader
+
+
+class WppfSimulatedPolarDialog:
+    def __init__(self, pv_bin: np.ndarray, pv_sim: np.ndarray | None,
+                 extent: list[float] | None = None, parent=None):
+        self.ui = UiLoader().load_file('wppf_simulated_polar_dialog.ui',
+                                       parent)
+
+        if pv_sim is None:
+            pv_sim = np.zeros_like(pv_bin)
+
+        self.pv_bin = pv_bin
+        self.pv_sim = pv_sim
+        self.extent = extent
+
+        self.axes_images = []
+
+        self.cmap = HexrdConfig().default_cmap
+        self.norm = None
+        self.transform = lambda x: x
+
+        self.setup_canvas()
+        self.setup_color_map()
+
+    def setup_color_map(self):
+        self.color_map_editor = ColorMapEditor(self, self.ui)
+        self.ui.color_map_editor_layout.addWidget(self.color_map_editor.ui)
+        self.color_map_editor.update_bounds(self.scaled_image_data)
+        self.color_map_editor.data = self.data
+
+    def setup_canvas(self):
+        canvas = FigureCanvas(Figure(tight_layout=True))
+
+        # Get the canvas to take up the majority of the screen most of the time
+        canvas.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        figure = canvas.figure
+        top_ax = figure.add_subplot(2, 1, 1)
+        bottom_ax = figure.add_subplot(2, 1, 2, sharex=top_ax)
+
+        top_ax.set_ylabel(r'$\eta$ (deg)')
+        bottom_ax.set_ylabel(r'$\eta$ (deg)')
+        bottom_ax.set_xlabel(r'2$\theta$ (deg)')
+        top_ax.label_outer()
+
+        top_ax.set_title('Binned')
+        bottom_ax.set_title('Simulated')
+
+        axes = [top_ax, bottom_ax]
+
+        axes_images = []
+        for i, ax in enumerate(axes):
+            axes_images.append(ax.imshow(
+                self.get_scaled_image_data(i),
+                extent=self.extent,
+                cmap=self.cmap,
+                norm=self.norm,
+            ))
+
+        for ax in axes:
+            ax.relim()
+            ax.autoscale_view()
+            ax.axis('auto')
+
+        figure.tight_layout()
+        self.ui.canvas_layout.addWidget(canvas)
+
+        self.toolbar = NavigationToolbar(canvas, self.ui, coordinates=True)
+        self.ui.canvas_layout.addWidget(self.toolbar)
+
+        # Center the toolbar
+        self.ui.canvas_layout.setAlignment(self.toolbar, Qt.AlignCenter)
+
+        self.figure = figure
+        self.axes = axes
+        self.axes_images = axes_images
+        self.canvas = canvas
+
+        self.draw_later()
+
+    def set_cmap(self, cmap):
+        self.cmap = cmap
+        for im in self.axes_images:
+            im.set_cmap(cmap)
+
+        self.draw_later()
+
+    def set_norm(self, norm):
+        self.norm = norm
+        for im in self.axes_images:
+            im.set_norm(norm)
+
+        self.draw_later()
+
+    def set_scaling(self, transform):
+        self.transform = transform
+        for i, im in enumerate(self.axes_images):
+            im.set_data(self.get_scaled_image_data(i))
+
+        self.draw_later()
+
+    @property
+    def data(self):
+        # Just stack together the top and bottom arrays.
+        # This is necessary for things like B&C editor
+        return np.stack([self.get_data(i) for i in range(2)])
+
+    @property
+    def scaled_image_data(self):
+        return self.transform(self.data)
+
+    def set_data(self, pv_bin: np.ndarray, pv_sim: np.ndarray | None):
+        if pv_sim is None:
+            pv_sim = np.zeros_like(pv_bin)
+
+        self.pv_bin = pv_bin
+        self.pv_sim = pv_sim
+        self.on_data_modified()
+
+    def on_data_modified(self):
+        for i, ax_im in enumerate(self.axes_images):
+            ax_im.set_data(self.get_scaled_image_data(i))
+            ax_im.set_extent(self.extent)
+
+        self.color_map_editor.data = self.data
+
+        self.draw_later()
+
+    def get_data(self, i: int):
+        return self.pv_bin if i == 0 else self.pv_sim
+
+    def get_scaled_image_data(self, i: int):
+        return self.transform(self.get_data(i))
+
+    def show(self):
+        self.ui.show()
+
+    def draw_later(self):
+        self.figure.canvas.draw_idle()

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -14,7 +14,7 @@ import yaml
 
 import hexrd.imageseries.save
 from hexrd.config.loader import NumPyIncludeLoader
-from hexrd.instrument import HEDMInstrument
+from hexrd.instrument import calc_beam_vec, HEDMInstrument
 from hexrd.instrument.constants import PHYSICS_PACKAGE_DEFAULTS, PINHOLE_DEFAULTS
 from hexrd.instrument.physics_package import HEDPhysicsPackage
 from hexrd.material import load_materials_hdf5, save_materials_hdf5, Material
@@ -2189,6 +2189,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def sample_rmat(self, v: np.ndarray):
         phi, n = angleAxisOfRotMat(v)
         self.sample_tilt = phi * n.flatten()
+
+    @property
+    def sample_normal(self) -> np.ndarray:
+        bvec = self.beam_vector
+        return np.dot(self.sample_rmat, [0., 0., np.sign(bvec[2])])
+
+    @property
+    def beam_vector(self) -> np.ndarray:
+        d = self.active_beam['vector']
+        return calc_beam_vec(d['azimuth'], d['polar_angle'])
 
     def _polar_pixel_size_tth(self):
         return self.config['image']['polar']['pixel_size_tth']

--- a/hexrdgui/html_delegate.py
+++ b/hexrdgui/html_delegate.py
@@ -1,0 +1,147 @@
+from PySide6.QtCore import QModelIndex, QSize, Qt
+from PySide6.QtGui import QFontMetrics, QPainter, QTextDocument
+from PySide6.QtWidgets import QStyle, QStyledItemDelegate, QStyleOptionViewItem
+
+
+class HtmlDelegate(QStyledItemDelegate):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        # Store the custom stylesheet.
+        self._stylesheet = ''
+        self._document_margin = 4.0
+
+    def set_stylesheet(self, css_string: str):
+        """Sets the custom CSS stylesheet to be used for all items."""
+        self._stylesheet = css_string
+
+    def _add_stylesheet(self, html_content: str) -> str:
+        return (
+            '<html>'
+            f'<head><style>{self._stylesheet}</style></head>'
+            f'<body>{html_content}</body>'
+            '</html>'
+        )
+
+    def _get_display_string(self, index: QModelIndex):
+        data = index.data(Qt.DisplayRole)
+        if data is not None and not isinstance(data, str):
+            # Ensure it is a string
+            data = str(data)
+        return data
+
+    def paint(
+        self,
+        painter: QPainter,
+        option: QStyleOptionViewItem,
+        index: QModelIndex,
+    ):
+        data = self._get_display_string(index)
+        if not data:
+            return
+
+        # Use a temporary QTextDocument to get the plain text from the HTML.
+        temp_doc = QTextDocument()
+        temp_doc.setHtml(data)
+        plain_text = temp_doc.toPlainText()
+
+        # Check if the plain text needs to be truncated with an ellipsis.
+        font_metrics = QFontMetrics(option.font)
+        text_width = font_metrics.horizontalAdvance(plain_text)
+
+        # Allow for a small margin.
+        available_width = option.rect.width() - 4
+
+        # If text is too long, elide it.
+        if text_width > available_width:
+            elided_text = font_metrics.elidedText(
+                plain_text, Qt.ElideRight, available_width)
+            # Re-wrap the elided text in a simple HTML structure to preserve
+            # formatting.
+            html_content = f'<span>{elided_text}</span>'
+        else:
+            # If it fits, use the original HTML content.
+            html_content = data
+
+        # Use a QTextDocument to handle the HTML rendering.
+        full_html = self._add_stylesheet(html_content)
+        doc = QTextDocument()
+        doc.setHtml(full_html)
+        doc.setDefaultFont(option.font)
+        doc.setDocumentMargin(self._document_margin)
+
+        # Draw the text document.
+        painter.save()
+        painter.setClipRect(option.rect)
+
+        # Handle item selection state
+        if option.state & QStyle.State_Selected:
+            painter.fillRect(option.rect, option.palette.highlight())
+
+        # Move the painter to the correct position for the text document.
+        painter.translate(option.rect.x(), option.rect.y())
+
+        # Align the text within the item.
+        # text_option = doc.defaultTextOption()
+        # text_option.setWrapMode(QTextOption.WordWrap)
+        # doc.setDefaultTextOption(text_option)
+
+        doc.drawContents(
+            painter,
+            option.rect.translated(-option.rect.x(), -option.rect.y()),
+        )
+        painter.restore()
+
+    def sizeHint(
+        self,
+        option: QStyleOptionViewItem,
+        index: QModelIndex,
+    ) -> QSize:
+        data = self._get_display_string(index)
+        if not data:
+            return QSize(0, 0)
+
+        doc = QTextDocument()
+        doc.setHtml(self._add_stylesheet(data))
+        doc.setDefaultFont(option.font)
+        doc.setDocumentMargin(self._document_margin)
+
+        return QSize(doc.idealWidth(), doc.size().height())
+
+
+def _stacked_notation_table_stylesheet() -> str:
+    return """
+        .stacked-notation-table {
+            border-collapse: collapse;
+            vertical-align: middle;
+        }
+        .stacked-notation-table .sup {
+            vertical-align: top;
+            font-size: small;
+        }
+        .stacked-notation-table .sub {
+            vertical-align: bottom;
+            font-size: small;
+        }
+    """
+
+
+def aligned_sub_sup_html(base: str, sup: str, sub: str) -> str:
+    # This automatically generates HTML to align superscripts
+    # and subscripts on top of one another.
+    # Unlike a bunch of other methods for doing this, this
+    # specific method is actually acceptable to Qt's limited
+    # css support.
+    return f"""
+        <style>
+            {_stacked_notation_table_stylesheet()}
+        </style>
+        <table class="stacked-notation-table">
+            <tr>
+                <td rowspan="2">{base}</td>
+                <td class="sup">{sup}</td>
+            </tr>
+            <tr>
+                <td class="sub">{sub}</td>
+            </tr>
+        </table>
+    """

--- a/hexrdgui/resources/ui/color_map_editor.ui
+++ b/hexrdgui/resources/ui/color_map_editor.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>352</width>
+    <width>362</width>
     <height>145</height>
    </rect>
   </property>
@@ -28,6 +28,12 @@
    </property>
    <item>
     <widget class="QGroupBox" name="group_box">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="styleSheet">
       <string notr="true">QGroupBox{padding-top:15px; margin-top:-20px}</string>
      </property>

--- a/hexrdgui/resources/ui/select_items_widget.ui
+++ b/hexrdgui/resources/ui/select_items_widget.ui
@@ -48,19 +48,6 @@
      <column/>
     </widget>
    </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -546,6 +546,196 @@
          </item>
         </layout>
        </widget>
+       <widget class="QWidget" name="texture_tab">
+        <attribute name="title">
+         <string>Texture</string>
+        </attribute>
+        <layout class="QGridLayout" name="gridLayout_8">
+         <item row="0" column="0">
+          <widget class="QLabel" name="selected_texture_material_label">
+           <property name="text">
+            <string>Texture Settings for Material:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="selected_texture_material"/>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QGroupBox" name="texture_settings_group">
+           <property name="title">
+            <string/>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_9">
+            <item row="0" column="2">
+             <widget class="QComboBox" name="texture_sample_symmetry">
+              <property name="currentText">
+               <string>monoclinic</string>
+              </property>
+              <item>
+               <property name="text">
+                <string>monoclinic</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>orthorhombic</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>axial</string>
+               </property>
+              </item>
+              <item>
+               <property name="text">
+                <string>triclinic</string>
+               </property>
+              </item>
+             </widget>
+            </item>
+            <item row="2" column="2">
+             <widget class="QSpinBox" name="texture_ell_max">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string/>
+              </property>
+              <property name="minimum">
+               <number>2</number>
+              </property>
+              <property name="maximum">
+               <number>10000000</number>
+              </property>
+              <property name="singleStep">
+               <number>2</number>
+              </property>
+              <property name="value">
+               <number>16</number>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="0">
+             <widget class="QCheckBox" name="include_texture_model">
+              <property name="text">
+               <string>Model texture for this material?</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="QLabel" name="texture_sample_symmetry_label">
+              <property name="text">
+               <string>Sample symmetry:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="1">
+             <widget class="QLabel" name="texture_ell_max_label">
+              <property name="text">
+               <string>Spherical harmonic degree:</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item row="3" column="0" colspan="2">
+          <spacer name="verticalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>0</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="2" column="0" colspan="2">
+          <widget class="QGroupBox" name="spectrum_binning_group">
+           <property name="title">
+            <string/>
+           </property>
+           <layout class="QGridLayout" name="gridLayout_10">
+            <item row="0" column="0">
+             <widget class="QLabel" name="texture_azimuthal_interval_label">
+              <property name="text">
+               <string>Azimuthal Interval:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="2">
+             <widget class="QLabel" name="texture_integration_range_label">
+              <property name="text">
+               <string>Integration Range:</string>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="1">
+             <widget class="ScientificDoubleSpinBox" name="texture_azimuthal_interval">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>0.000010000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10000000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>5.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="0" column="3">
+             <widget class="ScientificDoubleSpinBox" name="texture_integration_range">
+              <property name="keyboardTracking">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string>°</string>
+              </property>
+              <property name="decimals">
+               <number>8</number>
+              </property>
+              <property name="minimum">
+               <double>0.000010000000000</double>
+              </property>
+              <property name="maximum">
+               <double>10000000.000000000000000</double>
+              </property>
+              <property name="value">
+               <double>1.000000000000000</double>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="2" colspan="2">
+             <widget class="QPushButton" name="texture_plot_pole_figures">
+              <property name="text">
+               <string>Plot Pole Figures</string>
+              </property>
+             </widget>
+            </item>
+            <item row="2" column="0" colspan="2">
+             <widget class="QPushButton" name="texture_show_simulated_spectrum">
+              <property name="text">
+               <string>Show Simulated Spectrum</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+        </layout>
+       </widget>
       </widget>
      </item>
     </layout>
@@ -585,6 +775,14 @@
   <tabstop>num_amorphous_peaks</tabstop>
   <tabstop>amorphous_select_experiment_files</tabstop>
   <tabstop>amorphous_expt_smoothing</tabstop>
+  <tabstop>selected_texture_material</tabstop>
+  <tabstop>include_texture_model</tabstop>
+  <tabstop>texture_sample_symmetry</tabstop>
+  <tabstop>texture_ell_max</tabstop>
+  <tabstop>texture_azimuthal_interval</tabstop>
+  <tabstop>texture_integration_range</tabstop>
+  <tabstop>texture_show_simulated_spectrum</tabstop>
+  <tabstop>texture_plot_pole_figures</tabstop>
   <tabstop>export_params</tabstop>
   <tabstop>import_params</tabstop>
   <tabstop>reset_params_to_defaults</tabstop>

--- a/hexrdgui/resources/ui/wppf_options_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_options_dialog.ui
@@ -637,6 +637,13 @@
               </property>
              </widget>
             </item>
+            <item row="2" column="0">
+             <widget class="QLabel" name="texture_index_label">
+              <property name="text">
+               <string>Texture Index: None</string>
+              </property>
+             </widget>
+            </item>
            </layout>
           </widget>
          </item>

--- a/hexrdgui/resources/ui/wppf_simulated_polar_dialog.ui
+++ b/hexrdgui/resources/ui/wppf_simulated_polar_dialog.ui
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>wppf_simulated_polar_dialog</class>
+ <widget class="QDialog" name="wppf_simulated_polar_dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>650</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Simulated Polar Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="leftMargin">
+    <number>6</number>
+   </property>
+   <property name="topMargin">
+    <number>6</number>
+   </property>
+   <property name="rightMargin">
+    <number>6</number>
+   </property>
+   <property name="bottomMargin">
+    <number>6</number>
+   </property>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="color_map_editor_layout"/>
+   </item>
+   <item row="1" column="0">
+    <layout class="QVBoxLayout" name="canvas_layout"/>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/hexrdgui/select_items_dialog.py
+++ b/hexrdgui/select_items_dialog.py
@@ -27,6 +27,10 @@ class SelectItemsDialog(QDialog):
         self.button_box.rejected.connect(self.reject)
 
     @property
+    def items(self):
+        return self.select_items_widget.items
+
+    @property
     def selected_items(self):
         return self.select_items_widget.selected_items
 


### PR DESCRIPTION
This adds a number of new features in support of textures in the WPPF module.

WPPF texture settings:

<img width="1284" height="275" alt="image" src="https://github.com/user-attachments/assets/e2a1f615-f65a-431c-8e86-79c2b0b6a4c6" />

Texture parameters:

<img width="1248" height="515" alt="image" src="https://github.com/user-attachments/assets/e50f69ac-69c9-4240-a0b6-6c132d84e171" />

Pole figures:

<img width="1520" height="604" alt="image" src="https://github.com/user-attachments/assets/714c0ec4-8fc7-4b95-b135-f79d8d1fe634" />

Simulated polar view (which considers texture):

<img width="895" height="868" alt="image" src="https://github.com/user-attachments/assets/3b259460-654a-4a68-87c1-ba33c9bda0f0" />


Depends on: hexrd/hexrd#842