### PR TITLE
Remove pinning of conda-build version

### DIFF
--- a/packaging/environment.yml
+++ b/packaging/environment.yml
@@ -7,9 +7,7 @@ dependencies:
   - coloredlogs
   - conda
   - cmake
-  # FIXME: we have some issues with conda-build 25 and greater
-  # We should figure out these issues and remove this pin after
-  - conda-build<25
+  - conda-build
   - conda-pack
   - click
   - conda-libmamba-solver


### PR DESCRIPTION
This pinning was to avoid an issue that may be resolved.