### PR TITLE
Add custom beam energy for powder overlays

### DIFF
--- a/hexrdgui/calibration/auto/powder_runner.py
+++ b/hexrdgui/calibration/auto/powder_runner.py
@@ -22,6 +22,7 @@ from hexrdgui.calibration.material_calibration_dialog_callbacks import (
 )
 from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.overlays import reject_overlays_with_custom_energy
 from hexrdgui.utils import masks_applied_to_panel_buffers
 
 
@@ -50,6 +51,8 @@ class PowderRunner(QObject):
         overlays = self.visible_powder_overlays
         if len(overlays) != 1:
             raise Exception('There must be exactly one visible powder overlay')
+
+        reject_overlays_with_custom_energy(overlays, 'Powder calibration')
 
     def _run(self) -> None:
         # First, have the user pick some options

--- a/hexrdgui/calibration/calibration_runner.py
+++ b/hexrdgui/calibration/calibration_runner.py
@@ -38,6 +38,7 @@ from hexrdgui.create_hedm_instrument import create_hedm_instrument
 from hexrdgui.constants import OverlayType, ViewType
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.line_picker_dialog import LinePickerDialog
+from hexrdgui.overlays import reject_overlays_with_custom_energy
 from hexrdgui.overlays.overlay import Overlay
 from hexrdgui.progress_dialog import ProgressDialog
 from hexrdgui.select_item_dialog import SelectItemDialog
@@ -86,6 +87,8 @@ class CalibrationRunner(QObject):
         active_overlays = self.active_overlays
         if not active_overlays:
             raise Exception('No visible overlays')
+
+        reject_overlays_with_custom_energy(active_overlays, 'Calibration')
 
         any_updates = False
         for overlay in active_overlays:

--- a/hexrdgui/calibration/wppf_runner.py
+++ b/hexrdgui/calibration/wppf_runner.py
@@ -11,6 +11,7 @@ from hexrd.wppf import Rietveld
 
 from hexrdgui.calibration.wppf_options_dialog import WppfOptionsDialog
 from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.overlays import reject_overlays_with_custom_energy
 
 
 class WppfRunner:
@@ -45,6 +46,8 @@ class WppfRunner:
     def validate(self) -> None:
         if not self.visible_powder_overlays:
             raise Exception('At least one visible powder overlay is required')
+
+        reject_overlays_with_custom_energy(self.visible_powder_overlays, 'WPPF')
 
     @property
     def visible_powder_overlays(self) -> list:

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -2270,6 +2270,8 @@ class HexrdConfig(QObject, metaclass=QSingleton):
             material_name=material_name,
             type=type,
         )
+        # Give it a distinct color if other overlays already exist.
+        overlays.assign_cycled_style(overlay, self.overlays)
         self.overlays.append(overlay)
         self.overlay_list_modified.emit()
         self.overlay_config_changed.emit()

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -61,6 +61,7 @@ from hexrdgui.masking.create_raw_mask import convert_polar_to_raw, rebuild_raw_m
 from hexrdgui.constants import ViewType, DOCUMENTATION_URL
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.image_calculator_dialog import ImageCalculatorDialog
+from hexrdgui.overlays import overlays_with_custom_energy
 from hexrdgui.image_file_manager import ImageFileManager
 from hexrdgui.image_load_manager import ImageLoadManager
 from hexrdgui.llnl_import_tool_dialog import LLNLImportToolDialog
@@ -1278,6 +1279,19 @@ class MainWindow(QObject):
         canvas = self.ui.image_tab_widget.image_canvases[0]
 
         overlays = HexrdConfig().overlays
