### PR TITLE
Utility function for estimating coverage

### DIFF
--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -676,7 +676,8 @@ class MainWindow(QObject):
             self.ui,
             'Load Materials File',
             HexrdConfig().working_dir,
-            'All supported files (*.h5 *.hdf5 *.cif);;HDF5 files (*.h5 *.hdf5);;CIF files (*.cif)',
+            'All supported files (*.h5 *.hdf5 *.cif);;'
+            'HDF5 files (*.h5 *.hdf5);;CIF files (*.cif)',
         )
         if not selected_file:
             return
@@ -1048,7 +1049,10 @@ class MainWindow(QObject):
                 ph_masks.append((det_key, contour))
 
         if not ph_masks:
-            msg = 'Failed to find contours to generate the pinhole mask. Please ensure the input is reasonable.'
+            msg = (
+                'Failed to find contours to generate the pinhole mask. '
+                'Please ensure the input is reasonable.'
+            )
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             return
 
@@ -1776,7 +1780,10 @@ class MainWindow(QObject):
 
     def load_recent_state_file(self, path: str) -> None:
         if not Path(path).exists():
-            msg = f'Recent state file: "{path}"\n\nno longer exists. Remove from recent files list?'
+            msg = (
+                f'Recent state file: "{path}"\n\nno longer exists. '
+                'Remove from recent files list?'
+            )
             response = QMessageBox.question(self.ui, 'HEXRD', msg)
             if response == QMessageBox.StandardButton.Yes:
                 HexrdConfig().recent_state_files.remove(path)
@@ -1925,5 +1932,8 @@ class MainWindow(QObject):
             # extension is not in known list
             self.open_image_files(selected_files=[str(p) for p in paths])
         except Exception:
-            error_message = 'Unable to guess file type (state, instrument, materials, or image). Please use File menu to load.'
+            error_message = (
+                'Unable to guess file type (state, instrument, materials, or '
+                'image). Please use File menu to load.'
+            )
             QMessageBox.critical(self.ui, 'Error', error_message)

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -115,6 +115,7 @@ class MainWindow(QObject):
         self._powder_runner: PowderRunner | None = None
         self._indexing_config_view: IndexingTreeViewDialog | None = None
         self._fit_grains_config_view: FitGrainsTreeViewDialog | None = None
+        self._coverage_plot_dialog: CoveragePlotDialog | None = None
 
         loader = UiLoader()
         self.ui = loader.load_file('main_window.ui', parent)
@@ -1331,12 +1332,15 @@ class MainWindow(QObject):
 
     def on_action_view_coverage_triggered(self, checked: bool) -> None:
         if checked:
-            if not hasattr(self, '_coverage_plot_dialog'):
+            if self._coverage_plot_dialog is None:
                 self._coverage_plot_dialog = CoveragePlotDialog(self.ui)
+                # Uncheck the menu action when the dialog is closed
+                self._coverage_plot_dialog.rejected.connect(
+                    lambda: self.ui.action_view_coverage.setChecked(False)
+                )
             self._coverage_plot_dialog.show()
-        else:
-            if hasattr(self, '_coverage_plot_dialog'):
-                self._coverage_plot_dialog.hide()
+        elif self._coverage_plot_dialog is not None:
+            self._coverage_plot_dialog.hide()
 
     def new_mouse_position(self, info: dict[str, Any]) -> None:
         if self.image_mode == ViewType.polar:

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -86,6 +86,7 @@ from hexrdgui.utils.dialog import add_help_url
 from hexrdgui.utils.physics_package import (
     ask_to_create_physics_package_if_missing,
 )
+from hexrdgui.utils.coverage_plot import CoveragePlotDialog
 from hexrdgui.zoom_canvas_dialog import ZoomCanvasDialog
 from hexrdgui.rerun_clustering_dialog import RerunClusteringDialog
 from hexrdgui.physics_package_manager_dialog import PhysicsPackageManagerDialog
@@ -289,6 +290,7 @@ class MainWindow(QObject):
             self.view_fit_grains_config
         )
         self.ui.action_view_overlay_picks.triggered.connect(self.view_overlay_picks)
+        self.ui.action_view_coverage.triggered.connect(self.on_action_view_coverage_triggered)
         self.ui.calibration_tab_widget.currentChanged.connect(self.update_config_gui)
         self.image_mode_widget.tab_changed.connect(self.change_image_mode)
         self.threshold_mask_dialog.mask_applied.connect(self.update_all)
@@ -1122,6 +1124,7 @@ class MainWindow(QObject):
         self.ui.action_edit_apply_laue_mask_to_polar.setEnabled(is_polar)
         self.ui.action_edit_apply_powder_mask_to_polar.setEnabled(is_polar)
         self.ui.action_export_to_maud.setEnabled(is_polar and has_images)
+        self.ui.action_view_coverage.setEnabled(is_polar)
 
     def start_fast_powder_calibration(self) -> None:
         if not HexrdConfig().has_images:
@@ -1329,6 +1332,15 @@ class MainWindow(QObject):
         dialog.ui.accepted.connect(on_accepted)
         dialog.ui.finished.connect(on_finished)
 
+    def on_action_view_coverage_triggered(self, checked: bool) -> None:
+        if checked:
+            if not hasattr(self, '_coverage_plot_dialog'):
+                self._coverage_plot_dialog = CoveragePlotDialog(self.ui)
+            self._coverage_plot_dialog.show()
+        else:
+            if hasattr(self, '_coverage_plot_dialog'):
+                self._coverage_plot_dialog.hide()
+
     def new_mouse_position(self, info: dict[str, Any]) -> None:
         if self.image_mode == ViewType.polar:
             # Use a special function for polar
@@ -1514,6 +1526,10 @@ class MainWindow(QObject):
             'action_transform_detectors': {
                 True: '',
                 False: 'Image data must be loaded',
+            },
+            'action_view_coverage': {
+                True: '',
+                False: 'Polar view must be active',
             },
         }
 

--- a/hexrdgui/main_window.py
+++ b/hexrdgui/main_window.py
@@ -1,18 +1,17 @@
 from __future__ import annotations
 
-from functools import partial
 import os
-from pathlib import Path
 import shutil
 import tempfile
 from collections.abc import Sequence
-from typing import Any, TYPE_CHECKING
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import h5py
 import numpy as np
