### PR TITLE
Invalidate polar cache for panel distortion params

### DIFF
--- a/hexrdgui/calibration/polarview.py
+++ b/hexrdgui/calibration/polarview.py
@@ -360,6 +360,19 @@ class PolarView:
                 'rmat_s': ct.identity_3x3,
             }
 
+        # Add the distortion name and params to the cache key. The distortion
+        # object is hashed by identity, but calibration mutates its params in
+        # place, so without this the polar view returns a stale warp after a
+        # refine. The name covers toggling off/switching functions. These keys
+        # are popped before projecting (see `project_on_detector`).
+        distortion = detector.distortion
+        kwargs['_distortion_func_name'] = (
+            distortion.maptype if distortion is not None else None
+        )
+        kwargs['_distortion_params'] = (
+            np.asarray(distortion.params) if distortion is not None else None
+        )
+
         return arg, kwargs
 
     def _compute_xypts(self, det_key: str) -> np.ndarray:
@@ -796,6 +809,12 @@ def project_on_detector(
     # `gvec_angs` argument with them. Then, the `gvec_args` will be passed
     # first to `_project_on_detector_plane`, along with any extra args and
     # kwargs.
+
+    # These are only here to make the cache key distortion-aware (see
+    # `args_project_on_detector`); the projection function doesn't accept them.
+    kwargs.pop('_distortion_func_name', None)
+    kwargs.pop('_distortion_params', None)
+
     dummy_ome = np.zeros((ntth * neta))
 
     gvec_angs = np.vstack(

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -1604,6 +1604,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
                 }
 
             self.panel_distortion_modified.emit(path[1])
+            # Toggling/switching the distortion also affects the warped image.
+            self.rerender_needed.emit()
             return
 
         try:
@@ -1673,6 +1675,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
         if path[2:4] == ['distortion', 'parameters']:
             self.panel_distortion_modified.emit(path[1])
+            # The distortion also affects the warped image, not just overlays.
+            self.rerender_needed.emit()
             return
 
         # Otherwise, assume we need to re-render the whole image

--- a/tests/test_polar_distortion_cache.py
+++ b/tests/test_polar_distortion_cache.py
@@ -1,0 +1,101 @@
+"""Regression tests for distortion-aware polar view caching.
+
+`project_on_detector` is memoized and a distortion object is hashed by
+identity, but calibration mutates its params in place. So the cache must key on
+the distortion name/params (injected by `args_project_on_detector`), or it
+returns a stale warp after a refine.
+"""
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+
+from hexrd.core.distortion import get_mapping
+from hexrd.core.distortion.distortionabc import DistortionABC
+
+from hexrdgui.calibration.polarview import PolarView, project_on_detector
+
+
+# GE_41RT forward/inverse takes 6 params.
+GE_PARAMS = [-5.24e-7, -7.15e-5, -5.19e-4, 2, 4, 2]
+
+
+def make_args(
+    distortion: DistortionABC | None,
+) -> tuple[tuple[Any, ...], dict[str, Any]]:
+    # `args_project_on_detector` only reads `self.chi`/`self.tvec_s`, so a
+    # lightweight stand-in avoids building a full instrument.
+    fake_self = SimpleNamespace(chi=0.0, tvec_s=np.zeros(3))
+    detector = SimpleNamespace(
+        bvec=np.array([0.0, 0.0, -1.0]),
+        rmat=np.eye(3),
+        tvec=np.zeros(3),
+        distortion=distortion,
+    )
+    # The stand-ins only need to quack like a PolarView/Detector here.
+    return PolarView.args_project_on_detector(
+        fake_self,  # type: ignore[arg-type]
+        detector,  # type: ignore[arg-type]
+    )
+
+
+def stub_projection(
+    gvec_angs: np.ndarray, *args: Any, **kwargs: Any
+) -> tuple[np.ndarray, None, np.ndarray]:
+    # Return a value derived from the current distortion params so a stale
+    # cache hit is detectable. Duck-type to stay robust to arg-order changes;
+    # use a sentinel when distortion is off.
+    distortion = next(
+        (a for a in args if hasattr(a, 'params') and hasattr(a, 'maptype')),
+        None,
+    )
+    value = -1.0 if distortion is None else float(distortion.params[0])
+    n = len(gvec_angs)
+    xys = np.full((n, 2), value)
+    valid_mask = np.ones(n, dtype=bool)
+    return xys, None, valid_mask
+
+
+def project(distortion: DistortionABC | None) -> np.ndarray:
+    args, kwargs = make_args(distortion)
+    grid = (np.array([[0.5]]), np.array([[0.5]]))
+    return project_on_detector(grid, 1, 1, stub_projection, *args, **kwargs)
+
+
+def test_args_include_distortion_in_cache_key() -> None:
+    distortion = get_mapping('GE_41RT', GE_PARAMS)
+    _, kwargs = make_args(distortion)
+
+    assert kwargs['_distortion_func_name'] == 'GE_41RT'
+    assert np.array_equal(kwargs['_distortion_params'], distortion.params)
+
+
+def test_no_distortion_uses_none_in_cache_key() -> None:
+    _, kwargs = make_args(None)
+
+    assert kwargs['_distortion_func_name'] is None
+    assert kwargs['_distortion_params'] is None
+
+
+def test_cache_invalidated_on_in_place_param_change() -> None:
+    # The calibration scenario: params mutated in place. Without the fix, the
+    # second call returns the stale warp.
+    distortion = get_mapping('GE_41RT', GE_PARAMS)
+
+    before = project(distortion)
+
+    distortion.params = [9.9, 0.0, 0.0, 2, 4, 2]
+    after = project(distortion)
+
+    assert not np.array_equal(before, after)
+
+
+def test_cache_invalidated_on_distortion_toggle() -> None:
+    # Toggling off should not reuse the with-distortion warp.
+    distortion = get_mapping('GE_41RT', [1.0, 0.0, 0.0, 2, 4, 2])
+
+    with_distortion = project(distortion)
+    without_distortion = project(None)
+
+    assert not np.array_equal(with_distortion, without_distortion)


### PR DESCRIPTION
Previously, the polar cache would not be updated when panel distortion parameters were changed (such as is done during calibration refinement). This meant the polar view would not be fully updated.

We need to add the distortion parameters as kwargs so that the polar view cache would be invalidated automatically.

This also triggers a rerender when users change distortion parameters.