### PR TITLE
Subtract minimum before all scaling operations

### DIFF
--- a/hexrdgui/calibration/cartesian_plot.py
+++ b/hexrdgui/calibration/cartesian_plot.py
@@ -43,6 +43,7 @@ class InstrumentViewer:
         HexrdConfig().apply_panel_buffer_to_images(self.images_dict)
 
         self.img: np.ma.MaskedArray | None = None
+        self.unmasked_min: float | None = None
 
         # Perform some checks before proceeding
         self.check_keys_match()
@@ -335,6 +336,7 @@ class InstrumentViewer:
         # In case there were any nans...
         nan_mask = np.isnan(img)
         self.img = np.ma.masked_array(img, mask=nan_mask, fill_value=0.0)
+        self.unmasked_min = float(np.nanmin(self.img))
 
     def update_images_dict(self) -> None:
         if HexrdConfig().any_intensity_corrections:

--- a/hexrdgui/calibration/polar_plot.py
+++ b/hexrdgui/calibration/polar_plot.py
@@ -64,6 +64,10 @@ class InstrumentViewer:
         return self.pv.snip_background
 
     @property
+    def unmasked_min(self) -> float | None:
+        return self.pv.unmasked_min
+
+    @property
     def erosion_mask(self) -> np.ndarray | None:
         return self.pv.erosion_mask
 

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -90,6 +90,7 @@ class PolarView:
 
         self.raw_img: np.ma.MaskedArray | None = None
         self.snipped_img: np.ndarray | None = None
+        self.unmasked_min: float | None = None
         self.computation_img: np.ndarray | None = None
         self.display_image: np.ndarray | None = None
 
@@ -463,6 +464,7 @@ class PolarView:
 
         # We only apply "visible" masks to the display image
         img = self.apply_tth_distortion(img)
+        self.unmasked_min = float(np.nanmin(img))
         disp_img = self.apply_visible_masks(img)
         self.display_image = disp_img
 

--- a/hexrdgui/calibration/stereo_plot.py
+++ b/hexrdgui/calibration/stereo_plot.py
@@ -34,6 +34,7 @@ class InstrumentViewer:
         self.instr_pv = create_view_hedm_instrument()
         self.pv: PolarView | None = None
         self.img: np.ndarray | None = None
+        self.unmasked_min: float | None = None
 
         self.draw_stereo()
 
@@ -109,6 +110,8 @@ class InstrumentViewer:
             self.draw_stereo_from_raw()
 
         self.fill_image_with_nans()
