### PR TITLE
Update the template instance with the current image plate

### DIFF
--- a/hexrdgui/llnl_import_tool_dialog.py
+++ b/hexrdgui/llnl_import_tool_dialog.py
@@ -736,8 +736,8 @@ class LLNLImportToolDialog(QObject):
         # TD_TC000-000_FIDDLE_CAMERA-02-DB_SHOT_RAW-FIDDLE-CAMERA_N240717-001-999.h5
         # ->
         # TD_TC000-000_FIDDLE_CAMERA-*-DB_SHOT_RAW-FIDDLE-CAMERA_N240717-001-*.h5
-        image = re.sub("CAMERA-\d{2}-", "CAMERA-*-", selected_file)
-        files = re.sub("-\d{3}.h", "-*.h", image)
+        image = re.sub(r"CAMERA-\d{2}-", "CAMERA-*-", selected_file)
+        files = re.sub(r"-\d{3}.h", "-*.h", image)
 
         # Sort matched files. We know that those ending in -999 are data files.
         # Dark files may have different values at the end (-003, -005, etc.) so


### PR DESCRIPTION
Previously the interactive template instance was re-created for each new detector on new image load. The current image was not being updated when the selection was changed if the detector was not changed as well. Since the PXRDIP isntrument has multiple image plates for a single detector image this meant that we were not fetching the correct previous positions for the templates. This change now keeps the template in sync with the import tool's current image plate.

Closes #1958 