### PR TITLE
Reuse existing table for eta omega maps

### DIFF
--- a/hexrdgui/calibration/hedm/calibration_options_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_options_dialog.py
@@ -272,12 +272,17 @@ class HEDMCalibrationOptionsDialog(QObject):
         self.ui.threshold.setValue(v)
 
     def choose_hkls(self) -> None:
-        kwargs = {
-            'material': self.material,
-            'title_prefix': 'Select hkls for HEDM calibration: ',
-            'parent': self.ui,
-        }
-        self._reflections_table = ReflectionsTable(**kwargs)
+        if not hasattr(self, '_reflections_table'):
+            kwargs = {
+                'material': self.material,
+                'title_prefix': 'Select hkls for HEDM calibration: ',
+                'parent': self.ui,
+            }
+            self._reflections_table = ReflectionsTable(**kwargs)
+        else:
+            # Make sure the material is up to date
+            self._reflections_table.material = self.material
+
         self._reflections_table.show()
 
     def update_num_hkls(self) -> None:

--- a/hexrdgui/indexing/ome_maps_select_dialog.py
+++ b/hexrdgui/indexing/ome_maps_select_dialog.py
@@ -211,12 +211,17 @@ class OmeMapsSelectDialog(QObject):
         self.ui.tab_widget.setCurrentWidget(method_tab)
 
     def choose_hkls(self) -> None:
-        kwargs = {
-            'material': self.material,
-            'title_prefix': 'Select hkls for eta omega map generation: ',
-            'parent': self.ui,
-        }
-        self._table = ReflectionsTable(**kwargs)
+        if not hasattr(self, '_table'):
+            kwargs = {
+                'material': self.material,
+                'title_prefix': 'Select hkls for eta omega map generation: ',
+                'parent': self.ui,
+            }
+            self._table = ReflectionsTable(**kwargs)
+        else:
+            # Make sure the material is up to date
+            self._table.material = self.material
+
         self._table.show()
 
     def update_num_hkls(self) -> None:


### PR DESCRIPTION
Don't create a new one from scratch every time. If we do, we end up with more than one reflections table and it can cause bugs.

Reuse the existing one if one exists.