### PR TITLE
Add GE_41RT_newton to the distortion options

### DIFF
--- a/hexrdgui/calibration/calibration_dialog_callbacks.py
+++ b/hexrdgui/calibration/calibration_dialog_callbacks.py
@@ -34,8 +34,6 @@ from hexrdgui.utils.matplotlib import remove_artist
 
 
 # Number of decimal places to round calibration parameters
-ROUND_DECIMALS = 3
-
 
 class CalibrationDialogCallbacks(ABCQObject):
     """A class with default behavior for calibration dialog callbacks"""
@@ -63,7 +61,6 @@ class CalibrationDialogCallbacks(ABCQObject):
         self.draw_picks_lines: list[Artist] = []
         self.undo_stack: list[dict[str, Any]] = []
 
-        self.round_param_numbers()
         # Make sure the tree view is updated
         self.dialog.update_tree_view()
 
@@ -262,7 +259,6 @@ class CalibrationDialogCallbacks(ABCQObject):
 
         constraints.params.update(**params)
         self.calibrator.reset_lmfit_params()
-        self.round_param_numbers()
         self.update_dialog_from_calibrator()
 
     def reset_saved_constraint_params(self) -> None:
@@ -371,9 +367,6 @@ class CalibrationDialogCallbacks(ABCQObject):
         x0 = self.calibrator.params.valuesdict()
         result = self.calibrator.run_calibration(odict=odict, **extra_kwargs)
 
-        # Round the calibrator numbers to 3 decimal places
-        self.round_param_numbers()
-
         x1 = result.params.valuesdict()
 
         results_message = 'Calibration Results:\n'
@@ -413,18 +406,6 @@ class CalibrationDialogCallbacks(ABCQObject):
         if self.calibrator_is_structureless:
             # Only do this for structureless calibration
             self.calibrator.tth_distortion = self.dialog.tth_distortion
-
-    def round_param_numbers(self) -> None:
-        params_dict = self.calibrator.params
-
-        attrs = [
-            'value',
-            'min',
-            'max',
-        ]
-        for param in params_dict.values():
-            for attr in attrs:
-                setattr(param, attr, round(getattr(param, attr), ROUND_DECIMALS))
 
     def on_edit_picks_finished(self) -> None:
         # Show this again

--- a/hexrdgui/calibration/calibration_dialog_callbacks.py
+++ b/hexrdgui/calibration/calibration_dialog_callbacks.py
@@ -33,8 +33,6 @@ from hexrdgui.utils.abc_qobject import ABCQObject
 from hexrdgui.utils.matplotlib import remove_artist
 
 
-# Number of decimal places to round calibration parameters
-
 class CalibrationDialogCallbacks(ABCQObject):
     """A class with default behavior for calibration dialog callbacks"""
 

--- a/hexrdgui/calibration/hedm/calibration_dialog.py
+++ b/hexrdgui/calibration/hedm/calibration_dialog.py
@@ -453,8 +453,6 @@ class HEDMCalibrationCallbacks(MaterialCalibrationDialogCallbacks):
             # The dialog parameters should have the deltas set on them
             prev_params = dialog.params_dict
             self._copy_deltas(prev_params, params_dict, copy_vary=False)
-            # Round the calibrator numbers to 3 decimal places
-            self.round_param_numbers()
             dialog.params_dict = params_dict
 
         # Next, apply strain settings
@@ -612,9 +610,6 @@ class HEDMCalibrationCallbacks(MaterialCalibrationDialogCallbacks):
 
         # And trigger that calibrator to update its calibrator parameters
         self.calibrator.update_all_from_params(ic.params)
-
-        # Round the calibrator numbers to 3 decimal places
-        self.round_param_numbers()
 
         x1 = result.params.valuesdict()
 

--- a/hexrdgui/calibration/wppf_options_dialog.py
+++ b/hexrdgui/calibration/wppf_options_dialog.py
@@ -2889,6 +2889,9 @@ def load_yaml_dict(module: types.ModuleType, filename: str) -> dict:
 
 
 class DefaultWPPFTreeItemModel(DefaultCalibrationTreeItemModel):
