### PR TITLE
For ROI subpanel instruments, save monolith images

### DIFF
--- a/hexrdgui/indexing/fit_grains_results_dialog.py
+++ b/hexrdgui/indexing/fit_grains_results_dialog.py
@@ -21,7 +21,6 @@ from PySide6.QtWidgets import QFileDialog, QMenu, QMessageBox, QSizePolicy
 if TYPE_CHECKING:
     from matplotlib.backend_bases import PickEvent
     from matplotlib.colors import Colormap
-    from hexrd.core.imageseries.imageseriesabc import ImageSeriesABC
     from hexrd.material import Material
 
 from hexrd.matrixutil import vecMVToSymm
@@ -35,6 +34,7 @@ from hexrdgui.navigation_toolbar import NavigationToolbar
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
 from hexrdgui.utils.dialog import add_help_url
+from hexrdgui.utils.imageseries import get_monolithic_ims
 from hexrdgui.utils.matplotlib import remove_artist
 
 
@@ -798,7 +798,7 @@ class FitGrainsResultsDialog(QObject):
             subpanel_ims = ims_dict[first_det]
 
             # Get the monolithic image (unwrap rectangle op)
-            monolithic_ims = _get_monolithic_ims(subpanel_ims)
+            monolithic_ims = get_monolithic_ims(subpanel_ims)
 
             path = str(Path(selected_directory) / f'{group}.npz')
             HexrdConfig().save_imageseries(
@@ -847,52 +847,6 @@ class FitGrainsResultsDialog(QObject):
 
         self.async_runner.progress_title = 'Saving workflow configuration'
         self.async_runner.run(self._save_workflow_files, selected_directory)
-
-
-def _get_monolithic_ims(
-    subpanel_ims: ImageSeriesABC,
-) -> ImageSeriesABC:
-    """Get monolithic image from a subpanel's image series.
-
-    Recursively unwraps the image series chain, collecting all
-    non-rectangle operations and frame_list selections along the way.
-    The result is a single image series rooted at the base adapter
-    with all non-rectangle processing preserved.
-
-    The chain may contain arbitrary nesting of:
-    - ``ImageSeries`` / ``OmegaImageSeries`` (use ``_adapter``)
-    - ``ProcessedImageSeries`` (use ``_imser``, hold ``_oplist``)
-    """
-    from hexrd.core.imageseries.process import ProcessedImageSeries
-
-    # Walk the full chain, collecting non-rectangle ops and frame_lists.
-    non_rect_ops: list = []
-    frame_list: list[int] | None = None
-    ims: ImageSeriesABC = subpanel_ims
-
-    while True:
-        if isinstance(ims, ProcessedImageSeries):
-            # Collect ops (excluding rectangle) and frame_list
-            non_rect_ops.extend(op for op in ims._oplist if op[0] != 'rectangle')
-            if frame_list is None and ims._hasframelist:
-                frame_list = list(ims._frames)
-            ims = ims._imser
-        elif hasattr(ims, '_adapter'):
-            ims = ims._adapter
-        else:
-            # Reached the base adapter — stop.
-            break
-
-    # ims is now the root image series (e.g. FrameCacheImageSeriesAdapter
-    # wrapped in ImageSeries).  Rebuild with only the collected ops.
-    if not non_rect_ops and frame_list is None:
-        return ims
-
-    kwargs: dict = {}
-    if frame_list is not None:
-        kwargs['frame_list'] = frame_list
-
-    return ProcessedImageSeries(ims, non_rect_ops, **kwargs)
 
 
 if __name__ == '__main__':

--- a/hexrdgui/save_images_dialog.py
+++ b/hexrdgui/save_images_dialog.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import QThreadPool
 from PySide6.QtWidgets import QFileDialog, QInputDialog, QWidget
 
 from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.utils.imageseries import get_monolithic_ims
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.progress_dialog import ProgressDialog
 from hexrdgui.async_worker import AsyncWorker
@@ -25,7 +26,10 @@ class SaveImagesDialog:
 
     def setup_gui(self) -> None:
         self.ui.detectors.clear()
-        self.ui.detectors.addItems(HexrdConfig().detector_names)
+        if HexrdConfig().instrument_has_roi:
+            self.ui.detectors.addItems(HexrdConfig().detector_group_names)
+        else:
+            self.ui.detectors.addItems(HexrdConfig().detector_names)
         self.ui.pwd.setText(self.parent_dir)
         self.ui.pwd.setToolTip(self.parent_dir)
         if HexrdConfig().is_aggregated:
@@ -53,12 +57,39 @@ class SaveImagesDialog:
             self.ui.pwd.setText(self.parent_dir)
             self.ui.pwd.setToolTip(self.parent_dir)
 
+    def _get_ims(
+        self,
+        name: str,
+        ims_dict: dict | None,
+    ) -> Any:
+        """Get the image series for a detector or group name.
+
+        When the instrument has ROI-based detector groups, unwraps the
+        rectangle operation from the first sub-panel to recover the
+        monolithic image series.
+        """
+        if ims_dict is None:
+            return None
+
+        if HexrdConfig().instrument_has_roi:
+            first_det = HexrdConfig().detectors_in_group(name)[0]
+            subpanel_ims = ims_dict.get(first_det)
+            if subpanel_ims is None:
+                return None
+            return get_monolithic_ims(subpanel_ims)
+
+        return ims_dict.get(name)
+
     def save_images(self) -> None:
         if self.ui.ignore_agg.isChecked():
             ims_dict = HexrdConfig().unagg_images
         else:
             ims_dict = HexrdConfig().imageseries_dict
-        dets = HexrdConfig().detector_names
+
+        if HexrdConfig().instrument_has_roi:
+            dets = HexrdConfig().detector_group_names
+        else:
+            dets = HexrdConfig().detector_names
         if self.ui.single_detector.isChecked():
             dets = [self.ui.detectors.currentText()]
 
@@ -105,7 +136,7 @@ class SaveImagesDialog:
 
             worker = AsyncWorker(
                 HexrdConfig().save_imageseries,
-                ims_dict.get(det) if ims_dict is not None else None,
+                self._get_ims(det, ims_dict),
                 det,
                 path,
                 selected_format,

--- a/hexrdgui/utils/imageseries.py
+++ b/hexrdgui/utils/imageseries.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from hexrd.core.imageseries.imageseriesabc import ImageSeriesABC
+
+
+def get_monolithic_ims(
+    subpanel_ims: ImageSeriesABC,
+) -> ImageSeriesABC:
+    """Get monolithic image from a subpanel's image series.
+
+    Recursively unwraps the image series chain, collecting all
+    non-rectangle operations and frame_list selections along the way.
+    The result is a single image series rooted at the base adapter
+    with all non-rectangle processing preserved.
+
+    The chain may contain arbitrary nesting of:
+    - ``ImageSeries`` / ``OmegaImageSeries`` (use ``_adapter``)
+    - ``ProcessedImageSeries`` (use ``_imser``, hold ``_oplist``)
+    """
+    from hexrd.core.imageseries.process import ProcessedImageSeries
+
+    # Walk the full chain, collecting non-rectangle ops and frame_lists.
+    non_rect_ops: list = []
+    frame_list: list[int] | None = None
+    ims: ImageSeriesABC = subpanel_ims
+
+    while True:
+        if isinstance(ims, ProcessedImageSeries):
+            # Collect ops (excluding rectangle) and frame_list
+            non_rect_ops.extend(op for op in ims._oplist if op[0] != 'rectangle')
+            if frame_list is None and ims._hasframelist:
+                frame_list = list(ims._frames)
+            ims = ims._imser
+        elif hasattr(ims, '_adapter'):
+            ims = ims._adapter
+        else:
+            # Reached the base adapter — stop.
+            break
+
+    # ims is now the root image series (e.g. FrameCacheImageSeriesAdapter
+    # wrapped in ImageSeries).  Rebuild with only the collected ops.
+    if not non_rect_ops and frame_list is None:
+        return ims
+
+    kwargs: dict = {}
+    if frame_list is not None:
+        kwargs['frame_list'] = frame_list
+
+    return ProcessedImageSeries(ims, non_rect_ops, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 import gc
 import os
+import sys
 from pathlib import Path
 
 import pytest
@@ -8,6 +9,7 @@ from PySide6.QtCore import QSettings
 from PySide6.QtWidgets import QApplication
 
 from hexrdgui.main_window import MainWindow
+from hexrdgui.messages_widget import MessagesWidget
 
 
 @pytest.fixture
@@ -44,10 +46,15 @@ def main_window(qtbot):
     qtbot.addWidget(window.ui)
     yield window
 
-    # Release messages widget Writers from stdout/stderr call stacks
-    # before Qt destroys the underlying C++ objects.
-    window.progress_dialog.messages_widget.release_output()
-    window.messages_widget.release_output()
+    # Release all messages widget Writers from stdout/stderr call stacks
+    # before Qt destroys the underlying C++ objects. Various components
+    # (e.g. indexing Runner, ImageLoadManager) may have created their own
+    # ProgressDialogs with MessagesWidgets that also capture output, so
+    # we drain the entire stack rather than releasing individual widgets.
+    MessagesWidget.STDOUT_CALL_STACK[:] = [sys.__stdout__]
+    MessagesWidget.STDERR_CALL_STACK[:] = [sys.__stderr__]
+    sys.stdout = sys.__stdout__
+    sys.stderr = sys.__stderr__
 
     # Destroy the MainWindow QObject so Qt auto-disconnects all signal
     # connections (e.g. HexrdConfig signals → this window's slots).

--- a/tests/test_save_images.py
+++ b/tests/test_save_images.py
@@ -1,0 +1,146 @@
+"""
+Test that the Save Images dialog writes group-level (monolithic) images
+when the instrument has ROI-based detector groups, rather than individual
+sub-panel images.
+
+Uses the same Dexelas HEDM state file and NPZ images as the workflow test.
+
+Run with:
+    cd hexrdgui/tests && python -m pytest test_save_images.py -v -s
+"""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication, QInputDialog
+
+import hexrd.imageseries
+
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.save_images_dialog import SaveImagesDialog
+
+from utils import select_files_when_asked
+
+
+@pytest.fixture
+def dexelas_hedm_path(example_repo_path):
+    return example_repo_path / 'state_examples' / 'Dexelas_HEDM'
+
+
+def _load_dexelas_state_and_images(qtbot, main_window, dexelas_hedm_path):
+    """Load the ROI Dexelas state file and its two NPZ images."""
+    state_file = dexelas_hedm_path / 'roi_dexelas_hedm.h5'
+    npz1 = dexelas_hedm_path / 'mruby-0129_000004_ff1_000012-cachefile.npz'
+    npz2 = dexelas_hedm_path / 'mruby-0129_000004_ff2_000012-cachefile.npz'
+
+    for p in (state_file, npz1, npz2):
+        assert p.exists(), f'Missing test file: {p}'
+
+    main_window.load_state_file(state_file)
+    QApplication.processEvents()
+
+    load_panel = main_window.simple_image_series_dialog
+    with select_files_when_asked([str(npz1), str(npz2)]):
+        qtbot.mouseClick(load_panel.ui.image_files, Qt.MouseButton.LeftButton)
+
+    qtbot.mouseClick(load_panel.ui.read, Qt.MouseButton.LeftButton)
+    QApplication.processEvents()
+
+
+def test_save_images_writes_group_files(
+    qtbot, main_window, dexelas_hedm_path, tmp_path
+):
+    _load_dexelas_state_and_images(qtbot, main_window, dexelas_hedm_path)
+
+    # Verify ROI setup: 8 sub-panel detectors in 2 groups
+    assert len(HexrdConfig().detector_names) == 8
+    assert HexrdConfig().instrument_has_roi
+    group_names = HexrdConfig().detector_group_names
+    assert set(group_names) == {'ff1', 'ff2'}
+
+    # Record the sub-panel image shape for comparison
+    ims_dict = HexrdConfig().imageseries_dict
+    first_subpanel = HexrdConfig().detectors_in_group('ff1')[0]
+    subpanel_shape = ims_dict[first_subpanel][0].shape
+
+    # Create the dialog and verify the combo shows group names
+    HexrdConfig().set_images_dir(str(tmp_path))
+    dialog = SaveImagesDialog(main_window.ui)
+
+    combo_items = [
+        dialog.ui.detectors.itemText(i)
+        for i in range(dialog.ui.detectors.count())
+    ]
+    assert set(combo_items) == {'ff1', 'ff2'}, (
+        f'Expected group names in combo, got: {combo_items}'
+    )
+
+    # Configure the dialog for NPZ output
+    dialog.ui.file_stem.setText('test')
+    npz_index = dialog.ui.format.findText('npz')
+    dialog.ui.format.setCurrentIndex(npz_index)
+
+    # Mock the threshold dialog to auto-return 0
+    with patch.object(
+        QInputDialog, 'getDouble', return_value=(0.0, True)
+    ):
+        dialog.save_images()
+
+    QApplication.processEvents()
+
+    # Verify that only group-level files were created (not sub-panel files)
+    npz_files = sorted(tmp_path.glob('*.npz'))
+    npz_names = [f.name for f in npz_files]
+    assert set(npz_names) == {'test_ff1.npz', 'test_ff2.npz'}, (
+        f'Expected 2 group files, got: {npz_names}'
+    )
+
+    # Load the saved images and verify they are monolithic (larger than
+    # sub-panel images)
+    for npz_file in npz_files:
+        saved_ims = hexrd.imageseries.open(
+            str(npz_file), 'frame-cache', style='npz'
+        )
+        saved_shape = saved_ims[0].shape
+        assert saved_shape != subpanel_shape, (
+            f'{npz_file.name}: shape {saved_shape} matches sub-panel '
+            f'shape -- expected monolithic (larger) image'
+        )
+        # Monolithic image should be larger in at least one dimension
+        assert (
+            saved_shape[0] >= subpanel_shape[0]
+            and saved_shape[1] >= subpanel_shape[1]
+        ), (
+            f'{npz_file.name}: saved shape {saved_shape} is not larger '
+            f'than sub-panel shape {subpanel_shape}'
+        )
+
+    # Also verify the saved images match the originals
+    npz1 = dexelas_hedm_path / 'mruby-0129_000004_ff1_000012-cachefile.npz'
+    npz2 = dexelas_hedm_path / 'mruby-0129_000004_ff2_000012-cachefile.npz'
+    for group, orig_npz in [('ff1', npz1), ('ff2', npz2)]:
+        orig_ims = hexrd.imageseries.open(
+            str(orig_npz), 'frame-cache', style='npz'
+        )
+        saved_ims = hexrd.imageseries.open(
+            str(tmp_path / f'test_{group}.npz'), 'frame-cache', style='npz'
+        )
+        assert orig_ims[0].shape == saved_ims[0].shape, (
+            f'{group}: original shape {orig_ims[0].shape} != '
+            f'saved shape {saved_ims[0].shape}'
+        )
+        assert len(saved_ims) == len(orig_ims), (
+            f'{group}: frame count {len(saved_ims)} != {len(orig_ims)}'
+        )
+        # Verify first and last frame values are close
+        np.testing.assert_allclose(
+            saved_ims[0], orig_ims[0], atol=1,
+            err_msg=f'{group}: first frame values differ',
+        )
+        np.testing.assert_allclose(
+            saved_ims[-1], orig_ims[-1], atol=1,
+            err_msg=f'{group}: last frame values differ',
+        )

--- a/tests/test_save_images.py
+++ b/tests/test_save_images.py
@@ -50,6 +50,7 @@ def _load_dexelas_state_and_images(qtbot, main_window, dexelas_hedm_path):
     QApplication.processEvents()
 
 
+@pytest.mark.qt_no_exception_capture
 def test_save_images_writes_group_files(
     qtbot, main_window, dexelas_hedm_path, tmp_path
 ):


### PR DESCRIPTION
This follows what we are already doing in the HEDM workflow export, where we started saving the original monolith images, so that the workflow can be repeated for similar inputs.

Now, instead of saving separate images for each subpanel when saving the images from the main window menus, we save the original monolith images as well.

Fixes: #1992