### PR TITLE
Allow fast powder asymmetry params manual set

### DIFF
--- a/hexrdgui/calibration/auto/powder_calibration_dialog.py
+++ b/hexrdgui/calibration/auto/powder_calibration_dialog.py
@@ -2,15 +2,48 @@ from __future__ import annotations
 
 from typing import Any, TYPE_CHECKING
 
-from PySide6.QtWidgets import QMessageBox, QWidget
+from PySide6.QtWidgets import QDoubleSpinBox, QLabel, QMessageBox, QWidget
 
 import numpy as np
+
+from hexrd.core.fitting.spectrum import pink_beam_asymmetry_params
 
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.ui_loader import UiLoader
 
 if TYPE_CHECKING:
     from hexrd.material import Material
+
+# Number of generic (label, spinbox) rows in the asymmetry group in the .ui.
+# Must be at least as large as the biggest set in pink_beam_asymmetry_params.
+NUM_ASYMMETRY_ROWS = 4
+
+# Pretty labels for each shape parameter shown in the dialog.
+ASYMMETRY_PARAM_LABELS = {
+    'alpha0': 'α₀',
+    'alpha1': 'α₁',
+    'beta0': 'β₀',
+    'beta1': 'β₁',
+    'sigma0': 'σ₀',
+    'sigma1': 'σ₁',
+    'tau0': 'τ₀',
+    'tau1': 'τ₁',
+    'tau2': 'τ₂',
+}
+
+# Sensible defaults (matching the hexrd/WPPF defaults for each profile), used
+# when a config has no value yet and the user never populates from WPPF.
+ASYMMETRY_PARAM_DEFAULTS = {
+    'alpha0': 14.4,
+    'alpha1': 0.0,
+    'beta0': 3.016,
+    'beta1': -7.94,
+    'sigma0': 0.1,
+    'sigma1': 0.1,
+    'tau0': 1.58,
+    'tau1': -1.35,
+    'tau2': 0.36,
+}
 
 
 class PowderCalibrationDialog:
@@ -20,7 +53,14 @@ class PowderCalibrationDialog:
 
         self.material = material
 
+        # All shape-parameter values, keyed by name. The visible spinboxes
+        # show whichever subset matches the selected pink-beam peak type;
+        # `_shown_params` tracks which params those spinboxes currently hold.
+        self._asymmetry_values = dict(ASYMMETRY_PARAM_DEFAULTS)
+        self._shown_params: list[str] = []
+
         self.setup_combo_boxes()
+        self.setup_connections()
         self.update_gui()
 
     def setup_combo_boxes(self) -> None:
@@ -33,6 +73,82 @@ class PowderCalibrationDialog:
         for t in background_types:
             label = background_type_to_label(t)
             self.ui.background_type.addItem(label, t)
