### PR TITLE
Draw azimuthal overlays over the lineout lines

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,12 @@ jobs:
   pytest:
     name: ${{ matrix.config.name }}
     runs-on: ${{ matrix.config.os }}
+    # A green run takes 7-12 minutes. Without a bound, a test that blocks
+    # (nothing dismisses a modal dialog under `offscreen`) burns the 6h default.
+    timeout-minutes: 30
     strategy:
-      fail-fast: true
+      # Don't cancel the other platforms; their failure modes differ.
+      fail-fast: false
       matrix:
         python-version: ['3.11', '3.14']
         config:

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path
 import sys
 from typing import TYPE_CHECKING
+import weakref
 
 from PySide6.QtCore import Signal, QCoreApplication, QObject, QSettings, QTimer
 
@@ -357,7 +358,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
         self.default_cmap = constants.DEFAULT_CMAP
         self._previous_structureless_calibration_picks_data = None
         self._image_mode = constants.ViewType.raw
-        self._active_canvas = None
+        self._active_canvas: weakref.ref[ImageCanvas] | None = None
         self._sample_tilt = np.asarray([0, 0, 0], float)
         self.recent_state_files: list[str] = []
         self._apply_absorption_correction = False
@@ -920,14 +921,16 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @property
     def active_canvas(self) -> ImageCanvas | None:
-        return self._active_canvas
+        # Weak: this singleton outlives every canvas, and a strong reference
+        # would pin the canvas (and its window) past its C++ destruction.
+        return self._active_canvas() if self._active_canvas is not None else None
 
     @active_canvas.setter
     def active_canvas(self, v: ImageCanvas | None) -> None:
-        if v is self._active_canvas:
+        if v is self.active_canvas:
             return
 
-        self._active_canvas = v
+        self._active_canvas = weakref.ref(v) if v is not None else None
         self.active_canvas_changed.emit()
 
     def image(self, name: str, idx: int) -> np.ndarray:
@@ -966,10 +969,11 @@ class HexrdConfig(QObject, metaclass=QSingleton):
 
     @property
     def omega_imageseries_dict(self) -> dict[str, Any] | None:
+        # Snapshot, for the same reason as `raw_images_dict` below.
         if self.is_aggregated:
-            imsd = self.unagg_images
+            imsd = dict(self.unagg_images)
         else:
-            imsd = self.imageseries_dict
+            imsd = dict(self.imageseries_dict)
 
         if not imsd:
             return None
@@ -999,11 +1003,12 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def raw_images_dict(self) -> dict[str, np.ndarray]:
         """Get a dict of images with the current index"""
         idx = self.current_imageseries_idx
-        ret = {}
-        for key in self.imageseries_dict.keys():
-            ret[key] = self.image(key, idx)
 
-        return ret
+        # Snapshot first. This runs in the view-generation worker thread
+        # while the main thread may be clearing and refilling the dict, and
+        # reading a frame releases the GIL.
+        imsd = dict(self.imageseries_dict)
+        return {key: ims[idx] for key, ims in imsd.items()}
 
     @property
     def intensity_corrected_images_dict(self) -> dict[str, np.ndarray]:

--- a/hexrdgui/image_canvas.py
+++ b/hexrdgui/image_canvas.py
@@ -84,6 +84,10 @@ if TYPE_CHECKING:
 FONTSIZE_LABEL_INCREASE = 4
 FONTSIZE_TICKS_INCREASE = 4
 
+# Draw the azimuthal overlays above the azimuthal lineout lines (which use
+# matplotlib's default zorder), so that they are easier to see.
+AZIMUTHAL_OVERLAY_ZORDER = 5
+
 
 class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
     cmap_modified = Signal()
@@ -1909,9 +1913,17 @@ class ImageCanvas(InteractiveCanvasMixin, FigureCanvas):
             result = material.powder_overlay
             # Plot the result so that the plot scales correctly with the data
             # since the fill artist is not taken into account for rescaling.
