### PR TITLE
Store sparse state file images as fch5

### DIFF
--- a/hexrdgui/state.py
+++ b/hexrdgui/state.py
@@ -264,10 +264,8 @@ def load_imageseries_dict(h5_file: h5py.File) -> None:
     imsd.clear()
 
     root = 'images'
-    for det, ims in list(h5_file[root].items()):
-        imsd[det] = imageseries.open(
-            h5_file, 'hdf5', path=f'{root}/{det}', close_when_finished=False
-        )
+    for det in list(h5_file[root]):
+        imsd[det] = open_imageseries(h5_file, f'{root}/{det}')
 
     HexrdConfig().reset_unagg_imgs(new_imgs=True)
 
@@ -287,14 +285,58 @@ STATE_IMAGE_COMPRESSION = hdf5plugin.Blosc(
     cname='zstd', clevel=5, shuffle=hdf5plugin.Blosc.SHUFFLE
 )
 
+# Maximum nonzero fraction (sampled) for which the sparse fch5 format is used.
+# Matches hexrd's frame-cache sparsity warning cutoff; above it, dense storage
+# compresses as well or better.
+FCH5_MAX_NZ_FRACTION = 0.1
+
+
+def _write_as_fch5(ims: Any) -> bool:
+    """Decide whether an imageseries should be stored as an fch5 frame cache.
+
+    The frame cache zeroes out values at or below the threshold, so with a
+    threshold of 0 it is only guaranteed lossless for unsigned integer data.
+    Anything else (or data that is not actually sparse) keeps the dense hdf5
+    layout.
+    """
+    if len(ims) == 0 or np.dtype(ims.dtype).kind != 'u':
+        return False
+
+    # Sample a few frames to estimate sparsity
+    sample_idx = {0, len(ims) // 2, len(ims) - 1}
+    fullness = max(np.count_nonzero(ims[i]) / ims[i].size for i in sample_idx)
+    return fullness <= FCH5_MAX_NZ_FRACTION
+
 
 def write_imageseries(h5_file: h5py.File, path: str, ims: Any) -> None:
-    """Write an imageseries into the state file with blosc-zstd compression.
+    """Write an imageseries into the state file.
 
-    Delegates to hexrd's 'hdf5' imageseries writer with a custom compression
-    filter (instead of its gzip-1 default), so it still reads back via
-    ``imageseries.open(h5_file, 'hdf5', path=...)``.
+    Sparse unsigned-integer data is written as an fch5 frame cache (sparse
+    storage, blosc-zstd compressed by hexrd). Everything else keeps the dense
+    'hdf5' imageseries layout with a blosc-zstd filter (instead of its gzip-1
+    default). Either way, it reads back via ``open_imageseries()``.
     """
-    imageseries.write(
-        ims, h5_file, 'hdf5', path=path, compression=STATE_IMAGE_COMPRESSION
-    )
+    if _write_as_fch5(ims):
+        # threshold=0 drops only exact zeros, which the sparse format
+        # reconstructs implicitly, so this round-trips losslessly.
+        imageseries.write(
+            ims, h5_file, 'frame-cache', style='fch5', threshold=0, path=path
+        )
+    else:
+        imageseries.write(
+            ims, h5_file, 'hdf5', path=path, compression=STATE_IMAGE_COMPRESSION
+        )
+
+
+def open_imageseries(h5_file: h5py.File, path: str) -> Any:
+    """Open an imageseries stored in a state file at the given path.
+
+    Detects whether the group holds an fch5 frame cache (new state files) or
+    a dense hdf5 imageseries (older state files, and the dense fallback) and
+    opens it with the matching format. Either way the returned imageseries
+    reads from the open ``h5_file``, so the file must stay open.
+    """
+    if 'HEXRD_FRAMECACHE_VERSION' in h5_file[path].attrs:
+        return imageseries.open(h5_file, 'frame-cache', style='fch5', path=path)
+
+    return imageseries.open(h5_file, 'hdf5', path=path, close_when_finished=False)

--- a/tests/test_state_fch5.py
+++ b/tests/test_state_fch5.py
@@ -1,0 +1,72 @@
+"""Tests for storing state-file imageseries as fch5 frame caches."""
+
+from pathlib import Path
+
+import h5py
+import numpy as np
+
+from hexrd.core import imageseries
+
+from hexrdgui.state import open_imageseries, write_imageseries
+
+
+def make_imageseries(data: np.ndarray):
+    ims = imageseries.open(None, 'array', data=data)
+    ims.metadata['omega'] = np.linspace(0, 180, len(data)).reshape(-1, 1)
+    return ims
+
+
+def roundtrip(tmp_path: Path, data: np.ndarray) -> bool:
+    """Write, reopen, and verify an imageseries; return whether fch5 was used."""
+    ims = make_imageseries(data)
+    path = tmp_path / 'state.h5'
+    with h5py.File(path, 'w') as f:
+        write_imageseries(f, 'images/det', ims)
+
+    with h5py.File(path, 'r') as f:
+        loaded = open_imageseries(f, 'images/det')
+        assert loaded.dtype == data.dtype
+        for i in range(len(data)):
+            assert np.array_equal(np.asarray(loaded[i]), data[i])
+        assert np.allclose(loaded.metadata['omega'], ims.metadata['omega'])
+        group = f['images/det']
+        if 'HEXRD_FRAMECACHE_VERSION' in group.attrs:
+            # Sparse storage: only the nonzero values are stored
+            assert group['data'].shape[0] == np.count_nonzero(data)
+            return True
+
+        return False
+
+
+def test_sparse_unsigned_written_as_fch5(tmp_path: Path) -> None:
+    data = np.zeros((5, 64, 64), dtype=np.uint16)
+    data[:, ::8, ::8] = 1000
+    assert roundtrip(tmp_path, data)
+
+
+def test_ineligible_data_falls_back_to_dense(tmp_path: Path) -> None:
+    # Signed data: fch5 with threshold=0 would zero out negative values
+    data = np.zeros((5, 64, 64), dtype=np.int32)
+    data[:, ::8, ::8] = 1000
+    data[:, 3, 3] = -7
+    assert not roundtrip(tmp_path, data)
+
+    # Unsigned but not sparse: dense storage compresses better
+    data = np.arange(5 * 64 * 64, dtype=np.uint32).reshape(5, 64, 64) + 1
+    assert not roundtrip(tmp_path, data)
+
+
+def test_old_state_layout_still_loads(tmp_path: Path) -> None:
+    # Old state files always used the dense hdf5 layout with the gzip default
+    data = np.zeros((5, 64, 64), dtype=np.uint16)
+    data[:, ::8, ::8] = 1000
+    ims = make_imageseries(data)
+    path = tmp_path / 'state.h5'
+    with h5py.File(path, 'w') as f:
+        imageseries.write(ims, f, 'hdf5', path='images/det')
+
+    with h5py.File(path, 'r') as f:
+        loaded = open_imageseries(f, 'images/det')
+        for i in range(len(data)):
+            assert np.array_equal(np.asarray(loaded[i]), data[i])
+        assert np.allclose(loaded.metadata['omega'], ims.metadata['omega'])

--- a/tests/test_state_image_compression.py
+++ b/tests/test_state_image_compression.py
@@ -1,7 +1,9 @@
-"""Tests for blosc-zstd compression of state-file image data.
+"""Tests for blosc-zstd compression of dense image data in state files.
 
-The on-disk layout matches hexrd's 'hdf5' imageseries writer, so it round-trips
-through ``imageseries.open(..., 'hdf5', ...)`` and stays backward compatible.
+Data that is not eligible for the sparse fch5 format (signed dtypes, dense
+frames) keeps the 'hdf5' imageseries layout with a blosc-zstd filter, so it
+round-trips through ``imageseries.open(..., 'hdf5', ...)`` and stays backward
+compatible.
 """
 
 from pathlib import Path
@@ -15,9 +17,11 @@ from hexrdgui.state import write_imageseries
 
 
 def make_imageseries() -> tuple:
-    # A small, sparse, non-negative imageseries with omega metadata.
-    data = np.zeros((5, 64, 64), dtype=np.uint16)
+    # A small, sparse imageseries with omega metadata. The signed dtype (with
+    # negative values) keeps it on the dense hdf5 path.
+    data = np.zeros((5, 64, 64), dtype=np.int16)
     data[:, ::8, ::8] = 1000
+    data[:, 3, 3] = -5
     ims = imageseries.open(None, 'array', data=data)
     ims.metadata['omega'] = np.linspace(0, 180, 5).reshape(-1, 1)
     return ims, data


### PR DESCRIPTION
Sparse unsigned-integer imageseries are written as fch5 frame caches (lossless at threshold=0), which saves much faster and smaller than the dense layout. Signed, float, or non-sparse data keeps the dense blosc-zstd path, and loading detects the format per detector group, so older state files still load unchanged.