### PR TITLE
Pin matplotlib to be less than 3.11 temporarily

### DIFF
--- a/conda.recipe/meta.yaml
+++ b/conda.recipe/meta.yaml
@@ -23,7 +23,9 @@ requirements:
     - python >={{ python_min }}
     - fabio
     - hexrd=={{ hexrd_version }}
-    - matplotlib-base
+    # matplotlib 3.11.0 deadlocks the Qt GUI during image-series loading on
+    # Windows/macOS. Pin below 3.11 until resolved upstream.
+    - matplotlib-base <3.11
     - Pillow
     - pyhdf
     # This next one is needed to fix the app name on Mac

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,10 @@ from setuptools import setup, find_packages, Extension
 install_reqs = [
     'hexrd',
     'fabio>=0.11',
-    'matplotlib',
+    # matplotlib 3.11.0 deadlocks the Qt GUI during image-series loading on
+    # Windows/macOS (the GUI test suite hangs indefinitely). Pin below 3.11
+    # until the issue is resolved upstream.
+    'matplotlib<3.11',
     'Pillow',
     'pyside6',
     'pyyaml',


### PR DESCRIPTION
Until the upstream issue is resolved that is creating some kind of deadlock with Qt.