-from skimage import measure
-
-from PySide6.QtCore import QEvent, QObject, Qt, QThreadPool, Signal, QTimer, QUrl
+from hexrd.resources import instrument_templates
+from PySide6.QtCore import QEvent, QObject, Qt, QThreadPool, QTimer, QUrl, Signal
 from PySide6.QtGui import QDesktopServices
 from PySide6.QtWidgets import (
     QApplication,
@@ -23,31 +22,18 @@ from PySide6.QtWidgets import (
     QMessageBox,
     QWidget,
 )
+from skimage import measure
 
+from hexrdgui import resource_loader, state
 from hexrdgui.about_dialog import AboutDialog
 from hexrdgui.absorption_correction_options_dialog import (
     AbsorptionCorrectionOptionsDialog,
 )
 from hexrdgui.async_runner import AsyncRunner
 from hexrdgui.beam_marker_style_editor import BeamMarkerStyleEditor
-from hexrdgui.calibration_slider_widget import CalibrationSliderWidget
-from hexrdgui.create_hedm_instrument import create_hedm_instrument
-from hexrdgui.color_map_editor import ColorMapEditor
-from hexrdgui.config_dialog import ConfigDialog
-from hexrdgui.edit_colormap_list_dialog import EditColormapListDialog
-from hexrdgui.masking.constants import MaskType
-from hexrdgui.masking.mask_manager import MaskManager
-from hexrdgui.median_filter_dialog import MedianFilterDialog
-from hexrdgui.progress_dialog import ProgressDialog
 from hexrdgui.cal_tree_view import CalTreeView
-from hexrdgui.masking.hand_drawn_mask_dialog import HandDrawnMaskDialog
-from hexrdgui.image_stack_dialog import ImageStackDialog
-from hexrdgui.indexing.run import FitGrainsRunner, IndexingRunner
-from hexrdgui.indexing.fit_grains_results_dialog import FitGrainsResultsDialog
-from hexrdgui.input_dialog import InputDialog
-from hexrdgui.instrument_form_view_widget import InstrumentFormViewWidget
-from hexrdgui.calibration.calibration_runner import CalibrationRunner
 from hexrdgui.calibration.auto.powder_runner import PowderRunner
+from hexrdgui.calibration.calibration_runner import CalibrationRunner
 from hexrdgui.calibration.hedm.calibration_runner import HEDMCalibrationRunner
 from hexrdgui.calibration.hkl_picks_tree_view_dialog import (
     HKLPicksTreeViewDialog,
@@ -56,42 +42,55 @@ from hexrdgui.calibration.hkl_picks_tree_view_dialog import (
 )
 from hexrdgui.calibration.structureless import StructurelessCalibrationRunner
 from hexrdgui.calibration.wppf_runner import WppfRunner
-from hexrdgui.masking.create_polar_mask import rebuild_polar_masks
-from hexrdgui.masking.create_raw_mask import convert_polar_to_raw, rebuild_raw_masks
-from hexrdgui.constants import ViewType, DOCUMENTATION_URL
+from hexrdgui.calibration_slider_widget import CalibrationSliderWidget
+from hexrdgui.color_map_editor import ColorMapEditor
+from hexrdgui.config_dialog import ConfigDialog
+from hexrdgui.constants import DOCUMENTATION_URL, ViewType
+from hexrdgui.create_hedm_instrument import create_hedm_instrument
+from hexrdgui.edit_colormap_list_dialog import EditColormapListDialog
 from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.image_calculator_dialog import ImageCalculatorDialog
-from hexrdgui.overlays import overlays_with_custom_energy
 from hexrdgui.image_file_manager import ImageFileManager
 from hexrdgui.image_load_manager import ImageLoadManager
+from hexrdgui.image_mode_widget import ImageModeWidget
+from hexrdgui.image_stack_dialog import ImageStackDialog
+from hexrdgui.indexing.fit_grains_results_dialog import FitGrainsResultsDialog
+from hexrdgui.indexing.fit_grains_tree_view_dialog import FitGrainsTreeViewDialog
+from hexrdgui.indexing.indexing_tree_view_dialog import IndexingTreeViewDialog
+from hexrdgui.indexing.run import FitGrainsRunner, IndexingRunner
+from hexrdgui.input_dialog import InputDialog
+from hexrdgui.instrument_form_view_widget import InstrumentFormViewWidget
 from hexrdgui.llnl_import_tool_dialog import LLNLImportToolDialog
 from hexrdgui.load_images_dialog import LoadImagesDialog
-from hexrdgui.simple_image_series_dialog import SimpleImageSeriesDialog
+from hexrdgui.masking.constants import MaskType
+from hexrdgui.masking.create_polar_mask import rebuild_polar_masks
+from hexrdgui.masking.create_raw_mask import convert_polar_to_raw, rebuild_raw_masks
+from hexrdgui.masking.hand_drawn_mask_dialog import HandDrawnMaskDialog
+from hexrdgui.masking.mask_manager import MaskManager
+from hexrdgui.masking.mask_manager_dialog import MaskManagerDialog
+from hexrdgui.masking.mask_regions_dialog import MaskRegionsDialog
+from hexrdgui.masking.threshold_mask_dialog import ThresholdMaskDialog
+from hexrdgui.materials_panel import MaterialsPanel
+from hexrdgui.median_filter_dialog import MedianFilterDialog
+from hexrdgui.messages_widget import MessagesWidget
+from hexrdgui.overlays import overlays_with_custom_energy
+from hexrdgui.physics_package_manager_dialog import PhysicsPackageManagerDialog
 from hexrdgui.pinhole_mask_dialog import PinholeMaskDialog
 from hexrdgui.pinhole_panel_buffer import generate_pinhole_panel_buffer
 from hexrdgui.polarization_options_dialog import PolarizationOptionsDialog
-from hexrdgui.masking.mask_manager_dialog import MaskManagerDialog
-from hexrdgui.masking.mask_regions_dialog import MaskRegionsDialog
-from hexrdgui.materials_panel import MaterialsPanel
-from hexrdgui.messages_widget import MessagesWidget
+from hexrdgui.progress_dialog import ProgressDialog
+from hexrdgui.rerun_clustering_dialog import RerunClusteringDialog
 from hexrdgui.save_images_dialog import SaveImagesDialog
-from hexrdgui.masking.threshold_mask_dialog import ThresholdMaskDialog
+from hexrdgui.simple_image_series_dialog import SimpleImageSeriesDialog
 from hexrdgui.transform_dialog import TransformDialog
-from hexrdgui.indexing.indexing_tree_view_dialog import IndexingTreeViewDialog
-from hexrdgui.indexing.fit_grains_tree_view_dialog import FitGrainsTreeViewDialog
-from hexrdgui.image_mode_widget import ImageModeWidget
 from hexrdgui.ui_loader import UiLoader
 from hexrdgui.utils import block_signals
+from hexrdgui.utils.coverage_plot import CoveragePlotDialog
 from hexrdgui.utils.dialog import add_help_url
 from hexrdgui.utils.physics_package import (
     ask_to_create_physics_package_if_missing,
 )
-from hexrdgui.utils.coverage_plot import CoveragePlotDialog
 from hexrdgui.zoom_canvas_dialog import ZoomCanvasDialog
-from hexrdgui.rerun_clustering_dialog import RerunClusteringDialog
-from hexrdgui.physics_package_manager_dialog import PhysicsPackageManagerDialog
-from hexrdgui import resource_loader, state
-from hexrd.resources import instrument_templates
 
 if TYPE_CHECKING:
     from PySide6.QtGui import QIcon
@@ -290,7 +289,9 @@ class MainWindow(QObject):
             self.view_fit_grains_config
         )
         self.ui.action_view_overlay_picks.triggered.connect(self.view_overlay_picks)
-        self.ui.action_view_coverage.triggered.connect(self.on_action_view_coverage_triggered)
+        self.ui.action_view_coverage.triggered.connect(
+            self.on_action_view_coverage_triggered
+        )
         self.ui.calibration_tab_widget.currentChanged.connect(self.update_config_gui)
         self.image_mode_widget.tab_changed.connect(self.change_image_mode)
         self.threshold_mask_dialog.mask_applied.connect(self.update_all)
@@ -674,8 +675,7 @@ class MainWindow(QObject):
             self.ui,
             'Load Materials File',
             HexrdConfig().working_dir,
-            'All supported files (*.h5 *.hdf5 *.cif);;'
-            'HDF5 files (*.h5 *.hdf5);;CIF files (*.cif)',
+            'All supported files (*.h5 *.hdf5 *.cif);;HDF5 files (*.h5 *.hdf5);;CIF files (*.cif)',
         )
         if not selected_file:
             return
