### PR TITLE
Fix activation policy for macos

### DIFF
--- a/hexrdgui/macos_fix_activation_policy.py
+++ b/hexrdgui/macos_fix_activation_policy.py
@@ -1,0 +1,17 @@
+"""Register as a regular GUI app before QApplication is created.
+
+Without a .app bundle, macOS does not recognize the process as a GUI
+application, which causes TSM (Text Services Manager) errors when Qt
+tries to connect to the window server for text input.
+"""
+
+
+def macos_fix_activation_policy() -> None:
+    try:
+        from AppKit import NSApplication, NSApplicationActivationPolicyRegular
+    except ImportError:
+        return
+
+    NSApplication.sharedApplication().setActivationPolicy_(
+        NSApplicationActivationPolicyRegular
+    )

--- a/hexrdgui/main.py
+++ b/hexrdgui/main.py
@@ -52,6 +52,13 @@ def main() -> None:
     QCoreApplication.setOrganizationName('hexrd')
     QCoreApplication.setApplicationName('hexrd')
 
+    if sys.platform.startswith('darwin'):
+        from hexrdgui.macos_fix_activation_policy import (
+            macos_fix_activation_policy,
+        )
+
+        macos_fix_activation_policy()
+
     app = QApplication(sys.argv)
 
     if sys.platform.startswith('darwin'):


### PR DESCRIPTION
This is to remove startup warnings like the following, which happen when starting `hexrdgui` from a conda environment:

```bash
  2026-05-20 12:27:41.089 python3.14[24745:67216389] TSMSendMessageToUIServer:
  CFMessagePortSendRequest FAILED(-1) to send to port com.apple.tsm.uiserver
  2026-05-20 12:27:41.090 python3.14[24745:67216389] TSMSendMessageToUIServer:
  CFMessagePortSendRequest FAILED(-1) to send to port com.apple.tsm.uiserver
  2026-05-20 12:27:41.091 python3.14[24745:67216389] TSMSendMessageToUIServer:
  CFMessagePortSendRequest FAILED(-1) to send to port com.apple.tsm.uiserver
```