### PR TITLE
Add test for full HEDM workflow

### DIFF
--- a/hexrdgui/calibration/raw_iviewer.py
+++ b/hexrdgui/calibration/raw_iviewer.py
@@ -139,6 +139,8 @@ class InstrumentViewer:
         ret: dict[str, Any] = {}
         for det_key, data in overlay.data.items():
             panel = self.instr.detectors[det_key]
+            if panel.roi is None:
+                continue
 
             def raw_to_stitched(x: np.ndarray) -> None:
                 # x is in "ji" coordinates

--- a/hexrdgui/messages_widget.py
+++ b/hexrdgui/messages_widget.py
@@ -226,7 +226,11 @@ class Writer(QObject):
             i = self.call_stack.index(self)
             self.call_stack[i - 1].write(text)
 
-        self.text_received.emit(text)
+        try:
+            self.text_received.emit(text)
+        except RuntimeError:
+            # The underlying C++ object may have been deleted
+            pass
 
     def flush(self) -> None:
         if self in self.call_stack:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -42,7 +42,17 @@ def main_window(qtbot):
     window = MainWindow()
     window.confirm_application_close = False
     qtbot.addWidget(window.ui)
-    return window
+    yield window
+
+    # Release messages widget Writers from stdout/stderr call stacks
+    # before Qt destroys the underlying C++ objects.
+    window.progress_dialog.messages_widget.release_output()
+    window.messages_widget.release_output()
+
+    # Destroy the MainWindow QObject so Qt auto-disconnects all signal
+    # connections (e.g. HexrdConfig signals → this window's slots).
+    window.deleteLater()
+    QApplication.processEvents()
 
 
 # This next fixture is necessary starting in Qt 6.8, to ensure

--- a/tests/test_hedm_workflow.py
+++ b/tests/test_hedm_workflow.py
@@ -68,9 +68,9 @@ def test_hedm_full_workflow(qtbot, main_window, dexelas_hedm_path, tmp_path):
 
     load_panel = main_window.simple_image_series_dialog
     with select_files_when_asked([str(npz1), str(npz2)]):
-        qtbot.mouseClick(load_panel.ui.image_files, Qt.LeftButton)
+        qtbot.mouseClick(load_panel.ui.image_files, Qt.MouseButton.LeftButton)
 
-    qtbot.mouseClick(load_panel.ui.read, Qt.LeftButton)
+    qtbot.mouseClick(load_panel.ui.read, Qt.MouseButton.LeftButton)
     QApplication.processEvents()
 
     assert not is_dummy_data()


### PR DESCRIPTION
This test performs the entire HEDM workflow in the GUI, verifies that the grain parameters look correct, export the full workflow so that the CLI can run it, and then verify that when ran in the CLI, the same numbers are also obtained.