@@ -1047,10 +1047,7 @@ class MainWindow(QObject):
                 ph_masks.append((det_key, contour))
 
         if not ph_masks:
-            msg = (
-                'Failed to find contours to generate the pinhole mask. '
-                'Please ensure the input is reasonable.'
-            )
+            msg = 'Failed to find contours to generate the pinhole mask. Please ensure the input is reasonable.'
             QMessageBox.critical(self.ui, 'HEXRD', msg)
             return
 
@@ -1775,10 +1772,7 @@ class MainWindow(QObject):
 
     def load_recent_state_file(self, path: str) -> None:
         if not Path(path).exists():
-            msg = (
-                f'Recent state file: "{path}"\n\nno longer exists. '
-                'Remove from recent files list?'
-            )
+            msg = f'Recent state file: "{path}"\n\nno longer exists. Remove from recent files list?'
             response = QMessageBox.question(self.ui, 'HEXRD', msg)
             if response == QMessageBox.StandardButton.Yes:
                 HexrdConfig().recent_state_files.remove(path)
@@ -1927,8 +1921,5 @@ class MainWindow(QObject):
             # extension is not in known list
             self.open_image_files(selected_files=[str(p) for p in paths])
         except Exception:
-            error_message = (
-                'Unable to guess file type (state, instrument, materials, or '
-                'image). Please use File menu to load.'
-            )
+            error_message = 'Unable to guess file type (state, instrument, materials, or image). Please use File menu to load.'
             QMessageBox.critical(self.ui, 'Error', error_message)

--- a/hexrdgui/resources/ui/main_window.ui
+++ b/hexrdgui/resources/ui/main_window.ui
@@ -168,6 +168,7 @@
     <addaction name="action_view_indexing_config"/>
     <addaction name="action_view_fit_grains_config"/>
     <addaction name="action_view_overlay_picks"/>
+    <addaction name="action_view_coverage"/>
     <addaction name="colormaps_menu"/>
    </widget>
    <widget class="QMenu" name="menu_edit">
@@ -795,6 +796,17 @@
   <action name="action_view_overlay_picks">
    <property name="text">
     <string>Overlay Picks</string>
+   </property>
+  </action>
+  <action name="action_view_coverage">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Coverage</string>
+   </property>
+   <property name="toolTip">
+    <string>Show coverage plot</string>
    </property>
   </action>
   <action name="action_show_beam_marker">

