### PR TITLE
Allow cmap scaling changes when image not ready

### DIFF
--- a/hexrdgui/color_map_editor.py
+++ b/hexrdgui/color_map_editor.py
@@ -1,5 +1,6 @@
 import copy
 
+from PySide6.QtCore import QTimer
 from PySide6.QtGui import QColor
 from PySide6.QtWidgets import QColorDialog
 
@@ -24,6 +25,9 @@ class ColorMapEditor:
         # 2. set_norm: a function to set the norm on the image
         # 3. set_scaling: a function to set the scaling on the image
         # 4. scaled_image_data: a property to get the scaled image data
+        # 5. image_ready: an optional boolean property indicating if the image
+        #                 is ready. If not present, the image is assumed to
+        #                 be ready.
 
         self.image_object = image_object
 
@@ -268,4 +272,14 @@ class ColorMapEditor:
 
         # Reset the bounds, as the histogram could potentially have moved.
         # This will update the data too.
-        self.update_bounds(self.image_object.scaled_image_data)
+        # Wait until the image is ready to do the update.
+
+        def do_bound_update_if_ready():
+            if not getattr(self.image_object, 'image_ready', True):
+                # If the image is not ready, try again in 250 milliseconds
+                QTimer.singleShot(250, do_bound_update_if_ready)
+                return
+
+            self.update_bounds(self.image_object.scaled_image_data)
+
+        do_bound_update_if_ready()

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -413,6 +413,10 @@ class ImageCanvas(FigureCanvas):
         return list(self.scaled_display_image_dict.values())
 
     @property
+    def image_ready(self) -> bool:
+        return self.iviewer is not None
+
+    @property
     def blit_artists(self):
         return self.blit_manager.artists
 
@@ -1692,11 +1696,13 @@ class ImageCanvas(FigureCanvas):
             image_names = list(self.raw_axes)
             self.load_images(image_names)
         else:
-            for axes_img, img in zip(
-                self.axes_images,
-                self.scaled_display_images,
-            ):
-                axes_img.set_data(img)
+            # If the image is not ready, these will be set later
+            if self.image_ready:
+                for axes_img, img in zip(
+                    self.axes_images,
+                    self.scaled_display_images,
+                ):
+                    axes_img.set_data(img)
 
         self.update_azimuthal_integral_plot()
         self.draw_idle()

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -323,6 +323,10 @@ class ImageTabWidget(QTabWidget):
         # return the whole image data dict.
         return self.image_canvases[0].scaled_display_image_dict
 
+    @property
+    def image_ready(self) -> bool:
+        return self.image_canvases[0].image_ready
+
     def on_motion_notify_event(self, event):
         # Clear the info if the mouse leaves a plot
         if event.inaxes is None:


### PR DESCRIPTION
Previously, error messages would appear if the cmap scaling was changed while the image was still being generated (such as the polar view being generated).

Now, error messages are not generated, and the cmap scaling change is handled gracefully.