-            (line,) = self.azimuthal_integral_axis.plot(tth, result, lw=0)
+            # Draw the overlays on top of the lineout lines (which use the
+            # default zorder) so they do not get hidden underneath them.
+            (line,) = self.azimuthal_integral_axis.plot(
+                tth, result, lw=0, zorder=AZIMUTHAL_OVERLAY_ZORDER
+            )
             fill = self.azimuthal_integral_axis.fill_between(
-                tth, result, color=overlay['color'], alpha=overlay['opacity']
+                tth,
+                result,
+                color=overlay['color'],
+                alpha=overlay['opacity'],
+                zorder=AZIMUTHAL_OVERLAY_ZORDER,
             )
             fill.set_label(f'{overlay["name"]}({density}g/cm³)')
             self.azimuthal_overlay_artists.append(

--- a/hexrdgui/image_load_manager.py
+++ b/hexrdgui/image_load_manager.py
@@ -4,6 +4,7 @@ import functools
 import os
 import time
 import glob
+import weakref
 from concurrent.futures import ThreadPoolExecutor, Future
 from typing import Any, TYPE_CHECKING
 from collections.abc import Callable
@@ -61,6 +62,17 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
     def __init__(self) -> None:
         super().__init__(None)
         self.transformed_images = False
+        self.progress_dialog: ProgressDialog | None = None
+        self._ui_parent_ref: weakref.ref[QWidget] | None = None
+
+    @property
+    def ui_parent(self) -> QWidget | None:
+        # Weak: this singleton outlives every window handed to it.
+        return self._ui_parent_ref() if self._ui_parent_ref is not None else None
+
+    @ui_parent.setter
+    def ui_parent(self, parent: QWidget | None) -> None:
+        self._ui_parent_ref = weakref.ref(parent) if parent is not None else None
 
     @property
     def thread_pool(self) -> QThreadPool:
@@ -203,6 +215,7 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
         worker.signals.error.connect(self.on_process_ims_error)
         worker.signals.finished.connect(progress_dialog.accept)
         progress_dialog.exec()
+        self.progress_dialog = None
 
     def set_state(
         self,
@@ -527,6 +540,7 @@ class ImageLoadManager(QObject, metaclass=QSingleton):
         dict.
         """
         n_macro_steps = self.progress_macro_steps
+        assert self.progress_dialog is not None
         orig_progress = self.progress_dialog.value()
         while not all([f.done() for f in futures]):
             total = sum([v for v in progress_dict.values()])

--- a/hexrdgui/masking/mask_manager_dialog.py
+++ b/hexrdgui/masking/mask_manager_dialog.py
@@ -160,6 +160,8 @@ class MaskManagerDialog(QObject):
         scroll_value = scrollbar.value()
         item = self.mask_tree_items.pop(name)
         parent = item.parent()
+        # Mask items always sit under a mask-type item
+        assert parent is not None
         parent.removeChild(item)
         MaskManager().remove_mask(name)
         # If parent has no more children, remove it too

--- a/hexrdgui/tree_views/base_tree_item_model.py
+++ b/hexrdgui/tree_views/base_tree_item_model.py
@@ -79,7 +79,8 @@ class BaseTreeItemModel(QAbstractItemModel):
         self, index: QModelIndex | QPersistentModelIndex | None = None
     ) -> QObject | QModelIndex:
         if index is None:
-            return super().parent()
+            # PySide6 6.11 stubs made this `QObject | None`
+            return super().parent()  # type: ignore[return-value]
 
         if not index.isValid():
             return QModelIndex()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,13 @@
 import gc
 import os
 import sys
+import traceback
 from pathlib import Path
 
 import pytest
 
 from PySide6.QtCore import QEvent, QSettings
-from PySide6.QtWidgets import QApplication
+from PySide6.QtWidgets import QApplication, QMessageBox
 
 from hexrdgui.main_window import MainWindow
 from hexrdgui.messages_widget import MessagesWidget
@@ -34,6 +35,45 @@ def default_config_path(single_ge_path):
 @pytest.fixture
 def default_data_path(single_ge_path):
     return single_ge_path / 'imageseries/RUBY_0000-fc_GE.npz'
+
+
+@pytest.fixture(autouse=True)
+def message_boxes(monkeypatch):
+    """Record modal message boxes instead of letting them hang the run.
+
+    Under `offscreen` nobody clicks "OK", so these block forever and the job
+    goes quiet with no failing test to point at. Any box still recorded at
+    teardown fails the test; a test that expects one checks it and clears it.
+    """
+    shown: list[str] = []
+
+    def make_stub(method, result):
+        def stub(parent, title, text='', *args, **kwargs):
+            # The stack says which error path popped the box, which is what a
+            # job that just went quiet cannot tell you.
+            shown.append(
+                f'QMessageBox.{method}({title!r}, {text!r})\n'
+                + ''.join(traceback.format_stack()[:-1])
+            )
+            return result
+
+        return stub
+
+    # The helpers that spin their own modal event loop, and what each should
+    # return in place of the button nobody is there to click.
+    results = {
+        'about': None,
+        'critical': QMessageBox.StandardButton.Ok,
+        'information': QMessageBox.StandardButton.Ok,
+        'question': QMessageBox.StandardButton.No,
+        'warning': QMessageBox.StandardButton.Ok,
+    }
+    for method, result in results.items():
+        monkeypatch.setattr(QMessageBox, method, make_stub(method, result))
+
+    yield shown
+
+    assert not shown, 'Unexpected modal message box(es):\n' + '\n'.join(shown)
 
 
 @pytest.fixture

--- a/tests/test_hedm_workflow.py
+++ b/tests/test_hedm_workflow.py
@@ -23,8 +23,8 @@ import numpy as np
 import pytest
 import yaml
 
-from PySide6.QtCore import Qt, QTimer
-from PySide6.QtWidgets import QApplication, QMessageBox
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import QApplication
 
 from hexrdgui.hexrd_config import HexrdConfig
 
@@ -36,7 +36,9 @@ def dexelas_hedm_path(example_repo_path):
     return example_repo_path / 'state_examples' / 'Dexelas_HEDM'
 
 
-def test_hedm_full_workflow(qtbot, main_window, dexelas_hedm_path, tmp_path):
+def test_hedm_full_workflow(
+    qtbot, main_window, message_boxes, dexelas_hedm_path, tmp_path
+):
     # ── paths ──────────────────────────────────────────────────────────
     state_file = dexelas_hedm_path / 'roi_dexelas_hedm.h5'
     npz1 = dexelas_hedm_path / 'mruby-0129_000004_ff1_000012-cachefile.npz'
@@ -131,19 +133,14 @@ def test_hedm_full_workflow(qtbot, main_window, dexelas_hedm_path, tmp_path):
     QApplication.processEvents()
 
     # ── Step I: click "Fit Grains" (accept options dialog) ─────────────
-    # Applying min sfac excludes [0,0,6] which was an active HKL.
-    # validate() will show a QMessageBox.critical() informing the user
-    # that it will re-enable those HKLs.  Auto-close it.
-    def close_active_hkl_warning():
-        for w in QApplication.topLevelWidgets():
-            if isinstance(w, QMessageBox):
-                w.accept()
-                return
-        # If not found yet, try again shortly
-        QTimer.singleShot(50, close_active_hkl_warning)
-
-    QTimer.singleShot(0, close_active_hkl_warning)
+    # Applying min sfac excludes [0,0,6], which was an active HKL, so
+    # validate() warns that it will re-enable those HKLs. The `message_boxes`
+    # fixture recorded it rather than showing it; consume it.
     options_dialog.ui.accept()
+
+    (hkl_warning,) = message_boxes
+    assert 'Active HKLs' in hkl_warning and '[0, 0, 6]' in hkl_warning
+    message_boxes.clear()
 
     # fit_grains runs asynchronously via progress_dialog.exec().
     # On completion, fit_grains_finished() → view_fit_grains_results()

--- a/tests/test_singletons.py
+++ b/tests/test_singletons.py
@@ -1,0 +1,72 @@
+"""HexrdConfig and ImageLoadManager live for the whole process.
+
+That makes two things easy to get wrong: what they hand out to background
+threads while the main thread mutates it, and what they keep alive.
+"""
+
+import threading
+import time
+import weakref
+
+import numpy as np
+
+from PySide6.QtWidgets import QWidget
+
+from hexrdgui.hexrd_config import HexrdConfig
+from hexrdgui.image_load_manager import ImageLoadManager
+
+
+class DummyImageSeries(list):
+    def __getitem__(self, idx):
+        # A real imageseries decompresses/reads here, releasing the GIL.
+        # That is the window a concurrent swap slips into.
+        time.sleep(0)
+        return super().__getitem__(idx)
+
+
+def test_image_accessors_survive_a_concurrent_swap(qtbot):
+    # The view generation reads these from its worker thread, while loading
+    # images clears `imageseries_dict` and refills it one detector at a time.
+    config = HexrdConfig()
+    original = dict(config.imageseries_dict)
+    entries = {f'det_{i}': DummyImageSeries([np.zeros((4, 4))]) for i in range(16)}
+    stop = threading.Event()
+
+    def swap():
+        while not stop.is_set():
+            config.imageseries_dict.clear()
+            config.imageseries_dict.update(entries)
+
+    thread = threading.Thread(target=swap, daemon=True)
+    thread.start()
+    try:
+        for _ in range(500):
+            # Neither may raise, and each must see a whole dict, not a
+            # half-refilled one.
+            assert len(config.raw_images_dict) in (0, len(entries))
+            config.omega_imageseries_dict
+    finally:
+        stop.set()
+        thread.join()
+        config.imageseries_dict.clear()
+        config.imageseries_dict.update(original)
+
+
+def test_singletons_hold_widgets_weakly(qtbot):
+    # A strong reference would pin a whole torn-down window for the rest of
+    # the process, leaving Python wrappers over freed C++ objects behind.
+    for singleton, attribute in (
+        (ImageLoadManager(), 'ui_parent'),
+        (HexrdConfig(), 'active_canvas'),
+    ):
+        previous = getattr(singleton, attribute)
+        try:
+            widget = QWidget()
+            ref = weakref.ref(widget)
+            setattr(singleton, attribute, widget)
+            assert getattr(singleton, attribute) is widget
+
+            del widget
+            assert ref() is None, f'{attribute} kept the widget alive'
+        finally:
+            setattr(singleton, attribute, previous)


### PR DESCRIPTION
The overlay fills were created at matplotlib's default collection zorder, which placed them underneath the azimuthal lineout line. Give them a higher zorder so they are visible on top.