### PR TITLE
Support APS HDF5 dark path and mask import

### DIFF
--- a/hexrdgui/calibration/panel_buffer_dialog.py
+++ b/hexrdgui/calibration/panel_buffer_dialog.py
@@ -71,6 +71,7 @@ class PanelBufferDialog(QObject):
     def setup_connections(self) -> None:
         self.ui.config_mode.currentIndexChanged.connect(self.update_mode_tab)
         self.ui.file_name.editingFinished.connect(self.update_enable_states)
+        self.ui.invert_mask.toggled.connect(self.update_enable_states)
         self.ui.select_file_button.clicked.connect(self.select_file)
         self.ui.show_panel_buffer.clicked.connect(self.show_panel_buffer)
         self.ui.clear_panel_buffer.clicked.connect(self.clear_panel_buffer)
@@ -117,7 +118,11 @@ class PanelBufferDialog(QObject):
 
     def select_file(self) -> None:
         selected_file, selected_filter = QFileDialog.getOpenFileName(
-            self.ui, 'Load Panel Buffer', HexrdConfig().working_dir, 'NPY files (*.npy)'
+            self.ui,
+            'Load Panel Buffer',
+            HexrdConfig().working_dir,
+            'Mask files (*.npy *.tif *.tiff);;NumPy files (*.npy);;'
+            'TIFF files (*.tif *.tiff)',
         )
 
         if selected_file:
@@ -161,9 +166,9 @@ class PanelBufferDialog(QObject):
             return copy.deepcopy(self.current_saved_buffer_value)
 
         try:
-            array = np.load(self.file_name)
-        except FileNotFoundError:
-            msg = f'"{self.file_name}" does not exist'
+            array = self._load_mask_file(self.file_name)
+        except (FileNotFoundError, OSError):
+            msg = f'"{self.file_name}" does not exist or could not be read'
             print(msg)
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             self.show()
@@ -171,13 +176,32 @@ class PanelBufferDialog(QObject):
 
         # Must match the detector size
         if array.shape != self.detector_shape:
-            msg = 'The NumPy array shape must match the detector'
+            msg = 'The mask array shape must match the detector'
             print(msg)
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             self.show()
             return None
 
+        if self.ui.invert_mask.isChecked():
+            # External masks mark the pixels to EXCLUDE; a panel buffer uses
+            # True = valid, so invert into the panel-buffer convention.
+            return ~array.astype(bool)
+
+        # Otherwise the file is already a panel buffer (True = valid).
         return array
+
+    def _load_mask_file(self, file_name: str) -> np.ndarray:
+        # Load a mask/panel-buffer file as a 2D array. Supports NumPy (.npy)
+        # and any single-image format fabio can read (e.g. TIFF).
+        ext = os.path.splitext(file_name)[1].lower()
+        if ext == '.npy':
+            return np.load(file_name)
+
+        # Defer the import to avoid a heavier import at module load.
+        from hexrdgui.image_file_manager import ImageFileManager
+
+        ims = ImageFileManager().open_file(file_name)
+        return np.asarray(ims[0])
 
     @property
     def current_saved_buffer_value(self) -> Any:

--- a/hexrdgui/image_file_manager.py
+++ b/hexrdgui/image_file_manager.py
@@ -74,7 +74,7 @@ class ImageFileManager(metaclass=Singleton):
                 s = load_panel_state
                 # Need this index for some load panel state items
                 ims_idx = list(ims_dict).index(det_key)
-                for list_key in ('trans', 'dark', 'dark_files'):
+                for list_key in ('trans', 'dark', 'dark_files', 'dark_paths'):
                     if len(s.get(list_key, [])) > ims_idx:
                         s[list_key].pop(ims_idx)
                         load_panel_modified = True
@@ -132,8 +132,13 @@ class ImageFileManager(metaclass=Singleton):
         if self.remember:
             HexrdConfig().hdf5_path = self.path
 
-    def open_file(self, f: Any, options: Any = None) -> Any:
+    def open_file(self, f: Any, options: Any = None, path: Any = None) -> Any:
         # f could be either a file or numpy array
+        # `path` optionally overrides self.path (a [group, dataname] list) for
+        # this call only, without mutating self.path. This is needed when the
+        # data and dark frames live at different dataset paths (e.g. the dark
+        # is in the same HDF5 file as the data, but a different dataset).
+        hdf5_path = self.path if path is None else path
         ext = os.path.splitext(f)[1] if isinstance(f, str) else None
         if ext is None:
             ims = imageseries.open(None, 'array', data=f)