+
+    def setup_connections(self) -> None:
+        # Re-sync the asymmetry fields when the peak fit type changes or the
+        # group is toggled (the inputs are hidden entirely while unchecked).
+        self.ui.peak_fit_type.currentIndexChanged.connect(self.sync_asymmetry_fields)
+        self.ui.use_wppf_asymmetry_check.toggled.connect(self.sync_asymmetry_fields)
+        self.ui.populate_from_wppf_button.clicked.connect(
+            self.populate_asymmetry_from_wppf
+        )
+
+    def asym_label(self, i: int) -> QLabel:
+        return getattr(self.ui, f'asym_label_{i}')
+
+    def asym_value(self, i: int) -> QDoubleSpinBox:
+        return getattr(self.ui, f'asym_value_{i}')
+
+    @property
+    def asymmetry_params(self) -> tuple[str, ...]:
+        # The shape params for the selected pink-beam type (empty otherwise).
+        return pink_beam_asymmetry_params.get(self.peak_fit_type, ())
+
+    def capture_shown_asymmetry_values(self) -> None:
+        # Preserve any edits in the spinboxes (which retain their values even
+        # while hidden) before they get repopulated for a different peak type.
+        for i, name in enumerate(self._shown_params):
+            self._asymmetry_values[name] = self.asym_value(i).value()
+
+    def render_asymmetry_fields(self) -> None:
+        params = self.asymmetry_params
+        # The whole section only makes sense for the pink-beam profiles.
+        self.ui.asymmetry_container.setVisible(bool(params))
+
+        # Hide the inputs entirely (not just disable them) while the option is
+        # off - they are only needed in rare cases and otherwise waste space.
+        checked = self.use_wppf_asymmetry
+        self.ui.populate_from_wppf_button.setVisible(checked)
+        for i in range(NUM_ASYMMETRY_ROWS):
+            label = self.asym_label(i)
+            spinbox = self.asym_value(i)
+            applies = i < len(params)
+            if applies:
+                name = params[i]
+                label.setText(f'{ASYMMETRY_PARAM_LABELS[name]}:')
+                spinbox.setValue(self._asymmetry_values[name])
+            label.setVisible(checked and applies)
+            spinbox.setVisible(checked and applies)
+
+        self._shown_params = list(params)
+
+    def sync_asymmetry_fields(self) -> None:
+        self.capture_shown_asymmetry_values()
+        self.render_asymmetry_fields()
+
+    def populate_asymmetry_from_wppf(self) -> None:
+        params = self.asymmetry_params
+        wppf_params = (
+            HexrdConfig()
+            .config.get('calibration', {})
+            .get('wppf', {})
+            .get('params_dict', {})
+        )
+        missing = [k for k in params if k not in wppf_params]
+        if not params or missing:
+            QMessageBox.warning(
+                self.ui,
+                'HEXRD',
+                'Could not find pink-beam asymmetry parameters from a '
+                'previous WPPF run. Missing: ' + ', '.join(missing) + '.\n\n'
+                'Run a WPPF refinement with the matching pink-beam peak '
+                'shape first.',
+            )
+            return
+
+        for name in params:
+            self._asymmetry_values[name] = float(wppf_params[name]['value'])
+        self.render_asymmetry_fields()
 
     def update_gui(self) -> None:
         if self.tth_tol is None:
@@ -51,8 +167,23 @@ class PowderCalibrationDialog:
         self.auto_guess_initial_fwhm = options['auto_guess_initial_fwhm']
         self.initial_fwhm = options['initial_fwhm']
 
+        # Asymmetry group (may not exist in older configs). Load all known
+        # shape values (with `_shown_params` empty) before touching the
+        # checkbox or peak type, so the signals they fire don't capture stale
+        # spinbox values over the values we just loaded.
+        asym_cfg = options.get('fixed_pink_asymmetry') or {}
+        self._asymmetry_values = {
+            name: float(asym_cfg.get(name, default))
+            for name, default in ASYMMETRY_PARAM_DEFAULTS.items()
+        }
+        self._shown_params = []
+        self.use_wppf_asymmetry = bool(asym_cfg.get('enabled', False))
+
         self.peak_fit_type = options['pk_type']
         self.background_type = options['bg_type']
+
+        # Render the fields for the current peak type (also sets visibility).
+        self.render_asymmetry_fields()
 
     def update_config(self) -> None:
         options = HexrdConfig().config['calibration']['powder']
@@ -66,6 +197,14 @@ class PowderCalibrationDialog:
 
         options['pk_type'] = self.peak_fit_type
         options['bg_type'] = self.background_type
+
+        # Capture any edits currently in the visible spinboxes, then persist
+        # the full set of shape values (all peak types) plus the toggle.
+        self.capture_shown_asymmetry_values()
+        options['fixed_pink_asymmetry'] = {
+            'enabled': self.use_wppf_asymmetry,
+            **self._asymmetry_values,
+        }
 
     def exec(self) -> bool:
         if not self.ui.exec():
@@ -140,6 +279,14 @@ class PowderCalibrationDialog:
 
         if not found:
             raise Exception(f'Unknown background type: {v}')
+
+    @property
+    def use_wppf_asymmetry(self) -> bool:
+        return self.ui.use_wppf_asymmetry_check.isChecked()
+
+    @use_wppf_asymmetry.setter
+    def use_wppf_asymmetry(self, b: bool) -> None:
+        self.ui.use_wppf_asymmetry_check.setChecked(b)
 
 
 # If this gets added as a list to hexrd, we can import it from there

