### PR TITLE
Migrate deprecated `importlib.resources` functions

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -494,7 +494,7 @@ class PolarView:
                 corr_field_polar_dict[key] = self.warp_image(corr_field[key], panel)
 
             corr_field_polar = np.ma.sum(
-                np.ma.stack(corr_field_polar_dict.values()), axis=0
+                np.ma.stack(list(corr_field_polar_dict.values())), axis=0
             )
 
         self._corr_field_polar_cached = corr_field_polar
@@ -540,7 +540,7 @@ class PolarView:
         # !!! assignment to img fills NaNs with zeros
         # !!! NOTE: cannot set `data` attribute on masked_array,
         #           but can manipulate mask
-        self.raw_img = np.ma.sum(np.ma.stack(self.warp_dict.values()), axis=0)
+        self.raw_img = np.ma.sum(np.ma.stack(list(self.warp_dict.values())), axis=0)
         self.apply_image_processing()
 
     @property
@@ -619,7 +619,7 @@ class PolarView:
             corrections = intensity_corrections[det_key]
             output[det_key] = self.warp_image(corrections, panel)
 
-        stacked = np.ma.stack(output.values()).filled(np.nan)
+        stacked = np.ma.stack(list(output.values())).filled(np.nan)
 
         # In case there are overlapping detectors, we do nanmean for
         # the intensities instead of nansum.  All-NaN slices are expected

--- a/hexrdgui/calibration/stereo_project.py
+++ b/hexrdgui/calibration/stereo_project.py
@@ -84,7 +84,7 @@ def stereo_project(
     mask = np.logical_and(mask[:, 0], mask[:, 1])
 
     stereo = np.zeros((stereo_size, stereo_size))
-    fmask = np.ones_like(stereo)
+    fmask = np.ones_like(stereo, dtype=bool)
     for d in instr_cp.detectors:
         intensity = np.empty((angs.shape[0],))
         det = instr_cp.detectors[d]

--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -1794,12 +1794,11 @@ class WppfOptionsDialog(QObject):
 
         if has_nan(expt_spectrum):
             # Store as masked array
-            kwargs = {
-                'data': expt_spectrum,
-                'mask': np.isnan(expt_spectrum),
-                'fill_value': 0.0,
-            }
-            expt_spectrum = np.ma.masked_array(**kwargs)
+            expt_spectrum = np.ma.masked_array(
+                data=expt_spectrum,
+                mask=np.isnan(expt_spectrum),
+                fill_value=0.0,
+            )
 
         if self.limit_tth:
             expt_spectrum = expt_spectrum[expt_spectrum[:, 0] >= self.min_tth]

--- a/hexrdgui/resource_loader.py
+++ b/hexrdgui/resource_loader.py
@@ -15,10 +15,11 @@ def load_resource(
     module: types.ModuleType, name: str, binary: bool = False
 ) -> str | bytes:
     """This will return a string of a resource's contents"""
+    resource = importlib_resources.files(module) / name
     if binary:
-        return importlib_resources.read_binary(module, name)
+        return resource.read_bytes()
 
-    return importlib_resources.read_text(module, name)
+    return resource.read_text()
 
 
 def resource_path(module: types.ModuleType, name: str) -> Any:
@@ -26,7 +27,7 @@ def resource_path(module: types.ModuleType, name: str) -> Any:
 
 
 def module_contents(module: types.ModuleType) -> Any:
-    return importlib_resources.contents(module)
+    return [r.name for r in importlib_resources.files(module).iterdir()]
 
 
 def import_dynamic_module(name: str) -> types.ModuleType:
@@ -34,4 +35,4 @@ def import_dynamic_module(name: str) -> types.ModuleType:
 
 
 def path(module: types.ModuleType, name: str) -> Any:
-    return importlib_resources.path(module, name)
+    return importlib_resources.as_file(importlib_resources.files(module) / name)

--- a/hexrdgui/resource_loader.py
+++ b/hexrdgui/resource_loader.py
@@ -19,7 +19,10 @@ def load_resource(
     if binary:
         return resource.read_bytes()
 
-    return resource.read_text()
+    # Explicit utf-8: the legacy importlib.resources.read_text() defaulted to
+    # utf-8, but Traversable.read_text() uses the platform default encoding
+    # (cp1252 on Windows), which fails on utf-8 resources.
+    return resource.read_text(encoding='utf-8')
 
 
 def resource_path(module: types.ModuleType, name: str) -> Any:


### PR DESCRIPTION
These need to be migrated to use `files()` instead.