@@ -141,7 +146,7 @@ class ImageFileManager(metaclass=Singleton):
             from pyhdf.SD import SD, SDC
 
             hdf = SD(f, SDC.READ)
-            dset = hdf.select(self.path[1])
+            dset = hdf.select(hdf5_path[1])
             ims = imageseries.open(None, 'array', data=dset)
         elif ext in self.HDF5_FILE_EXTS:
             regular_hdf5 = True
@@ -165,7 +170,7 @@ class ImageFileManager(metaclass=Singleton):
                     ims = imageseries.open(f, eiger_stream_format)
                     regular_hdf5 = False
                 else:
-                    dset = data['/'.join(self.path)]
+                    dset = data['/'.join(hdf5_path)]
                     ndim = dset.ndim
                     if ndim < 3:
                         # Handle raw two dimesional data
@@ -173,7 +178,7 @@ class ImageFileManager(metaclass=Singleton):
 
             if regular_hdf5 and ndim >= 3:
                 ims = imageseries.open(
-                    f, 'hdf5', path=self.path[0], dataname=self.path[1]
+                    f, 'hdf5', path=hdf5_path[0], dataname=hdf5_path[1]
                 )
         elif ext == '.npz':
             ims = imageseries.open(f, 'frame-cache', style='npz')

--- a/hexrdgui/image_load_manager.py
+++ b/hexrdgui/image_load_manager.py
@@ -282,7 +282,14 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
         i = self.data['idx'] if 'idx' in self.data else idx
         dark_idx = self.state['dark'][i]
         if dark_idx == UI_DARK_INDEX_FILE:
-            ims = ImageFileManager().open_file(self.state['dark_files'][idx])
+            # The dark file may store its frames at a different dataset path
+            # than the data (e.g. /exchange/dark vs /exchange/data, possibly
+            # in the same HDF5 file). Pass that path through if we have one.
+            dark_paths = self.state.get('dark_paths') or []
+            dark_path = dark_paths[idx] if idx < len(dark_paths) else None
+            ims = ImageFileManager().open_file(
+                self.state['dark_files'][idx], path=dark_path
+            )
 
         # Create or load the dark image if selected
         frames = len(ims)

--- a/hexrdgui/resources/ui/panel_buffer_dialog.ui
+++ b/hexrdgui/resources/ui/panel_buffer_dialog.ui
@@ -179,6 +179,19 @@
         </widget>
        </item>
        <item row="1" column="1" colspan="2">
+        <widget class="QCheckBox" name="invert_mask">
+         <property name="toolTip">
+          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Check this if the file marks the pixels to EXCLUDE (the common convention for external mask files, where True/nonzero means &quot;masked out&quot;). The array will be inverted into the panel-buffer convention (True = valid).&lt;/p&gt;&lt;p&gt;Leave unchecked if the file is already a panel buffer (True = valid pixel).&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
+         <property name="text">
+          <string>File marks excluded (masked) pixels</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1" colspan="2">
         <widget class="QPushButton" name="show_panel_buffer">
          <property name="text">
           <string>Show Panel Buffer</string>

--- a/hexrdgui/simple_image_series_dialog.py
+++ b/hexrdgui/simple_image_series_dialog.py
@@ -20,6 +20,7 @@ from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.image_file_manager import ImageFileManager
 from hexrdgui.image_load_manager import ImageLoadManager
+from hexrdgui.load_hdf5_dialog import LoadHDF5Dialog
 from hexrdgui.load_images_dialog import LoadImagesDialog
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
@@ -129,6 +130,10 @@ class SimpleImageSeriesDialog(QObject):
             'trans': UI_TRANS_INDEX_NONE,
             'dark': UI_DARK_INDEX_NONE,
             'dark_files': None,
+            # Per-detector [group, dataname] for the dark dataset, used when
+            # the dark file is HDF5 and its frames are at a different path
+            # than the data (e.g. /exchange/dark vs /exchange/data).
+            'dark_paths': None,
         }
 
         for k, default in list_defaults.items():
@@ -166,6 +171,7 @@ class SimpleImageSeriesDialog(QObject):
             )
             self.enable_read()
             self.state['dark_files'][self.idx] = None
+            self.state['dark_paths'][self.idx] = None
         self.enable_read()
 
     def detectors_changed(self) -> None:
@@ -212,6 +218,10 @@ class SimpleImageSeriesDialog(QObject):
         self.enable_read()
 
     def select_dark_img(self, selected_file: bool | str = False) -> None:
