### PR TITLE
Resize eta omega maps dialog to fit display

### DIFF
--- a/hexrdgui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrdgui/indexing/ome_maps_viewer_dialog.py
@@ -39,7 +39,7 @@ from hexrdgui.scaling import SCALING_OPTIONS
 from hexrdgui.select_items_widget import SelectItemsWidget
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
-from hexrdgui.utils.dialog import add_help_url
+from hexrdgui.utils.dialog import add_help_url, fit_window_to_screen
 from hexrdgui.utils.matplotlib import remove_artist
 
 import hexrdgui.constants
@@ -201,6 +201,13 @@ class OmeMapsViewerDialog(QObject):
     def show(self) -> None:
         self.update_plot()
         self.ui.show()
+
+        # The .ui file specifies a large default size (1900x1149). On any
+        # smaller display - and especially over remote desktops - that can
+        # open larger than the screen with its title bar/edges off-screen and
+        # unreachable for resizing or moving. Clamp it to the available screen
+        # area once the window has been mapped (so frame geometry is known).
+        QTimer.singleShot(0, lambda: fit_window_to_screen(self.ui))
 
     def show_later(self) -> None:
         # In case this was called in a separate thread (which will

--- a/hexrdgui/utils/dialog.py
+++ b/hexrdgui/utils/dialog.py
@@ -1,5 +1,67 @@
+from PySide6.QtCore import QPoint, QRect, QSize
 from PySide6.QtGui import QDesktopServices
-from PySide6.QtWidgets import QDialogButtonBox
+from PySide6.QtWidgets import QApplication, QDialogButtonBox, QWidget
+
+
+def fit_geometry_to_available(
+    geom: QRect, frame: QRect, available: QRect, margin: int = 0
+) -> tuple[QSize, QPoint]:
+    """Pure geometry behind `fit_window_to_screen` (no live Qt window calls).
+
+    Given a window's current geometry (decoration-exclusive), its frame
+    geometry (decoration-inclusive), and the screen's available rect, return
+    ``(size, frame_pos)``: the size to resize the window to and the position
+    to move the window frame's top-left to, such that the whole frame fits
+    inside ``available``. Kept side-effect-free so it can be unit tested with
+    a fabricated screen rect on any platform.
+    """
+    # The difference between frame and geometry is the decoration thickness
+    # (title bar, borders). Subtract it so the window plus its decorations
+    # fits on-screen.
+    decoration_w = frame.width() - geom.width()
+    decoration_h = frame.height() - geom.height()
+
+    max_w = max(available.width() - decoration_w - margin, 0)
+    max_h = max(available.height() - decoration_h - margin, 0)
+    size = geom.size().boundedTo(QSize(max_w, max_h))
+
+    # Clamp the (decoration-inclusive) frame top-left so the whole frame -
+    # and in particular the title bar - stays within the available area.
+    frame_w = size.width() + decoration_w
+    frame_h = size.height() + decoration_h
+    x = min(max(frame.x(), available.x()), available.x() + available.width() - frame_w)
+    y = min(max(frame.y(), available.y()), available.y() + available.height() - frame_h)
+    return size, QPoint(x, y)
+
+
+def fit_window_to_screen(window: QWidget, margin: int = 0) -> None:
+    """Ensure a top-level window fits within the available screen area.
+
+    Shrinks the window if it is larger than the screen's available
+    geometry, and moves it so that the whole window frame (including the
+    title bar and edges) stays on-screen. This prevents the window from
+    opening larger than the display - on any small screen, and especially
+    over remote desktops (VNC/RDP/NoMachine) - where its decorations would
+    otherwise be off-screen and therefore impossible to grab to resize or
+    move.
+
+    Should be called after the window has been shown, so that the frame
+    (decoration) geometry is known.
+    """
+    screen = window.screen() or QApplication.primaryScreen()
+    if screen is None:
+        return
+
+    size, pos = fit_geometry_to_available(
+        window.geometry(),
+        window.frameGeometry(),
+        screen.availableGeometry(),
+        margin,
+    )
+    if size != window.size():
+        window.resize(size)
+    # window.move() positions the frame top-left for top-level windows.
+    window.move(pos)
 
 
 def open_url(url: str) -> bool:

