### PR TITLE
Fix polar mask conversion near beam center

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -100,6 +100,9 @@ class PolarView:
 
         # Cache this and invalidate it when needed
         self._corr_field_polar_cached: np.ma.MaskedArray | None = None
+        self._pixel_lookup_cache: dict[
+            str, tuple[np.ndarray, np.ndarray, np.ndarray]
+        ] = {}
 
         self.snip_background: np.ndarray | None = None
         self.erosion_mask: np.ndarray | None = None
@@ -373,42 +376,47 @@ class PolarView:
         # Store as masked array
         return np.ma.masked_array(data=wimg, mask=nan_mask, fill_value=0.0)
 
+    def _get_pixel_lookup(
+        self, det_key: str
+    ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+        """Get cached (polar_idx, raw_rows, raw_cols) for a detector.
+
+        These map polar pixel indices to raw detector pixel coordinates,
+        reusable across all masks on the same detector.
+        """
+        if det_key not in self._pixel_lookup_cache:
+            panel = self.detectors[det_key]
+            xypts = self._compute_xypts(det_key)
+
+            valid = ~np.isnan(xypts[:, 0])
+            if not valid.any():
+                empty = np.array([], dtype=int)
+                self._pixel_lookup_cache[det_key] = (empty, empty, empty)
+            else:
+                pixel_coords = panel.cartToPixel(xypts[valid], pixels=True)
+                rows = pixel_coords[:, 0]
+                cols = pixel_coords[:, 1]
+                idx = np.where(valid)[0]
+                self._pixel_lookup_cache[det_key] = (idx, rows, cols)
+
+        return self._pixel_lookup_cache[det_key]
+
     def warp_binary_mask(self, raw_mask: np.ndarray, det_key: str) -> np.ndarray:
         """Warp a binary mask from raw detector pixel space to polar.
 
         Uses nearest-neighbor sampling via the same coordinate mapping
         as warp_image (memoized in project_on_detector).
-
-        Parameters
-        ----------
-        raw_mask : np.ndarray
-            Boolean array in detector pixel space (True=unmasked).
-        det_key : str
-            Detector key in self.detectors.
-
-        Returns
-        -------
-        np.ndarray
-            Boolean array in polar space (True=unmasked).
         """
-        panel = self.detectors[det_key]
-        xypts = self._compute_xypts(det_key)
+        idx, rows, cols = self._get_pixel_lookup(det_key)
 
         result = np.ones(self.ntth * self.neta, dtype=bool)
-
-        valid = ~np.isnan(xypts[:, 0])
-        if not valid.any():
+        if len(idx) == 0:
             return result.reshape(self.shape)
-
-        pixel_coords = panel.cartToPixel(xypts[valid], pixels=True)
-        rows = pixel_coords[:, 0]
-        cols = pixel_coords[:, 1]
 
         h, w = raw_mask.shape
         in_bounds = (rows >= 0) & (rows < h) & (cols >= 0) & (cols < w)
 
-        idx = np.where(valid)[0][in_bounds]
-        result[idx] = raw_mask[rows[in_bounds], cols[in_bounds]]
+        result[idx[in_bounds]] = raw_mask[rows[in_bounds], cols[in_bounds]]
 
         return result.reshape(self.shape)
 
@@ -449,7 +457,7 @@ class PolarView:
         if apply_tth_distortion and HexrdConfig().polar_tth_distortion:
             mask_float = (~polar_mask).astype(np.float64)
             distorted = self.apply_tth_distortion(mask_float)
-            polar_mask = ~(np.asarray(distorted.filled(0)) > 0.5)
+            polar_mask = ~(np.ma.filled(distorted, 0) > 0.5)
 
         return polar_mask
 

--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -76,6 +76,10 @@ class PolarView:
             # This is a dummy polar view
             self._images_dict: dict[str, np.ndarray] | None = None
         else:
+            # Ensure the memoize cache is large enough for all detectors
+            num_dets = len(instrument.detectors)
+            project_on_detector.set_cache_maxsize(max(16, num_dets * 2))
+
             # Use an image dict with the panel buffers applied.
             # This keeps invalid pixels from bleeding out in the polar view
             self.images_dict = HexrdConfig().images_dict
@@ -341,6 +345,14 @@ class PolarView:
 
         return arg, kwargs
 
+    def _compute_xypts(self, det_key: str) -> np.ndarray:
+        panel = self.detectors[det_key]
+        args, kwargs = self.args_project_on_detector(panel)
+        func_projection = self.func_project_on_detector(panel)
+        return project_on_detector(
+            self.angular_grid, self.ntth, self.neta, func_projection, *args, **kwargs
+        )
+
     def warp_image(self, img: np.ndarray, panel: Detector) -> np.ma.MaskedArray:
         # The first 3 arguments of this function get converted into
         # the first argument of `_project_on_detector_plane`, and then
@@ -360,6 +372,86 @@ class PolarView:
         nan_mask = np.isnan(wimg)
         # Store as masked array
         return np.ma.masked_array(data=wimg, mask=nan_mask, fill_value=0.0)
+
+    def warp_binary_mask(self, raw_mask: np.ndarray, det_key: str) -> np.ndarray:
+        """Warp a binary mask from raw detector pixel space to polar.
+
+        Uses nearest-neighbor sampling via the same coordinate mapping
+        as warp_image (memoized in project_on_detector).
+
+        Parameters
+        ----------
+        raw_mask : np.ndarray
+            Boolean array in detector pixel space (True=unmasked).
+        det_key : str
+            Detector key in self.detectors.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean array in polar space (True=unmasked).
+        """
+        panel = self.detectors[det_key]
+        xypts = self._compute_xypts(det_key)
+
+        result = np.ones(self.ntth * self.neta, dtype=bool)
+
+        valid = ~np.isnan(xypts[:, 0])
+        if not valid.any():
+            return result.reshape(self.shape)
+
+        pixel_coords = panel.cartToPixel(xypts[valid], pixels=True)
+        rows = pixel_coords[:, 0]
+        cols = pixel_coords[:, 1]
+
+        h, w = raw_mask.shape
+        in_bounds = (rows >= 0) & (rows < h) & (cols >= 0) & (cols < w)
+
+        idx = np.where(valid)[0][in_bounds]
+        result[idx] = raw_mask[rows[in_bounds], cols[in_bounds]]
+
+        return result.reshape(self.shape)
+
+    def create_polar_mask_from_raw_data(
+        self,
+        raw_data: list[tuple[str, np.ndarray]],
+        apply_tth_distortion: bool = True,
+    ) -> np.ndarray:
+        """Create polar mask by rasterizing in raw space and warping.
+
+        This avoids the coordinate-singularity bug that occurs when
+        converting polygon perimeters through the beam center.
+
+        Parameters
+        ----------
+        raw_data : list of (det_key, polygon_array) tuples
+            Raw mask polygon data.
+        apply_tth_distortion : bool
+            Whether to apply tth distortion to the result.
+
+        Returns
+        -------
+        np.ndarray
+            Boolean array (True=unmasked, False=masked).
+        """
+        from hexrdgui.masking.create_raw_mask import create_raw_mask
+
+        raw_masks = create_raw_mask(raw_data)
+        polar_mask = np.ones(self.shape, dtype=bool)
+        for det_key, raw_mask in raw_masks:
+            if det_key not in self.detectors:
+                continue
+            if raw_mask.all():
+                continue
+            warped = self.warp_binary_mask(raw_mask, det_key)
+            polar_mask &= warped
+
+        if apply_tth_distortion and HexrdConfig().polar_tth_distortion:
+            mask_float = (~polar_mask).astype(np.float64)
+            distorted = self.apply_tth_distortion(mask_float)
+            polar_mask = ~(np.asarray(distorted.filled(0)) > 0.5)
+
+        return polar_mask
 
     def invalidate_corr_field_polar_cache(self) -> None:
         self._corr_field_polar_cached = None
@@ -552,7 +644,7 @@ class PolarView:
             if mask.type == MaskType.threshold or not mask.visible:
                 continue
             mask_arr = mask.get_masked_arrays(  # type: ignore[call-arg]
-                ViewType.polar, self.instr
+                ViewType.polar, self.instr, polar_view=self
             )
             total_mask = np.logical_or(total_mask, ~mask_arr)
         if (tm := MaskManager().threshold_mask) and tm.visible:
@@ -571,7 +663,7 @@ class PolarView:
             if mask.type == MaskType.threshold or not mask.show_border:
                 continue
             mask_arr = mask.get_masked_arrays(  # type: ignore[call-arg]
-                ViewType.polar, self.instr
+                ViewType.polar, self.instr, polar_view=self
             )
             total_mask = np.logical_or(total_mask, ~mask_arr)
         return total_mask

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -2432,7 +2432,8 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
                     # Do not apply tth distortion for the pinhole mask
                     apply_tth_distortion = mask.type != MaskType.pinhole
                     if self.mode == ViewType.polar and hasattr(self.iviewer, 'pv'):
-                        pv = self.iviewer.pv
+                        polar_iviewer = cast('PolarViewer', self.iviewer)
+                        pv = polar_iviewer.pv
                         polar_mask = pv.create_polar_mask_from_raw_data(
                             mask.data,
                             apply_tth_distortion=apply_tth_distortion,
@@ -2539,11 +2540,12 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         if self.mode != ViewType.polar or not hasattr(self.iviewer, 'pv'):
             return False
 
+        polar_iviewer = cast('PolarViewer', self.iviewer)
+        pv = polar_iviewer.pv
+
         visible = MaskManager().visible_highlights
         if not visible:
             return True
-
-        pv = self.iviewer.pv
         combined_mask = np.ones(pv.shape, dtype=bool)
         for name in visible:
             mask = MaskManager().masks[name]
@@ -2565,7 +2567,7 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
         overlay[masked_pixels] = rgba
         overlay[masked_pixels, 3] = MaskManager().highlight_opacity
 
-        extent = np.degrees(pv.extent)
+        extent = tuple(np.degrees(pv.extent))
         im = axis.imshow(overlay, extent=extent, interpolation='none')
         im.set_animated(True)
 

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -13,6 +13,7 @@ from matplotlib.axes import Axes
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.lines import Line2D
+from matplotlib.colors import to_rgba
 from matplotlib.patches import Circle, Polygon
 from matplotlib.ticker import AutoLocator, AutoMinorLocator, Formatter, FuncFormatter
 
@@ -21,6 +22,7 @@ import matplotlib.pyplot as plt
 import matplotlib.transforms as tx
 
 import numpy as np
+from skimage import measure
 
 from hexrd import distortion as distortion_pkg
 
@@ -2429,27 +2431,43 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
                 if mask.type != MaskType.threshold:
                     # Do not apply tth distortion for the pinhole mask
                     apply_tth_distortion = mask.type != MaskType.pinhole
-                    verts = create_polar_line_data_from_raw(
-                        instr,
-                        mask.data,
-                        apply_tth_distortion=apply_tth_distortion,
-                    )
-                    if self.mode == ViewType.polar:
-                        # Check for any major jumps in eta. That probably means
-                        # the border is wrapping around.
-                        for i, vert in enumerate(verts):
-                            # If there are two points far away, assume there
-                            # is a gap in the eta range.
-                            eta_diff = np.abs(np.diff(vert[:, 1]))
-                            delta_eta_est = np.nanmedian(eta_diff)
-                            tolerance = delta_eta_est * 10
-                            (big_gaps,) = np.nonzero(eta_diff > tolerance)
-                            verts[i] = np.insert(
-                                vert,
-                                big_gaps + 1,
-                                np.nan,
-                                axis=0,
+                    if self.mode == ViewType.polar and hasattr(self.iviewer, 'pv'):
+                        pv = self.iviewer.pv
+                        polar_mask = pv.create_polar_mask_from_raw_data(
+                            mask.data,
+                            apply_tth_distortion=apply_tth_distortion,
+                        )
+                        contours = measure.find_contours(~polar_mask)
+                        verts = []
+                        for contour in contours:
+                            rows, cols = contour[:, 0], contour[:, 1]
+                            tth = (
+                                np.degrees(pv.tth_min)
+                                + (cols + 0.5) * pv.tth_pixel_size
                             )
+                            eta = (
+                                np.degrees(pv.eta_min)
+                                + (rows + 0.5) * pv.eta_pixel_size
+                            )
+                            verts.append(np.column_stack([tth, eta]))
+                    else:
+                        verts = create_polar_line_data_from_raw(
+                            instr,
+                            mask.data,
+                            apply_tth_distortion=apply_tth_distortion,
+                        )
+                        if self.mode == ViewType.polar:
+                            for i, vert in enumerate(verts):
+                                eta_diff = np.abs(np.diff(vert[:, 1]))
+                                delta_eta_est = np.nanmedian(eta_diff)
+                                tolerance = delta_eta_est * 10
+                                (big_gaps,) = np.nonzero(eta_diff > tolerance)
+                                verts[i] = np.insert(
+                                    vert,
+                                    big_gaps + 1,
+                                    np.nan,
+                                    axis=0,
+                                )
 
                     if self.mode == ViewType.stereo:
                         # Now convert from polar to stereo
@@ -2490,6 +2508,9 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
     def highlight_masks(self, axis: Axes, det: str | None = None) -> None:
         # Don't update the blit manager here, so we can better control
         # it elsewhere
+        if self._highlight_masks_polar(axis):
+            return
+
         all_verts = self.get_mask_verts('highlights', det)
         if not all_verts:
             return
@@ -2508,6 +2529,49 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
             polygon.set_animated(True)
             axis.add_patch(polygon)
             highlight_artists.append(polygon)
+
+    def _highlight_masks_polar(self, axis: Axes) -> bool:
+        """Overlay polar mask highlights as an RGBA image.
+
+        Returns True if handled (polar mode with PolarView available),
+        False to fall back to polygon-based highlighting.
+        """
+        if self.mode != ViewType.polar or not hasattr(self.iviewer, 'pv'):
+            return False
+
+        visible = MaskManager().visible_highlights
+        if not visible:
+            return True
+
+        pv = self.iviewer.pv
+        combined_mask = np.ones(pv.shape, dtype=bool)
+        for name in visible:
+            mask = MaskManager().masks[name]
+            if mask.type == MaskType.threshold:
+                continue
+            apply_tth_distortion = mask.type != MaskType.pinhole
+            polar_mask = pv.create_polar_mask_from_raw_data(
+                mask.data,
+                apply_tth_distortion=apply_tth_distortion,
+            )
+            combined_mask &= polar_mask
+
+        masked_pixels = ~combined_mask
+        if not masked_pixels.any():
+            return True
+
+        rgba = to_rgba(MaskManager().highlight_color)
+        overlay = np.zeros((*pv.shape, 4), dtype=np.float32)
+        overlay[masked_pixels] = rgba
+        overlay[masked_pixels, 3] = MaskManager().highlight_opacity
+
+        extent = np.degrees(pv.extent)
+        im = axis.imshow(overlay, extent=extent, interpolation='none')
+        im.set_animated(True)
+
+        highlight_artists = self.mask_highlight_artists.setdefault('default', [])
+        highlight_artists.append(im)
+        return True
 
     def remove_all_mask_highlight_artists(self) -> None:
         self.blit_manager.remove_artists('mask_highlights')

--- a/hexrdgui/masking/mask_manager.py
+++ b/hexrdgui/masking/mask_manager.py
@@ -163,12 +163,21 @@ class RegionMask(Mask):
         self._highlight = value
 
     def update_masked_arrays(
-        self, view: str = ViewType.raw, instr: HEDMInstrument | None = None
+        self,
+        view: str = ViewType.raw,
+        instr: HEDMInstrument | None = None,
+        polar_view: Any = None,
     ) -> None:
         self.masked_arrays_view_mode = view
         assert self._raw is not None
         if view == ViewType.raw:
             self.masked_arrays = create_raw_mask(self._raw)
+        elif polar_view is not None:
+            apply_tth_distortion = self.type != MaskType.pinhole
+            self.masked_arrays = polar_view.create_polar_mask_from_raw_data(
+                self._raw,
+                apply_tth_distortion=apply_tth_distortion,
+            )
         else:
             # Do not apply tth distortion for pinhole mask types
             apply_tth_distortion = self.type != MaskType.pinhole
@@ -182,9 +191,10 @@ class RegionMask(Mask):
         self,
         image_mode: str = ViewType.raw,
         instr: HEDMInstrument | None = None,
+        polar_view: Any = None,
     ) -> Any:
         if self.masked_arrays is None or self.masked_arrays_view_mode != image_mode:
-            self.update_masked_arrays(image_mode, instr)
+            self.update_masked_arrays(image_mode, instr, polar_view=polar_view)
 
         return self.masked_arrays
 


### PR DESCRIPTION
The old approach converted polygon perimeter vertices from raw to polar coordinates and rasterized in polar space. When a mask edge crossed near the beam center, the eta coordinate swung ~180 degrees, inflating the polygon into a huge triangle. The new approach rasterizes the polygon in raw pixel space first, then warps the binary mask to polar using the same cached coordinate mapping as image warping. Also scales the project_on_detector memoize cache to the number of detectors.

This new method may be very slightly slower, but will produce accurate results around the beam center.