### PR TITLE
Remove unneeded call to `self.overlay_axes_data()`

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -468,7 +468,6 @@ class ImageCanvas(FigureCanvas):
         type = overlay.type
         style = overlay.style
         highlight_style = overlay.highlight_style
-        self.overlay_axes_data(overlay)
         for axis, det_key, data in self.overlay_axes_data(overlay):
             highlights = [x[2] for x in overlay.highlights if x[0] == det_key]
             kwargs = {


### PR DESCRIPTION
This was added by mistake. It somehow resulted in the stitched ROI overlays not working properly.

Removing it fixes the issue.