### PR TITLE
Restore panel subset properly when loading state

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -770,8 +770,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.update_status_bar.emit(msg)
 
     def on_detectors_changed(self) -> None:
-        # Reset azimuthal lineout detectors
-        self._azimuthal_lineout_detectors = None
+        # Reset azimuthal lineout detectors, unless we are loading state
+        # (the saved state already has the correct lineout detectors for the
+        # saved instrument).
+        if not self.loading_state:
+            self._azimuthal_lineout_detectors = None
 
     @property
     def indexing_config(self) -> dict[str, Any]:

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1528,7 +1528,11 @@ class MainWindow(QObject):
             return
 
         overwriting_last_loaded = False
-        if selected_file == HexrdConfig().last_loaded_state_file:
+        last_loaded = HexrdConfig().last_loaded_state_file
+        if (
+            last_loaded is not None
+            and Path(selected_file).resolve() == Path(last_loaded).resolve()
+        ):
             # We are over-writing the last loaded state file.
             # We must save to a temp file to avoid over-writing the
             # imageseries, which are already open...


### PR DESCRIPTION
We were accidentally erasing the panel subset setting while loading the state file.

Don't do that so that the panel subset gets saved/restored properly.