+        # When called without a file, the user is actively choosing one, so we
+        # also prompt for the dark dataset path (HDF5). Re-entrant calls that
+        # pass an existing file (e.g. apply-to-all) keep the stored path.
+        prompt_path = not selected_file
         if not selected_file:
             # This takes one image to use for dark subtraction.
             caption = 'Select image file'
@@ -220,6 +230,15 @@ class SimpleImageSeriesDialog(QObject):
             )
 
         if selected_file:
+            # A truthy selected_file is always a path string here (either passed
+            # in or returned by the file dialog above).
+            assert isinstance(selected_file, str)
+            if prompt_path:
+                dark_path = self.select_dark_dataset_path(selected_file)
+            else:
+                # Propagate the dataset path already chosen for this detector.
+                dark_path = self.state['dark_paths'][self.idx]
+
             if self.ui.all_detectors.isChecked():
                 files = ImageLoadManager().match_files([selected_file])
                 if files and all(len(f) for f in files):
@@ -227,9 +246,11 @@ class SimpleImageSeriesDialog(QObject):
                     for i, f in enumerate(files):
                         self.dark_files[i] = files[i][0]
                         self.state['dark_files'][i] = files[i][0]
+                        self.state['dark_paths'][i] = dark_path
                 else:
                     self.dark_files = [selected_file] * self.num_dets
                     self.state['dark_files'] = [selected_file] * self.num_dets