--- a/tests/test_dialog_fit.py
+++ b/tests/test_dialog_fit.py
@@ -1,0 +1,74 @@
+"""Tests for window/screen fitting in hexrdgui.utils.dialog.
+
+The eta-omega map viewer (and other large dialogs) can open larger than the
+display, leaving the title bar/edges off-screen and unreachable on window
+managers that don't auto-clamp (Linux/X11, NoMachine). macOS clamps windows
+itself, so that failure mode is not reproducible there; these tests exercise
+the platform-independent clamping math directly with a fabricated screen.
+"""
+
+from PySide6.QtCore import QPoint, QRect, QSize
+
+from hexrdgui.utils.dialog import fit_geometry_to_available
+
+
+# A typical small/remote screen, with no decoration on the geometry by
+# default (frame == geom) unless a test overrides it.
+AVAILABLE = QRect(0, 0, 1280, 720)
+
+
+def _fit(geom, available=AVAILABLE, frame=None, margin=0):
+    # By default the frame equals the geometry (no decorations).
+    if frame is None:
+        frame = QRect(geom)
+    return fit_geometry_to_available(geom, frame, available, margin)
+
+
+def test_oversized_window_is_shrunk_to_available():
+    # Window far larger than the screen (the #2026 scenario: 4000x3000).
+    size, pos = _fit(QRect(0, 0, 4000, 3000))
+    assert size == QSize(1280, 720)
+    assert pos == QPoint(0, 0)
+
+
+def test_window_within_screen_is_unchanged():
+    geom = QRect(100, 50, 800, 600)
+    size, pos = _fit(geom)
+    assert size == QSize(800, 600)
+    # Fully on-screen already -> left where it is.
+    assert pos == QPoint(100, 50)
+
+
+def test_offscreen_window_is_moved_back_on_screen():
+    # On-screen-sized but positioned with its top-left off the bottom-right.
+    geom = QRect(1200, 700, 400, 300)
+    size, pos = _fit(geom)
+    assert size == QSize(400, 300)
+    # Clamped so the whole frame fits: x = 1280-400, y = 720-300.
+    assert pos == QPoint(880, 420)
+    assert AVAILABLE.contains(QRect(pos, size))
+
+
+def test_decorations_are_accounted_for():
+    # Window content exactly fills the screen, but a 10px border + 30px title
+    # bar means the *frame* would overflow. It must be shrunk to leave room.
+    geom = QRect(0, 0, 1280, 720)
+    frame = QRect(-10, -30, 1280 + 20, 720 + 40)  # 10px sides, 30px top
+    size, pos = _fit(geom, frame=frame)
+    assert size == QSize(1280 - 20, 720 - 40)  # 1260 x 680
+    # Frame top-left clamped to the available origin.
+    assert pos == QPoint(0, 0)
+
+
+def test_margin_leaves_breathing_room():
+    size, _ = _fit(QRect(0, 0, 4000, 3000), margin=20)
+    assert size == QSize(1260, 700)
+
+
+def test_non_origin_screen_offset():
+    # Multi-monitor: available screen does not start at (0, 0).
+    available = QRect(1920, 0, 1280, 720)
+    size, pos = _fit(QRect(0, 0, 4000, 3000), available=available)
+    assert size == QSize(1280, 720)
+    assert pos == QPoint(1920, 0)
+    assert available.contains(QRect(pos, size))


### PR DESCRIPTION
If the eta omega maps dialog is larger than the display, resize it automatically so it fits within the display.

This was important because in some cases, especially remote desktops, the dialog would be too large, and the resize handle would be unreachable, which made it impossible to use.

This also adds a few tests for the relevant resize testing code.

Fixes: #2026