+        if self.img is not None:
+            self.unmasked_min = float(np.nanmin(self.img))
 
     def draw_stereo_from_raw(self) -> None:
         self.img = stereo_project(

--- a/hexrdgui/calibration/wppf_simulated_polar_dialog.py
+++ b/hexrdgui/calibration/wppf_simulated_polar_dialog.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Callable
+from typing import TYPE_CHECKING
 
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import QSizePolicy, QWidget
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 from hexrdgui.color_map_editor import ColorMapEditor
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.navigation_toolbar import NavigationToolbar
+from hexrdgui.scaling import SCALING_OPTIONS
 from hexrdgui.ui_loader import UiLoader
 
 
@@ -117,8 +118,8 @@ class WppfSimulatedPolarDialog:
 
         self.draw_later()
 
-    def set_scaling(self, transform: Callable[[np.ndarray], np.ndarray]) -> None:
-        self.transform = transform
+    def set_scaling(self, scaling_name: str) -> None:
+        self.transform = SCALING_OPTIONS[scaling_name]
         for i, im in enumerate(self.axes_images):
             im.set_data(self.get_scaled_image_data(i))
 

--- a/hexrdgui/color_map_editor.py
+++ b/hexrdgui/color_map_editor.py
@@ -274,8 +274,8 @@ class ColorMapEditor:
         self.image_object.set_norm(norm)
 
     def update_scaling(self) -> None:
-        new_scaling = SCALING_OPTIONS[self.ui.scaling.currentText()]
-        self.image_object.set_scaling(new_scaling)
+        scaling_name = self.ui.scaling.currentText()
+        self.image_object.set_scaling(scaling_name)
 
         # Reset the bounds, as the histogram could potentially have moved.
         # This will update the data too.

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -38,6 +38,7 @@ from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.masking.constants import MaskType
 from hexrdgui.masking.create_polar_mask import create_polar_line_data_from_raw
 from hexrdgui.masking.mask_manager import MaskManager
+from hexrdgui.scaling import create_scaling_function
 from hexrdgui.snip_viewer_dialog import SnipViewerDialog
 from hexrdgui.utils.array import split_array
 from hexrdgui.utils.conversions import (
@@ -114,7 +115,7 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         self.wppf_difference_axis: Axes | None = None
         self.auto_picked_data_artists: list[Any] = []
         self.beam_marker_artists: list[Any] = []
-        self._transform = lambda x: x
+        self._scaling_name: str = 'none'
         self._last_stereo_size = None
         self.stereo_border_artists: list[Any] = []
         self.azimuthal_overlay_artists: list[Any] = []
@@ -379,8 +380,9 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
             images_dict = iviewer.raw_images_to_stitched(image_names, images_dict)
 
             # We also apply the scaling manually here
+            scaling = create_scaling_function(self._scaling_name, self.unmasked_min)
             for k, img in images_dict.items():
-                images_dict[k] = self._transform(img)
+                images_dict[k] = scaling(img)
 
         return images_dict
 
@@ -1714,17 +1716,43 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         self.clear_figure()
         self.draw_idle()
 
+    @property
+    def unmasked_min(self) -> float | None:
+        """The minimum from unmasked image data.
+
+        Used by scaling functions so that the display doesn't jump
+        when user-drawn masks happen to remove the current minimum
+        pixel value.
+
+        For non-raw views, each viewer stores an unmasked_min right
+        before masks are applied during image generation.
+        """
+        try:
+            if self.mode == ViewType.raw:
+                images = HexrdConfig().images_dict
+                return float(min(np.nanmin(img) for img in images.values()))
+            elif self.iviewer is not None:
+                iviewer = cast(
+                    'PolarViewer | CartesianViewer | StereoViewer',
+                    self.iviewer,
+                )
+                return iviewer.unmasked_min
+        except (ValueError, AttributeError):
+            pass
+
+        return None
+
     def transform(self, img: np.ndarray) -> np.ndarray:
         if self.mode == ViewType.raw and HexrdConfig().stitch_raw_roi_images:
             # We actually perform the transformation manually later.
             # Don't do it now.
             return img
 
-        return self._transform(img)
+        return create_scaling_function(self._scaling_name, self.unmasked_min)(img)
 
-    def set_scaling(self, transform: Callable[[np.ndarray], np.ndarray]) -> None:
+    def set_scaling(self, scaling_name: str) -> None:
         # Apply the scaling, and set the data
-        self._transform = transform
+        self._scaling_name = scaling_name
         if self.mode == ViewType.raw and HexrdConfig().stitch_raw_roi_images:
             # Apply the transformation by loading the images
             image_names = list(self.raw_axes)

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -346,8 +346,8 @@ class ImageTabWidget(QTabWidget):
         self.norm = norm
         self.update_canvas_norms()
 
-    def set_scaling(self, scaling: Any) -> None:
-        self.scaling = scaling
+    def set_scaling(self, scaling_name: str) -> None:
+        self.scaling = scaling_name
         self.update_canvas_scaling()
 
     @property

--- a/hexrdgui/indexing/indexing_results_dialog.py
+++ b/hexrdgui/indexing/indexing_results_dialog.py
@@ -18,6 +18,7 @@ from hexrdgui.grains_viewer_dialog import GrainsViewerDialog
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.indexing.utils import write_grains_txt
 from hexrdgui.navigation_toolbar import NavigationToolbar
+from hexrdgui.scaling import SCALING_OPTIONS
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
 from hexrdgui.utils.dialog import add_help_url
@@ -266,8 +267,8 @@ class IndexingResultsDialog(QObject):
             self.im.set_norm(norm)
             self.draw()
 
-    def set_scaling(self, transform: Any) -> None:
-        self.transform = transform
+    def set_scaling(self, scaling_name: str) -> None:
+        self.transform = SCALING_OPTIONS[scaling_name]
         self.update_plot()
 
     def view_grains(self) -> None:

--- a/hexrdgui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrdgui/indexing/ome_maps_viewer_dialog.py
@@ -35,6 +35,7 @@ from hexrdgui.color_map_editor import ColorMapEditor
 from hexrdgui.hand_picked_fibers_widget import HandPickedFibersWidget
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.navigation_toolbar import NavigationToolbar
+from hexrdgui.scaling import SCALING_OPTIONS
 from hexrdgui.select_items_widget import SelectItemsWidget
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
@@ -45,8 +46,6 @@ import hexrdgui.constants
 import hexrdgui.resources.indexing
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
-
     import matplotlib as mpl
 
 
@@ -638,8 +637,8 @@ class OmeMapsViewerDialog(QObject):
             self.im.set_norm(norm)
             self.draw()
 
-    def set_scaling(self, transform: Callable[[np.ndarray], np.ndarray]) -> None:
-        self.transform = transform
+    def set_scaling(self, scaling_name: str) -> None:
+        self.transform = SCALING_OPTIONS[scaling_name]
         self.update_plot()
 
     def create_spots(self) -> None:

--- a/hexrdgui/scaling.py
+++ b/hexrdgui/scaling.py
@@ -12,19 +12,25 @@ def none(x: np.ndarray) -> np.ndarray:
     return x
 
 
-def sqrt(x: np.ndarray) -> np.ndarray:
-    y = np.sqrt(x + 1)
-    return y - np.nanmin(y)
+def sqrt(x: np.ndarray, global_min: float | None = None) -> np.ndarray:
+    min_val = global_min if global_min is not None else np.nanmin(x)
+    return np.sqrt(x - min_val)
 
 
-def log(x: np.ndarray) -> np.ndarray:
-    y = np.log(x + 1)
-    return y - np.nanmin(y)
+def log(x: np.ndarray, global_min: float | None = None) -> np.ndarray:
+    min_val = global_min if global_min is not None else np.nanmin(x)
+    return np.log(x - min_val + 1)
 
 
-def log_log_sqrt(x: np.ndarray) -> np.ndarray:
-    y = np.log(np.log(np.sqrt(x + 1) + 1) + 1)
-    return y - np.nanmin(y)
+def log_log_sqrt(x: np.ndarray, global_min: float | None = None) -> np.ndarray:
+    min_val = global_min if global_min is not None else np.nanmin(x)
+    return np.log(np.log(np.sqrt(x - min_val) + 1) + 1)
+
+
+def _fill_masked(x: Any, fill_value: float = np.nan) -> np.ndarray:
+    if isinstance(x, np.ma.masked_array):
+        return x.filled(fill_value)
+    return x
 
 
 # This decorator automatically rescales the transform output to have
@@ -37,14 +43,9 @@ def rescale_to_original(
         old_range = (np.nanmin(old), np.nanmax(old))
         return np.interp(new, new_range, old_range)
 
-    def fill_masked(x: Any, fill_value: float = np.nan) -> np.ndarray:
-        if isinstance(x, np.ma.masked_array):
-            return x.filled(fill_value)
-        return x
-
     @functools.wraps(func)
     def wrapper(old: np.ndarray) -> np.ndarray:
-        new = func(fill_masked(old))
+        new = func(_fill_masked(old))
         return rescale_to_old(new, old)
 
     return wrapper
@@ -65,3 +66,43 @@ for k, v in SCALING_OPTIONS.items():
         continue
 
     SCALING_OPTIONS[k] = rescale_to_original(v)
+
+
+def create_scaling_function(
+    name: str,
+    global_min: float | None = None,
+) -> Callable[[np.ndarray], np.ndarray]:
+    """Create a scaling function, optionally with a fixed global minimum.
+
+    When global_min is provided, the scaling function uses that fixed
+    value instead of computing np.nanmin(x) on each call. This prevents
+    the image display from jumping when user masks happen to remove the
+    current minimum pixel value.
+
+    The rescale-to-original step also uses global_min as the stable
+    lower bound, so that the output range doesn't shift when masked
+    pixels change the apparent data range.
+
+    When global_min is None, falls back to the default SCALING_OPTIONS
+    behavior (computing the min on-the-fly).
+    """
+    if name == 'none' or global_min is None:
+        return SCALING_OPTIONS[name]
+
+    # Look up the unwrapped function by name. The module-level sqrt/log/
+    # log_log_sqrt still accept global_min; only the SCALING_OPTIONS
+    # entries got wrapped by rescale_to_original.
+    base_func = {'sqrt': sqrt, 'log': log, 'log-log-sqrt': log_log_sqrt}[name]
+
+    def wrapper(old: np.ndarray) -> np.ndarray:
+        x = _fill_masked(old)
+        new = base_func(x, global_min=global_min)
+
+        # Rescale to the original data range, using stable bounds
+        # for the lower end so masking doesn't shift the display.
+        # All scaling functions produce 0 at x=global_min.
+        new_range = (0.0, np.nanmax(new))
+        old_range = (global_min, np.nanmax(old))
+        return np.interp(new, new_range, old_range)
+
+    return wrapper

--- a/hexrdgui/snip_viewer_dialog.py
+++ b/hexrdgui/snip_viewer_dialog.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any
 
 import h5py
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
@@ -12,6 +12,7 @@ from PySide6.QtWidgets import QFileDialog, QSizePolicy, QWidget
 from hexrdgui.color_map_editor import ColorMapEditor
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.navigation_toolbar import NavigationToolbar
+from hexrdgui.scaling import SCALING_OPTIONS
 from hexrdgui.ui_loader import UiLoader
 
 
@@ -94,8 +95,8 @@ class SnipViewerDialog:
         self.im.set_norm(norm)
         self.draw_later()
 
-    def set_scaling(self, transform: Callable[[np.ndarray], np.ndarray]) -> None:
-        self.transform = transform
+    def set_scaling(self, scaling_name: str) -> None:
+        self.transform = SCALING_OPTIONS[scaling_name]
         self.im.set_data(self.scaled_image_data)
         self.draw_later()
 


### PR DESCRIPTION
We are reverting back the change from #1882, but we are instead
keeping a record of the minimum of the image before masking, and
always using that minimum in the subtraction.

The scaling looks better, and the images look nicer, after this
change. Keeping the recorded minimum also prevents the "jumping"
in scaling that occurred when masking out the minimum pixel. So
the issue that #1882 was trying to fix is now resolved too.
