### PR TITLE
*.esg file fix

### DIFF
--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -213,12 +213,13 @@ class InstrumentViewer:
         filename = Path(filename)
 
         with open(filename, 'w') as fid:
-            eta_vec = np.degrees(self.angular_grid[0])
+            eta_vec = np.degrees(self.angular_grid[0][:, 0])
+            tth = np.degrees(self.angular_grid[1][0, :])
             intensities = self.img
             first_block = True
-            for i, eta in enumerate(np.average(eta_vec, axis=1).flatten()):
-                if np.all(np.isnan(intensities[i])):
-                    # Skip this block
+            for i, eta in enumerate(eta_vec):
+                if np.sum(~np.isnan(intensities[i])) <= 3:
+                    # Skip the block if it has less than 3 non-nan points
                     continue
 
                 if first_block:
@@ -229,9 +230,7 @@ class InstrumentViewer:
 
                 fid.write(hstr)
                 fid.write(block_hdr)
-                integral_data = HexrdConfig().last_unscaled_azimuthal_integral_data
-                assert integral_data is not None
-                tth = integral_data[0]
+
                 for rho, inten in zip(tth, intensities[i]):
                     if np.isnan(inten):
                         continue


### PR DESCRIPTION
bug found in MAUD ESG reader by codex. The reader fails when there are less than 3 points in a row which are non-nans. This fix makes sure there are at least 3 non-nan points. Tested fix  with LCLS data. Before, quad 2 was completely skipped, which now loads correctly.

<img width="749" height="573" alt="image" src="https://github.com/user-attachments/assets/6d61413d-f1b8-4b4f-abf7-81f82e538137" />


<img width="745" height="600" alt="image" src="https://github.com/user-attachments/assets/298b7067-ebf8-4f81-938c-fb58fc75bdbb" />


Relevant lines from chatgpt below:

This one is much more specific: it is not just your file format. There is a bug in MAUD’s ESG reader.
In EsquiGoCIFDataFile.readallSpectra, MAUD counts the number of loop columns in i, then later fills points using j. But when it computes the weight, it calls datafile.getYData(i) instead of datafile.getYData(j). For a 2-column loop like yours (_pd_proc_2theta_corrected + _pd_calc_intensity_total), i becomes 2, so if a block ends up with fewer than 3 parsed points, MAUD throws exactly Index 2 out of bounds. That matches your stack trace.

```
// parsed loop columns -> i
int maxCIFEntries = i;

// parsed points -> datanumber
for (int j = 0; j < datanumber; j++) {
    ...
    datafile.setYData(j, xy[indexIntensity][j]);
    double tmpweight = Math.sqrt(datafile.getYData(i));   // <- bug, should be j
}
```