### PR TITLE
Migrate transforms functions to their new versions

### DIFF
--- a/hexrdgui/calibration/display_plane.py
+++ b/hexrdgui/calibration/display_plane.py
@@ -11,7 +11,7 @@ class DisplayPlane:
 
     def __init__(self, tilt=tilt_DFTL, tvec=tvec_DFLT):
         self.tilt = tilt
-        self.rmat = xfcapi.makeDetectorRotMat(self.tilt)
+        self.rmat = xfcapi.make_detector_rmat(self.tilt)
         self.tvec = tvec
 
     def panel_size(self, instr):

--- a/hexrdgui/calibration/hedm/calibration_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_dialog.py
@@ -3,11 +3,10 @@ import numpy as np
 
 from PySide6.QtCore import Signal
 
-from hexrd import rotations
+from hexrd.rotations import angularDifference, mapAngle
 import hexrd.constants as cnst
 from hexrd.fitting.calibration.calibrator import Calibrator
 from hexrd.fitting.calibration.lmfit_param_handling import fix_detector_y
-from hexrd.transforms import xfcapi
 
 from hexrdgui.calibration.calibration_dialog import CalibrationDialog
 from hexrdgui.calibration.hedm.calibration_results_dialog import (
@@ -483,7 +482,7 @@ class HEDMCalibrationCallbacks(MaterialCalibrationDialogCallbacks):
                 x_diff = abs(xyo_det[det_key][ig][:, 0] - xyo_f[det_key][ig][:, 0])
                 y_diff = abs(xyo_det[det_key][ig][:, 1] - xyo_f[det_key][ig][:, 1])
                 ome_diff = np.degrees(
-                    xfcapi.angularDifference(
+                    angularDifference(
                         xyo_det[det_key][ig][:, 2], xyo_f[det_key][ig][:, 2]
                     )
                 )
@@ -637,7 +636,7 @@ def parse_spots_data(spots_data, instr, grain_ids, ome_period=None, refit_idx=No
 
             # re-map omegas if need be
             if ome_period is not None:
-                xyo_det_values[:, 2] = rotations.mapAngle(
+                xyo_det_values[:, 2] = mapAngle(
                     xyo_det_values[:, 2],
                     ome_period,
                 )

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -4,7 +4,7 @@ from skimage.filters.edges import binary_erosion
 from skimage.morphology import footprint_rectangle
 from skimage.transform import warp
 
-from hexrd.transforms.xfcapi import mapAngle
+from hexrd.rotations import mapAngle
 from hexrd.utils.decorators import memoize
 from hexrd.utils.warnings import ignore_warnings
 

--- a/hexrdgui/fiber_pick_utils.py
+++ b/hexrdgui/fiber_pick_utils.py
@@ -65,7 +65,7 @@ def _pick_to_fiber(
     # the sample direction
     tth = pd.getTTh()[map_index]  # !!! in radians
     angs = np.atleast_2d(np.hstack([tth, np.radians(pick_coords)]))
-    samp_dir = xfcapi.anglesToGVec(angs, bHat_l=beam_vec, chi=chi).reshape(3, 1)
+    samp_dir = xfcapi.angles_to_gvec(angs, beam_vec=beam_vec, chi=chi).reshape(3, 1)
 
     # make the fiber
     qfib = discreteFiber(
@@ -74,7 +74,7 @@ def _pick_to_fiber(
 
     if as_expmap:
         phis = 2.0 * np.arccos(qfib[0, :])
-        ns = xfcapi.unitRowVector(qfib[1:, :].T)
+        ns = xfcapi.unit_vector(qfib[1:, :].T)
         expmaps = phis * ns.T
         return expmaps.T  # (3, ndiv)
     else:
@@ -126,7 +126,7 @@ def _angles_from_orientation(instr, eta_ome_maps, orientation):
     if len(expmap) == 4:
         # have a quat; convert here
         phi = 2.0 * np.arccos(expmap[0])
-        n = xfcapi.unitRowVector(expmap[1:])
+        n = xfcapi.unit_vector(expmap[1:])
         expmap = phi * n
     elif len(expmap) > 4:
         raise RuntimeError("orientation must be a single exponential map or quaternion")

--- a/hexrdgui/indexing/indexing_results_dialog.py
+++ b/hexrdgui/indexing/indexing_results_dialog.py
@@ -9,7 +9,7 @@ from PySide6.QtCore import Signal, QObject, Qt, QTimer
 from PySide6.QtWidgets import QFileDialog, QSizePolicy
 
 from hexrd.cli.fit_grains import GrainData
-from hexrd.transforms import xfcapi
+from hexrd.rotations import mapAngle
 
 from hexrdgui.color_map_editor import ColorMapEditor
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
@@ -372,7 +372,7 @@ class IndexingResultsDialog(QObject):
         output = np.degrees(np.concatenate(all_angles))
 
         # Fix eta period
-        output[:, 0] = xfcapi.mapAngle(
+        output[:, 0] = mapAngle(
             output[:, 0], np.degrees(self.eta_period), units='degrees'
         )
         return output

--- a/hexrdgui/indexing/utils.py
+++ b/hexrdgui/indexing/utils.py
@@ -11,7 +11,7 @@ def generate_grains_table(qbar):
     gw = instrument.GrainDataWriter(array=grains_table)
     for i, q in enumerate(qbar.T):
         phi = 2 * np.arccos(q[0])
-        n = xfcapi.unitRowVector(q[1:])
+        n = xfcapi.unit_vector(q[1:])
         grain_params = np.hstack([phi * n, constants.zeros_3, constants.identity_6x1])
         gw.dump_grain(i, 1, 0, grain_params)
     gw.close()

--- a/hexrdgui/instrument_form_view_widget.py
+++ b/hexrdgui/instrument_form_view_widget.py
@@ -17,6 +17,7 @@ from hexrd.instrument import (
     calc_beam_vec,
     HEDMInstrument,
 )
+from hexrd.matrixutil import rowNorm
 from hexrd.transforms import xfcapi
 
 from hexrdgui import constants, resource_loader
@@ -532,7 +533,7 @@ class InstrumentFormViewWidget(QObject):
 
         # Only add the note it if is not close to its unit vector
         beam_vec = np.asarray(self.cartesian_beam_vector)
-        unit_vec = xfcapi.unitRowVector(beam_vec)
+        unit_vec = xfcapi.unit_vector(beam_vec)
 
         if np.all(np.isclose(unit_vec, beam_vec, atol=1e-3)):
             return
@@ -575,7 +576,7 @@ class InstrumentFormViewWidget(QObject):
             return
 
         beam_vec = np.atleast_2d(self.cartesian_beam_vector)
-        self.beam_vector_magnitude = xfcapi.rowNorm(beam_vec).item()
+        self.beam_vector_magnitude = rowNorm(beam_vec).item()
 
     def update_cartesian_beam_vector_from_magnitude(self):
         if not self.beam_vector_is_finite:

--- a/hexrdgui/overlays/laue_overlay.py
+++ b/hexrdgui/overlays/laue_overlay.py
@@ -4,8 +4,8 @@ from enum import Enum
 from numba import njit
 import numpy as np
 
+from hexrd.rotations import mapAngle
 from hexrd.instrument import switch_xray_source
-from hexrd.transforms import xfcapi
 from hexrd.utils.hkl import hkl_to_str
 
 from hexrdgui.constants import OverlayType, ViewType
@@ -253,27 +253,11 @@ class LaueOverlay(Overlay):
             point_groups[det_key]['hkls'] = hkls
 
             angles = angles[0][idx, :]  # these are in radians
-            angles[:, 1] = xfcapi.mapAngle(
+            angles[:, 1] = mapAngle(
                 angles[:, 1], np.radians(self.eta_period), units='radians'
             )
 
             energies = energy[0][idx]
-
-            """
-            # !!! apply offset corrections to angles
-            # convert to angles in LAB ref
-            angles_corr, _ = xfcapi.detectorXYToGvec(
-                xy_data, panel.rmat, HexrdConfig().sample_rmat,
-                panel.tvec, instr.tvec, constants.zeros_3,
-                beamVec=instr.beam_vector,
-                etaVec=instr.eta_vector
-            )
-            # FIXME modify output to be array
-            angles_corr = np.vstack(angles_corr).T
-            angles_corr[:, 1] = xfcapi.mapAngle(
-                angles_corr[:, 1], np.radians(self.eta_period), units='radians'
-            )
-            """
             if display_mode in (ViewType.polar, ViewType.stereo):
                 # If the polar view is being distorted, apply this tth
                 # distortion to the angles as well.

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -6,7 +6,7 @@ from hexrd import constants
 from hexrd.material import unitcell
 
 from hexrd.instrument import switch_xray_source
-from hexrd.transforms import xfcapi
+from hexrd.rotations import mapAngle
 from hexrd.xrdutil.phutil import invalidate_past_critical_beta
 from hexrd.utils.hkl import hkl_to_str
 
@@ -516,7 +516,7 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                     raw_ang_crds = ang_crds
 
                 # Need to ensure the angles are mapped
-                raw_ang_crds[:, 1] = xfcapi.mapAngle(
+                raw_ang_crds[:, 1] = mapAngle(
                     raw_ang_crds[:, 1], np.radians(self.eta_period), units='radians'
                 )
 
@@ -550,7 +550,7 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                 ang_crds = np.degrees(ang_crds)
 
                 # fix eta period
-                ang_crds[:, 1] = xfcapi.mapAngle(
+                ang_crds[:, 1] = mapAngle(
                     ang_crds[:, 1], self.eta_period, units='degrees'
                 )
 

--- a/hexrdgui/overlays/rotation_series_overlay.py
+++ b/hexrdgui/overlays/rotation_series_overlay.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from hexrd.findorientations import _process_omegas
-from hexrd.transforms.xfcapi import mapAngle
+from hexrd.rotations import mapAngle
 
 from hexrdgui.constants import OverlayType, ViewType
 from hexrdgui.overlays.constants import (

--- a/hexrdgui/utils/__init__.py
+++ b/hexrdgui/utils/__init__.py
@@ -21,7 +21,7 @@ from hexrd.rotations import (
     RotMatEuler,
     rotMatOfExpMap,
 )
-from hexrd.transforms.xfcapi import makeRotMatOfExpMap
+from hexrd.transforms.xfcapi import make_rmat_of_expmap
 from hexrd.utils.decorators import memoize
 from hexrd.utils.hkl import str_to_hkl
 from hexrd.utils.panel_buffer import panel_buffer_as_2d_array
@@ -59,7 +59,7 @@ def convert_tilt_convention(iconfig, old_convention, new_convention):
     for key in det_keys:
         tilts = iconfig['detectors'][key]['transform']['tilt']
         tilt = np.asarray(tilts)
-        rme.rmat = makeRotMatOfExpMap(tilt)
+        rme.rmat = make_rmat_of_expmap(tilt)
         # Use np.ndarray.tolist() to convert back to native python types
         tilts[:] = np.asarray(rme.angles).tolist()
 
@@ -78,7 +78,7 @@ def convert_angle_convention(angles, old_convention, new_convention):
 
     # Update to the new mapping
     rme = RotMatEuler(np.zeros(3), **new_convention)
-    rme.rmat = makeRotMatOfExpMap(np.array(angles))
+    rme.rmat = make_rmat_of_expmap(np.array(angles))
     return np.array(rme.angles).tolist()
 
 

--- a/hexrdgui/utils/const_chi.py
+++ b/hexrdgui/utils/const_chi.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from hexrd import constants
 from hexrd.rotations import make_rmat_euler
-from hexrd.transforms.xfcapi import angles_to_gvec, angles_to_dvec, gvecToDetectorXY
+from hexrd.transforms.xfcapi import angles_to_gvec, angles_to_dvec, gvec_to_xy
 from hexrd.xrdutil.utils import _project_on_detector_cylinder, _dvec_to_angs
 
 
@@ -111,15 +111,15 @@ def generate_ring_points_chi(const_chi, sample_tilt, instr):
 
             gvecs = chi_vecs_to_gvecs(chivecs, sample_tilt)
 
-            xy_det = gvecToDetectorXY(
+            xy_det = gvec_to_xy(
                 gvecs,
-                rMat_d=panel.rmat,
-                rMat_s=constants.identity_3x3,
-                rMat_c=constants.identity_3x3,
-                tVec_d=panel.tvec,
-                tVec_s=instr.tvec,
-                tVec_c=constants.zeros_3,
-                beamVec=panel.bvec,
+                rmat_d=panel.rmat,
+                rmat_s=constants.identity_3x3,
+                rmat_c=constants.identity_3x3,
+                tvec_d=panel.tvec,
+                tvec_s=instr.tvec,
+                tvec_c=constants.zeros_3,
+                beam_vec=panel.bvec,
             )
 
         elif panel.detector_type == 'cylindrical':

--- a/hexrdgui/utils/conversions.py
+++ b/hexrdgui/utils/conversions.py
@@ -3,8 +3,8 @@ from typing import Union
 import numpy as np
 
 from hexrd import constants
-from hexrd.rotations import make_rmat_euler
-from hexrd.transforms.xfcapi import angles_to_gvec, mapAngle
+from hexrd.rotations import make_rmat_euler, mapAngle
+from hexrd.transforms.xfcapi import angles_to_gvec
 
 from hexrdgui.constants import KEV_TO_WAVELENGTH
 

--- a/hexrdgui/utils/stereo2angle.py
+++ b/hexrdgui/utils/stereo2angle.py
@@ -1,5 +1,7 @@
 import numpy as np
-from hexrd.transforms.xfcapi import makeEtaFrameRotMat, anglesToDVec, Xl
+
+from hexrd.constants import lab_x
+from hexrd.transforms.xfcapi import make_beam_rmat, angles_to_dvec
 
 
 def ij2xy(ij, stereo_size):
@@ -131,7 +133,7 @@ def ij2ang(ij, stereo_size, bvec):
 
     tth = np.squeeze(np.arccos(np.dot(bvec, vhat_l.T)))
 
-    rm = makeEtaFrameRotMat(bvec, Xl)
+    rm = make_beam_rmat(bvec, lab_x)
 
     vx, vy = np.dot(rm[:, 0:2].T, vhat_l.T)
     # vx = np.dot(rm[:,0], vhat_l.T)
@@ -166,7 +168,7 @@ def ang2ij(angs, stereo_size, bvec):
     """
     angs_cp = np.atleast_2d(angs)
     zrs = np.zeros((angs_cp.shape[0], 1))
-    vhat_l = anglesToDVec(np.hstack((angs_cp, zrs)), bHat_l=bvec)
+    vhat_l = angles_to_dvec(np.hstack((angs_cp, zrs)), beam_vec=bvec)
     return xy2ij(v3d2xy(vhat_l), stereo_size)
 
 
@@ -203,7 +205,7 @@ if __name__ == '__main__':
     plt.figure()
     plt.imshow(eta)
 
-    # slower one since it uses anglesToDVec
+    # slower one since it uses angles_to_dvec
     ij = ang2ij(ang, stereo_size, bvec)
 
     plt.show()


### PR DESCRIPTION
This migrates all uses of the old transforms functions to the new ones.

The conversion guide located [here](https://github.com/HEXRD/hexrd/wiki/old_xfcapi-Conversion-Guide) was followed.

This will be necessary after hexrd/hexrd#887 is merged.