### PR TITLE
Support material names containing `-`

### DIFF
--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -1330,7 +1330,8 @@ class WppfOptionsDialog(QObject):
             texture_dict = tree_dict.setdefault('Texture', {})
             for mat_name in self.textured_materials:
                 # Look for param names that match
-                prefix = f'{mat_name}_c_'
+                mat_name_sanitized = mat_name.replace('-', '_')
+                prefix = f'{mat_name_sanitized}_c_'
                 matching_names = [k for k in params if k.startswith(prefix)]
                 if not matching_names:
                     continue
@@ -1839,6 +1840,7 @@ class WppfOptionsDialog(QObject):
             self.ui.texture_ell_max.setValue(settings['ell_max'])
 
         self.update_texture_model_enable_states()
+        self.update_texture_index_label()
 
     def update_texture_model_enable_states(self):
         # Determine whether we should disable the model texture
@@ -1976,7 +1978,7 @@ class WppfOptionsDialog(QObject):
 
     @property
     def varying_texture_params(self):
-        for mat_name in self.textured_materials:
+        for mat_name in self.textured_materials_sanitized:
             prefix = f'{mat_name}_c_'
             for param in self.params.values():
                 if param.name.startswith(prefix) and param.vary:
@@ -1989,7 +1991,10 @@ class WppfOptionsDialog(QObject):
         if not self.varying_texture_params:
             return False
 
-        prefixes = [f'{mat_name}_c_' for mat_name in self.textured_materials]
+        prefixes = [
+            f'{mat_name}_c_' for mat_name in
+            self.textured_materials_sanitized
+        ]
         for name, param in self.params.items():
             if param.vary and not any(name.startswith(x) for x in prefixes):
                 return True
@@ -2227,6 +2232,10 @@ class WppfOptionsDialog(QObject):
             return []
 
         return list(self.texture_model_kwargs)
+
+    @property
+    def textured_materials_sanitized(self) -> list[str]:
+        return [name.replace('-', '_') for name in self.textured_materials]
 
     @property
     def texture_model_kwargs(self) -> dict[str]:


### PR DESCRIPTION
This sanitizes material names in places where they need to be sanitized. Specifically, it fixes the issue for texture models in WPPF.

This fixes the issue within the GUI, whereas #848 fixes the issue within hexrd.

Fixes: #1919