--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -7,6 +7,7 @@ import numpy as np
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtWidgets import QMessageBox, QWidget
 
+from hexrd.core.fitting.spectrum import pink_beam_asymmetry_params
 from hexrd.fitting.calibration import InstrumentCalibrator, PowderCalibrator
 
 from hexrdgui.async_runner import AsyncRunner
@@ -65,6 +66,15 @@ class PowderRunner(QObject):
         else:
             fwhm_estimate = options['initial_fwhm']
 
+        # Pink-beam shape (asymmetry) parameters from a prior WPPF run, fixed
+        # for every peak. Only applied if the toggle is on AND the pktype is a
+        # pink-beam profile; the relevant params depend on the pktype.
+        fixed_pink_asymmetry = None
+        asym_cfg = options.get('fixed_pink_asymmetry')
+        asym_params = pink_beam_asymmetry_params.get(options['pk_type'])
+        if asym_cfg is not None and asym_cfg.get('enabled') and asym_params is not None:
+            fixed_pink_asymmetry = {k: float(asym_cfg[k]) for k in asym_params}
+
         engineering_constraints = guess_engineering_constraints(self.instr)
 
         # Get an intensity-corrected masked dict of the images
@@ -81,6 +91,7 @@ class PowderRunner(QObject):
             'bgtype': options['bg_type'],
             'tth_distortion': self.active_overlay.tth_distortion_dict,
             'xray_source': self.active_overlay.xray_source,
+            'fixed_pink_asymmetry': fixed_pink_asymmetry,
         }
 
         self.pc = PowderCalibrator(**kwargs)

--- a/hexrdgui/resources/calibration/default_calibration_config.yml
+++ b/hexrdgui/resources/calibration/default_calibration_config.yml
@@ -6,6 +6,23 @@ powder:
   bg_type: 'linear'
   auto_guess_initial_fwhm: true
   initial_fwhm: 1.0
+  # Fixed pink-beam shape (asymmetry) parameters, typically taken from a
+  # prior WPPF refinement. Only applied when `enabled` is true AND pk_type is
+  # a pink-beam profile; the params used depend on the pktype (alpha/beta for
+  # pink_beam_dcs, sigma for pink_beam_heating, tau for pink_beam_exponential).
+  # Defaults match the WPPF defaults for each profile so they are sensible if
+  # the user enables the option without ever populating from WPPF.
+  fixed_pink_asymmetry:
+    enabled: false
+    alpha0: 14.4
+    alpha1: 0.0
+    beta0: 3.016
+    beta1: -7.94
+    sigma0: 0.1
+    sigma1: 0.1
+    tau0: 1.58
+    tau1: -1.35
+    tau2: 0.36
 laue_auto_picker:
   npdiv: 2
   tth_tol: 5.0

--- a/hexrdgui/resources/ui/powder_calibration_dialog.ui
+++ b/hexrdgui/resources/ui/powder_calibration_dialog.ui
@@ -7,14 +7,14 @@
     <x>0</x>
     <y>0</y>
     <width>750</width>
-    <height>395</height>
+    <height>560</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Auto Pick Powder Points</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="3" column="0" colspan="3">
+   <item row="4" column="0" colspan="3">
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
@@ -22,6 +22,128 @@
      <property name="centerButtons">
       <bool>false</bool>
      </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="3">
