### PR TITLE
Do not export tth width if it is `None`

### DIFF
--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1428,9 +1428,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             'active': current_material,
             # type: ignore[union-attr]
             'dmin': selected_material.dmin.getVal('angstrom'),
-            'tth_width': tth_width,
             'reset_exclusions': False,
         }
+
+        # Only write tth_width if the material actually has one. Writing
+        # `tth_width: null` would defeat HEXRD's default handling (the default
+        # only applies when the key is absent, not when it is null) and cause
+        # the workflow to fail. When it is absent, find-orientations supplies
+        # its own default width where one is required.
+        if tth_width is not None:
+            material['tth_width'] = tth_width
 
         if self.instrument_has_roi:
             names = self.detector_group_names

--- a/hexrdgui/indexing/fit_grains_options_dialog.py
+++ b/hexrdgui/indexing/fit_grains_options_dialog.py
@@ -323,10 +323,16 @@ class FitGrainsOptionsDialog(QObject):
         return [w.itemText(i) for i in range(w.count())]
 
     def selected_material_changed(self) -> None:
-        if self._table is not None:
-            self._table.material = self.material
+        # self.material can be None (e.g. transiently while the material combo
+        # box is being repopulated in update_materials(), where clear() emits
+        # currentIndexChanged with an empty selection). The reflections table
+        # cannot display a None material, so guard against it to avoid an
+        # AttributeError.
+        material = self.material
+        if self._table is not None and material is not None:
+            self._table.material = material
 
-        self.ui.grains_table_view.material = self.material
+        self.ui.grains_table_view.material = material
         self.update_num_hkls()
 
     @property

--- a/hexrdgui/indexing/ome_maps_select_dialog.py
+++ b/hexrdgui/indexing/ome_maps_select_dialog.py
@@ -126,8 +126,14 @@ class OmeMapsSelectDialog(QObject):
         return [w.itemText(i) for i in range(w.count())]
 
     def selected_material_changed(self) -> None:
-        if hasattr(self, '_table'):
-            self._table.material = self.material
+        # self.material can be None (e.g. transiently while the material combo
+        # box is being repopulated in update_materials(), where clear() emits
+        # currentIndexChanged with an empty selection). The reflections table
+        # cannot display a None material, so guard against it to avoid an
+        # AttributeError.
+        material = self.material
+        if hasattr(self, '_table') and material is not None:
+            self._table.material = material
 
         self.update_num_hkls()
 

--- a/tests/test_indexing_material_combo.py
+++ b/tests/test_indexing_material_combo.py
@@ -1,0 +1,49 @@
+"""Regression tests for the material combo box in the indexing dialogs.
+
+Repopulating the material combo box (for example, when importing a materials
+file) clears and refills it. QComboBox.clear() emits currentIndexChanged with
+an empty selection, which used to drive selected_material_changed() with a
+None material and crash when a reflections table was open:
+
+    AttributeError: 'NoneType' object has no attribute 'name'
+"""
+
+import numpy as np
+
+from hexrdgui.indexing.fit_grains_options_dialog import FitGrainsOptionsDialog
+from hexrdgui.indexing.ome_maps_select_dialog import OmeMapsSelectDialog
+
+
+def test_fit_grains_options_material_repopulation(main_window, qtbot):
+    dialog = FitGrainsOptionsDialog(grains_table=np.zeros((1, 21)))
+    qtbot.addWidget(dialog.ui)
+
+    # Opening the reflections table is the precondition for the crash.
+    table = dialog.reflections_table
+    assert table is not None
+    qtbot.addWidget(table.ui)
+
+    # Repopulating the combo box (as happens when materials are imported)
+    # clears it, which emits currentIndexChanged with an empty selection.
+    # This must not raise.
+    dialog.update_materials()
+
+    # The reflections table should still track the selected material.
+    assert dialog.material is not None
+    assert dialog._table.material is dialog.material
+
+
+def test_ome_maps_select_material_repopulation(main_window, qtbot):
+    dialog = OmeMapsSelectDialog()
+    qtbot.addWidget(dialog.ui)
+
+    # Opening the reflections table is the precondition for the crash.
+    dialog.choose_hkls()
+    assert dialog._table is not None
+    qtbot.addWidget(dialog._table.ui)
+
+    # Must not raise (see module docstring).
+    dialog.update_materials()
+
+    assert dialog.material is not None
+    assert dialog._table.material is dialog.material


### PR DESCRIPTION
The HEDM workflow requires a valid tth width. Don't export it unless it is a valid value. If we don't export it, it will default to `None`.

Fixes: https://github.com/HEXRD/hexrdgui/issues/2022