+
+        # Picks are tied to the instrument energy, so refuse overlays that are
+        # being visualized at a custom beam energy.
+        bad = overlays_with_custom_energy(overlays)
+        if bad:
+            names = ', '.join(o.name for o in bad)
+            msg = (
+                'Viewing overlay picks is not supported for powder overlays '
+                'with a custom beam energy.\n\nThese overlays use a custom '
+                f'energy: {names}.'
+            )
+            QMessageBox.critical(self.ui, 'HEXRD', msg)
+            return
 
         kwargs = {
             'dictionary': overlays_to_tree_format(overlays),

--- a/hexrdgui/overlays/__init__.py
+++ b/hexrdgui/overlays/__init__.py
@@ -48,10 +48,7 @@ def from_dict(d: Any) -> Any:
 
 def overlays_with_custom_energy(overlays: Any) -> list:
     """Return powder overlays that are visualizing at a custom beam energy."""
-    return [
-        o for o in overlays
-        if isinstance(o, PowderOverlay) and o.has_custom_energy
-    ]
+    return [o for o in overlays if isinstance(o, PowderOverlay) and o.has_custom_energy]
 
 
 def reject_overlays_with_custom_energy(
@@ -75,6 +72,41 @@ def reject_overlays_with_custom_energy(
         'Re-check "Use energy from instrument?" for these overlays before '
         'continuing.'
     )
+
+
+# Distinct (ring, range) color pairs cycled across powder overlays so that
+# multiple overlays are easy to tell apart. The first pair matches the
+# historical default (cyan rings, green ranges).
+POWDER_OVERLAY_COLOR_CYCLE = [
+    ('#00ffff', '#00ff00'),  # cyan / green
+    ('#ff7f0e', '#ffbb78'),  # orange / light orange
+    ('#1f77b4', '#aec7e8'),  # blue / light blue
+    ('#d62728', '#ff9896'),  # red / light red
+    ('#9467bd', '#c5b0d5'),  # purple / light purple
+    ('#8c564b', '#c49c94'),  # brown / light brown
+]
+
+
+def assign_cycled_style(overlay: Any, existing_overlays: Any) -> None:
+    """Give a newly-created powder overlay a distinct color pair.
+
+    Picks the least-used (ring, range) color pair among the existing powder
+    overlays, so multiple overlays are easy to tell apart. This is a no-op
+    for other overlay types.
+    """
+    if not isinstance(overlay, PowderOverlay):
+        return
+
+    used = [
+        (o.style['data']['c'], o.style['ranges']['c'])
+        for o in existing_overlays
+        if isinstance(o, PowderOverlay)
+    ]
+    counts = [used.count(pair) for pair in POWDER_OVERLAY_COLOR_CYCLE]
+    ring_color, range_color = POWDER_OVERLAY_COLOR_CYCLE[counts.index(min(counts))]
+
+    overlay.style['data']['c'] = ring_color
+    overlay.style['ranges']['c'] = range_color
 
 
 def update_overlay_data(instr: HEDMInstrument, display_mode: Any) -> None:
@@ -113,4 +145,5 @@ __all__ = [
     'RotationSeriesOverlay',
     'overlays_with_custom_energy',
     'reject_overlays_with_custom_energy',
+    'assign_cycled_style',
 ]

--- a/hexrdgui/overlays/__init__.py
+++ b/hexrdgui/overlays/__init__.py
@@ -46,6 +46,37 @@ def from_dict(d: Any) -> Any:
     return compatibility.from_dict(cls, d)
 
 
+def overlays_with_custom_energy(overlays: Any) -> list:
+    """Return powder overlays that are visualizing at a custom beam energy."""
+    return [
+        o for o in overlays
+        if isinstance(o, PowderOverlay) and o.has_custom_energy
+    ]
+
+
+def reject_overlays_with_custom_energy(
+    overlays: Any,
+    operation: str = 'This operation',
+) -> None:
+    """Raise if any of the overlays use a custom beam energy.
+
+    Custom beam energies are a visualization-only feature (for example, to
+    check for harmonics), so analysis routines must refuse them rather than
+    silently produce incorrect results.
+    """
+    bad = overlays_with_custom_energy(overlays)
+    if not bad:
+        return
+
+    names = ', '.join(o.name for o in bad)
+    raise Exception(
+        f'{operation} does not support powder overlays with a custom beam '
+        f'energy.\n\nThe following overlays use a custom energy: {names}.\n\n'
+        'Re-check "Use energy from instrument?" for these overlays before '
+        'continuing.'
+    )
+
+
 def update_overlay_data(instr: HEDMInstrument, display_mode: Any) -> None:
     from hexrdgui.hexrd_config import HexrdConfig
 
@@ -80,4 +111,6 @@ __all__ = [
     'Overlay',
     'PowderOverlay',
     'RotationSeriesOverlay',
+    'overlays_with_custom_energy',
+    'reject_overlays_with_custom_energy',
 ]

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from contextlib import contextmanager
 import copy
-from typing import Any, TYPE_CHECKING
+from typing import Any, Generator, TYPE_CHECKING
 
 import numpy as np
 
@@ -16,7 +17,7 @@ from hexrd.rotations import mapAngle
 from hexrd.xrdutil.phutil import invalidate_past_critical_beta
 from hexrd.utils.hkl import hkl_to_str
 
-from hexrdgui.constants import OverlayType, ViewType
+from hexrdgui.constants import OverlayType, ViewType, WAVELENGTH_TO_KEV
 from hexrdgui.overlays.overlay import Overlay
 from hexrdgui.polar_distortion_object import PolarDistortionObject
 from hexrdgui.utils import array_index_in_list
@@ -38,6 +39,7 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         tth_distortion_type: str | None = None,
         tth_distortion_kwargs: dict | None = None,
         clip_with_panel_buffer: bool = False,
+        custom_energy: float | None = None,
         **overlay_kwargs: Any,
     ) -> None:
         self._xray_source: str | None = None
@@ -55,6 +57,11 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         self.tth_distortion_kwargs = tth_distortion_kwargs
         self.clip_with_panel_buffer = clip_with_panel_buffer
 
+        # If set, the powder rings are drawn at this beam energy (in keV)
+        # instead of the instrument's. This is for visualization only (e.g.
+        # checking for harmonics) and is rejected by analysis routines.
+        self.custom_energy = custom_energy
+
         self.validate_tth_distortion_kwargs()
 
         # Store hkl means if we are in the polar view (for azimuthal lineout)
@@ -70,6 +77,7 @@ class PowderOverlay(Overlay, PolarDistortionObject):
             'tth_distortion_type',
             'tth_distortion_kwargs',
             'clip_with_panel_buffer',
+            'custom_energy',
         ]
 
     @property
