### PR TITLE
Resize eta omega maps dialog to fit display

### DIFF
--- a/hexrdgui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrdgui/indexing/ome_maps_viewer_dialog.py
@@ -39,7 +39,18 @@ from hexrdgui.scaling import SCALING_OPTIONS
 from hexrdgui.select_items_widget import SelectItemsWidget
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
-from hexrdgui.utils.dialog import add_help_url, fit_window_to_screen
+from hexrdgui.utils.dialog import (
+    add_help_url,
+    fit_window_to_screen,
+    restore_window_geometry,
+    save_window_geometry,
+)
+
+# QSettings key for persisting this dialog's size/position across sessions.
+GEOMETRY_SETTINGS_KEY = 'ome_maps_viewer_dialog/geometry'
+# Leave a small margin so the window (and its resize handle) is not flush to the
+# screen edge after auto-fitting.
+FIT_MARGIN = 50
 from hexrdgui.utils.matplotlib import remove_artist
 
 import hexrdgui.constants
@@ -200,14 +211,24 @@ class OmeMapsViewerDialog(QObject):
 
     def show(self) -> None:
         self.update_plot()
+
+        # Restore the user's last size/position, if we have saved one.
+        restore_window_geometry(self.ui, GEOMETRY_SETTINGS_KEY)
+
+        # The .ui file specifies a large default size (1900x1149). On a smaller
+        # display - especially over remote desktops - that opens larger than the
+        # screen with its edges/resize-handle off-screen and unreachable.
+        # Shrink it to fit BEFORE showing: some window managers (notably over
+        # NoMachine) ignore a resize requested after an oversized window has been
+        # mapped, so it must map at a size that already fits. The dialog content
+        # is in a scroll area (see the .ui) so it can shrink to any size.
+        fit_window_to_screen(self.ui, FIT_MARGIN)
+
         self.ui.show()
 
-        # The .ui file specifies a large default size (1900x1149). On any
-        # smaller display - and especially over remote desktops - that can
-        # open larger than the screen with its title bar/edges off-screen and
-        # unreachable for resizing or moving. Clamp it to the available screen
-        # area once the window has been mapped (so frame geometry is known).
-        QTimer.singleShot(0, lambda: fit_window_to_screen(self.ui))
+        # Backstop: clamp again after mapping, once decoration geometry is known
+        # (also re-clamps a restored geometry saved on a larger display).
+        QTimer.singleShot(0, lambda: fit_window_to_screen(self.ui, FIT_MARGIN))
 
     def show_later(self) -> None:
         # In case this was called in a separate thread (which will
@@ -227,10 +248,16 @@ class OmeMapsViewerDialog(QObject):
             return
 
         self.save_config()
+        self._save_geometry()
         self.accepted.emit()
 
     def on_rejected(self) -> None:
+        self._save_geometry()
         self.rejected.emit()
+
+    def _save_geometry(self) -> None:
+        # Remember the dialog's size/position for next time.
+        save_window_geometry(self.ui, GEOMETRY_SETTINGS_KEY)
 
     def validate(self) -> None:
         if self.quaternion_method_name == 'hand_picked':

--- a/hexrdgui/resources/ui/ome_maps_viewer_dialog.ui
+++ b/hexrdgui/resources/ui/ome_maps_viewer_dialog.ui
@@ -10,7 +10,17 @@
     <height>1149</height>
    </rect>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
+  <layout class="QVBoxLayout" name="outer_layout">
+   <item>
+    <widget class="QScrollArea" name="scroll_area">
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <widget class="QWidget" name="scroll_contents">
+      <layout class="QGridLayout" name="gridLayout">
    <item row="3" column="3" rowspan="7">
     <layout class="QVBoxLayout" name="canvas_layout"/>
    </item>
@@ -931,7 +941,11 @@
      </layout>
     </widget>
    </item>
-   <item row="11" column="1" colspan="4">
+      </layout>
+     </widget>
+    </widget>
+   </item>
+   <item>
     <widget class="QDialogButtonBox" name="button_box">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>

--- a/hexrdgui/utils/dialog.py
+++ b/hexrdgui/utils/dialog.py
@@ -1,4 +1,4 @@
-from PySide6.QtCore import QPoint, QRect, QSize
+from PySide6.QtCore import QByteArray, QPoint, QRect, QSettings, QSize
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import QApplication, QDialogButtonBox, QWidget
 
@@ -62,6 +62,24 @@ def fit_window_to_screen(window: QWidget, margin: int = 0) -> None:
         window.resize(size)
     # window.move() positions the frame top-left for top-level windows.
     window.move(pos)
+
+
+def save_window_geometry(window: QWidget, key: str) -> None:
+    """Persist a window's size/position/state to QSettings under ``key``."""
+    QSettings().setValue(key, window.saveGeometry())
+
+
+def restore_window_geometry(window: QWidget, key: str) -> bool:
+    """Restore a window's geometry previously saved with `save_window_geometry`.
+
+    Returns True if a saved geometry was found and applied. Callers should still
+    run `fit_window_to_screen` after the window is shown so a geometry saved on a
+    larger display is clamped back onto the current screen.
+    """
+    data = QSettings().value(key)
+    if isinstance(data, QByteArray) and not data.isEmpty():
+        return bool(window.restoreGeometry(data))
+    return False
 
 
 def open_url(url: str) -> bool:


### PR DESCRIPTION
The previous PR, https://github.com/HEXRD/hexrdgui/pull/2028, did not work for every system, especially NoMachine at CHESS.

This new setup accurately determines window size and sets it before displaying. I also tested it and verified it works on NoMachine. We also save the eta omega maps dialog size after it is accepted and, the next time the eta omega maps dialog is shown, it is shown with the same size as the user set last time. This hopefully makes it so that users don't have to keep resizing it.

Fixes: #2026