### PR TITLE
Skip multiplication for layer type

### DIFF
--- a/hexrdgui/pinhole_correction_editor.py
+++ b/hexrdgui/pinhole_correction_editor.py
@@ -192,7 +192,10 @@ class PinholeCorrectionEditor(QObject):
         vp = v.copy()
         # These units are in mm, but we display in micrometers
         for key, value in v.items():
-            if key in ('num_phi_elements', 'absorption_length', 'layer_type'):
+            if key == 'layer_type':
+                # This is a string, not numeric. Skip conversion.
+                continue
+            elif key in ('num_phi_elements', 'absorption_length'):
                 multiplier = 1.0
             else:
                 multiplier = 1e3


### PR DESCRIPTION
The layer type is a string and should not be multiplied.

Originally, the multiplication worked fine, because the multiplier was an integer of 1, and doing things like `'sample' * 1` results in `'sample'` - just the string.

However, we changed the multiplier to a float in the type annotations PR, and we can't multiply a float with a string, so we would get an error.

This fixes the code so the layer type string does not get multiplied at all.