@@ -115,6 +123,35 @@ class PowderOverlay(Overlay, PolarDistortionObject):
     @property
     def has_widths(self) -> bool:
         return self.material.planeData.tThWidth is not None
+
+    @property
+    def has_custom_energy(self) -> bool:
+        return self.custom_energy is not None
+
+    @contextmanager
+    def custom_energy_override(self) -> Generator[None, None, None]:
+        """Temporarily set the material wavelength to this overlay's custom
+        beam energy, restoring it afterward.
+
+        This lets us draw the powder rings at a different beam energy (e.g.
+        to check for harmonics) without modifying the instrument, the
+        material's persistent state, or any other overlay. The restore
+        happens in a ``finally`` so the shared plane data is never left
+        perturbed.
+        """
+        if self.custom_energy is None:
+            yield
+            return
+
+        plane_data = self.plane_data
+        # The wavelength setter interprets a bare float as keV (see hexrd's
+        # processWavelength), while the getter returns Angstroms.
+        original_energy = WAVELENGTH_TO_KEV / plane_data.wavelength
+        try:
+            plane_data.wavelength = self.custom_energy
+            yield
+        finally:
+            plane_data.wavelength = original_energy
 
     @property
     def tvec(self) -> np.ndarray:
@@ -263,19 +300,22 @@ class PowderOverlay(Overlay, PolarDistortionObject):
         plane_data = self.plane_data
         display_mode = self.display_mode
 
-        tths = plane_data.getTTh()
-        hkls = plane_data.getHKLs()
-        etas = np.radians(np.linspace(-180.0, 180.0, num=self.eta_steps + 1))
+        # Override the wavelength while reading tth/hkls/ranges if this
+        # overlay is being visualized at a custom beam energy.
+        with self.custom_energy_override():
+            tths = plane_data.getTTh()
+            hkls = plane_data.getHKLs()
+            etas = np.radians(np.linspace(-180.0, 180.0, num=self.eta_steps + 1))
 
-        if tths.size == 0:
-            # No overlays
-            return {}
+            if tths.size == 0:
+                # No overlays
+                return {}
 
-        if plane_data.tThWidth is not None:
-            # Need to get width data as well
-            indices, ranges = plane_data.getMergedRanges()
-            r_lower = [r[0] for r in ranges]
-            r_upper = [r[1] for r in ranges]
+            if plane_data.tThWidth is not None:
+                # Need to get width data as well
+                indices, ranges = plane_data.getMergedRanges()
+                r_lower = [r[0] for r in ranges]
+                r_upper = [r[1] for r in ranges]
 
         point_groups: dict[str, Any] = {}
         for det_key, panel in instr.detectors.items():

