### PR TITLE
Fix several issues related to imageseries

### DIFF
--- a/hexrdgui/image_series_toolbar.py
+++ b/hexrdgui/image_series_toolbar.py
@@ -126,13 +126,6 @@ class ImageSeriesToolbar(QWidget):
         self.omega_label = QLabel(self._parent_widget())
         self.omega_label.setVisible(False)
 
-        # Compute the text width for the maximum size label we will have
-        # with the current font, and set the label width to be fixed at
-        # this width. This will prevent the slider from shifting around
-        # while we are sliding.
-        example_label_text = omega_label_text(359.999, 359.999)
-        text_width = self.text_width(example_label_text)
-        self.omega_label.setFixedWidth(text_width)
         self.frame.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
         self.layout = QGridLayout(self.widget)
@@ -164,10 +157,6 @@ class ImageSeriesToolbar(QWidget):
             elif size and not self._show and current_tab:
                 self._show = True
             self.widget.setVisible(self._show)
-            if not self.slider.minimumWidth():
-                parent = self._parent_widget()
-                if parent is not None:
-                    self.slider.setMinimumWidth(parent.width() // 2)
             if not size == self.slider.maximum():
                 self.slider.setMaximum(size)
                 self.frame.setToolTip(f'Max: {size}')
@@ -180,6 +169,7 @@ class ImageSeriesToolbar(QWidget):
             self.widget.setVisible(self._show)
 
         self.update_omega_label_text()
+        self.update_omega_label_minimum_width()
 
     def update_range(self, current_tab: bool) -> None:
         self.set_range(current_tab)
@@ -217,6 +207,23 @@ class ImageSeriesToolbar(QWidget):
             return
 
         self.omega_label.setText(omega_label_text(*ome_range))  # type: ignore[misc]
+
+    def update_omega_label_minimum_width(self) -> None:
+        """Set a minimum width based on the actual omega data so the
+        slider does not shift around while sliding. Find the pair
+        that produces the longest formatted string."""
+        assert self.omega_label is not None
+        imsd = HexrdConfig().omega_imageseries_dict
+        if imsd is None:
+            return
+
+        first_ims = next(iter(imsd.values()))
+        longest_text = ''
+        for pair in first_ims.omega:
+            text = omega_label_text(round(pair[0], 3), round(pair[1], 3))
+            if len(text) > len(longest_text):
+                longest_text = text
+        self.omega_label.setMinimumWidth(self.text_width(longest_text))
 
     def update_back_forward_buttons(self, val: int) -> None:
         assert self.back_button is not None

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -161,7 +161,13 @@ class ImageTabWidget(QTabWidget):
 
     def change_ims_image(self, pos: int) -> None:
         HexrdConfig().current_imageseries_idx = pos
-        self.update_needed.emit()
+
+        if HexrdConfig().image_mode == ViewType.raw:
+            # Update image data on existing canvases without clearing
+            # and rebuilding tabs, which causes a render flash.
+            self._update_raw_images()
+        else:
+            self.update_needed.emit()
 
         is_aggregated = HexrdConfig().is_aggregated
         has_omegas = HexrdConfig().has_omegas
@@ -177,6 +183,14 @@ class ImageTabWidget(QTabWidget):
             if redraw:
                 for canvas in self.active_canvases:
                     canvas.redraw_overlay(overlay)
+
+    def _update_raw_images(self) -> None:
+        """Update raw image data on existing canvases without rebuilding tabs."""
+        if HexrdConfig().tab_images:
+            for i, name in enumerate(self.image_names):
+                self.image_canvases[i].load_images(image_names=[name])
+        else:
+            self.image_canvases[0].load_images(image_names=self.image_names)
 
     @Slot(bool)
     def show_toolbar(self, b: bool) -> None:

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -663,6 +663,9 @@ class MainWindow(QObject):
         self.color_map_editor.reset_range()
         self.update_image_mode_enable_states()
 
+        for overlay in HexrdConfig().overlays:
+            overlay.on_new_images_loaded()
+
     def on_action_open_materials_triggered(self) -> None:
         selected_file, selected_filter = QFileDialog.getOpenFileName(
             self.ui,

--- a/hexrdgui/overlays/overlay.py
+++ b/hexrdgui/overlays/overlay.py
@@ -130,9 +130,7 @@ class Overlay(ABC):
         self.setup_connections()
 
     def setup_connections(self) -> None:
-        from hexrdgui.image_load_manager import ImageLoadManager
-
-        ImageLoadManager().new_images_loaded.connect(self.on_new_images_loaded)
+        pass
 
     @property
     def plot_data_keys(self) -> tuple[str, ...]:


### PR DESCRIPTION
1. The image series slider at the bottom no longer has a fixed minimum width. Previously, this could make the GUI take up more horizontal space than is available on a monitor, and would not allow you to resize. It is better if it just takes up the amount of available width, and allow the window to be resized, rather than forcing a minimum width.

2. The omage label now only takes up the maximum amount of space that it could take up for the particular imageseries that was loaded. Previously, it would take up potentially more space than would be needed. Now, we iterate through the possibilities and determine the max space.

3. Render flash in the raw view when changing image series frames is now fixed. It was only present for the raw view because the raw view is loaded synchronously in the main thread (as opposed to the other views which are loaded in a background thread).

4. Remove the `new_images_loaded` connection in the rotation series overlays and instead call the relevant function from the main window. Since the rotation series overlays are not QObjects, they would not disconnect properly when they were deleted. Iterating through them in the main window fixes this issue.

Fixes: #1990