+    <widget class="QWidget" name="asymmetry_container" native="true">
+     <layout class="QVBoxLayout" name="asymmetry_vbox">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QCheckBox" name="use_wppf_asymmetry_check">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Fix the pink-beam shape (asymmetry) parameters to values taken from a prior WPPF refinement. Applied to every peak in every ring, with vary=False, replacing the per-ring shape fit. The parameters shown depend on the selected pink-beam peak fit type (α/β for DCS, σ for heating, τ for exponential).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Use WPPF peak asymmetry parameters (pink beam only)</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <layout class="QGridLayout" name="gridLayout_asym">
+      <item row="0" column="0">
+       <widget class="QLabel" name="asym_label_0">
+        <property name="text">
+         <string>α₀:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="ScientificDoubleSpinBox" name="asym_value_0">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="minimum">
+         <double>-10000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="asym_label_1">
+        <property name="text">
+         <string>α₁:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="ScientificDoubleSpinBox" name="asym_value_1">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="minimum">
+         <double>-10000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="asym_label_2">
+        <property name="text">
+         <string>β₀:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="ScientificDoubleSpinBox" name="asym_value_2">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="minimum">
+         <double>-10000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
+       <widget class="QLabel" name="asym_label_3">
+        <property name="text">
+         <string>β₁:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="ScientificDoubleSpinBox" name="asym_value_3">
+        <property name="decimals">
+         <number>6</number>
+        </property>
+        <property name="minimum">
+         <double>-10000000.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>10000000.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="4" column="0" colspan="2">
+       <widget class="QPushButton" name="populate_from_wppf_button">
+        <property name="toolTip">
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Populate the shape parameters from the most recent WPPF refinement.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        </property>
+        <property name="text">
+         <string>Populate from last WPPF run</string>
+        </property>
+       </widget>
+      </item>
+       </layout>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="0" column="1" rowspan="2" colspan="2">