--- a/hexrdgui/powder_overlay_editor.py
+++ b/hexrdgui/powder_overlay_editor.py
@@ -60,6 +60,9 @@ class PowderOverlayEditor(HexrdConfigDisconnectMixin):
         self.pinhole_correction_editor.settings_modified.connect(self.update_config)
 
         self.ui.enable_width.toggled.connect(self.update_enable_states)
+        self.ui.use_instrument_energy.toggled.connect(
+            self.on_use_instrument_energy_toggled
+        )
         self.refinements_selector.selection_changed.connect(self.update_refinements)
 
         self.ui.reflections_table.pressed.connect(self.show_reflections_table)
@@ -134,6 +137,23 @@ class PowderOverlayEditor(HexrdConfigDisconnectMixin):
         enable_width = self.ui.enable_width.isChecked()
         self.ui.tth_width.setEnabled(enable_width)
 
+        # The custom energy spinbox is only enabled when not using the
+        # instrument's energy.
+        use_instrument_energy = self.ui.use_instrument_energy.isChecked()
+        self.ui.custom_energy.setEnabled(not use_instrument_energy)
+
+    def on_use_instrument_energy_toggled(self, checked: bool) -> None:
+        if not checked:
+            # Switching to a custom energy: start from the current beam
+            # energy. This only fires for user toggles (signals are blocked
+            # while loading the GUI from an overlay), so a saved custom
+            # energy is never clobbered.
+            energy = HexrdConfig().beam_energy
+            if energy:
+                self.ui.custom_energy.setValue(energy)
+
+        self.update_enable_states()
+
     def update_gui(self) -> None:
         if self.overlay is None:
             return
@@ -144,6 +164,7 @@ class PowderOverlayEditor(HexrdConfigDisconnectMixin):
                 self.ui.xray_source.addItems(HexrdConfig().beam_names)
 
             self.tth_width_gui = self.tth_width_config
+            self.custom_energy_gui = self.custom_energy_config
             self.offset_gui = self.offset_config
             self.distortion_type_gui = self.distortion_type_config
             self.distortion_kwargs_gui = self.distortion_kwargs_config
@@ -156,6 +177,7 @@ class PowderOverlayEditor(HexrdConfigDisconnectMixin):
 
     def update_config(self) -> None:
         self.tth_width_config = self.tth_width_gui
+        self.custom_energy_config = self.custom_energy_gui
         self.offset_config = self.offset_gui
         self.distortion_config = self.distortion_gui
         self.clip_with_panel_buffer_config = self.clip_with_panel_buffer_gui
@@ -200,6 +222,41 @@ class PowderOverlayEditor(HexrdConfigDisconnectMixin):
         self.ui.enable_width.setChecked(enable_width)
         if enable_width and v is not None:
             self.ui.tth_width.setValue(np.degrees(v))
+
+    @property
+    def custom_energy_config(self) -> float | None:
+        if self.overlay is None:
+            return None
+
+        return self.overlay.custom_energy
+
+    @custom_energy_config.setter
+    def custom_energy_config(self, v: float | None) -> None:
+        if self.overlay is None:
+            return
+
+        # update_config() flags the overlay for regeneration after this.
+        self.overlay.custom_energy = v
+
+    @property
+    def custom_energy_gui(self) -> float | None:
+        if self.ui.use_instrument_energy.isChecked():
+            return None
+
+        return self.ui.custom_energy.value()
+
+    @custom_energy_gui.setter
+    def custom_energy_gui(self, v: float | None) -> None:
+        use_instrument_energy = v is None
+        self.ui.use_instrument_energy.setChecked(use_instrument_energy)
+        if v is not None:
+            self.ui.custom_energy.setValue(v)
+        else:
+            # Default the spinbox to the instrument energy, so that unchecking
+            # the box starts the user from a sensible value.
+            energy = HexrdConfig().beam_energy
+            if energy:
+                self.ui.custom_energy.setValue(energy)
 
     @property
     def offset_config(self) -> np.ndarray | None:
