### PR TITLE
Use blosc-zstd to compress state file images

### DIFF
--- a/hexrdgui/state.py
+++ b/hexrdgui/state.py
@@ -6,6 +6,7 @@ from typing import Any, TextIO
 from PySide6.QtCore import QTimer
 
 import h5py
+import hdf5plugin
 import numpy as np
 import yaml
 
@@ -192,7 +193,7 @@ def save(h5_file: h5py.File) -> None:
     # Finally, write the imageseries...
     root = 'images'
     for det, ims in HexrdConfig().imageseries_dict.items():
-        imageseries.write(ims, h5_file, 'hdf5', path=f'{root}/{det}')
+        write_imageseries(h5_file, f'{root}/{det}', ims)
 
 
 def load(h5_file: h5py.File) -> None:
@@ -276,3 +277,24 @@ def load_imageseries_dict(h5_file: h5py.File) -> None:
 
 def update_if_needed(file_path: str) -> Any:
     return state_compatibility.update_if_needed(file_path)
+
+
+# Compression used for image data in state files. blosc-zstd compresses our
+# (often sparse) image data dramatically better than the previous gzip-1
+# default, while staying lossless. h5py reads it back transparently as long as
+# hdf5plugin is imported (which it is, above).
+STATE_IMAGE_COMPRESSION = hdf5plugin.Blosc(
+    cname='zstd', clevel=5, shuffle=hdf5plugin.Blosc.SHUFFLE
+)
+
+
+def write_imageseries(h5_file: h5py.File, path: str, ims: Any) -> None:
+    """Write an imageseries into the state file with blosc-zstd compression.
+
+    Delegates to hexrd's 'hdf5' imageseries writer with a custom compression
+    filter (instead of its gzip-1 default), so it still reads back via
+    ``imageseries.open(h5_file, 'hdf5', path=...)``.
+    """
+    imageseries.write(
+        ims, h5_file, 'hdf5', path=path, compression=STATE_IMAGE_COMPRESSION
+    )

--- a/tests/test_state_image_compression.py
+++ b/tests/test_state_image_compression.py
@@ -1,0 +1,52 @@
+"""Tests for blosc-zstd compression of state-file image data.
+
+The on-disk layout matches hexrd's 'hdf5' imageseries writer, so it round-trips
+through ``imageseries.open(..., 'hdf5', ...)`` and stays backward compatible.
+"""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from hexrd.core import imageseries
+
+from hexrdgui.state import write_imageseries
+
+
+def make_imageseries() -> tuple:
+    # A small, sparse, non-negative imageseries with omega metadata.
+    data = np.zeros((5, 64, 64), dtype=np.uint16)
+    data[:, ::8, ::8] = 1000
+    ims = imageseries.open(None, 'array', data=data)
+    ims.metadata['omega'] = np.linspace(0, 180, 5).reshape(-1, 1)
+    return ims, data
+
+
+def test_roundtrip_lossless(tmp_path: Path) -> None:
+    ims, data = make_imageseries()
+    path = tmp_path / 'state.h5'
+    with h5py.File(path, 'w') as f:
+        write_imageseries(f, 'images/det', ims)
+
+    with h5py.File(path, 'r') as f:
+        loaded = imageseries.open(
+            f, 'hdf5', path='images/det', close_when_finished=False
+        )
+        for i in range(len(data)):
+            assert np.array_equal(np.asarray(loaded[i]), data[i])
+        assert np.allclose(loaded.metadata['omega'], ims.metadata['omega'])
+
+
+def test_images_are_compressed(tmp_path: Path) -> None:
+    ims, data = make_imageseries()
+    path = tmp_path / 'state.h5'
+    with h5py.File(path, 'w') as f:
+        write_imageseries(f, 'images/det', ims)
+
+    with h5py.File(path, 'r') as f:
+        dataset = f['images/det/images']
+        # Sparse data compresses dramatically, and the blosc filter (id 32001)
+        # is applied rather than the old gzip default.
+        assert dataset.id.get_storage_size() < data.nbytes // 2
+        assert '32001' in dataset._filters


### PR DESCRIPTION
State files previously stored image data with gzip-1, which is large for HEDM-sized data. Compress it with blosc-zstd instead (lossless, ~25x smaller for typical sparse detector images). The data still reads back through the standard 'hdf5' imageseries loader, so existing state files remain compatible.

This relies on the hdf5 imageseries writer accepting a custom compression filter (the corresponding hexrd change).

Depends on: https://github.com/HEXRD/hexrd/pull/954