### PR TITLE
Show invalid eta-ome map bins as masked

### DIFF
--- a/hexrdgui/color_map_editor.py
+++ b/hexrdgui/color_map_editor.py
@@ -230,6 +230,15 @@ class ColorMapEditor:
         self.ui.minimum.setValue(self.bounds[0])
         self.ui.maximum.setValue(self.bounds[1])
 
+    def enable_show_invalid(self, color: Any = constants.DEFAULT_INVALID_COLOR) -> None:
+        # Set the invalid (NaN) pixel color and enable displaying it,
+        # without prompting the user with a color dialog
+        self.bad_color = np.asarray(color, dtype=float)
+        with block_signals(self.ui.show_invalid):
+            self.ui.show_invalid.setChecked(True)
+
+        self.update_cmap()
+
     def show_invalid_toggled(self, b: bool) -> None:
         if b:
             color = QColor.fromRgbF(*self.bad_color)

--- a/hexrdgui/constants.py
+++ b/hexrdgui/constants.py
@@ -60,6 +60,9 @@ class PolarXAxisType:
 
 DEFAULT_EULER_ANGLE_CONVENTION = {'axes_order': 'xyz', 'extrinsic': True}
 
+# Default color for displaying invalid (NaN) pixels
+DEFAULT_INVALID_COLOR = (0.5, 0.5, 0.5, 1.0)
+
 DEFAULT_WPPF_PLOT_STYLE = {
     'marker': 'x',
     's': 30,

--- a/hexrdgui/indexing/indexing_results_dialog.py
+++ b/hexrdgui/indexing/indexing_results_dialog.py
@@ -214,6 +214,10 @@ class IndexingResultsDialog(QObject):
         # Set the initial max as 20
         self.color_map_editor.ui.maximum.setValue(20)
 
+        # Eta bins the panel buffer excludes (and bins off the detector)
+        # are NaN in the maps. Show them as masked by default.
+        self.color_map_editor.enable_show_invalid()
+
     @property
     def scaled_image_data(self) -> np.ndarray:
         return self.transform(self.image_data)

--- a/hexrdgui/indexing/ome_maps_viewer_dialog.py
+++ b/hexrdgui/indexing/ome_maps_viewer_dialog.py
@@ -527,6 +527,10 @@ class OmeMapsViewerDialog(QObject):
         # Set the initial max as 20
         self.color_map_editor.ui.maximum.setValue(20)
 
+        # Eta bins the panel buffer excludes (and bins off the detector)
+        # are NaN in the maps. Show them as masked by default.
+        self.color_map_editor.enable_show_invalid()
+
     def setup_hkls_table(self) -> None:
         selected = self.config['find_orientations']['seed_search']['hkl_seeds']
         hkls = self.hkls


### PR DESCRIPTION
Bins excluded by the panel buffer or off the detector are NaN in the eta-omega maps. Display them with a gray invalid color by default in the maps viewer and indexing results dialogs.