--- a/hexrdgui/utils/coverage_plot.py
+++ b/hexrdgui/utils/coverage_plot.py
@@ -1,0 +1,226 @@
+"""Coverage plot dialog for viewing detector coverage in polar mode."""
+
+import numpy as np
+from PySide6.QtWidgets import QDialog, QVBoxLayout
+from PySide6.QtCore import Qt
+
+from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.figure import Figure
+from matplotlib.ticker import AutoLocator, AutoMinorLocator
+
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.calibration.polar_plot import polar_viewer
+
+# Font size increases matching image_canvas.py
+FONTSIZE_LABEL_INCREASE = 4
+FONTSIZE_TICKS_INCREASE = 4
+
+def calculate_coverage_data(polar_view, nan_mask):
+    """Calculate coverage data from polar view.
+
+    this portion calculates the total solid angle that
+    is captured as the % of maximum possible i.e. hemisphere
+
+    Args:
+        polar_view: PolarView instance
+        nan_mask: Boolean mask indicating NaN/masked pixels
+    """
+    instr = polar_view.instr
+    sa_total = 0.0
+
+    for k, v in instr.detectors.items():
+        sa_total += v.pixel_solid_angles.sum()
+
+    frac_sa = sa_total/2/np.pi
+    msg = fr"total covered solid angle out of 2$\pi$ is {frac_sa*100:.2f}%"
+
+    tth = np.degrees(polar_view.angular_grid[1][0,:])
+    azimuthal_frac = 100*np.nansum(~nan_mask, axis=0)/nan_mask.shape[0]
+
+    return (tth, azimuthal_frac), msg
+
+class CoveragePlotDialog(QDialog):
+    """Dialog displaying live-updating coverage plot for polar view."""
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.setWindowTitle("Coverage")
+        # self.resize(800, 600)
+
+        # Create matplotlib figure and canvas
+        self.figure = Figure(figsize=(12, 4))
+        self.canvas = FigureCanvas(self.figure)
+        self.ax = self.figure.add_subplot(111)
+
+        # Initialize plot with empty data (black line matching azimuthal average)
+        self.line, = self.ax.plot([], [], '-k', linewidth=2.5)
+
+        # Setup axis styling to match polar view azimuthal average
+        self._setup_axis_style()
+
+        # Setup layout
+        layout = QVBoxLayout()
+        layout.addWidget(self.canvas)
+        self.setLayout(layout)
+
+        # Adjust subplot parameters to prevent label clipping
+        self.figure.tight_layout()
+
+        # Connect to HexrdConfig signals for live updates
+        HexrdConfig().rerender_needed.connect(self.update_plot)
+        HexrdConfig().instrument_config_loaded.connect(self.update_plot)
+        HexrdConfig().detector_transforms_modified.connect(self.on_detector_transforms_modified)
+
+        # Track parent UI for menu action access
+        self._parent_ui = parent
+
+    def _setup_axis_style(self):
+        """Setup axis styling to match polar view azimuthal average plot."""
+        # Get font sizes from HexrdConfig (matching image_canvas.py)
+        base_font_size = HexrdConfig().font_size
+        label_fontsize = base_font_size + FONTSIZE_LABEL_INCREASE
+        ticks_fontsize = base_font_size + FONTSIZE_TICKS_INCREASE
+
+        # Set labels with serif font
+        self.ax.set_xlabel(r'2$\theta$ [deg]', fontsize=label_fontsize, family='serif')
+        self.ax.set_ylabel(r'% azimuthal coverage', fontsize=label_fontsize, family='serif')
+
+        # Setup major and minor tick locators
+        self.ax.yaxis.set_major_locator(AutoLocator())
+        self.ax.yaxis.set_minor_locator(AutoMinorLocator())
+        self.ax.xaxis.set_major_locator(AutoLocator())
+        self.ax.xaxis.set_minor_locator(AutoMinorLocator())
+
+        # Configure tick parameters (matching image_canvas.py)
+        major_tick_kwargs = {
+            'left': True,
+            'right': True,
+            'bottom': True,
+            'top': True,
+            'which': 'major',
+            'length': 10,
+            'labelfontfamily': 'serif',
+            'labelsize': ticks_fontsize,
+        }
+
+        minor_tick_kwargs = {
+            **major_tick_kwargs,
+            'which': 'minor',
+            'length': 2,
+        }
+
+        self.ax.tick_params(**major_tick_kwargs)
+        self.ax.tick_params(**minor_tick_kwargs)
+
+        # Setup grid (matching polar axis style)
+        default_grid_kwargs = {
+            'visible': True,
+            'linewidth': 0.075,
+            'linestyle': '--',
+            'color': 'k',
+            'alpha': 0.9,
+        }
+
+        # Grid for minor y ticks
+        self.ax.grid(
+            **{
+                **default_grid_kwargs,
+                'which': 'minor',
+                'axis': 'y',
+                'linewidth': 0.25,
+                'linestyle': '-',
+                'alpha': 0.75,
+            }
+        )
+
+        # Grid for major ticks
+        self.ax.grid(**{**default_grid_kwargs, 'which': 'major'})
+
+    def on_detector_transforms_modified(self, detectors):
+        """Called when detector transforms (translation/tilt) are modified."""
+        self.update_plot()
+
+    def update_plot(self):
+        """Update the plot with current coverage data."""
+        # Only update if dialog is visible
+        if not self.isVisible():
+            return
+
+        # Get fresh polar viewer instance (reflects current config)
+        polar_viewer = self._get_polar_viewer()
+        if polar_viewer is None:
+            return
+
+        # Get the warped image and compute nan mask
+        if polar_viewer.raw_img is None:
+            return
+
+        # Use the mask from the masked array
+        nan_mask = polar_viewer.raw_img.mask
+
+        # Calculate coverage data
+        (x_data, y_data), msg = calculate_coverage_data(polar_viewer, nan_mask)
+
+        # Clear and redraw with proper styling
+        self.ax.clear()
+        self._setup_axis_style()
+
+        # Plot data with black line matching azimuthal average
+        self.line, = self.ax.plot(x_data, y_data, '-k', linewidth=2.5)
+
+        # Add centered text annotation with smaller font
+        base_font_size = HexrdConfig().font_size
+        text_fontsize = base_font_size + 2  # Slightly smaller than labels
+        self.ax.text(0.5, 0.95, msg, transform=self.ax.transAxes,
+                    fontsize=text_fontsize, color='red',
+                    ha='center', va='top', family='serif')
+
+        # Apply tight layout to prevent label clipping
+        self.figure.tight_layout()
+
+        # Redraw canvas (non-blocking)
+        self.canvas.draw_idle()
+
+    def _get_polar_viewer(self):
+        """Get the current polar viewer instance.
+
+        Creates a fresh InstrumentViewer to reflect current configuration.
+        """
+        try:
+            instrument_viewer = polar_viewer()
+            if hasattr(instrument_viewer, 'pv'):
+                return instrument_viewer.pv
+        except Exception:
+            pass
+        return None
+
+    def show(self):
+        """Show the dialog and update plot."""
+        super().show()
+        self.update_plot()
+
+    def closeEvent(self, event):
+        """Handle dialog close event."""
+        # Uncheck the menu action when dialog is closed
+        if self._parent_ui and hasattr(self._parent_ui, 'action_view_coverage'):
+            self._parent_ui.action_view_coverage.setChecked(False)
+
+        # Disconnect signals to prevent memory leaks
+        # Use try-except to handle cases where signals are already disconnected
+        try:
+            HexrdConfig().rerender_needed.disconnect(self.update_plot)
+        except (RuntimeError, TypeError):
+            pass
+
+        try:
+            HexrdConfig().instrument_config_loaded.disconnect(self.update_plot)
+        except (RuntimeError, TypeError):
+            pass
+
+        try:
+            HexrdConfig().detector_transforms_modified.disconnect(self.on_detector_transforms_modified)
+        except (RuntimeError, TypeError):
+            pass
+
+        super().closeEvent(event)