+    # Keep the previous behavior of displaying full float values
+    FORMAT_FLOATS_FOR_DISPLAY = False
+
     COLUMNS = {
         **DefaultCalibrationTreeItemModel.COLUMNS,
         'Uncertainty': '_stderr',
@@ -2901,6 +2904,9 @@ class DefaultWPPFTreeItemModel(DefaultCalibrationTreeItemModel):
 
 
 class DeltaWPPFTreeItemModel(DeltaCalibrationTreeItemModel):
+    # Keep the previous behavior of displaying full float values
+    FORMAT_FLOATS_FOR_DISPLAY = False
+
     COLUMNS = {
         **DeltaCalibrationTreeItemModel.COLUMNS,
         'Uncertainty': '_stderr',

--- a/hexrdgui/hexrd_config.py
+++ b/hexrdgui/hexrd_config.py
@@ -2934,7 +2934,7 @@ class HexrdConfig(QObject, metaclass=QSingleton):
     def num_distortion_parameters(func_name: str) -> int:
         if func_name == 'None':
             return 0
-        elif func_name == 'GE_41RT':
+        elif func_name in ('GE_41RT', 'GE_41RT_newton'):
             return 6
         elif func_name == 'Dexela_2923':
             return 8

--- a/hexrdgui/overlays/powder_overlay.py
+++ b/hexrdgui/overlays/powder_overlay.py
@@ -561,10 +561,13 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                 assert sd is not None
                 ang_crds = sd.apply(xys)
             elif offset_distortion:
-                # Compute ang_crds in the regular way
+                # Compute ang_crds in the regular way.
+                # The xys are in the raw frame, so undo the panel
+                # distortion to match the corrected polar image.
                 ang_crds, _ = panel.cart_to_angles(
                     xys,
                     tvec_s=instr.tvec,
+                    apply_distortion=True,
                 )
 
             if offset_distortion:
@@ -602,9 +605,12 @@ class PowderOverlay(Overlay, PolarDistortionObject):
                     # In the polar view, the nominal angles refer to the SAMPLE
                     # CS origin, so we omit the addition of any offset to the
                     # diffraction COM in the sample frame!
+                    # The xys are in the raw frame, so undo the panel
+                    # distortion to match the corrected polar image.
                     ang_crds, _ = panel.cart_to_angles(
                         xys,
                         tvec_s=instr.tvec,
+                        apply_distortion=True,
                     )
 
                 if len(ang_crds) == 0:

--- a/hexrdgui/resources/ui/instrument_form_view_widget.ui
+++ b/hexrdgui/resources/ui/instrument_form_view_widget.ui
@@ -952,6 +952,11 @@
            </item>
            <item>
             <property name="text">
+             <string>GE_41RT_newton</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
              <string>Dexela_2923</string>
             </property>
            </item>

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -26,8 +26,11 @@ from hexrdgui.tree_views.tree_item import TreeItem
 # Global constants
 KEY_COL = BaseTreeItemModel.KEY_COL
 
-# Display-only float format for value/min/max/delta columns
-FLOAT_DISPLAY_FORMAT = '{:.8g}'
+# Display-only float formats for value/min/max/delta columns.
+# Lattice and distortion parameters need more precision than the rest.
+FLOAT_DISPLAY_FORMAT = '{:.3f}'
+PRECISE_FLOAT_DISPLAY_FORMAT = '{:.5g}'
+PRECISE_PARAM_SUFFIXES = ('_a', '_b', '_c', '_alpha', '_beta', '_gamma')
 
 
 class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
@@ -63,9 +66,19 @@ class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
             if isinstance(value, float):
                 # Round for display only; the underlying value keeps
                 # full precision (editors receive it via EditRole).
-                return FLOAT_DISPLAY_FORMAT.format(value)
+                return self.display_format(index).format(value)
 
         return value
+
+    def display_format(self, index: QModelIndex | QPersistentModelIndex) -> str:
+        # Lattice and distortion parameters are displayed with more
+        # precision than other parameters.
+        config = self.config_path(self.path_to_item(self.get_item(index)))
+        name = getattr(config.get('_param'), 'name', '')
+        if '_distortion_param' in name or name.endswith(PRECISE_PARAM_SUFFIXES):
+            return PRECISE_FLOAT_DISPLAY_FORMAT
+
+        return FLOAT_DISPLAY_FORMAT
 
     def flags(self, index: QModelIndex | QPersistentModelIndex) -> Qt.ItemFlag:
         if not index.isValid():

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -66,7 +66,11 @@ class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
             if isinstance(value, float):
                 # Round for display only; the underlying value keeps
                 # full precision (editors receive it via EditRole).
-                return self.display_format(index).format(value)
+                text = self.display_format(index).format(value)
+                if '.' in text and 'e' not in text:
+                    # Don't display trailing zeros
+                    text = text.rstrip('0').rstrip('.')
+                return '0' if text == '-0' else text
 
         return value
 

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -36,6 +36,9 @@ PRECISE_PARAM_SUFFIXES = ('_a', '_b', '_c', '_alpha', '_beta', '_gamma')
 class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
     UNEDITABLE_COLUMN_INDICES: list[int] = []
 
+    # Whether float values are rounded for display (see data())
+    FORMAT_FLOATS_FOR_DISPLAY = True
+
     def __init__(
         self,
         dictionary: dict[str, Any],
@@ -63,7 +66,7 @@ class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
                 # If it's a bool, we want to display a checkbox via
                 # a persistent editor, rather than the default display.
                 return
-            if isinstance(value, float):
+            if isinstance(value, float) and self.FORMAT_FLOATS_FOR_DISPLAY:
                 # Round for display only; the underlying value keeps
                 # full precision (editors receive it via EditRole).
                 text = self.display_format(index).format(value)

--- a/hexrdgui/tree_views/multi_column_dict_tree_view.py
+++ b/hexrdgui/tree_views/multi_column_dict_tree_view.py
@@ -26,6 +26,9 @@ from hexrdgui.tree_views.tree_item import TreeItem
 # Global constants
 KEY_COL = BaseTreeItemModel.KEY_COL
 
+# Display-only float format for value/min/max/delta columns
+FLOAT_DISPLAY_FORMAT = '{:.8g}'
+
 
 class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
     UNEDITABLE_COLUMN_INDICES: list[int] = []
@@ -52,10 +55,15 @@ class MultiColumnDictTreeItemModel(BaseDictTreeItemModel):
     ) -> Any:
         value = super().data(index, role)
 
-        if isinstance(value, bool) and role == Qt.ItemDataRole.DisplayRole:
-            # If it's a bool, we want to display a checkbox via
-            # a persistent editor, rather than the default display.
-            return
+        if role == Qt.ItemDataRole.DisplayRole:
+            if isinstance(value, bool):
+                # If it's a bool, we want to display a checkbox via
+                # a persistent editor, rather than the default display.
+                return
+            if isinstance(value, float):
+                # Round for display only; the underlying value keeps
+                # full precision (editors receive it via EditRole).
+                return FLOAT_DISPLAY_FORMAT.format(value)
 
         return value
 


### PR DESCRIPTION
Exposes the "_newton" GE_41RT variant in the detector distortion combo box, and treats it as a 6-parameter function like GE_41RT.

This is really necessary for some GE detectors that appear to exhibit pincushion effects, rather than barrel distortion effects. The new closed form method cannot handle the pincushion modeling.