### PR TITLE
Avoid duplicate dialog windows for spot diagnostics and zoom

### DIFF
--- a/hexrdgui/calibration/hedm/calibration_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_dialog.py
@@ -319,6 +319,20 @@ class HEDMCalibrationCallbacks(MaterialCalibrationDialogCallbacks):
         )
         xyo_pred = compute_xyo(self.calibrators)
 
+        # Reuse the existing dialog if we already created one, so we don't
+        # leak duplicate windows. The grain ids and spots data are fixed for
+        # the calibration session, so updating the data is sufficient.
+        existing = getattr(self, '_spot_diagnostics_dialog', None)
+        if existing is not None:
+            existing.update_data(
+                self.instr,
+                xyo_pred=xyo_pred,
+                pred_angs=pred_angs,
+                meas_angs=meas_angs,
+            )
+            existing.show()
+            return
+
         self._spot_diagnostics_dialog = SpotDiagnosticsDialog(
             instr=self.instr,
             spots_data=self.spots_data,

--- a/hexrdgui/indexing/fit_grains_results_dialog.py
+++ b/hexrdgui/indexing/fit_grains_results_dialog.py
@@ -736,6 +736,12 @@ class FitGrainsResultsDialog(QObject):
         instr = cfg.instrument.hedm
         grain_ids = sorted(self.spots_data.keys())
 
+        # Close any previously-opened dialog so we don't leak duplicate
+        # windows. The data is recomputed below, so we build a fresh one.
+        existing = getattr(self, '_spot_diagnostics_dialog', None)
+        if existing is not None:
+            existing.ui.close()
+
         self._spot_diagnostics_dialog = SpotDiagnosticsDialog(
             instr=instr,
             spots_data=self.spots_data,

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1067,6 +1067,14 @@ class MainWindow(QObject):
 
     def on_show_raw_zoom_dialog(self) -> None:
         assert self.active_canvas is not None
+
+        # Close any existing zoom dialog first, so we don't leak a duplicate
+        # window or leave its canvas button-press handler connected. Closing
+        # emits "finished", which triggers its cleanup.
+        existing = getattr(self, '_zoom_dialog', None)
+        if existing is not None:
+            existing.ui.close()
+
         dialog = ZoomCanvasDialog(self.active_canvas, parent=self.ui)
         self._zoom_dialog = dialog
         dialog.show()


### PR DESCRIPTION
Reuse or close the existing dialog instead of recreating it each time, which leaked duplicate windows (and a stale canvas handler for zoom).