--- a/hexrdgui/utils/coverage_plot.py
+++ b/hexrdgui/utils/coverage_plot.py
@@ -6,7 +6,8 @@ import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.ticker import AutoLocator, AutoMinorLocator
-from PySide6.QtWidgets import QDialog, QVBoxLayout, QWidget
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QDialog, QLabel, QVBoxLayout, QWidget
 
 from hexrdgui.constants import ViewType
 from hexrdgui.hexrd_config import HexrdConfig
@@ -32,7 +33,7 @@ def calculate_coverage_data(
     sa_total = sum(panel.pixel_solid_angles.sum() for panel in instr.detectors.values())
 
     frac_sa = sa_total / 2 / np.pi
-    msg = rf'total covered solid angle out of 2$\pi$ is {frac_sa * 100:.1f}%'
+    msg = f'Total covered solid angle out of 2π is {frac_sa * 100:.1f}%'
 
     raw_img = polar_view.raw_img
     assert raw_img is not None
@@ -61,23 +62,19 @@ class CoveragePlotDialog(QDialog):
         (self.coverage_line,) = self.ax.plot([], [], '-k', linewidth=2.5)
         (self.mean_line,) = self.ax.plot([], [], '--k', linewidth=2.5)
 
-        # Centered text annotations, slightly smaller than the labels
-        text_kwargs: dict[str, Any] = {
-            'transform': self.ax.transAxes,
-            'fontsize': HexrdConfig().font_size + 2,
-            'color': 'red',
-            'ha': 'center',
-            'va': 'top',
-            'family': 'serif',
-        }
-        self.solid_angle_text = self.ax.text(0.5, 0.95, '', **text_kwargs)
-        self.average_text = self.ax.text(0.5, 0.85, '', **text_kwargs)
-
         # Setup axis styling to match polar view azimuthal average
         self._setup_axis_style()
 
+        # Centered summary labels displayed above the plot
+        self.solid_angle_label = QLabel()
+        self.average_label = QLabel()
+        for label in (self.solid_angle_label, self.average_label):
+            label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+
         # Setup layout
         layout = QVBoxLayout()
+        layout.addWidget(self.solid_angle_label)
+        layout.addWidget(self.average_label)
         layout.addWidget(self.canvas)
         self.setLayout(layout)
 
@@ -190,9 +187,9 @@ class CoveragePlotDialog(QDialog):
 
         self.coverage_line.set_data(x_data, y_data)
         self.mean_line.set_data(x_data, np.full_like(x_data, mean))
-        self.solid_angle_text.set_text(solid_angle_msg)
-        self.average_text.set_text(
-            rf'Average azimuthal coverage in 2$\theta$ FOV = {mean:0.1f}%'
+        self.solid_angle_label.setText(solid_angle_msg)
+        self.average_label.setText(
+            f'Average azimuthal coverage in 2θ FOV = {mean:0.1f}%'
         )
 
         self.ax.relim()

--- a/hexrdgui/utils/coverage_plot.py
+++ b/hexrdgui/utils/coverage_plot.py
@@ -65,11 +65,15 @@ class CoveragePlotDialog(QDialog):
         # Setup axis styling to match polar view azimuthal average
         self._setup_axis_style()
 
-        # Centered summary labels displayed above the plot
+        # Centered summary labels displayed above the plot, with a font
+        # size matching the plot's axis labels
         self.solid_angle_label = QLabel()
         self.average_label = QLabel()
         for label in (self.solid_angle_label, self.average_label):
             label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+            font = label.font()
+            font.setPointSize(HexrdConfig().font_size + FONTSIZE_LABEL_INCREASE)
+            label.setFont(font)
 
         # Setup layout
         layout = QVBoxLayout()

--- a/hexrdgui/utils/coverage_plot.py
+++ b/hexrdgui/utils/coverage_plot.py
@@ -1,40 +1,44 @@
 """Coverage plot dialog for viewing detector coverage in polar mode."""
 
+from typing import TYPE_CHECKING, Any, cast
+
 import numpy as np
 from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.ticker import AutoLocator, AutoMinorLocator
-from PySide6.QtWidgets import QDialog, QVBoxLayout
+from PySide6.QtWidgets import QDialog, QVBoxLayout, QWidget
 
-from hexrdgui.calibration.polar_plot import polar_viewer
+from hexrdgui.constants import ViewType
 from hexrdgui.hexrd_config import HexrdConfig
+
+if TYPE_CHECKING:
+    from hexrdgui.calibration.polar_plot import InstrumentViewer
 
 # Font size increases matching image_canvas.py
 FONTSIZE_LABEL_INCREASE = 4
 FONTSIZE_TICKS_INCREASE = 4
 
 
-def calculate_coverage_data(polar_view, nan_mask):
-    """Calculate coverage data from polar view.
+def calculate_coverage_data(
+    polar_view: 'InstrumentViewer',
+) -> tuple[tuple[np.ndarray, np.ndarray], str]:
+    """Calculate coverage data from the polar view.
 
-    this portion calculates the total solid angle that
-    is captured as the % of maximum possible i.e. hemisphere
-
-    Args:
-        polar_view: PolarView instance
-        nan_mask: Boolean mask indicating NaN/masked pixels
+    Returns the azimuthal coverage (in %) as a function of two-theta,
+    along with a message describing the total solid angle captured as a
+    % of the maximum possible (i.e. hemisphere).
     """
     instr = polar_view.instr
-    sa_total = 0.0
-
-    for k, v in instr.detectors.items():
-        sa_total += v.pixel_solid_angles.sum()
+    sa_total = sum(panel.pixel_solid_angles.sum() for panel in instr.detectors.values())
 
     frac_sa = sa_total / 2 / np.pi
     msg = rf'total covered solid angle out of 2$\pi$ is {frac_sa * 100:.1f}%'
 
+    raw_img = polar_view.raw_img
+    assert raw_img is not None
+    nan_mask = np.ma.getmaskarray(raw_img)
     tth = np.degrees(polar_view.angular_grid[1][0, :])
-    azimuthal_frac = 100 * np.nansum(~nan_mask, axis=0) / nan_mask.shape[0]
+    azimuthal_frac = 100 * (~nan_mask).sum(axis=0) / nan_mask.shape[0]
 
     return (tth, azimuthal_frac), msg
 
@@ -42,19 +46,32 @@ def calculate_coverage_data(polar_view, nan_mask):
 class CoveragePlotDialog(QDialog):
     """Dialog displaying live-updating coverage plot for polar view."""
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
 
         self.setWindowTitle('Coverage')
-        # self.resize(800, 600)
 
         # Create matplotlib figure and canvas
         self.figure = Figure(figsize=(12, 4))
         self.canvas = FigureCanvas(self.figure)
         self.ax = self.figure.add_subplot(111)
 
-        # Initialize plot with empty data (black line matching azimuthal average)
-        (self.line,) = self.ax.plot([], [], '-k', linewidth=2.5)
+        # Coverage curve and its average (black lines matching the
+        # azimuthal average plot)
+        (self.coverage_line,) = self.ax.plot([], [], '-k', linewidth=2.5)
+        (self.mean_line,) = self.ax.plot([], [], '--k', linewidth=2.5)
+
+        # Centered text annotations, slightly smaller than the labels
+        text_kwargs: dict[str, Any] = {
+            'transform': self.ax.transAxes,
+            'fontsize': HexrdConfig().font_size + 2,
+            'color': 'red',
+            'ha': 'center',
+            'va': 'top',
+            'family': 'serif',
+        }
+        self.solid_angle_text = self.ax.text(0.5, 0.95, '', **text_kwargs)
+        self.average_text = self.ax.text(0.5, 0.85, '', **text_kwargs)
 
         # Setup axis styling to match polar view azimuthal average
         self._setup_axis_style()
@@ -67,17 +84,30 @@ class CoveragePlotDialog(QDialog):
         # Adjust subplot parameters to prevent label clipping
         self.figure.tight_layout()
 
-        # Connect to HexrdConfig signals for live updates
-        HexrdConfig().rerender_needed.connect(self.update_plot)
-        HexrdConfig().instrument_config_loaded.connect(self.update_plot)
-        HexrdConfig().detector_transforms_modified.connect(
-            self.on_detector_transforms_modified
-        )
+        self.setup_connections()
 
-        # Track parent UI for menu action access
-        self._parent_ui = parent
+    def setup_connections(self) -> None:
+        # The image canvas emits this after it finishes regenerating the
+        # view, so we can reuse its polar view rather than computing our
+        # own. This covers rerenders, config loads, etc.
+        HexrdConfig().image_view_loaded.connect(self.update_plot)
 
-    def _setup_axis_style(self):
+        # Interactive detector translation/tilt edits update the canvas's
+        # polar view in place without emitting image_view_loaded, so listen
+        # for those separately. The image canvas connects to this signal
+        # before this dialog is created, so its polar view has already been
+        # updated by the time our slot runs.
+        HexrdConfig().detector_transforms_modified.connect(self.update_plot)
+
+    @property
+    def polar_view(self) -> 'InstrumentViewer | None':
+        """The active canvas's polar view, or None if not in polar mode."""
+        canvas = HexrdConfig().active_canvas
+        if canvas is None or canvas.mode != ViewType.polar:
+            return None
+        return cast('InstrumentViewer', canvas.iviewer)
+
+    def _setup_axis_style(self) -> None:
         """Setup axis styling to match polar view azimuthal average plot."""
         # Get font sizes from HexrdConfig (matching image_canvas.py)
         base_font_size = HexrdConfig().font_size
@@ -97,7 +127,7 @@ class CoveragePlotDialog(QDialog):
         self.ax.xaxis.set_minor_locator(AutoMinorLocator())
 
         # Configure tick parameters (matching image_canvas.py)
-        major_tick_kwargs = {
+        major_tick_kwargs: dict[str, Any] = {
             'left': True,
             'right': True,
             'bottom': True,
@@ -118,7 +148,7 @@ class CoveragePlotDialog(QDialog):
         self.ax.tick_params(**minor_tick_kwargs)
 
         # Setup grid (matching polar axis style)
-        default_grid_kwargs = {
+        default_grid_kwargs: dict[str, Any] = {
             'visible': True,
             'linewidth': 0.075,
             'linestyle': '--',
@@ -141,119 +171,37 @@ class CoveragePlotDialog(QDialog):
         # Grid for major ticks
         self.ax.grid(**{**default_grid_kwargs, 'which': 'major'})
 
-    def on_detector_transforms_modified(self, detectors):
-        """Called when detector transforms (translation/tilt) are modified."""
-        self.update_plot()
-
-    def update_plot(self):
+    def update_plot(self, *args: Any) -> None:
         """Update the plot with current coverage data."""
         # Only update if dialog is visible
         if not self.isVisible():
             return
 
-        # Get fresh polar viewer instance (reflects current config)
-        polar_viewer = self._get_polar_viewer()
-        if polar_viewer is None:
+        if HexrdConfig().loading_state:
+            # A rerender will occur when state loading finishes
             return
 
-        # Get the warped image and compute nan mask
-        if polar_viewer.raw_img is None:
+        polar_view = self.polar_view
+        if polar_view is None or polar_view.raw_img is None:
             return
 
-        # Use the mask from the masked array
-        nan_mask = polar_viewer.raw_img.mask
+        (x_data, y_data), solid_angle_msg = calculate_coverage_data(polar_view)
+        mean = np.nanmean(y_data)
 
-        # Calculate coverage data
-        (x_data, y_data), msg = calculate_coverage_data(polar_viewer, nan_mask)
-        y_mean = np.nanmean(y_data) * np.ones_like(x_data)
-
-        msg2 = (
-            rf'Average azimuthal coverage in 2$\theta$ FOV = {np.nanmean(y_data):0.1f}%'
+        self.coverage_line.set_data(x_data, y_data)
+        self.mean_line.set_data(x_data, np.full_like(x_data, mean))
+        self.solid_angle_text.set_text(solid_angle_msg)
+        self.average_text.set_text(
+            rf'Average azimuthal coverage in 2$\theta$ FOV = {mean:0.1f}%'
         )
 
-        # Clear and redraw with proper styling
-        self.ax.clear()
-        self._setup_axis_style()
-
-        # Plot data with black line matching azimuthal average
-        (self.line,) = self.ax.plot(x_data, y_data, '-k', linewidth=2.5)
-
-        # Plot average coverage over angular field of view
-        (self.line,) = self.ax.plot(x_data, y_mean, '--k', linewidth=2.5)
-
-        # Add centered text annotation with smaller font
-        base_font_size = HexrdConfig().font_size
-        text_fontsize = base_font_size + 2  # Slightly smaller than labels
-        self.ax.text(
-            0.5,
-            0.95,
-            msg,
-            transform=self.ax.transAxes,
-            fontsize=text_fontsize,
-            color='red',
-            ha='center',
-            va='top',
-            family='serif',
-        )
-        self.ax.text(
-            0.5,
-            0.85,
-            msg2,
-            transform=self.ax.transAxes,
-            fontsize=text_fontsize,
-            color='red',
-            ha='center',
-            va='top',
-            family='serif',
-        )
-
-        # Apply tight layout to prevent label clipping
-        self.figure.tight_layout()
+        self.ax.relim()
+        self.ax.autoscale_view()
 
         # Redraw canvas (non-blocking)
         self.canvas.draw_idle()
 
-    def _get_polar_viewer(self):
-        """Get the current polar viewer instance.
-
-        Creates a fresh InstrumentViewer to reflect current configuration.
-        """
-        try:
-            instrument_viewer = polar_viewer()
-            if hasattr(instrument_viewer, 'pv'):
-                return instrument_viewer.pv
-        except Exception:
-            pass
-        return None
-
-    def show(self):
+    def show(self) -> None:
         """Show the dialog and update plot."""
         super().show()
         self.update_plot()
-
-    def closeEvent(self, event):
-        """Handle dialog close event."""
-        # Uncheck the menu action when dialog is closed
-        if self._parent_ui and hasattr(self._parent_ui, 'action_view_coverage'):
-            self._parent_ui.action_view_coverage.setChecked(False)
-
-        # Disconnect signals to prevent memory leaks
-        # Use try-except to handle cases where signals are already disconnected
-        try:
-            HexrdConfig().rerender_needed.disconnect(self.update_plot)
-        except (RuntimeError, TypeError):
-            pass
-
-        try:
-            HexrdConfig().instrument_config_loaded.disconnect(self.update_plot)
-        except (RuntimeError, TypeError):
-            pass
-
-        try:
-            HexrdConfig().detector_transforms_modified.disconnect(
-                self.on_detector_transforms_modified
-            )
-        except (RuntimeError, TypeError):
-            pass
-
-        super().closeEvent(event)

--- a/hexrdgui/utils/coverage_plot.py
+++ b/hexrdgui/utils/coverage_plot.py
@@ -1,19 +1,18 @@
 """Coverage plot dialog for viewing detector coverage in polar mode."""
 
 import numpy as np
-from PySide6.QtWidgets import QDialog, QVBoxLayout
-from PySide6.QtCore import Qt
-
-from matplotlib.backends.backend_qtagg import FigureCanvas
+from matplotlib.backends.backend_qtagg import FigureCanvasQTAgg as FigureCanvas
 from matplotlib.figure import Figure
 from matplotlib.ticker import AutoLocator, AutoMinorLocator
+from PySide6.QtWidgets import QDialog, QVBoxLayout
 
-from hexrdgui.hexrd_config import HexrdConfig
 from hexrdgui.calibration.polar_plot import polar_viewer
+from hexrdgui.hexrd_config import HexrdConfig
 
 # Font size increases matching image_canvas.py
 FONTSIZE_LABEL_INCREASE = 4
 FONTSIZE_TICKS_INCREASE = 4
+
 
 def calculate_coverage_data(polar_view, nan_mask):
     """Calculate coverage data from polar view.
@@ -31,13 +30,14 @@ def calculate_coverage_data(polar_view, nan_mask):
     for k, v in instr.detectors.items():
         sa_total += v.pixel_solid_angles.sum()
 
-    frac_sa = sa_total/2/np.pi
-    msg = fr"total covered solid angle out of 2$\pi$ is {frac_sa*100:.1f}%"
+    frac_sa = sa_total / 2 / np.pi
+    msg = rf'total covered solid angle out of 2$\pi$ is {frac_sa * 100:.1f}%'
 
-    tth = np.degrees(polar_view.angular_grid[1][0,:])
-    azimuthal_frac = 100*np.nansum(~nan_mask, axis=0)/nan_mask.shape[0]
+    tth = np.degrees(polar_view.angular_grid[1][0, :])
+    azimuthal_frac = 100 * np.nansum(~nan_mask, axis=0) / nan_mask.shape[0]
 
     return (tth, azimuthal_frac), msg
+
 
 class CoveragePlotDialog(QDialog):
     """Dialog displaying live-updating coverage plot for polar view."""
@@ -45,7 +45,7 @@ class CoveragePlotDialog(QDialog):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.setWindowTitle("Coverage")
+        self.setWindowTitle('Coverage')
         # self.resize(800, 600)
 
         # Create matplotlib figure and canvas
@@ -54,7 +54,7 @@ class CoveragePlotDialog(QDialog):
         self.ax = self.figure.add_subplot(111)
 
         # Initialize plot with empty data (black line matching azimuthal average)
-        self.line, = self.ax.plot([], [], '-k', linewidth=2.5)
+        (self.line,) = self.ax.plot([], [], '-k', linewidth=2.5)
 
         # Setup axis styling to match polar view azimuthal average
         self._setup_axis_style()
@@ -70,7 +70,9 @@ class CoveragePlotDialog(QDialog):
         # Connect to HexrdConfig signals for live updates
         HexrdConfig().rerender_needed.connect(self.update_plot)
         HexrdConfig().instrument_config_loaded.connect(self.update_plot)
-        HexrdConfig().detector_transforms_modified.connect(self.on_detector_transforms_modified)
+        HexrdConfig().detector_transforms_modified.connect(
+            self.on_detector_transforms_modified
+        )
 
         # Track parent UI for menu action access
         self._parent_ui = parent
@@ -84,7 +86,9 @@ class CoveragePlotDialog(QDialog):
 
         # Set labels with serif font
         self.ax.set_xlabel(r'2$\theta$ [deg]', fontsize=label_fontsize, family='serif')
-        self.ax.set_ylabel(r'% azimuthal coverage', fontsize=label_fontsize, family='serif')
+        self.ax.set_ylabel(
+            r'% azimuthal coverage', fontsize=label_fontsize, family='serif'
+        )
 
         # Setup major and minor tick locators
         self.ax.yaxis.set_major_locator(AutoLocator())
@@ -163,27 +167,45 @@ class CoveragePlotDialog(QDialog):
         (x_data, y_data), msg = calculate_coverage_data(polar_viewer, nan_mask)
         y_mean = np.nanmean(y_data) * np.ones_like(x_data)
 
-        msg2 = fr"Average azimuthal coverage in 2$\theta$ FOV = {np.nanmean(y_data):0.1f}%"
+        msg2 = (
+            rf'Average azimuthal coverage in 2$\theta$ FOV = {np.nanmean(y_data):0.1f}%'
+        )
 
         # Clear and redraw with proper styling
         self.ax.clear()
         self._setup_axis_style()
 
         # Plot data with black line matching azimuthal average
-        self.line, = self.ax.plot(x_data, y_data, '-k', linewidth=2.5)
+        (self.line,) = self.ax.plot(x_data, y_data, '-k', linewidth=2.5)
 
         # Plot average coverage over angular field of view
-        self.line, = self.ax.plot(x_data, y_mean, '--k', linewidth=2.5)
+        (self.line,) = self.ax.plot(x_data, y_mean, '--k', linewidth=2.5)
 
         # Add centered text annotation with smaller font
         base_font_size = HexrdConfig().font_size
         text_fontsize = base_font_size + 2  # Slightly smaller than labels
-        self.ax.text(0.5, 0.95, msg, transform=self.ax.transAxes,
-                    fontsize=text_fontsize, color='red',
-                    ha='center', va='top', family='serif')
-        self.ax.text(0.5, 0.85, msg2, transform=self.ax.transAxes,
-                    fontsize=text_fontsize, color='red',
-                    ha='center', va='top', family='serif')
+        self.ax.text(
+            0.5,
+            0.95,
+            msg,
+            transform=self.ax.transAxes,
+            fontsize=text_fontsize,
+            color='red',
+            ha='center',
+            va='top',
+            family='serif',
+        )
+        self.ax.text(
+            0.5,
+            0.85,
+            msg2,
+            transform=self.ax.transAxes,
+            fontsize=text_fontsize,
+            color='red',
+            ha='center',
+            va='top',
+            family='serif',
+        )
 
         # Apply tight layout to prevent label clipping
         self.figure.tight_layout()
@@ -228,7 +250,9 @@ class CoveragePlotDialog(QDialog):
             pass
 
         try:
-            HexrdConfig().detector_transforms_modified.disconnect(self.on_detector_transforms_modified)
+            HexrdConfig().detector_transforms_modified.disconnect(
+                self.on_detector_transforms_modified
+            )
         except (RuntimeError, TypeError):
             pass
 

--- a/hexrdgui/utils/coverage_plot.py
+++ b/hexrdgui/utils/coverage_plot.py
@@ -32,7 +32,7 @@ def calculate_coverage_data(polar_view, nan_mask):
         sa_total += v.pixel_solid_angles.sum()
 
     frac_sa = sa_total/2/np.pi
-    msg = fr"total covered solid angle out of 2$\pi$ is {frac_sa*100:.2f}%"
+    msg = fr"total covered solid angle out of 2$\pi$ is {frac_sa*100:.1f}%"
 
     tth = np.degrees(polar_view.angular_grid[1][0,:])
     azimuthal_frac = 100*np.nansum(~nan_mask, axis=0)/nan_mask.shape[0]
@@ -161,6 +161,9 @@ class CoveragePlotDialog(QDialog):
 
         # Calculate coverage data
         (x_data, y_data), msg = calculate_coverage_data(polar_viewer, nan_mask)
+        y_mean = np.nanmean(y_data) * np.ones_like(x_data)
+
+        msg2 = fr"Average azimuthal coverage in 2$\theta$ FOV = {np.nanmean(y_data):0.1f}%"
 
         # Clear and redraw with proper styling
         self.ax.clear()
@@ -169,10 +172,16 @@ class CoveragePlotDialog(QDialog):
         # Plot data with black line matching azimuthal average
         self.line, = self.ax.plot(x_data, y_data, '-k', linewidth=2.5)
 
+        # Plot average coverage over angular field of view
+        self.line, = self.ax.plot(x_data, y_mean, '--k', linewidth=2.5)
+
         # Add centered text annotation with smaller font
         base_font_size = HexrdConfig().font_size
         text_fontsize = base_font_size + 2  # Slightly smaller than labels
         self.ax.text(0.5, 0.95, msg, transform=self.ax.transAxes,
+                    fontsize=text_fontsize, color='red',
+                    ha='center', va='top', family='serif')
+        self.ax.text(0.5, 0.85, msg2, transform=self.ax.transAxes,
                     fontsize=text_fontsize, color='red',
                     ha='center', va='top', family='serif')
 


### PR DESCRIPTION
(written with help of Claude code)

Adding a utility function to plot azimuthal coverage as a function of two-theta  and solid angle coverage for a given setup.
The option shows up in the `View > Coverage` menu. This utility will be used for designing the next iteration of the time-resolved X-ray diffraction diagnostic. 

The behavior is as follows: 
 - The button is gray if the view mode is anything other than the `Polar` view.
 - The button is active in the `Polar` image mode and shows up as a separate figure.
 - A check mark appears next to coverage when the option is active. When plot is closed the check mark goes away.
 - The plot shows the azimuthal coverage in % as a function of two-theta as well as the solid angle coverage as a % of 2 pi, which is the maximum solid angle coverage in transmission geometry. The average azimuthal coverage is also plotted and displayed as text.
 - If the configuration is updated, then then the plot and the text auto updates. 

<img width="1261" height="983" alt="image" src="https://github.com/user-attachments/assets/41be0122-da9f-4271-a04f-a49c9be9d074" />

