### PR TITLE
Hide harmless loky warning

### DIFF
--- a/hexrdgui/ignore_warnings.py
+++ b/hexrdgui/ignore_warnings.py
@@ -1,0 +1,20 @@
+"""Suppress known harmless warnings. Call apply() early in main.py."""
+
+import os
+import warnings
+
+
+def apply():
+    # Suppress harmless leaked semaphore warning from loky at shutdown.
+    # The resource_tracker runs as a separate daemon process, so
+    # warnings.filterwarnings only covers the main process. We also
+    # set PYTHONWARNINGS so the filter propagates to the tracker.
+    warnings.filterwarnings(
+        'ignore',
+        message=r'resource_tracker:.*leaked semaphore',
+        category=UserWarning,
+    )
+    _pw = os.environ.get('PYTHONWARNINGS', '')
+    _filter = 'ignore:resource_tracker:UserWarning'
+    if _filter not in _pw:
+        os.environ['PYTHONWARNINGS'] = f'{_pw},{_filter}' if _pw else _filter

--- a/hexrdgui/main.py
+++ b/hexrdgui/main.py
@@ -1,17 +1,14 @@
+# Must be first - sets env vars before any child processes are spawned
+from hexrdgui.ignore_warnings import apply as apply_warning_filters
+
+apply_warning_filters()
+
 import argparse
 import atexit
 import gc
 import os
 import signal
 import sys
-import warnings
-
-# Suppress harmless leaked semaphore warning from loky at shutdown
-warnings.filterwarnings(
-    'ignore',
-    message=r'resource_tracker:.*leaked semaphore',
-    category=UserWarning,
-)
 
 if sys.platform.startswith('darwin'):
     # Prevent crashing when using OpenBLAS


### PR DESCRIPTION
Here is the warning, which would occur when closing the application:

```python
/usr/local/lib/python3.14/multiprocessing/resource_tracker.py:396: UserWarning: resource_tracker: There appear to be 2 leaked semaphore objects to clean up at shutdown: {'/loky-853470-5i9c59nk', '/loky-853470-v_q7ann3'}
```

This also moves the logic for ignoring warnings into an `ignore_warnings.py` file.