+                    self.state['dark_paths'] = [dark_path] * self.num_dets
                     msg = (
                         'Unable to match files - using the same dark file'
                         'for each detector.\nIf this is incorrect please '
@@ -240,9 +261,31 @@ class SimpleImageSeriesDialog(QObject):
             else:
                 self.dark_files[self.idx] = selected_file
                 self.state['dark_files'][self.idx] = selected_file
+                self.state['dark_paths'][self.idx] = dark_path
 
             self.dark_mode_changed()
             self.enable_read()
+
+    def select_dark_dataset_path(self, selected_file: str) -> list[str] | None:
+        # For HDF5 dark files, the dark frames may live at a different dataset
+        # path than the data (e.g. /exchange/dark vs /exchange/data). Since the
+        # dark may even be in the same file as the data, auto-detection would
+        # wrongly pick the data path, so always let the user choose the dark
+        # dataset. Returns a [group, dataname] list, or None for non-HDF5 files
+        # (the data path is then reused as before).
+        if not ImageFileManager().is_hdf(Path(selected_file).suffix):
+            return None
+
+        dialog = LoadHDF5Dialog(selected_file)
+        if not dialog.paths:
+            return None
+        if not dialog.ui.exec():
+            return None
+        if dialog.ui.hdf5_paths.currentItem() is None:
+            return None
+
+        group, dataname, _ = dialog.results()
+        return [group, dataname]
 
     def select_images(self) -> None:
         # This takes one or more images for a single detector.

--- a/tests/test_dark_dataset_path.py
+++ b/tests/test_dark_dataset_path.py
@@ -1,0 +1,66 @@
+"""Gap #1: the dark frame can be read from its own HDF5 dataset path.
+
+ImageFileManager.open_file gained an optional `path` kwarg that overrides
+self.path for a single call (without mutating it), so the dark frames can live
+at a different dataset path than the data (e.g. /exchange/dark vs
+/exchange/data), including in the same HDF5 file (the APS/Varex layout).
+"""
+import h5py
+import numpy as np
+import pytest
+
+from hexrdgui.image_file_manager import ImageFileManager
+
+
+@pytest.fixture
+def aps_like_file(tmp_path):
+    # Mirrors Andrew Chuang's layout: data + dark in one file, frames on axis 0.
+    f = tmp_path / 'aps_like.h5'
+    rng = np.random.default_rng(0)
+    data = (rng.random((5, 16, 16)) * 100 + 50).astype(np.uint16)
+    dark = (rng.random((3, 16, 16)) * 100 + 900).astype(np.uint16)  # higher mean
+    with h5py.File(f, 'w') as h5:
+        g = h5.create_group('exchange')
+        g.create_dataset('data', data=data)
+        g.create_dataset('dark', data=dark)
+    return str(f), data, dark
+
+
+def test_data_read_uses_self_path(qtbot, aps_like_file):
+    f, data, _ = aps_like_file
+    ifm = ImageFileManager()
+    ifm.path = ['exchange', 'data']
+    ims = ifm.open_file(f)
+    assert len(ims) == 5
+    assert ims.shape == (16, 16)
+    np.testing.assert_array_equal(ims[0], data[0])
+
+
+def test_dark_read_from_other_dataset_same_file(qtbot, aps_like_file):
+    f, _, dark = aps_like_file
+    ifm = ImageFileManager()
+    ifm.path = ['exchange', 'data']
+    # The point of gap #1: read dark from a DIFFERENT dataset in the SAME file.
+    dims = ifm.open_file(f, path=['exchange', 'dark'])
+    assert len(dims) == 3
+    np.testing.assert_array_equal(dims[0], dark[0])
+
+
+def test_self_path_not_mutated_by_dark_read(qtbot, aps_like_file):
+    f, data, _ = aps_like_file
+    ifm = ImageFileManager()
+    ifm.path = ['exchange', 'data']
+    ifm.open_file(f, path=['exchange', 'dark'])
+    # self.path must be preserved so later data reads stay correct
+    assert ifm.path == ['exchange', 'data']
+    again = ifm.open_file(f)
+    np.testing.assert_array_equal(again[0], data[0])
+
+
+def test_dark_has_higher_mean_than_data(qtbot, aps_like_file):
+    f, _, _ = aps_like_file
+    ifm = ImageFileManager()
+    ifm.path = ['exchange', 'data']
+    data = ifm.open_file(f)
+    dark = ifm.open_file(f, path=['exchange', 'dark'])
+    assert np.asarray(dark[0], float).mean() > np.asarray(data[0], float).mean()

--- a/tests/test_panel_buffer_mask_file.py
+++ b/tests/test_panel_buffer_mask_file.py
@@ -1,0 +1,54 @@
+"""Gap #2: import a static invalid-pixel mask file as a panel buffer.
+
+PanelBufferDialog loads a mask file and (when the "File marks excluded pixels"
+checkbox is set) inverts it into the panel-buffer convention (True = valid).
+These tests cover the new file loader, _load_mask_file, which reads both NumPy
+(.npy) and fabio-readable images (.tif), plus the invert convention.
+"""
+import numpy as np
+import pytest
+
+from hexrdgui.calibration.panel_buffer_dialog import PanelBufferDialog
+
+SHAPE = (16, 16)
+
+
+def _mask():
+    m = np.zeros(SHAPE, dtype=bool)
+    m[:, 3] = True
+    return m
+
+
+def test_load_mask_file_npy(qtbot, tmp_path):
+    m = _mask()
+    p = tmp_path / 'mask.npy'
+    np.save(p, m)
+    out = PanelBufferDialog._load_mask_file(None, str(p))
+    assert out.shape == SHAPE
+    np.testing.assert_array_equal(out.astype(bool), m)
+
+
+def test_load_mask_file_tiff(qtbot, tmp_path):
+    fabio = pytest.importorskip('fabio')
+    m = _mask()
+    p = tmp_path / 'mask.tif'
+    fabio.tifimage.TifImage(data=(m * 255).astype(np.uint16)).write(str(p))
+    out = PanelBufferDialog._load_mask_file(None, str(p))
+    assert out.shape == SHAPE
+    np.testing.assert_array_equal(out.astype(bool), m)
+
+
+def test_load_then_invert_to_valid_pixels(qtbot, tmp_path):
+    # End-to-end of the gap #2 pieces: load a file, then apply the dialog's
+    # invert (file marks excluded pixels) -> valid-pixel panel buffer.
+    m = _mask()
+    p = tmp_path / 'mask.npy'
+    np.save(p, m)
+    arr = PanelBufferDialog._load_mask_file(None, str(p))
+    # This mirrors what current_editing_buffer_value does when the
+    # "File marks excluded (masked) pixels" checkbox is checked.
+    buf = ~arr.astype(bool)
+    # Excluded pixels in the buffer == masked pixels in the file
+    assert int((~buf).sum()) == int(m.sum())
+    assert not buf[0, 3]   # masked -> excluded
+    assert buf[0, 0]       # unmasked -> valid


### PR DESCRIPTION
Add an optional per-call path override to ImageFileManager.open_file so the dark frames can be read from their own HDF5 dataset (e.g. /exchange/dark vs /exchange/data, including the same file), threaded through a new per-detector dark_paths state and a LoadHDF5Dialog prompt for HDF5 dark files.

Let the panel buffer dialog import a static mask file (.npy or .tif) and invert it (file marks excluded pixels) into the panel-buffer convention.