### PR TITLE
Speed up loading significantly in raw tabbed view

### DIFF
--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -120,6 +120,7 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         self.stereo_border_artists: list[Any] = []
         self.azimuthal_overlay_artists: list[Any] = []
         self.blit_manager = BlitManager(self)
+        self.display_images_dict: dict[str, np.ndarray] = {}
         self.raw_view_images_dict: dict[str, np.ndarray] = {}
         self._mask_boundary_artists: list[Any] = []
         self._latest_compute_view_worker: AsyncWorker | None = None
@@ -250,6 +251,7 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         self._invalidate_interaction_cache()
         self.iviewer = None
         self.mode = None
+        self.display_images_dict = {}
         self.raw_view_images_dict = {}
         self.clear_figure()
 
@@ -294,7 +296,12 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         while self.auto_picked_data_artists:
             remove_artist(self.auto_picked_data_artists.pop(0))
 
-    def load_images(self, image_names: Sequence[str]) -> None:
+    def load_images(
+        self,
+        image_names: Sequence[str],
+        *,
+        _tab_cache: dict[str, Any] | None = None,
+    ) -> None:
         HexrdConfig().emit_update_status_bar('Loading image view...')
 
         if self.mode != ViewType.raw or len(image_names) != len(self.axes_images):
@@ -304,9 +311,15 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
             self.mode = ViewType.raw
 
             # This will be used for drawing the rings
-            self.iviewer = raw_iviewer()
+            if _tab_cache is not None:
+                self.iviewer = _tab_cache['iviewer']
+            else:
+                self.iviewer = raw_iviewer()
 
-            images_dict = self.create_raw_view_images(image_names)
+            if _tab_cache is not None:
+                images_dict = _tab_cache['display_images']
+            else:
+                images_dict = self.create_raw_view_images(image_names)
 
             cols = 1
             if len(image_names) > 1:
@@ -330,13 +343,20 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
 
             self.figure.tight_layout()
         else:
-            images_dict = self.create_raw_view_images(image_names)
+            if _tab_cache is not None:
+                images_dict = _tab_cache['display_images']
+            else:
+                images_dict = self.create_raw_view_images(image_names)
             for i, name in enumerate(image_names):
                 img = images_dict[name]
                 self.axes_images[i].set_data(img)
 
+        self.display_images_dict = images_dict
+
         assert self.iviewer is not None
-        if MaskManager().contains_border_only_masks:
+        if _tab_cache is not None:
+            computed_images_dict = _tab_cache['computed_images']
+        elif MaskManager().contains_border_only_masks:
             # Create a computed version for the images dict
             computed_images_dict = self.scaled_image_dict
             if HexrdConfig().stitch_raw_roi_images:
@@ -361,12 +381,13 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
 
         self.update_beam_marker()
         self.update_auto_picked_data()
-        self.update_overlays()
+        self.update_overlays(skip_data_update=_tab_cache is not None)
 
-        # This always emits the full images dict, even if we are in
-        # tabbed mode and this canvas is only displaying one of the
-        # images from the dict.
-        HexrdConfig().image_view_loaded.emit(images_dict)
+        if _tab_cache is None:
+            # This always emits the full images dict, even if we are in
+            # tabbed mode and this canvas is only displaying one of the
+            # images from the dict.
+            HexrdConfig().image_view_loaded.emit(images_dict)
 
         msg = 'Image view loaded!'
         HexrdConfig().emit_update_status_bar(msg)
@@ -841,7 +862,7 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         # Redraw the overlay
         self.draw_overlay(overlay)
 
-    def update_overlays(self) -> None:
+    def update_overlays(self, *, skip_data_update: bool = False) -> None:
         if HexrdConfig().loading_state:
             # Skip the request if we are loading state
             return
@@ -867,7 +888,8 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
             if overlay.update_needed or not overlay.visible:
                 self.remove_overlay_artists(overlay.name)
 
-        self.iviewer.update_overlay_data()
+        if not skip_data_update:
+            self.iviewer.update_overlay_data()
 
         for overlay in HexrdConfig().overlays:
             self.draw_overlay(overlay)

--- a/hexrdgui/image_tab_widget.py
+++ b/hexrdgui/image_tab_widget.py
@@ -68,6 +68,10 @@ class ImageTabWidget(QTabWidget):
         # Track which tabs need a deferred update
         self._stale_tabs: set[int] = set()
 
+        # Cache of pre-computed data shared across tabbed canvases.
+        # Valid from load_images_tabbed until images/masks change.
+        self._tab_cache: dict[str, Any] | None = None
+
         self.setup_connections()
 
     def setup_connections(self) -> None:
@@ -108,16 +112,39 @@ class ImageTabWidget(QTabWidget):
         self.clear()
         self.allocate_canvases()
         self.allocate_toolbars()
+
+        idx = self.current_index
+
+        # Load the active canvas normally — it computes everything
+        # (iviewer, all-detector images, overlay data) as a side effect.
+        canvas = self.image_canvases[idx]
+        canvas.load_images(image_names=[self.image_names[idx]])
+
+        # Harvest results from the loaded canvas so remaining tabs can
+        # reuse them without recomputing.
+        self._tab_cache = {
+            'iviewer': canvas.iviewer,
+            'display_images': canvas.display_images_dict,
+            'computed_images': canvas.raw_view_images_dict,
+        }
+
+        # Build all tabs with signals blocked so _on_tab_changed doesn't
+        # fire prematurely. The rest are marked stale and loaded lazily
+        # when the user switches to them.
+        self.blockSignals(True)
         for i, name in enumerate(self.image_names):
-            self.image_canvases[i].load_images(image_names=[name])
+            if i != idx:
+                self._stale_tabs.add(i)
             self.addTab(self.image_canvases[i], name)
+        self.setCurrentIndex(idx)
+        self.blockSignals(False)
 
         self.update_canvas_cmaps()
         self.update_canvas_norms()
         self.tabBar().show()
-        self.setCurrentIndex(self.current_index)
 
     def load_images_untabbed(self) -> None:
+        self._tab_cache = None
         self._stale_tabs.clear()
         self.clear()
         self.image_canvases[0].load_images(image_names=self.image_names)
@@ -229,6 +256,7 @@ class ImageTabWidget(QTabWidget):
         In tabbed mode, only updates the currently visible canvas.
         Other tabs are marked stale and updated lazily on tab switch.
         """
+        self._tab_cache = None
         if HexrdConfig().tab_images:
             idx = self.current_index
             for i, name in enumerate(self.image_names):
@@ -245,7 +273,8 @@ class ImageTabWidget(QTabWidget):
             self._stale_tabs.discard(idx)
             if idx < len(self.image_names):
                 self.image_canvases[idx].load_images(
-                    image_names=[self.image_names[idx]]
+                    image_names=[self.image_names[idx]],
+                    _tab_cache=self._tab_cache,
                 )
 
     @Slot(bool)


### PR DESCRIPTION
Before, all detector images would be loaded, and all overlays computed, for every single tab in the tabbed view.

Now, all detector images are only loaded once, and all overlays are computed only once, for all tabs. It uses a new caching parameter to do this.