### PR TITLE
Pin conda-build to be less than 25

### DIFF
--- a/packaging/environment.yml
+++ b/packaging/environment.yml
@@ -7,7 +7,9 @@ dependencies:
   - coloredlogs
   - conda
   - cmake
-  - conda-build
+  # FIXME: we have some issues with conda-build 25 and greater
+  # We should figure out these issues and remove this pin after
+  - conda-build<25
   - conda-pack
   - click
   - conda-libmamba-solver


### PR DESCRIPTION
We have some packaging issues for conda-build when it is version 25. We should figure out these issues and fix it when we get a chance.

However, it might just be issues that conda-build will fix automatically. It seems they are rushing to come out with a new patch release.