### PR TITLE
Fix exporting HEDM workflow for subpanels

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1429,10 +1429,15 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'reset_exclusions': False,
         }
 
+        if self.instrument_has_roi:
+            names = self.detector_group_names
+        else:
+            names = self.detector_names
+
         data = []
-        for det in self.detector_names:
+        for name in names:
             data.append(
-                {'file': f'{det}.npz', 'args': {'path': 'imageseries'}, 'panel': det}
+                {'file': f'{name}.npz', 'args': {'path': 'imageseries'}, 'panel': name}
             )
 
         image_series = {'format': 'frame-cache', 'data': data}

--- a/hexrdgui/indexing/fit_grains_results_dialog.py
+++ b/hexrdgui/indexing/fit_grains_results_dialog.py
@@ -21,6 +21,7 @@ from PySide6.QtWidgets import QFileDialog, QMenu, QMessageBox, QSizePolicy
 if TYPE_CHECKING:
     from matplotlib.backend_bases import PickEvent
     from matplotlib.colors import Colormap
+    from hexrd.core.imageseries.imageseriesabc import ImageSeriesABC
     from hexrd.material import Material
 
 from hexrd.matrixutil import vecMVToSymm
@@ -726,20 +727,29 @@ class FitGrainsResultsDialog(QObject):
             # Convenience function to generate full path via pathlib
             return str(Path(selected_directory) / file_name)
 
+        has_roi = HexrdConfig().instrument_has_roi
+
         HexrdConfig().working_dir = selected_directory
 
         HexrdConfig().save_indexing_config(full_path('workflow.yml'))
         HexrdConfig().save_materials_hdf5(full_path('materials.h5'))
         HexrdConfig().save_instrument_config(
             full_path('instrument.hexrd'),
-            # Remove ROIs, since we are saving the imageseries without them
-            remove_rois=True,
+            # Keep ROIs when groups exist so exported workflow can be
+            # re-used with original monolithic frame-cache files
+            remove_rois=not has_roi,
         )
 
+        if has_roi:
+            self._save_group_images(selected_directory)
+        else:
+            self._save_detector_images(selected_directory)
+
+    def _save_detector_images(self, selected_directory: str) -> None:
         ims_dict = HexrdConfig().unagg_images
         assert ims_dict is not None
         for det in HexrdConfig().detector_names:
-            path = full_path(f'{det}.npz')
+            path = str(Path(selected_directory) / f'{det}.npz')
             kwargs: dict[str, Any] = {
                 'ims': ims_dict.get(det),
                 'name': det,
@@ -749,6 +759,27 @@ class FitGrainsResultsDialog(QObject):
                 'threshold': 0,
             }
             HexrdConfig().save_imageseries(**kwargs)
+
+    def _save_group_images(self, selected_directory: str) -> None:
+        ims_dict = HexrdConfig().unagg_images
+        assert ims_dict is not None
+        for group in HexrdConfig().detector_group_names:
+            # Get first subpanel in group to access its underlying image
+            first_det = HexrdConfig().detectors_in_group(group)[0]
+            subpanel_ims = ims_dict[first_det]
+
+            # Get the monolithic image (unwrap rectangle op)
+            monolithic_ims = _get_monolithic_ims(subpanel_ims)
+
+            path = str(Path(selected_directory) / f'{group}.npz')
+            HexrdConfig().save_imageseries(
+                ims=monolithic_ims,
+                name=group,
+                write_file=path,
+                selected_format='frame-cache',
+                cache_file=path,
+                threshold=0,
+            )
 
     def on_export_workflow_clicked(self) -> None:
         selected_directory = QFileDialog.getExistingDirectory(
@@ -760,11 +791,16 @@ class FitGrainsResultsDialog(QObject):
             return
 
         # Warn the user if any files will be over-written
+        if HexrdConfig().instrument_has_roi:
+            image_names = HexrdConfig().detector_group_names
+        else:
+            image_names = HexrdConfig().detector_names
+
         write_files = [
             'workflow.yml',
             'materials.h5',
             'instrument.hexrd',
-        ] + [f'{det}.npz' for det in HexrdConfig().detector_names]
+        ] + [f'{name}.npz' for name in image_names]
 
         overwrite_files = []
         for f in write_files:
@@ -782,6 +818,54 @@ class FitGrainsResultsDialog(QObject):
 
         self.async_runner.progress_title = 'Saving workflow configuration'
         self.async_runner.run(self._save_workflow_files, selected_directory)
+
+
+def _get_monolithic_ims(
+    subpanel_ims: ImageSeriesABC,
+) -> ImageSeriesABC:
+    """Get monolithic image from a subpanel's image series.
+
+    Recursively unwraps the image series chain, collecting all
+    non-rectangle operations and frame_list selections along the way.
+    The result is a single image series rooted at the base adapter
+    with all non-rectangle processing preserved.
+
+    The chain may contain arbitrary nesting of:
+    - ``ImageSeries`` / ``OmegaImageSeries`` (use ``_adapter``)
+    - ``ProcessedImageSeries`` (use ``_imser``, hold ``_oplist``)
+    """
+    from hexrd.core.imageseries.process import ProcessedImageSeries
+
+    # Walk the full chain, collecting non-rectangle ops and frame_lists.
+    non_rect_ops: list = []
+    frame_list: list[int] | None = None
+    ims: ImageSeriesABC = subpanel_ims
+
+    while True:
+        if isinstance(ims, ProcessedImageSeries):
+            # Collect ops (excluding rectangle) and frame_list
+            non_rect_ops.extend(
+                op for op in ims._oplist if op[0] != 'rectangle'
+            )
+            if frame_list is None and ims._hasframelist:
+                frame_list = list(ims._frames)
+            ims = ims._imser
+        elif hasattr(ims, '_adapter'):
+            ims = ims._adapter
+        else:
+            # Reached the base adapter — stop.
+            break
+
+    # ims is now the root image series (e.g. FrameCacheImageSeriesAdapter
+    # wrapped in ImageSeries).  Rebuild with only the collected ops.
+    if not non_rect_ops and frame_list is None:
+        return ims
+
+    kwargs: dict = {}
+    if frame_list is not None:
+        kwargs['frame_list'] = frame_list
+
+    return ProcessedImageSeries(ims, non_rect_ops, **kwargs)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Exporting the HEDM workflow seemed to work fine when only monolith panels were used. However, using a subpanel setup (where each subpanel takes image data from a region of the main panel image) had bugs - specifically, re-using the same exported workflow.yml file on the original input files (or files like the original ones) would not work.

This, along with hexrd/hexrd#900, are required to fix the issue.

Fixes: #1970