### PR TITLE
Sort detector names in the load images dialog

### DIFF
--- a/hexrdgui/load_images_dialog.py
+++ b/hexrdgui/load_images_dialog.py
@@ -104,7 +104,7 @@ class LoadImagesDialog:
         for i in range(table.rowCount()):
             if self.manual_assign:
                 det_cb = QComboBox()
-                det_cb.addItems(list(set(self.detectors)))
+                det_cb.addItems(sorted(list(set(self.detectors))))
                 table.setCellWidget(i, 0, det_cb)
                 table.cellWidget(i, 0).currentTextChanged.connect(
                     lambda v, i=i: self.selection_changed(v, i))


### PR DESCRIPTION
Otherwise, the detector names appear in random order, and it can be difficult to find the one you are looking for if you have a long list of them.