### PR TITLE
Suppress interactive pan when drawing masks

### DIFF
--- a/hexrdgui/interactive_canvas.py
+++ b/hexrdgui/interactive_canvas.py
@@ -79,6 +79,10 @@ class InteractiveCanvasMixin(_CanvasBase):
         # allowed after the user has zoomed into the canvas.
         self._zoom_has_occurred: bool = False
 
+        # External code (e.g. mask dialogs) can suppress panning so that
+        # left-click drag is forwarded to matplotlib callbacks instead.
+        self._pan_suppress_count: int = 0
+
         # Nav toolbar reference (set externally by image_tab_widget)
         self._nav_toolbar: NavigationToolbar | None = None
 
@@ -148,6 +152,15 @@ class InteractiveCanvasMixin(_CanvasBase):
             if ax.get_navigate_mode() is not None:
                 return True
         return False
+
+    def suppress_pan(self) -> None:
+        """Increment the pan suppression counter.  While > 0, left-click
+        drag is forwarded to matplotlib instead of being used for panning."""
+        self._pan_suppress_count += 1
+
+    def unsuppress_pan(self) -> None:
+        """Decrement the pan suppression counter."""
+        self._pan_suppress_count = max(0, self._pan_suppress_count - 1)
 
     # ------------------------------------------------------------------
     # Axis rect / pixmap helpers
@@ -505,6 +518,7 @@ class InteractiveCanvasMixin(_CanvasBase):
             event.button() == Qt.MouseButton.LeftButton
             and not self._toolbar_mode_active()
             and self._zoom_has_occurred
+            and self._pan_suppress_count == 0
         ):
             pos = event.position()
             ax = self._axes_under_cursor(pos.toPoint())

--- a/hexrdgui/masking/hand_drawn_mask_dialog.py
+++ b/hexrdgui/masking/hand_drawn_mask_dialog.py
@@ -76,8 +76,15 @@ class HandDrawnMaskDialog(QObject):
         self.bp_id = self.canvas.mpl_connect('button_press_event', self.button_pressed)
         self.enter_id = self.canvas.mpl_connect('axes_enter_event', self.axes_entered)
         self.exit_id = self.canvas.mpl_connect('axes_leave_event', self.axes_exited)
+        self.canvas.suppress_pan()
 
     def disconnect_canvas_connections(self) -> None:
+        had_connections = (
+            self.bp_id is not None
+            or self.enter_id is not None
+            or self.exit_id is not None
+        )
+
         if self.bp_id:
             self.canvas.mpl_disconnect(self.bp_id)
             self.bp_id = None
@@ -89,6 +96,9 @@ class HandDrawnMaskDialog(QObject):
         if self.exit_id:
             self.canvas.mpl_disconnect(self.exit_id)
             self.exit_id = None
+
+        if had_connections:
+            self.canvas.unsuppress_pan()
 
     def move_dialog_to_left(self) -> None:
         # This moves the dialog to the left border of the parent

--- a/hexrdgui/masking/mask_regions_dialog.py
+++ b/hexrdgui/masking/mask_regions_dialog.py
@@ -62,6 +62,8 @@ class MaskRegionsDialog(QObject):
         self.ui.show()
 
     def disconnect_all(self) -> None:
+        if self.canvas_ids:
+            self.canvas.unsuppress_pan()
         for id in self.canvas_ids:
             self.canvas.mpl_disconnect(id)
         self.canvas_ids.clear()
@@ -84,6 +86,7 @@ class MaskRegionsDialog(QObject):
         self.canvas_ids.append(
             self.canvas.mpl_connect('axes_leave_event', self.axes_exited)
         )
+        self.canvas.suppress_pan()
 
     def setup_ui_connections(self) -> None:
         self.ui.button_box.accepted.connect(self.apply_masks)


### PR DESCRIPTION
Otherwise, panning still works, and the interactive drawing is triggered after panning, which is not inutuitive.