--- a/tests/test_powder_calibration_dialog.py
+++ b/tests/test_powder_calibration_dialog.py
@@ -1,0 +1,260 @@
+"""Tests for the fixed asymmetry option in powder calibration.
+
+The powder calibration dialog lets the user pin the pink-beam shape
+(asymmetry) parameters for whichever pink-beam peak shape is selected -
+alpha/beta for DCS, sigma for heating, tau for exponential - optionally
+populating them from a prior WPPF refinement. A single adaptive group swaps
+the shown fields to match the selected peak type. PowderRunner only forwards
+them to the PowderCalibrator when the toggle is on AND the peak type is a
+pink-beam profile.
+"""
+
+from __future__ import annotations
+
+import copy
+from collections.abc import Iterator
+from unittest import mock
+from unittest.mock import MagicMock, PropertyMock
+
+import numpy as np
+import pytest
+from pytestqt.qtbot import QtBot
+
+from hexrd.material import Material
+
+from hexrdgui.hexrd_config import HexrdConfig
+import hexrdgui.calibration.auto.powder_calibration_dialog as dialog_mod
+import hexrdgui.calibration.auto.powder_runner as runner_mod
+from hexrdgui.calibration.auto.powder_calibration_dialog import (
+    ASYMMETRY_PARAM_LABELS,
+    NUM_ASYMMETRY_ROWS,
+    PowderCalibrationDialog,
+)
+from hexrdgui.calibration.auto.powder_runner import PowderRunner
+
+# The shape params shown for each pink-beam peak type, in order.
+PINK_PARAMS: dict[str, list[str]] = {
+    'pink_beam_dcs': ['alpha0', 'alpha1', 'beta0', 'beta1'],
+    'pink_beam_heating': ['sigma0', 'sigma1'],
+    'pink_beam_exponential': ['tau0', 'tau1', 'tau2'],
+}
+
+
+@pytest.fixture
+def restore_calibration_config() -> Iterator[None]:
+    # These tests mutate the global HexrdConfig singleton; snapshot and
+    # restore the calibration subtree so they don't leak into other tests.
+    calibration = HexrdConfig().config['calibration']
+    saved = copy.deepcopy(calibration)
+    yield
+    HexrdConfig().config['calibration'] = saved
+
+
+@pytest.fixture
+def dialog(qtbot: QtBot, restore_calibration_config: None) -> PowderCalibrationDialog:
+    material = Material()
+    # Ensure a tth width is set so the dialog doesn't prompt for one.
+    material.planeData.tThWidth = np.radians(0.2)
+    with mock.patch.object(dialog_mod.QMessageBox, 'warning'):
+        d = PowderCalibrationDialog(material)
+    qtbot.addWidget(d.ui)
+    return d
+
+
+def test_asymmetry_group_hidden_for_non_pink(
+    dialog: PowderCalibrationDialog,
+) -> None:
+    dialog.peak_fit_type = 'gaussian'
+    assert dialog.ui.asymmetry_container.isHidden()
+    assert dialog._shown_params == []
+
+
+@pytest.mark.parametrize('pktype,params', list(PINK_PARAMS.items()))
+def test_asymmetry_inputs_hidden_when_unchecked(
+    dialog: PowderCalibrationDialog, pktype: str, params: list[str]
+) -> None:
+    # For a pink-beam type the checkbox stays reachable, but the inputs and
+    # populate button collapse away until the box is checked.
+    dialog.peak_fit_type = pktype
+    dialog.use_wppf_asymmetry = False
+
+    assert dialog.ui.use_wppf_asymmetry_check.isVisibleTo(dialog.ui)
+    assert not dialog.ui.populate_from_wppf_button.isVisibleTo(dialog.ui)
+    for i in range(NUM_ASYMMETRY_ROWS):
+        assert not dialog.asym_value(i).isVisibleTo(dialog.ui)
+        assert not dialog.asym_label(i).isVisibleTo(dialog.ui)
+
+
+@pytest.mark.parametrize('pktype,params', list(PINK_PARAMS.items()))
+def test_asymmetry_group_shows_correct_fields(
+    dialog: PowderCalibrationDialog, pktype: str, params: list[str]
+) -> None:
+    dialog.peak_fit_type = pktype
+    dialog.use_wppf_asymmetry = True
+
+    assert not dialog.ui.asymmetry_container.isHidden()
+    assert dialog.ui.populate_from_wppf_button.isVisibleTo(dialog.ui)
+    assert dialog._shown_params == params
+
+    for i in range(NUM_ASYMMETRY_ROWS):
+        spinbox = dialog.asym_value(i)
+        if i < len(params):
+            assert spinbox.isVisibleTo(dialog.ui)
+            expected = f'{ASYMMETRY_PARAM_LABELS[params[i]]}:'
+            assert dialog.asym_label(i).text() == expected
+        else:
+            assert not spinbox.isVisibleTo(dialog.ui)
+
+
+def test_values_preserved_across_peak_type_switch(
+    dialog: PowderCalibrationDialog,
+) -> None:
+    dialog.peak_fit_type = 'pink_beam_dcs'
+    dialog.use_wppf_asymmetry = True
+    dialog.asym_value(0).setValue(99.9)  # alpha0
+
+    # Switch away and back; the edited value must survive.
+    dialog.peak_fit_type = 'pink_beam_heating'
+    dialog.peak_fit_type = 'pink_beam_dcs'
+
+    assert dialog.asym_value(0).value() == pytest.approx(99.9)
+
+
+@pytest.mark.parametrize('pktype,params', list(PINK_PARAMS.items()))
+def test_asymmetry_config_round_trip(
+    dialog: PowderCalibrationDialog, pktype: str, params: list[str]
+) -> None:
+    dialog.peak_fit_type = pktype
+    dialog.use_wppf_asymmetry = True
+    values = {name: 1.5 + i for i, name in enumerate(params)}
+    for i, name in enumerate(params):
+        dialog.asym_value(i).setValue(values[name])
+
+    dialog.update_config()
+
+    cfg = HexrdConfig().config['calibration']['powder']['fixed_pink_asymmetry']
+    assert cfg['enabled'] is True
+    for name, value in values.items():
+        assert cfg[name] == pytest.approx(value)
+    # All param keys (every peak type) are persisted, not just the active set.
+    for names in PINK_PARAMS.values():
+        for name in names:
+            assert name in cfg
+
+
+@pytest.mark.parametrize('pktype,params', list(PINK_PARAMS.items()))
+def test_populate_from_wppf_fills_values(
+    dialog: PowderCalibrationDialog, pktype: str, params: list[str]
+) -> None:
+    expected = {name: 0.5 + i for i, name in enumerate(params)}
+    HexrdConfig().config['calibration']['wppf'] = {
+        'params_dict': {name: {'value': v} for name, v in expected.items()}
+    }
+
+    dialog.peak_fit_type = pktype
+    dialog.use_wppf_asymmetry = True
+    dialog.populate_asymmetry_from_wppf()
+
+    for i, name in enumerate(params):
+        assert dialog.asym_value(i).value() == pytest.approx(expected[name])
+
+
+def test_populate_from_wppf_warns_when_missing(
+    dialog: PowderCalibrationDialog,
+) -> None:
+    # Only one of the heating params present -> nothing populated, user warned.
+    HexrdConfig().config['calibration']['wppf'] = {
+        'params_dict': {'sigma0': {'value': 1.0}}
+    }
+    dialog.peak_fit_type = 'pink_beam_heating'
+    dialog.asym_value(0).setValue(42.0)
+
+    with mock.patch.object(dialog_mod.QMessageBox, 'warning') as warning:
+        dialog.populate_asymmetry_from_wppf()
+
+    assert warning.called
+    assert dialog.asym_value(0).value() == pytest.approx(42.0)
+
+
+def _run_powder_runner(enabled: bool, pk_type: str) -> dict | None:
+    powder = HexrdConfig().config['calibration']['powder']
+    powder['pk_type'] = pk_type
+    powder['bg_type'] = 'linear'
+    powder['auto_guess_initial_fwhm'] = True
+    powder['fixed_pink_asymmetry'] = {
+        'enabled': enabled,
+        'alpha0': 11.0,
+        'alpha1': 0.4,
+        'beta0': 2.1,
+        'beta1': -5.2,
+        'sigma0': 0.3,
+        'sigma1': 1.1,
+        'tau0': 1.2,
+        'tau1': -0.8,
+        'tau2': 0.5,
+    }
+
+    overlay = MagicMock()
+    overlay.refinements = []
+    overlay.tth_distortion_dict = None
+    overlay.xray_source = None
+
+    runner = PowderRunner()
+
+    dialog_cls = MagicMock()
+    dialog_cls.return_value.exec.return_value = True
+
+    with (
+        mock.patch.object(runner_mod, 'PowderCalibrationDialog', dialog_cls),
+        mock.patch.object(
+            runner_mod, 'create_hedm_instrument', return_value=MagicMock()
+        ),
+        mock.patch.object(
+            runner_mod, 'guess_engineering_constraints', return_value=None
+        ),
+        mock.patch.object(runner_mod, 'PowderCalibrator') as powder_calibrator,
+        mock.patch.object(runner_mod, 'InstrumentCalibrator'),
+        mock.patch.object(
+            PowderRunner,
+            'active_overlay',
+            new_callable=PropertyMock,
+            return_value=overlay,
+        ),
+        mock.patch.object(
+            PowderRunner,
+            'material',
+            new_callable=PropertyMock,
+            return_value=MagicMock(),
+        ),
+        mock.patch.object(
+            type(HexrdConfig()),
+            'masked_images_dict',
+            new_callable=PropertyMock,
+            return_value={},
+        ),
+        mock.patch.object(runner, 'extract_powder_lines'),
+    ):
+        runner._run()
+        return powder_calibrator.call_args.kwargs['fixed_pink_asymmetry']
+
+
+@pytest.mark.parametrize('pktype,params', list(PINK_PARAMS.items()))
+def test_runner_forwards_only_active_params(
+    qtbot: QtBot,
+    restore_calibration_config: None,
+    pktype: str,
+    params: list[str],
+) -> None:
+    # Enabled + a pink-beam type: only that type's params are forwarded.
+    forwarded = _run_powder_runner(True, pktype)
+    assert forwarded is not None
+    assert set(forwarded) == set(params)
+
+
+def test_runner_skips_when_disabled_or_non_pink(
+    qtbot: QtBot, restore_calibration_config: None
+) -> None:
+    # Toggle off: nothing forwarded even for a pink-beam type.
+    assert _run_powder_runner(False, 'pink_beam_dcs') is None
+    # Non-pink peak type: nothing forwarded even when enabled.
+    assert _run_powder_runner(True, 'gaussian') is None


### PR DESCRIPTION
There is also a button to automatically load these from WPPF if available.

Depends on: hexrd/hexrd#947