@@ -356,6 +413,8 @@ class PowderOverlayEditor(HexrdConfigDisconnectMixin):
         return [
             self.ui.enable_width,
             self.ui.tth_width,
+            self.ui.use_instrument_energy,
+            self.ui.custom_energy,
             self.ui.clip_with_panel_buffer,
             self.ui.xray_source,
         ] + distortion_widgets

--- a/hexrdgui/resources/ui/powder_overlay_editor.ui
+++ b/hexrdgui/resources/ui/powder_overlay_editor.ui
@@ -44,6 +44,47 @@
      </property>
     </widget>
    </item>
+   <item row="5" column="1">
+    <widget class="QCheckBox" name="use_instrument_energy">
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Use the instrument's beam energy for this overlay. Uncheck to draw the powder rings at a custom beam energy (for example, to check for harmonics). This is for visualization only and is not supported by calibration or WPPF.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="text">
+      <string>Use energy from instrument?</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="2" colspan="3">
+    <widget class="ScientificDoubleSpinBox" name="custom_energy">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="toolTip">
+      <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Custom beam energy (keV) used to draw this overlay's powder rings.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+     </property>
+     <property name="keyboardTracking">
+      <bool>false</bool>
+     </property>
+     <property name="suffix">
+      <string> keV</string>
+     </property>
+     <property name="decimals">
+      <number>6</number>
+     </property>
+     <property name="minimum">
+      <double>0.001000000000000</double>
+     </property>
+     <property name="maximum">
+      <double>1000000.000000000000000</double>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1" colspan="4">
     <widget class="QGroupBox" name="distortion_group">
      <property name="styleSheet">
@@ -314,6 +355,8 @@
   <tabstop>xray_source</tabstop>
   <tabstop>enable_width</tabstop>
   <tabstop>tth_width</tabstop>
+  <tabstop>use_instrument_energy</tabstop>
+  <tabstop>custom_energy</tabstop>
   <tabstop>distortion_type</tabstop>
   <tabstop>distortion_tab_widget</tabstop>
   <tabstop>offset_0</tabstop>

--- a/tests/test_overlay_color_cycle.py
+++ b/tests/test_overlay_color_cycle.py
@@ -1,0 +1,55 @@
+"""Tests for cycling distinct colors across newly-created powder overlays."""
+
+from typing import Generator
+
+import pytest
+
+from PySide6.QtWidgets import QApplication
+
+from hexrd.material import Material
+
+from hexrdgui.constants import OverlayType
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.overlays import POWDER_OVERLAY_COLOR_CYCLE
+from hexrdgui.overlays.powder_overlay import PowderOverlay
+
+
+MATERIAL_NAME = 'color_cycle_test_material'
+
+
+@pytest.fixture
+def config(qapp: QApplication) -> Generator[HexrdConfig, None, None]:
+    # HexrdConfig is a singleton that requires a QApplication (qapp).
+    cfg = HexrdConfig()
+    cfg.add_material(MATERIAL_NAME, Material())
+    saved_overlays = list(cfg.overlays)
+    cfg.overlays.clear()
+    try:
+        yield cfg
+    finally:
+        cfg.overlays.clear()
+        cfg.overlays.extend(saved_overlays)
+        cfg.remove_material(MATERIAL_NAME)
+
+
+def color_pair(overlay: PowderOverlay) -> tuple[str, str]:
+    return (overlay.style['data']['c'], overlay.style['ranges']['c'])
+
+
+def test_new_overlays_get_distinct_pairs(config: HexrdConfig) -> None:
+    for _ in range(3):
+        config.append_overlay(MATERIAL_NAME, OverlayType.powder)
+
+    pairs = [color_pair(o) for o in config.overlays]
+    assert pairs == POWDER_OVERLAY_COLOR_CYCLE[:3]
+    assert len(set(pairs)) == 3
+
+
+def test_least_used_pair_reused_after_removal(config: HexrdConfig) -> None:
+    config.append_overlay(MATERIAL_NAME, OverlayType.powder)  # pair 0
+    config.append_overlay(MATERIAL_NAME, OverlayType.powder)  # pair 1
+    config.overlays.pop(0)  # free up pair 0
+    config.append_overlay(MATERIAL_NAME, OverlayType.powder)
+
+    # The freed pair should be reused rather than picking a third color.
+    assert color_pair(config.overlays[-1]) == POWDER_OVERLAY_COLOR_CYCLE[0]

