### PR TITLE
Try running CI on macos-15-intel

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,7 +22,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-13,
+            os: macos-15-intel,
             package: 'dmg'
           }
         - {

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
           }
         - {
             name: "MacOSX",
-            os: macos-13
+            os: macos-15-intel
           }
         - {
             name: "Windows",


### PR DESCRIPTION
macos-13 is deprecated and will be gone on December 8.

We should try to migrate to using only Apple silicon runners. But until then, try using macos-15-intel.