### PR TITLE
Fix numba warning on Linux for using TBB

### DIFF
--- a/hexrdgui/main.py
+++ b/hexrdgui/main.py
@@ -14,6 +14,19 @@ if sys.platform.startswith('darwin'):
     # Prevent crashing when using OpenBLAS
     os.environ['OPENBLAS_NUM_THREADS'] = '1'
 
+if sys.platform == 'linux':
+    # Use OpenMP instead of TBB as the numba threading layer on Linux.
+    # TBB prints an unavoidable C-level warning to stderr on every
+    # non-main-thread fork ("Attempted to fork from a non-main thread"),
+    # which is harmless but noisy in our Qt background thread workflow.
+    # OpenMP is equally thread-safe and performant, emits no fork
+    # warning, and has a built-in safety net: it terminates any forked
+    # child that accidentally calls a numba parallel=True function,
+    # rather than silently running with undefined behavior.
+    # workqueue is not viable (crashes on concurrent thread access).
+    # macOS/Windows use spawn, so TBB's warning never appears there.
+    os.environ.setdefault('NUMBA_THREADING_LAYER', 'omp')
+
 from PySide6.QtCore import QCoreApplication, Qt
 from PySide6.QtGui import QIcon, QPixmap
 from PySide6.QtWidgets import QApplication

--- a/hexrdgui/main.py
+++ b/hexrdgui/main.py
@@ -14,8 +14,8 @@ if sys.platform.startswith('darwin'):
     # Prevent crashing when using OpenBLAS
     os.environ['OPENBLAS_NUM_THREADS'] = '1'
 
-if sys.platform == 'linux':
-    # Use OpenMP instead of TBB as the numba threading layer on Linux.
+if sys.platform in ('linux', 'darwin'):
+    # Use OpenMP instead of TBB as the numba threading layer.
     # TBB prints an unavoidable C-level warning to stderr on every
     # non-main-thread fork ("Attempted to fork from a non-main thread"),
     # which is harmless but noisy in our Qt background thread workflow.
@@ -24,7 +24,6 @@ if sys.platform == 'linux':
     # child that accidentally calls a numba parallel=True function,
     # rather than silently running with undefined behavior.
     # workqueue is not viable (crashes on concurrent thread access).
-    # macOS/Windows use spawn, so TBB's warning never appears there.
     os.environ.setdefault('NUMBA_THREADING_LAYER', 'omp')
 
 from PySide6.QtCore import QCoreApplication, Qt


### PR DESCRIPTION
This fixes the following numba warning on Linux:

```
Numba: Attempted to fork from a non-main thread, the TBB library may be in an invalid state in the child process.
```

The main idea is that forked subprocesses (which we indeed do, in order to take advantage of copy-on-write mechanics and let subprocesses share data), which only happen on Linux (Windows and Mac do "spawn"), would always print this numba warning, even though we were never actually using TBB in an invalid way.

There's no way to suppress this warning, so we switch to OpenMP on Linux, which is just as performant.

In fact, it has one better feature too: it will crash if we try to run numba in parallel mode on a forked subprocess. TBB was just undefined, but the OpenMP implementation will actually crash, which prevents developers from ever doing that.