--- a/tests/test_powder_overlay_custom_energy.py
+++ b/tests/test_powder_overlay_custom_energy.py
@@ -1,0 +1,96 @@
+"""Tests for the per-overlay custom beam energy (harmonic visualization).
+
+A powder overlay can be drawn at a custom beam energy without modifying the
+instrument or the material's persistent state. The override is applied only
+while generating the overlay and is rejected by analysis routines.
+"""
+
+from pathlib import Path
+from typing import Generator
+
+import h5py
+import numpy as np
+import pytest
+
+from PySide6.QtWidgets import QApplication
+
+from hexrd.material import Material
+
+from hexrdgui import state
+from hexrdgui.constants import WAVELENGTH_TO_KEV
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.overlays import reject_overlays_with_custom_energy
+from hexrdgui.overlays.powder_overlay import PowderOverlay
+
+
+MATERIAL_NAME = 'custom_energy_test_material'
+
+
+@pytest.fixture
+def powder_overlay(qapp: QApplication) -> Generator[PowderOverlay, None, None]:
+    # HexrdConfig is a singleton that requires a QApplication (qapp).
+    config = HexrdConfig()
+    config.add_material(MATERIAL_NAME, Material())
+    try:
+        yield PowderOverlay(MATERIAL_NAME)
+    finally:
+        config.remove_material(MATERIAL_NAME)
+
+
+def test_custom_energy_override_changes_and_restores(
+    powder_overlay: PowderOverlay,
+) -> None:
+    plane_data = powder_overlay.plane_data
+    original_wavelength = plane_data.wavelength
+    original_tth = plane_data.getTTh().copy()
+
+    # Visualize at the second harmonic (double the instrument energy).
+    instrument_energy = WAVELENGTH_TO_KEV / original_wavelength
+    powder_overlay.custom_energy = 2 * instrument_energy
+
+    with powder_overlay.custom_energy_override():
+        # The wavelength (and thus the 2theta) reflects the custom energy.
+        assert not np.isclose(plane_data.wavelength, original_wavelength)
+        assert not np.array_equal(plane_data.getTTh(), original_tth)
+
+    # The shared plane data is restored exactly afterward.
+    assert np.isclose(plane_data.wavelength, original_wavelength)
+    assert np.array_equal(plane_data.getTTh(), original_tth)
+
+
+def test_custom_energy_persists_through_state_file(
+    powder_overlay: PowderOverlay,
+    tmp_path: Path,
+) -> None:
+    # Exercise the real HDF5 state serialization used by save/load: overlays
+    # are dictified into the config, dumped to YAML in the file, then read
+    # back and reconstructed.
+    config = HexrdConfig()
+    saved_overlays = list(config.overlays)
+    try:
+        powder_overlay.custom_energy = 42.5
+        instrument_energy_overlay = PowderOverlay(MATERIAL_NAME)  # None
+        config.overlays = [powder_overlay, instrument_energy_overlay]
+
+        snapshot = {'overlays_dictified': config.overlays_dictified}
+        file_path = tmp_path / 'state.h5'
+        with h5py.File(file_path, 'w') as f:
+            state._save_config(f, snapshot)
+        with h5py.File(file_path, 'r') as f:
+            loaded = state._load_config(f)
+
+        config.overlays_dictified = loaded['overlays_dictified']
+        energies = [o.custom_energy for o in config.overlays]
+        assert energies[0] == 42.5
+        assert energies[1] is None
+    finally:
+        config.overlays = saved_overlays
+
+
+def test_reject_overlays_with_custom_energy(powder_overlay: PowderOverlay) -> None:
+    # No custom energy -> not flagged, does not raise.
+    reject_overlays_with_custom_energy([powder_overlay], 'WPPF')
+
+    powder_overlay.custom_energy = 75.0
+    with pytest.raises(Exception, match='custom beam energy'):
+        reject_overlays_with_custom_energy([powder_overlay], 'WPPF')


### PR DESCRIPTION
Draw a powder overlay at a different beam energy to visualize harmonics, via a new checkbox + keV spinbox in the powder overlay editor. The wavelength override is visualization only; calibration and WPPF error out if an overlay uses a custom energy.